### PR TITLE
feat: Add mandatory guide association to activities

### DIFF
--- a/src/logging.ts
+++ b/src/logging.ts
@@ -2,6 +2,7 @@ export interface AuditEvent { timestamp: string; tool: string; parameters: Recor
 
 export function logAuditEvent(event: AuditEvent): void { console.error(JSON.stringify({ type: 'audit', ...event })); }
 export function logInfo(message: string, data?: Record<string, unknown>): void { console.error(JSON.stringify({ type: 'info', message, ...data, timestamp: new Date().toISOString() })); }
+export function logWarn(message: string, data?: Record<string, unknown>): void { console.error(JSON.stringify({ type: 'warn', message, ...data, timestamp: new Date().toISOString() })); }
 export function logError(message: string, error?: Error, data?: Record<string, unknown>): void { console.error(JSON.stringify({ type: 'error', message, error: error?.message, stack: error?.stack, ...data, timestamp: new Date().toISOString() })); }
 
 export function withAuditLog<T extends Record<string, unknown>, R>(toolName: string, handler: (params: T) => Promise<R>): (params: T) => Promise<R> {

--- a/tests/activity-loader.test.ts
+++ b/tests/activity-loader.test.ts
@@ -40,8 +40,19 @@ describe('activity-loader', () => {
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.value.id).toBe('start-workflow');
-        expect(result.value.version).toBe('2.0.0');
+        expect(result.value.version).toBe('2.1.0');
         expect(result.value.problem).toBeDefined();
+      }
+    });
+
+    it('should load activity with mandatory_guide reference', async () => {
+      const result = await readActivity(WORKFLOW_DIR, 'start-workflow');
+      
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.value.mandatory_guide).toBeDefined();
+        expect(result.value.mandatory_guide?.workflow_id).toBe('work-package');
+        expect(result.value.mandatory_guide?.index).toBe('00');
       }
     });
 
@@ -164,6 +175,47 @@ describe('activity-loader', () => {
           expect(activity.next_action.parameters).toBeDefined();
           expect(activity.next_action.parameters.skill_id).toBe(activity.primary_skill);
         }
+      }
+    });
+
+    it('should embed mandatory_guide content for activities with guides', async () => {
+      const result = await readActivityIndex(WORKFLOW_DIR);
+      
+      expect(result.success).toBe(true);
+      if (result.success) {
+        // start-workflow should have mandatory_guide with embedded content
+        const startWorkflow = result.value.activities.find(a => a.id === 'start-workflow');
+        expect(startWorkflow).toBeDefined();
+        expect(startWorkflow?.mandatory_guide).toBeDefined();
+        expect(startWorkflow?.mandatory_guide?.workflow_id).toBe('work-package');
+        expect(startWorkflow?.mandatory_guide?.index).toBe('00');
+        expect(startWorkflow?.mandatory_guide?.content).toBeDefined();
+        expect(typeof startWorkflow?.mandatory_guide?.content).toBe('string');
+        expect(startWorkflow?.mandatory_guide?.content).toContain('id: start-here');
+        expect(startWorkflow?.mandatory_guide?.format).toBe('toon');
+        
+        // resume-workflow should have mandatory_guide
+        const resumeWorkflow = result.value.activities.find(a => a.id === 'resume-workflow');
+        expect(resumeWorkflow).toBeDefined();
+        expect(resumeWorkflow?.mandatory_guide).toBeDefined();
+        expect(resumeWorkflow?.mandatory_guide?.content).toBeDefined();
+        expect(resumeWorkflow?.mandatory_guide?.content).toContain('id: resume-here');
+        
+        // end-workflow should have mandatory_guide
+        const endWorkflow = result.value.activities.find(a => a.id === 'end-workflow');
+        expect(endWorkflow).toBeDefined();
+        expect(endWorkflow?.mandatory_guide).toBeDefined();
+        expect(endWorkflow?.mandatory_guide?.content).toBeDefined();
+        expect(endWorkflow?.mandatory_guide?.content).toContain('id: end-here');
+      }
+    });
+
+    it('should include usage mentioning mandatory_guide', async () => {
+      const result = await readActivityIndex(WORKFLOW_DIR);
+      
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.value.usage).toContain('mandatory_guide');
       }
     });
   });


### PR DESCRIPTION
## Summary

Adds mandatory guide associations to activities so agents load the appropriate guide before proceeding with workflow execution. The guide content is embedded directly in the `get_activities` response - no extra call needed.

Closes #19

## Problem

When resuming a work-package workflow, the agent failed to follow the formal `resume-work` guide process. Activities don't have mandatory guide associations - the agent loaded the `workflow-execution` skill but had no indication that `resume-workflow` specifically requires following a specific guide first.

## Solution

### Activity Schema Change

Added `mandatory_guide` field to Activity interface:

```typescript
interface MandatoryGuide {
  workflow_id: string;
  index: string;
  content: string;  // Raw TOON/markdown content
  format: 'toon' | 'markdown';
}
```

### Activity Response Structure

```json
{
  "id": "resume-workflow",
  "problem": "Continue a previously started workflow",
  "primary_skill": "workflow-execution",
  "mandatory_guide": {
    "workflow_id": "work-package",
    "index": "18",
    "content": "id: resume-here\nversion: 1.0.0\n...",
    "format": "toon"
  },
  "next_action": {
    "tool": "get_skill",
    "parameters": { "skill_id": "workflow-execution" }
  }
}
```

### Guide Associations

| Activity | Guide | Index |
|----------|-------|-------|
| start-workflow | start-here | 00 |
| resume-workflow | resume-here | 18 (new) |
| end-workflow | end-here | 19 (new) |

## Changes

### Main Repository
- `src/loaders/activity-loader.ts`: Add `MandatoryGuide`, `MandatoryGuideRef` interfaces, update `readActivityIndex()` to embed guide content
- `src/logging.ts`: Add `logWarn` function
- `tests/activity-loader.test.ts`: Add tests for mandatory_guide embedding

### Workflows Branch
- `meta/intents/01-start-workflow.toon`: Add mandatory_guide reference
- `meta/intents/02-resume-workflow.toon`: Add mandatory_guide reference
- `meta/intents/03-end-workflow.toon`: Add mandatory_guide reference
- `work-package/guides/18-resume-here.toon`: New guide with 5-phase resumption process
- `work-package/guides/19-end-here.toon`: New guide with completion checklist

## Test Results

- 99 tests passing
- All activity-loader tests pass including new mandatory_guide tests