### PR TITLE
refactor: complete intent to activity rename

### DIFF
--- a/.cursor/rules/concept-rag.mdc
+++ b/.cursor/rules/concept-rag.mdc
@@ -3,4 +3,4 @@ alwaysApply: true
 ---
 # Overview
 
-Before using concept-rag MCP tools, fetch the `concept-rag://intents` resource.
+Before using concept-rag MCP tools, fetch the `concept-rag://activities` resource.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -78,7 +78,7 @@ Workflow-specific skills are stored in each workflow's `skills/` directory. Curr
 ### The Meta Workflow
 
 The `meta` workflow is the bootstrap workflow for the workflow-server. It contains:
-- **Activities** (`meta/intents/`): All user activities for workflow operations
+- **Activities** (`meta/activities/`): All user activities for workflow operations
 - **Universal skills** (`meta/skills/`): Skills that apply to all workflows
 
 ### Skill Resolution

--- a/docs/development.md
+++ b/docs/development.md
@@ -76,7 +76,7 @@ workflow-server/
 ├── workflows/                # Worktree (workflows branch)
 │   ├── meta/                 # Bootstrap workflow (manages other workflows)
 │   │   ├── meta.toon             # Meta workflow definition
-│   │   ├── intents/              # All activities (indexed, no separate index file)
+│   │   ├── activities/           # All activities (indexed, no separate index file)
 │   │   │   └── {NN}-{id}.toon    # Individual activities (01-start-workflow, etc.)
 │   │   └── skills/               # Universal skills (indexed)
 │   │       └── {NN}-{id}.toon    # Skills that apply to all workflows

--- a/src/loaders/activity-loader.ts
+++ b/src/loaders/activity-loader.ts
@@ -60,7 +60,7 @@ export interface ActivityWithGuidance extends Activity {
 
 /** Get the activity directory from the meta workflow */
 function getActivityDir(workflowDir: string): string {
-  return join(workflowDir, META_WORKFLOW_ID, 'intents');
+  return join(workflowDir, META_WORKFLOW_ID, 'activities');
 }
 
 export async function readActivity(workflowDir: string, activityId: string): Promise<Result<ActivityWithGuidance, ActivityNotFoundError>> {


### PR DESCRIPTION
## Summary

- Completes the rename from `intents` to `activities` that was partially done in #14
- Updates missed references in code (`activity-loader.ts`) and documentation (`api-reference.md`, `development.md`)
- Updates `.cursor/rules/concept-rag.mdc` resource URI from `concept-rag://intents` to `concept-rag://activities`

**Note:** The corresponding folder rename (`meta/intents/` → `meta/activities/`) has been pushed directly to the `workflows` branch.

## Test plan

- [x] All 99 tests pass