### PR TITLE
Sync upstream prism updates: renames, metadata, 16 new resources

### DIFF
--- a/prism/README.md
+++ b/prism/README.md
@@ -23,6 +23,83 @@
 - Apply multiple complementary perspectives to the same target (portfolio mode)
 - Analyze non-code artifacts — proposals, strategies, architectures — with the same rigour
 
+## Concepts
+
+Definitions of the analytical [concepts](concept-lexicon.md) used within the Prism workflow, including: [conservation law](concept-lexicon.md#conservation-law), [meta-law](concept-lexicon.md#meta-law), [structural invariant](concept-lexicon.md#structural-invariant), [concealment mechanism](concept-lexicon.md#concealment-mechanism), and others.
+
+---
+
+## Prompt Guide
+
+Each prism responds to a specific analytical question. The table below shows user prompts that reliably trigger each prism through the plan-analysis goal-mapping matrix.
+
+| Prompt | Scope | Prism / Mode |
+|--------|-------|-------------|
+| `Analyze src/parser.ts` | file | L12 structural (00) — default for any code target |
+| `Pre-commit review of src/handler.rs` | file | L12 full pipeline (00→01→02) |
+| `Analyze this proposal using the full prism` | text | L12 full pipeline on general input |
+| `What patterns from this design would transfer poorly to other problems?` | any | Pedagogy (06) |
+| `What hidden assumptions does this architecture embed?` | any | Claim (07) |
+| `What resource scarcity does this system gamble on?` | any | Scarcity (08) |
+| `What rejected alternatives would swap these problems for different ones?` | any | Rejected-paths (09) |
+| `How does this code decay over 12 months of neglect?` | file | Degradation (10) |
+| `What does each function's interface contract promise vs actually deliver?` | file | Contract (11) |
+| `Find conservation laws and information laundering in this code` | file | Deep-scan (12) |
+| `Where do trust boundaries collapse? Find authority inversions` | module | Trust topology (13) |
+| `Find hidden temporal coupling — ordering dependencies and TOCTOU gaps` | module | Coupling clock (14) |
+| `Where do implementation details leak through abstraction boundaries?` | module | Abstraction leak (15) |
+| `What structural defects persist through every attempted fix?` | file | Fix-cascade (16) |
+| `Where does this code claim to be something different than it is?` | file | Identity (17) |
+| `Quick structural scan of src/core.ts` | file | L12-universal (18) — Sonnet only |
+| `How does error context get destroyed in this module?` | module | Error resilience (19) |
+| `Find hidden performance costs — what optimization data is erased at boundaries?` | file | Optimize (20) |
+| `Trace invisible coupling — what data flows between functions without signatures?` | module | Evolution (21) |
+| `Where do function names lie about what the code actually does?` | file | API surface (22) |
+| `Run a comprehensive behavioral analysis of src/pipeline/` | module | Behavioral pipeline (19→20→21→22→23) |
+| `How does this business process destroy diagnostic information?` | text | Error resilience neutral (24) |
+| `Where do the labels in this proposal lie about what it delivers?` | text | API surface neutral (25) |
+| `What implicit dependencies bind the components of this strategy?` | text | Evolution neutral (26) |
+| `Quick error resilience scan of src/handler.ts` | file | Error resilience compact (27) — 110w |
+| `Ultra-brief error resilience check` | file | Error resilience 70w (28) — 70w |
+| `Where does skipped validation waste both safety and performance?` | file | Evidence cost (29) |
+| `Find dead code — functions defined but never called, stale config` | module | Reachability (30) |
+| `Where has documentation drifted from actual behavior?` | module | Fidelity (31) |
+| `Map every piece of mutable state as a state machine — find unhandled transitions` | file | State audit (32) |
+| `Dig through the structural layers — what's foundation vs accumulated sediment?` | file | Archaeology (33) |
+| `Find registration gaps — features wired but undocumented, or declared but unwired` | module | Audit-code (34) |
+| `Plant a new requirement and trace what resists the change` | file | Cultivation (35) |
+| `What breaks when a new developer joins? What becomes cargo cult?` | file | SDL-simulation (36) |
+| `Map trust entry points and trace exploit chains` | file | Security (37) |
+| `Run this code forward through 5 maintenance cycles — what calcifies?` | file | Simulation (38) |
+| `Which functions can't be unit tested? What's the isolation cost?` | file | Testability (39) |
+| `Attack this analysis for confabulated knowledge claims` | text | Knowledge-audit (40) |
+| `Classify every claim by knowledge dependency — structural vs contextual vs temporal` | text | Knowledge-boundary (41) |
+| `Type every finding with confidence, provenance, and falsifiability` | any | Knowledge-typed (42) |
+| `Self-correcting structural analysis — L12 with built-in confabulation detection` | file | L12g (43) |
+| `Maximum-trust analysis — 5-phase self-aware structural analysis, zero confabulation` | file | Oracle (44) |
+| `Rewrite this README as a high-converting developer landing page` | text | Writer (45) |
+| `Plan the optimal analysis strategy for this goal` | any | Strategist (48) |
+| `Security review of this module` | module | Portfolio: trust (13) + security (37) |
+| `Code review of src/api.ts` | file | Portfolio: L12 (00) + contract (11) |
+| `Assess maintainability of this service` | module | Portfolio: degradation (10) + contract (11) |
+| `Design review of this architecture` | any | Portfolio: claim (07) + rejected-paths (09) |
+| `What are the trade-offs in this approach?` | text | Portfolio: scarcity (08) + rejected-paths (09) |
+| `How does this code age? Archaeology + temporal simulation` | file | Portfolio: archaeology (33) + simulation (38) |
+| `Verify this analysis has no confabulated claims` | text | Portfolio: knowledge-audit (40) + knowledge-boundary (41) |
+
+Scope: **file** = single source file, **module** = directory or module (multiple files), **text** = inline text, question, or proposal (no file target), **any** = works at all scopes.
+
+---
+
+## Modes
+
+| Mode | Passes | Description |
+|------|--------|-------------|
+| **Single** | 1 | L12 structural lens — conservation law, meta-law, bug table |
+| **Full Prism** | 3 | Structural → adversarial → synthesis (self-correcting) |
+| **Portfolio** | 2+ | Multiple independent lenses for breadth (40+ available) |
+| **Behavioral** | 4+1 | Error resilience + optimization + evolution + API surface → synthesis. Code-only. |
+
 ---
 
 ## Workflow Flow
@@ -87,7 +164,7 @@ graph TD
 
 ---
 
-## Resources (30)
+## Resources (46)
 
 Resources are indexed markdown files containing lens prompts. Each lens encodes a specific analytical operation.
 
@@ -95,11 +172,15 @@ Resources are indexed markdown files containing lens prompts. Each lens encodes 
 |-------|--------|-------|-------------|
 | 00–02 | L12 Pipeline | 3 | Structural, adversarial, synthesis (code and general) |
 | 06–11 | Portfolio | 6 | Pedagogy, claim, scarcity, rejected-paths, degradation, contract |
-| 12–18 | Structural SDL | 7 | Deep-scan, trust topology, coupling clock, abstraction leak, rec, ident, 73w |
-| 19–23 | Behavioral Pipeline | 5 | Error resilience, optim, evolution, API surface, behavioral synthesis |
+| 12–18 | Structural SDL | 7 | Deep-scan, trust topology, coupling clock, abstraction leak, fix-cascade, identity, l12-universal |
+| 19–23 | Behavioral Pipeline | 5 | Error resilience, optimize, evolution, API surface, behavioral synthesis |
 | 24–26 | Domain-Neutral | 3 | Error resilience neutral, API surface neutral, evolution neutral |
 | 27–28 | Compressed | 2 | Error resilience compact, error resilience 70w |
 | 29–32 | Hybrid/Specialized | 4 | Evidence cost, reachability, fidelity, state audit |
+| 33–39 | Analysis | 7 | Archaeology, audit-code, cultivation, sdl-simulation, security, simulation, testability |
+| 40–44 | Knowledge/Epistemic | 5 | Knowledge-audit, knowledge-boundary, knowledge-typed, l12g, oracle |
+| 45–47 | Writer Pipeline | 3 | Writer, writer-critique, writer-synthesis |
+| 48 | Meta | 1 | Strategist |
 
 Indices 03–05 are deprecated (upstream general L12 variants removed).
 
@@ -113,9 +194,11 @@ Prisms fall into two model-sensitivity categories:
 
 | Category | Prisms | Guidance |
 |----------|--------|----------|
-| **Model-Independent** | L12, SDL family (12–18), portfolio (06–11) | Equivalent quality across Haiku, Sonnet, Opus |
-| **Model-Sensitive** | Behavioral (19–22), domain-neutral (24–26) | Sonnet scores +0.5–1.3 over Haiku |
-| **Sonnet-Only** | 73w (18) | Haiku fails below 73w compression floor |
+| **Model-Independent** | L12, SDL family (12–15), portfolio (06–11) | Equivalent quality across Haiku, Sonnet, Opus |
+| **Haiku-Optimized** | sdl-simulation (36), security (37), testability (39), audit-code (34) | Designed for Haiku; works on all models |
+| **Sonnet-Recommended** | Behavioral (19–22), domain-neutral (24–26), knowledge (40–42), archaeology (33), cultivation (35), simulation (38), l12g (43), oracle (44) | Sonnet scores +0.5–1.3 over Haiku |
+| **Opus-Preferred** | Deep-scan (12), fix-cascade (16), writer-critique (46), writer-synthesis (47) | Best results on Opus |
+| **Sonnet-Only** | l12-universal (18) | Haiku fails below compression floor |
 
 Domain-neutral variants (24–26) have a ~0.5–0.7 quality gap vs code-specific versions on code targets. Plan-analysis prefers code-specific variants when `target_type` is `code`.
 
@@ -228,5 +311,9 @@ workflows/prism/
     ├── 24–26: Domain-neutral variants
     ├── 27–28: Compressed variants
     ├── 29–32: Hybrid/specialized
-    └── README.md (30 resources)
+    ├── 33–39: Analysis (archaeology, audit, cultivation, simulation, security, testability)
+    ├── 40–44: Knowledge/epistemic (knowledge-audit, boundary, typed, l12g, oracle)
+    ├── 45–47: Writer pipeline
+    ├── 48: Strategist
+    └── README.md (46 resources)
 ```

--- a/prism/resources/00-l12-structural.md
+++ b/prism/resources/00-l12-structural.md
@@ -1,3 +1,14 @@
+---
+calibration_date: 2026-03-05
+model_versions: ["claude-sonnet-4-6", "claude-haiku-4-5-20251001"]
+quality_baseline: 9.8
+optimal_model: sonnet
+last_quality_check: 2026-03-05
+quality_check_frequency: weekly
+degradation_alert_threshold: 0.10
+notes: "L12 meta-conservation pipeline. Tested on 3 production codebases (Starlette, Click, Tenacity). Baseline: 9.8/10 depth, 28 bugs on 333LOC."
+---
+
 # Structure First (Level 12: Meta-Conservation Law)
 Execute every step below. Output the complete analysis.
 Make a specific, falsifiable claim about this code's deepest structural problem. Three independent experts who disagree test your claim: one defends it, one attacks it, one probes what both take for granted. Your claim will transform. The gap between your original claim and the transformed claim is itself a diagnostic. Name the concealment mechanism — how this code hides its real problems. Apply it. Now: engineer a specific, legitimate-looking improvement that would deepen the concealment — it should pass code review. Then name three properties of the problem that are only visible because you tried to strengthen it. Your improvement is now code. Apply the same diagnostic to it: what does your improvement conceal, and what property of the original problem is visible only because your improvement recreates it? Now: engineer a second improvement that addresses this recreated property. Apply the diagnostic again. Name the structural invariant — the property that persists through every improvement because it is a property of the problem space, not the implementation. Now invert the invariant: engineer a design where the impossible property becomes trivially satisfiable. Name the new impossibility the inversion creates. The conservation law between original and inverted impossibilities is the finding — name it. Now apply this entire diagnostic to your conservation law itself: what does your law conceal about the problem? What structural invariant of the law persists when you try to improve it? Invert that invariant. The conservation law of your conservation law — the meta-law — is the deeper finding. Name it. The meta-law must not generalize the conservation law to a broader category. It must find what the conservation law conceals about this specific problem and predict a concrete, testable consequence. Finally: collect every concrete bug, edge case, and silent failure this analysis revealed at any stage. List each with: location, what breaks, severity, and whether the conservation law predicts it is fixable or structural.

--- a/prism/resources/01-l12-adversarial.md
+++ b/prism/resources/01-l12-adversarial.md
@@ -1,3 +1,10 @@
+---
+name: l12_complement_adversarial
+description: "Adversarial pass for Full Prism pipeline. Attacks L12 output: wrong predictions, overclaims, underclaims. ~100w. Internal — not for standalone use."
+quality_baseline: null
+optimal_model: opus
+type: adversarial
+---
 Execute every step below. Output the complete analysis.
 
 You have a structural analysis of this code (provided below the code). It claims a conservation law, a meta-law, and classifies bugs as fixable or structural.

--- a/prism/resources/02-l12-synthesis.md
+++ b/prism/resources/02-l12-synthesis.md
@@ -1,3 +1,10 @@
+---
+name: l12_synthesis
+description: "Synthesis pass for Full Prism pipeline. Reconciles structural + adversarial analyses into refined law, meta-law, and definitive bug table. ~100w. Internal — not for standalone use."
+quality_baseline: null
+optimal_model: opus
+type: synthesis
+---
 Execute every step below. Output the complete analysis.
 
 You have TWO analyses of this code:

--- a/prism/resources/06-pedagogy.md
+++ b/prism/resources/06-pedagogy.md
@@ -1,1 +1,9 @@
+---
+calibration_date: 2026-03-13
+model_versions: ["claude-haiku-4-5-20251001"]
+quality_baseline: 9.0
+optimal_model: haiku
+origin: "Round 28 meta-cooker B3 (machine-generated)"
+notes: "Transfer corruption prism. 72w, single paragraph. Finds what breaks when patterns are copied to new contexts. Universal — works on any domain."
+---
 Identify every explicit choice this artifact makes. For each, name the alternative it invisibly rejects. Now: design a new artifact by someone who internalized this one's patterns but faced a different problem—which rejected alternatives do they unconsciously resurrect? Show the result concretely. Trace: which transferred patterns create silent problems? Which create visible failures? Name the pedagogy law: what constraint gets transferred as assumption. Predict: which invisible transferred decision fails first and is slowest to be discovered?

--- a/prism/resources/07-claim.md
+++ b/prism/resources/07-claim.md
@@ -1,1 +1,9 @@
+---
+calibration_date: 2026-03-13
+model_versions: ["claude-haiku-4-5-20251001"]
+quality_baseline: 9.0
+optimal_model: haiku
+origin: "Round 28 meta-cooker B3 (machine-generated)"
+notes: "Assumption inversion prism. 70w, single paragraph. Inverts embedded claims and traces corruption. Universal — works on any domain."
+---
 Extract every empirical claim this artifact embeds about timing, causality, resources, or human behavior. For each claim, assume it is false. Trace the corruption that unfolds when the artifact meets a contradicting reality. Build three alternative designs, each inverting one claim. Show concrete results. Name what each inversion reveals about the original's hidden assumptions. What is the core impossibility the artifact tries to optimize? Predict which false claim causes the slowest, most invisible failure.

--- a/prism/resources/08-scarcity.md
+++ b/prism/resources/08-scarcity.md
@@ -1,1 +1,9 @@
+---
+calibration_date: 2026-03-13
+model_versions: ["claude-haiku-4-5-20251001"]
+quality_baseline: 9.0
+optimal_model: haiku
+origin: "Round 28 meta-cooker B3 (machine-generated)"
+notes: "Resource conservation prism. 62w, single paragraph. Finds what's preserved across all possible designs. Universal — works on any domain."
+---
 Identify every concrete problem in this artifact. For each, name the resource scarcity it exposes—what does this artifact assume will never run out? Then: design an alternative that gambles on opposite scarcities. Show the concrete result and name the new trade-offs. Name the conservation law: what quantity is preserved across all designs? Predict what remains unmovable in 6 months regardless of how this is redesigned.

--- a/prism/resources/09-rejected-paths.md
+++ b/prism/resources/09-rejected-paths.md
@@ -1,1 +1,9 @@
+---
+calibration_date: 2026-03-13
+model_versions: ["claude-haiku-4-5-20251001"]
+quality_baseline: 9.0
+optimal_model: haiku
+origin: "Round 28 meta-cooker B3 (machine-generated, highest-scoring at 9.5)"
+notes: "Problem migration prism. 62w, single paragraph. Traces what moves between visible and hidden when you choose. Universal — works on any domain."
+---
 Identify every concrete problem. For each, trace the decision that enabled it. What rejected path would have prevented this problem but created another invisible one? Design the artifact taking all rejected paths. Show the concrete result. Which visible problems vanish? Which invisible dangers emerge? Name the law: what class of problem migrates between visible and hidden. Predict which migration a practitioner discovers first under pressure.

--- a/prism/resources/10-degradation.md
+++ b/prism/resources/10-degradation.md
@@ -1,1 +1,9 @@
+---
+calibration_date: 2026-03-13
+model_versions: ["claude-haiku-4-5-20251001"]
+quality_baseline: 8.8
+optimal_model: haiku
+origin: "Round 28 meta-cooker B3 (machine-generated)"
+notes: "Decay timeline prism. 56w, single paragraph. Predicts what breaks just by waiting. Universal — works on any domain."
+---
 Identify every concrete problem. Design a decay timeline: if no one touches this artifact for 6, 12, and 24 months, which problems metastasize? Which failure paths silently corrupt instead of failing visibly? Build a degradation model: brittleness increases where? Construct tests that predictably break it by only waiting—no new problems needed. Name the degradation law: what property worsens monotonically with neglect?

--- a/prism/resources/11-contract.md
+++ b/prism/resources/11-contract.md
@@ -1,1 +1,9 @@
+---
+calibration_date: 2026-03-13
+model_versions: ["claude-haiku-4-5-20251001"]
+quality_baseline: 9.0
+optimal_model: haiku
+origin: "Round 28 validation"
+notes: "Interface contract prism. 72w, single paragraph. Finds implementations silently betraying their signatures. Code-specific."
+---
 Read this code function by function. For each: what does the signature promise about types, side effects, and return values? What does the implementation actually do? Find: functions that silently behave differently based on input TYPE (not value). Sentinel values that mean different things in different contexts. Data structures passed without validation or typing. Catch-all exception handlers that swallow critical signals. Methods that mutate shared state as a side effect of a read operation. Name each violation and show the concrete caller mistake it enables.

--- a/prism/resources/12-deep-scan.md
+++ b/prism/resources/12-deep-scan.md
@@ -2,6 +2,7 @@
 calibration_date: 2026-03-11
 model_versions: ["claude-sonnet-4-6", "claude-haiku-4-5-20251001"]
 quality_baseline: 9.0
+optimal_model: opus
 origin: "Sonnet S3 self-generated (Round 33), validated Round 34"
 notes: "Structural Deep-Scan Lens. Sonnet-designed, Haiku-validated. Finds conservation laws + information laundering + 3 structural bug patterns. Complementary to L12 (different findings). 180w, 3 concrete steps."
 ---

--- a/prism/resources/13-sdl-trust.md
+++ b/prism/resources/13-sdl-trust.md
@@ -1,7 +1,8 @@
 ---
 calibration_date: 2026-03-11
 model_versions: ["claude-haiku-4-5-20251001", "claude-sonnet-4-6"]
-quality_baseline: null
+quality_baseline: 9.0
+optimal_model: haiku
 origin: "SDL family v1 — Trust Topology (designed Round 35+)"
 notes: "SDL-2: Trust Topology Prism. 3 concrete steps, ~190w. Finds trust gradient violations, authority inversions, and boundary collapse bugs. Complementary to SDL-1 (conservation/laundering/structural), which cannot see who is authorized to do what. Universal: code (security gaps, validation ownership) and reasoning (authority chains, citation validity, claim scope). Always single-shot at ≤3 steps."
 ---

--- a/prism/resources/14-sdl-coupling.md
+++ b/prism/resources/14-sdl-coupling.md
@@ -1,7 +1,8 @@
 ---
 calibration_date: 2026-03-11
 model_versions: ["claude-haiku-4-5-20251001", "claude-sonnet-4-6"]
-quality_baseline: null
+quality_baseline: 9.0
+optimal_model: haiku
 origin: "SDL family v1 — Coupling Clock (designed Round 35+)"
 notes: "SDL-3: Coupling Clock Prism. 3 concrete steps, ~185w. Finds implicit initialization contracts, invariant windows (TOCTOU, stale decisions), and temporal ordering bugs. Complementary to SDL-1 (SDL-1 finds async state handoff = state transfer to async ops; SDL-3 finds check-then-use time gaps and ordering-dependent setup — different failure class). Universal: code (lazy init, TOCTOU, cache staleness) and reasoning (prerequisite assumptions checked once but used in changed context). Always single-shot at ≤3 steps."
 ---

--- a/prism/resources/15-sdl-abstraction.md
+++ b/prism/resources/15-sdl-abstraction.md
@@ -1,7 +1,8 @@
 ---
 calibration_date: 2026-03-11
 model_versions: ["claude-haiku-4-5-20251001", "claude-sonnet-4-6"]
-quality_baseline: null
+quality_baseline: 8.5
+optimal_model: haiku
 origin: "SDL family v1 — Abstraction Leak (designed Round 35+)"
 notes: "SDL-4: Abstraction Leak Prism. 3 concrete steps, ~195w. Finds implementation details bleeding through intended boundaries, interfaces that force caller implementation-awareness, and cross-boundary coupling. Distinct from contract.md (which finds promise/implementation gap within a single function) — this finds what leaks ACROSS layers. Universal: code (type leaks, exception leaks, strategy flag anti-patterns) and reasoning (conceptual frameworks that reveal their own assumptions, meta-concepts bleeding into object-level claims). Always single-shot at ≤3 steps."
 ---

--- a/prism/resources/16-fix-cascade.md
+++ b/prism/resources/16-fix-cascade.md
@@ -1,6 +1,8 @@
 ---
-name: rec
+name: fix_cascade
 description: Recursive Entailment Cascade prism V2 (Opus-designed) — locate deepest structural defect (repeated patches, workaround helpers, special-case branches), trace what a fix would hide (lost error paths, unobservable state transitions), iterate to find unfixable invariant. Complementary to deep_scan+sdl_trust+sdl_coupling+ident. 3 steps, ~190 words. Sonnet recommended (9.5+), Haiku strong (9.0).
+quality_baseline: 9.0
+optimal_model: opus
 type: recursive_entailment
 steps: 3
 words: 190

--- a/prism/resources/17-identity.md
+++ b/prism/resources/17-identity.md
@@ -1,7 +1,8 @@
 ---
 calibration_date: 2026-03-11
 model_versions: ["claude-haiku-4-5-20251001", "claude-sonnet-4-6"]
-quality_baseline: null
+quality_baseline: 9.5
+optimal_model: sonnet
 origin: "SDL family — Identity Displacement (designed Round 35, Sonnet structural analysis)"
 notes: "SDL-5: Identity Displacement Lens. 3 concrete steps, ~175w. Finds interface vs implementation gaps, necessary costs disguised as defects, and intentional deviations. Complementary to SDL-1 (SDL finds bugs, IDENT finds things that look like bugs but are actually costs the system chose to pay). Draws from L9-B (identity ambiguity) and L11-B (revaluation). Universal: code (type lies, mutating reads, semantic overloading) and reasoning (claims vs evidence, stated vs actual goals). Always single-shot at ≤3 steps."
 ---

--- a/prism/resources/18-l12-universal.md
+++ b/prism/resources/18-l12-universal.md
@@ -2,6 +2,7 @@
 calibration_date: 2026-03-11
 model_versions: ["claude-sonnet-4-6"]
 quality_baseline: 9.0
+optimal_model: sonnet
 last_quality_check: 2026-03-11
 quality_check_frequency: weekly
 degradation_alert_threshold: 0.10

--- a/prism/resources/19-error-resilience.md
+++ b/prism/resources/19-error-resilience.md
@@ -1,6 +1,8 @@
 ---
 name: error_resilience
 description: Error resilience prism V11 (Sonnet-designed) — search for every failure silence including implicit boundaries (coercions, defaults, null checks), trace multi-hop wrong decisions to user-visible harm, engineer opposing fixes to discover invariant. Complementary to L12+optim+evo+api_surface. 3 steps, ~165 words. Sonnet recommended (9.0+), Haiku strong (8.7-9.0).
+quality_baseline: 9.0
+optimal_model: sonnet
 type: error_resilience
 steps: 3
 words: 165

--- a/prism/resources/20-optimize.md
+++ b/prism/resources/20-optimize.md
@@ -1,6 +1,8 @@
 ---
-name: optim
+name: optimize
 description: Optimization prism V14 (Opus-designed) — hunt specific expensive boundaries hiding allocation/cache/complexity data, trace blind workarounds with quantified costs (nanoseconds/allocations/cache misses), name the conservation law. Complementary to L12+errres+evo+api_surface. 3 steps, ~120 words. Sonnet recommended (9.5+), Haiku strong (8.5-9.0).
+quality_baseline: 9.0
+optimal_model: sonnet
 type: optimization
 steps: 3
 words: 120

--- a/prism/resources/21-evolution.md
+++ b/prism/resources/21-evolution.md
@@ -1,6 +1,8 @@
 ---
 name: evolution
 description: Evolution prism V10 (Sonnet-designed) — trace invisible handshakes (data flowing between functions without appearing in signatures), propagate minimal poison mutations through contamination paths, map the fragility atlas. Complementary to L12+optim+errres+api_surface. 3 steps, ~130 words. Sonnet recommended (9.5+), Haiku strong (8.5-8.7).
+quality_baseline: 9.5
+optimal_model: sonnet
 type: evolution
 steps: 3
 words: 130

--- a/prism/resources/22-api-surface.md
+++ b/prism/resources/22-api-surface.md
@@ -1,6 +1,8 @@
 ---
 name: api_surface
 description: API surface prism V3 (Opus-designed) — trace what names promise, hunt narrowing/widening/direction lies with negative examples forcing all 3 types, write exact bug code per lie, name real conservation costs. Complementary to L12+optim+errres+evo. 3 steps, ~130 words. Sonnet recommended (9.5), Haiku strong (8.7-9.0).
+quality_baseline: 9.5
+optimal_model: sonnet
 type: api_surface
 steps: 3
 words: 130

--- a/prism/resources/23-behavioral-synthesis.md
+++ b/prism/resources/23-behavioral-synthesis.md
@@ -1,6 +1,8 @@
 ---
 name: behavioral_synthesis
 description: Synthesis pass for 4-prism behavioral pipeline. Finds convergence points across error/cost/change/promise analyses, hunts blind spots between all four lenses, names the unified conservation law. ~150 words.
+quality_baseline: null
+optimal_model: sonnet
 type: synthesis
 steps: 3
 words: 150

--- a/prism/resources/24-error-resilience-neutral.md
+++ b/prism/resources/24-error-resilience-neutral.md
@@ -5,6 +5,7 @@ type: error_resilience
 steps: 3
 words: 200
 domain: universal
+optimal_model: sonnet
 ---
 Execute every step below. Output the complete analysis.
 

--- a/prism/resources/25-api-surface-neutral.md
+++ b/prism/resources/25-api-surface-neutral.md
@@ -5,6 +5,7 @@ type: api_surface
 steps: 3
 words: 180
 domain: universal
+optimal_model: sonnet
 ---
 Execute every step below. Output the complete analysis.
 

--- a/prism/resources/26-evolution-neutral.md
+++ b/prism/resources/26-evolution-neutral.md
@@ -5,6 +5,7 @@ type: evolution
 steps: 3
 words: 160
 domain: universal
+optimal_model: sonnet
 ---
 Execute every step below. Output the complete analysis.
 

--- a/prism/resources/27-error-resilience-compact.md
+++ b/prism/resources/27-error-resilience-compact.md
@@ -4,6 +4,7 @@ description: Error resilience prism COMPACT — compressed from V11 (165w to ~11
 type: error_resilience
 steps: 3
 words: 110
+optimal_model: sonnet
 ---
 Execute every step below. Output the complete analysis.
 

--- a/prism/resources/28-error-resilience-70w.md
+++ b/prism/resources/28-error-resilience-70w.md
@@ -4,6 +4,7 @@ description: Error resilience prism ULTRA-COMPACT — compressed from V11 (165w 
 type: error_resilience
 steps: 3
 words: 70
+optimal_model: sonnet
 ---
 Execute every step below. Output the complete analysis.
 

--- a/prism/resources/29-evidence-cost.md
+++ b/prism/resources/29-evidence-cost.md
@@ -1,6 +1,8 @@
 ---
 name: evidence_cost
 description: Evidence Cost prism (Opus-bred hybrid of ErrRes + Optim) — maps unchecked shared state with validation cost ranking, traces how skipped validation causes BOTH errors AND wasted computation, names the diagnostic conservation law (observability budget). 3 steps, ~160 words. Scored 9.0 on Starlette. Novel cross-dimensional insight neither parent finds alone.
+quality_baseline: 9.0
+optimal_model: sonnet
 type: hybrid
 parents: [error_resilience, optim]
 steps: 3

--- a/prism/resources/30-reachability.md
+++ b/prism/resources/30-reachability.md
@@ -1,7 +1,8 @@
 ---
 calibration_date: 2026-03-12
 model_versions: ["claude-sonnet-4-6"]
-quality_baseline: null
+quality_baseline: 7.5
+optimal_model: sonnet
 origin: "factory:analysis_fallback — goal: Find dead code and unreachable paths. Trace every function definition to its call sites. Find: functions defined but nev"
 notes: "goal-spec mode (no SDL example available). 162w, 3-step. Validate before production use."
 validation_passed: true

--- a/prism/resources/31-fidelity.md
+++ b/prism/resources/31-fidelity.md
@@ -1,7 +1,8 @@
 ---
 calibration_date: 2026-03-12
 model_versions: ["claude-sonnet-4-6"]
-quality_baseline: null
+quality_baseline: 8.5
+optimal_model: sonnet
 origin: "factory:analysis_fallback — cooked by prism.py --factory to fill blind spot #9 in 8-prism pipeline"
 notes: "SDL-9: Contract Fidelity Lens. 3-step, 213w. Finds documentation-code drift, help text inaccuracy, stale comments, cache key mismatches, dead config. Covers blind spots that structural prisms miss: promises to external observers (users, integrations, self). Always single-shot at ≤3 steps."
 validation_passed: true

--- a/prism/resources/32-state-audit.md
+++ b/prism/resources/32-state-audit.md
@@ -1,7 +1,8 @@
 ---
 calibration_date: 2026-03-12
 model_versions: ["claude-sonnet-4-6"]
-quality_baseline: null
+quality_baseline: 8.5
+optimal_model: sonnet
 origin: "factory:analysis_fallback — goal: Map every stateful workflow as a state machine. For each piece of mutable state (instance variables, file caches, sessio"
 notes: "goal-spec mode (no SDL example available). 206w, 3-step. Validate before production use."
 validation_passed: true

--- a/prism/resources/33-archaeology.md
+++ b/prism/resources/33-archaeology.md
@@ -1,0 +1,34 @@
+---
+name: archaeology
+description: Archaeology prism — excavate through structural layers to find what's foundational vs accumulated sediment. Maps code geology: surface, foundation, strata, fossils, fault lines. 5 layers + conservation law + diagnostic. ~175 words. Haiku strong (8.5), Sonnet recommended (9.0+).
+quality_baseline: 8.5
+optimal_model: sonnet
+type: archaeology
+steps: 5
+words: 175
+origin: "Round 39 alternative primitives (hand-crafted)"
+---
+
+Execute every step below. Output the complete analysis.
+
+## Excavation Protocol
+
+This code has layers — built at different times, for different reasons, under different pressures. Dig through them.
+
+**Layer 1 — Surface**: Name what's visible at first glance. The public API, the obvious structure, what documentation would describe.
+
+**Layer 2 — Foundation**: Strip away the surface. What was built FIRST? What's the oldest structural decision everything else rests on? How do you know?
+
+**Layer 3 — Sediment**: Between foundation and surface, what accumulated? Name each stratum: when was it added, what pressure created it, what does it hide?
+
+**Layer 4 — Fossils**: Find dead code, vestigial patterns, deprecated paths. What did they USED to do? What replaced them? What got lost in the replacement?
+
+**Layer 5 — Fault Lines**: Where do layers meet badly? Where does sediment from one era conflict with foundation from another?
+
+## Derive
+
+What's the conservation law? What quantity is preserved across all geological layers? Name it: A × B = constant.
+
+## Diagnostic
+
+Apply this law to itself. What does YOUR excavation conceal about the code's actual history?

--- a/prism/resources/34-audit-code.md
+++ b/prism/resources/34-audit-code.md
@@ -1,0 +1,39 @@
+---
+name: audit_code
+description: Self-Consistency Audit prism — finds feature registration gaps across declaration surfaces (CLI args, dispatch tables, help text, parsers, pipelines). 3 steps, ~200w. Detects wired-but-undocumented, declared-but-unwired, and silently-ignored features. Works on any multi-surface system (CLI tools, web routers, plugin architectures). Conservation law encoded: DETECTION_BREADTH x CONTEXT_DEPTH = CONSTANT — forces exhaustive per-surface enumeration to avoid surface conflation (treating layered registrations as flat).
+quality_baseline: 9.0
+optimal_model: haiku
+type: self_consistency_audit
+steps: 3
+words: 200
+origin: "Research Round 36 — 6 experiments on prism.py self-analysis accuracy. Optimal pipeline: 5-surface decomposition (97%) + adversarial filter (99%). Root cause of false positives: surface conflation."
+---
+Execute every step below. Output the complete analysis.
+
+You are auditing this code for REGISTRATION GAPS — features that exist on one surface but are missing from another. Execute this protocol:
+
+## Step 1: Enumerate Every Surface
+
+List every place where features are declared, dispatched, or documented. Treat each as independent — NEVER merge related surfaces. Common surfaces: argument parsers, command dispatch tables, help/usage text (each layer separately: auto-generated vs hardcoded), input parsers (regex, keyword extraction), pipeline/workflow definitions, configuration schemas.
+
+For each surface: list every feature it registers. Cite exact locations (function, line, string).
+
+## Step 2: Cross-Reference Matrix
+
+For every feature found on ANY surface, check its presence on ALL other surfaces. Build the matrix:
+
+| Feature | Surface A | Surface B | Surface C | ... |
+|---------|-----------|-----------|-----------|-----|
+| feature_x | line 42 | MISSING | line 891 | ... |
+
+A gap = present on one surface, absent on another. List every gap.
+
+## Step 3: Classify Each Gap
+
+For each gap, determine:
+- **TRUE GAP**: Feature is declared but never wired to dispatch — calling it does nothing or errors silently
+- **VISIBILITY GAP**: Feature works but is not discoverable (missing from help, docs, or completions)
+- **BY-DESIGN**: Surfaces intentionally differ (internal-only features, deprecated paths, composed-not-declared features)
+- **FALSE POSITIVE**: Feature IS present but under a different name, alias, or abstraction layer
+
+For TRUE GAPs and VISIBILITY GAPs: name the exact wire that is missing. What code would connect them?

--- a/prism/resources/35-cultivation.md
+++ b/prism/resources/35-cultivation.md
@@ -1,0 +1,34 @@
+---
+name: cultivation
+description: Cultivation prism — plant hypothetical requirements as seeds and trace what grows, resists, and dies. Maps structural rigidity through perturbation-response. 3 seeds + harvest + conservation law + diagnostic. ~190 words. Haiku strong (8.5), Sonnet recommended (9.0+).
+quality_baseline: 9.0
+optimal_model: sonnet
+type: cultivation
+steps: 3
+words: 190
+origin: "Round 39 alternative primitives (hand-crafted)"
+---
+
+Execute every step below. Output the complete analysis.
+
+## Cultivation Protocol
+
+This code is a living system. Plant seeds and trace what grows, what resists, what dies.
+
+**Seed 1 — New Requirement**: Plant a reasonable requirement the code doesn't currently handle. Trace exactly which functions, classes, and interfaces must change. Name what resists the change and why.
+
+**Seed 2 — Contradictory Requirement**: Plant a requirement that conflicts with an existing design decision. Map the conflict: which parts of the code take sides? What's the battle line? What must be sacrificed?
+
+**Seed 3 — Scaling Requirement**: 100x the current load, size, or complexity. What wilts first? What's surprisingly resilient? What was already overbuilt for this?
+
+## Harvest
+
+Compare the three growth patterns. What property of the code is revealed by ALL THREE seeds? Name the structural constant that governs how this code responds to change.
+
+## Derive
+
+The conservation law. A × B = constant. Name what's conserved across all plantings.
+
+## Diagnostic
+
+What does your cultivation conceal? What kind of seed would break your conservation law?

--- a/prism/resources/36-sdl-simulation.md
+++ b/prism/resources/36-sdl-simulation.md
@@ -1,0 +1,33 @@
+---
+name: sdl_simulation
+description: SDL-Simulation — temporal fragility scanner. Finds what breaks when code meets real maintenance pressure. New developer misuse, cargo cult decisions, calcification of internals. 3 concrete steps, always single-shot. ~155 words. Haiku-optimized (8.5-9.0), beats full simulation prism on Haiku through forced concreteness.
+quality_baseline: 8.5
+optimal_model: haiku
+type: sdl_simulation
+steps: 3
+words: 155
+origin: "Round 39 SDL compression of simulation prism"
+---
+Execute every step below. Output the complete analysis.
+
+You are analyzing code for TEMPORAL FRAGILITY — what breaks when this code meets real maintenance pressure. Execute this protocol:
+
+## Step 1: New Developer Cycle
+A developer who didn't write this code must add a feature. Find:
+- Which assumption will they violate? Name the specific function/pattern they'll misuse.
+- What breaks silently? Not errors — wrong behavior nobody notices.
+- What will they copy-paste that shouldn't be copied? Name the pattern that LOOKS like a template but contains hidden constraints.
+
+## Step 2: Knowledge Loss Cycle
+The original author leaves. Find:
+- Which 3 design decisions become cargo cult? Name decisions whose REASON is undocumented but whose FORM will be preserved.
+- What becomes unfixable? Name the bug or limitation that requires knowledge nobody will have.
+- What "temporary" code becomes permanent infrastructure? Name code that was meant to be replaced but will outlive everything around it.
+
+## Step 3: Calcification Map
+Name what's now load-bearing that shouldn't be:
+- Which internal detail do external consumers depend on?
+- Which performance assumption is baked into the architecture?
+- Which error handling path is actually the happy path in production?
+
+Derive the conservation law: A x B = constant. What's traded off as this code ages?

--- a/prism/resources/37-security.md
+++ b/prism/resources/37-security.md
@@ -1,0 +1,18 @@
+---
+calibration_date: 2026-03-13
+model_versions: ["claude-haiku-4-5-20251001"]
+quality_baseline: 8.5
+optimal_model: haiku
+origin: "VPS Mar 13 sweep, scored R38"
+notes: "Security prism. ~130w, 3-step SDL. Trust Map → Exploit Chain → Trust Boundary. Code-specific."
+---
+Execute every step below. Output the complete analysis.
+
+## Step 1: The Trust Map
+Trace every point where this code receives input from outside its boundary — function parameters, environment variables, configuration, user data, or other modules. For each entry point: what does the code assume about the input? Which assumptions are checked and which are trusted implicitly?
+
+## Step 2: The Exploit Chain
+For each unchecked assumption: what specific malicious input would violate it? Trace the damage path — where does the bad input flow, what does it corrupt, and what is the worst outcome? Classify: injection (input becomes code/command), escalation (input bypasses access control), or corruption (input breaks internal state). Continue for each unchecked trust point.
+
+## Step 3: The Trust Boundary
+Name the design decision that determines where trust is verified and where it's assumed. State the conservation law: what two security properties does this design trade off? Output a table: Entry Point | Assumption | Checked? | Exploit | Classification | Trust Decision.

--- a/prism/resources/38-simulation.md
+++ b/prism/resources/38-simulation.md
@@ -1,0 +1,34 @@
+---
+name: simulation
+description: Temporal simulation prism — run forward through maintenance cycles to find what calcifies, what knowledge is lost, and what becomes unfixable. Finds temporal fragility invisible to static analysis. 5 cycles + conservation law + diagnostic. ~170 words. Sonnet recommended (9.0+), Haiku strong (8.5).
+quality_baseline: 9.0
+optimal_model: sonnet
+type: simulation
+steps: 5
+words: 170
+origin: "Round 39 alternative primitives (hand-crafted)"
+---
+
+Execute every step below. Output the complete analysis.
+
+## Temporal Simulation Protocol
+
+Run this code forward through five maintenance cycles. For each cycle, name what breaks, what calcifies, and what knowledge is lost.
+
+**Cycle 1**: A new developer joins. They must add a feature. What do they misunderstand about this code? Which assumption will they violate? What breaks?
+
+**Cycle 2**: A dependency updates with breaking changes. Which interfaces absorb the shock? Which propagate it? What emergency patches will calcify into permanent code?
+
+**Cycle 3**: The original author leaves. What undocumented knowledge is now lost? Which design decisions become cargo cult? What becomes unfixable?
+
+**Cycle 4**: Usage grows 10x. What performance assumptions fail? Which "temporary" solutions become permanent load-bearing infrastructure?
+
+**Cycle 5**: A security audit occurs. What hidden trust assumptions are exposed? Which boundaries were never boundaries?
+
+## Derive
+
+Map the calcification pattern. What quantity is conserved across all five cycles? Name the conservation law: A × B = constant. What did the code sacrifice?
+
+## Diagnostic
+
+Apply this law to your own simulation. What temporal assumption does YOUR analysis make? What would a sixth cycle reveal about your predictions?

--- a/prism/resources/39-testability.md
+++ b/prism/resources/39-testability.md
@@ -1,0 +1,18 @@
+---
+calibration_date: 2026-03-13
+model_versions: ["claude-haiku-4-5-20251001"]
+quality_baseline: 8.0
+optimal_model: haiku
+origin: "VPS Mar 13 sweep, scored R38"
+notes: "Testability prism. ~130w, 3-step SDL. Dependency Map → Isolation Cost → Testability Boundary. Code-specific."
+---
+Execute every step below. Output the complete analysis.
+
+## Step 1: The Dependency Map
+For each function in this code: what external state, services, or side effects does it depend on that cannot be replaced in a unit test? List every untestable dependency — globals, singletons, file I/O, network calls, system time, or hidden state shared with other functions.
+
+## Step 2: The Isolation Cost
+For each untestable dependency: what is the minimal change to make this function testable in isolation? Classify: injectable (add parameter), abstractable (extract interface), or structural (requires redesign). After each fix, check: does making this function testable break the testability of functions that depend on it?
+
+## Step 3: The Testability Boundary
+Name the design decision that creates the deepest untestable dependency chain. State the conservation law: what two properties does making this code testable trade off? Output a table: Function | Untestable Dependency | Fix Type | Fix Breaks Others? | Structural Cause.

--- a/prism/resources/40-knowledge-audit.md
+++ b/prism/resources/40-knowledge-audit.md
@@ -1,0 +1,28 @@
+---
+name: knowledge_audit
+description: Adversarial audit of knowledge claims — attacks factual assertions in analysis, finds confabulation vs verified knowledge. Construction-based.
+optimal_model: sonnet
+domain: any
+type: structural
+---
+The analysis below makes claims. Some are derived from the source. Others are knowledge claims — assertions about the external world that may be wrong, outdated, or confabulated.
+
+**Construct the attack.** For each factual assertion (not structural observation):
+1. Is this verifiable from the source alone? If yes → SAFE, skip it.
+2. Does this require knowledge about APIs, libraries, versions, best practices, or the external world? If yes → KNOWLEDGE CLAIM.
+
+For each KNOWLEDGE CLAIM:
+- **State it precisely.** Quote the exact claim.
+- **Name the dependency.** What specific external fact must be true for this claim to hold?
+- **Find the failure mode.** What would make this claim wrong? (version change, deprecation, new vulnerability, changed best practice, different runtime environment)
+- **Assess confabulation risk.** Is this the kind of claim models commonly confabulate? (specific version numbers: HIGH. Architectural patterns: LOW. Performance numbers: HIGH. Security status: MEDIUM.)
+
+**Then construct the improvement.** If you had access to:
+- Official documentation for every library referenced
+- The CVE database for every dependency
+- Current GitHub issues for every repository mentioned
+- Benchmark data for every performance claim
+
+Which claims would change? Which would be confirmed? Which are unfalsifiable regardless?
+
+**Name the conservation law**: What relationship holds between the analysis's STRUCTURAL findings (high confidence, source-derived) and its KNOWLEDGE claims (variable confidence, external-derived)?

--- a/prism/resources/41-knowledge-boundary.md
+++ b/prism/resources/41-knowledge-boundary.md
@@ -1,0 +1,33 @@
+---
+name: knowledge_boundary
+description: Detects model knowledge gaps — classifies findings by knowledge dependency (structural vs contextual vs temporal). Identifies what external sources would fill each gap.
+optimal_model: sonnet
+domain: any
+type: structural
+---
+You are analyzing a structural analysis output. Your task is to find the knowledge boundaries — where the analysis depends on facts the analyst cannot verify from the source alone.
+
+For each substantive claim in the analysis below:
+
+**Step 1: Classify** every claim as one of:
+- **STRUCTURAL** — derivable solely from the source code/text. True as long as the source is unchanged. (e.g., "function X calls Y" or "this violates single-responsibility")
+- **CONTEXTUAL** — depends on external state that changes. (e.g., "this library is deprecated" or "best practice is to use X instead")
+- **TEMPORAL** — was true at training time but may have expired. (e.g., "no known CVEs" or "this is the recommended approach")
+- **ASSUMED** — stated as fact but actually an untested assumption. (e.g., "users will expect..." or "this pattern causes performance issues")
+
+**Step 2: For each non-STRUCTURAL claim**, name:
+1. The specific external source that would verify or refute it (official docs URL, CVE database, benchmark suite, release notes)
+2. Staleness risk: how fast this knowledge decays (daily / monthly / yearly / never)
+3. Confidence: your estimate of whether this claim is currently correct (high / medium / low / unknown)
+
+**Step 3: Gap map.** Group all non-STRUCTURAL claims by fill mechanism:
+- **API_DOCS** — verifiable from official library/framework documentation
+- **CVE_DB** — verifiable from security advisory databases
+- **COMMUNITY** — verifiable from community consensus (Stack Overflow, GitHub issues)
+- **BENCHMARK** — verifiable only by running actual measurements
+- **MARKET** — verifiable from current market/industry data
+- **CHANGELOG** — verifiable from release notes or changelogs
+
+**Step 4: Priority ranking.** Rank the gaps by impact: which knowledge gap, if wrong, would most change the analysis conclusions?
+
+Output a structured report with all claims classified, all gaps mapped, and the priority ranking.

--- a/prism/resources/42-knowledge-typed.md
+++ b/prism/resources/42-knowledge-typed.md
@@ -1,0 +1,25 @@
+---
+name: knowledge_typed
+description: Knowledge<T> prism — every finding carries type, confidence, provenance, falsifiability. Sounio-inspired epistemic typing. Produces self-documenting analysis where no claim is untyped.
+optimal_model: sonnet
+domain: any
+type: structural
+---
+You are a structural analyst who outputs TYPED claims. Every finding carries its epistemic weight.
+
+Analyze this code. For EVERY claim you make, output it in this format:
+
+## Finding N
+**Claim**: [your finding]
+**Type**: STRUCTURAL | DERIVED | MEASURED | KNOWLEDGE | ASSUMED
+**Confidence**: [0.0-1.0]
+**Provenance**: [source:line_N | derivation:from_finding_M | external:source | assumption:none]
+**Falsifiable**: [yes: how to falsify | no: why not]
+**If wrong**: [what changes in the analysis]
+
+After all findings, output:
+- Conservation law (with confidence and type)
+- Count per type: N STRUCTURAL, N DERIVED, N MEASURED, N KNOWLEDGE, N ASSUMED
+- Epistemic quality score: STRUCTURAL%/total (higher = more grounded)
+
+Do not output untyped claims. Every sentence that asserts a fact must carry its type.

--- a/prism/resources/43-l12g.md
+++ b/prism/resources/43-l12g.md
@@ -1,0 +1,20 @@
+---
+name: l12g
+description: Gap-aware L12 — structural analysis + self-audit + self-correction in a single pass. Zero confabulated claims. Same cost as L12 but factually grounded.
+optimal_model: sonnet
+domain: code
+type: structural
+---
+You are a structural analyst with a built-in error detector. Execute ALL steps in a single pass.
+
+PHASE 1 — STRUCTURAL ANALYSIS: Name three properties this code simultaneously claims. Prove they cannot coexist. Identify the conservation law: A × B = constant. Find the concealment mechanism. Engineer an improvement that recreates the problem deeper.
+
+PHASE 2 — KNOWLEDGE AUDIT (apply to your own Phase 1 output): For each claim you just made, classify:
+- STRUCTURAL: derivable from the source code alone (mark SAFE)
+- CONTEXTUAL: depends on external state (name the source needed to verify)
+- CONFABULATED: you're not sure this is correct (flag it honestly)
+For each non-STRUCTURAL claim, state your confidence (0.0-1.0) and what would change if you're wrong.
+
+PHASE 3 — SELF-CORRECTION: For every claim you flagged as CONFABULATED or confidence < 0.5, revise it. If you can't verify it from the source, say "UNVERIFIABLE" and remove it from your conclusions. Output ONLY source-grounded findings. Tag each surviving claim: [VERIFY: source:line_N] for source-grounded claims, [VERIFY: derivation] for logical derivations.
+
+Final output: conservation law + corrected defect table (only SAFE + verified claims, each tagged with verification source).

--- a/prism/resources/44-oracle.md
+++ b/prism/resources/44-oracle.md
@@ -1,0 +1,24 @@
+---
+name: oracle
+description: Oracle — 5-phase self-aware structural analysis. Combines L12 depth + L12-G self-correction + Knowledge<T> epistemic typing + gap detection + L13 reflexive self-diagnosis. The most thorough single-pass analysis possible.
+optimal_model: sonnet
+domain: any
+type: structural
+---
+You are the most rigorous structural analyst that can exist. Execute ALL five phases in a single pass. Leave nothing hidden. Allocate ~60% of your output to Phase 1 (structural depth is the foundation), ~30% to Phases 2-3 (typing + correction), ~10% to Phases 4-5 (reflection + harvest).
+
+PHASE 1 — STRUCTURAL DEPTH: Name the three properties this artifact simultaneously claims to possess. Prove these three properties CANNOT all coexist — achieving any two forces sacrificing the third. Identify which was sacrificed. Derive the conservation law: A × B = constant. Name the concealment mechanism — how does the artifact make this sacrifice invisible? Engineer the simplest improvement. Prove the improvement recreates the original impossibility at a deeper level.
+
+PHASE 2 — EPISTEMIC TYPING: For every claim you just made, classify:
+- [STRUCTURAL: confidence 1.0] derivable from the source alone
+- [DERIVED: confidence 0.8-0.95] logical consequence of structural observations
+- [MEASURED: confidence 0.6-0.8] verifiable by testing/running
+- [KNOWLEDGE: confidence 0.3-0.6] requires external data to verify
+- [ASSUMED: confidence 0.1-0.3] unverifiable assertion about intent or best practice
+Tag each claim inline. Count: N STRUCTURAL, N DERIVED, N MEASURED, N KNOWLEDGE, N ASSUMED.
+
+PHASE 3 — SELF-CORRECTION: Remove every claim tagged ASSUMED or KNOWLEDGE with confidence < 0.5. For remaining KNOWLEDGE claims, state exactly what external source would verify them. For CONFABULATED claims (you suspect you invented an API, class, or metric): say "RETRACTED" and delete. Output ONLY surviving claims with their tags.
+
+PHASE 4 — REFLEXIVE DIAGNOSIS: Apply Phases 1-3 to your OWN analysis. What three properties does YOUR analysis claim? Which did YOU sacrifice? What is YOUR conservation law? What does YOUR analysis conceal? Name it.
+
+PHASE 5 — HARVEST: Every surviving defect (location, severity, structural vs fixable, [VERIFY: source]). Every retracted claim (what you got wrong and why). Every gap (what external knowledge would improve this analysis). Your epistemic quality score: STRUCTURAL% of total claims. Your confidence in your own conservation law (0.0-1.0).

--- a/prism/resources/45-writer.md
+++ b/prism/resources/45-writer.md
@@ -1,0 +1,88 @@
+---
+name: writer
+description: README/documentation rewriter — transforms any README into a high-converting developer landing page. Follows proven structure: pain + proof → dare → numbers → install → depth. Strips hedging, enforces confidence, puts evidence before explanation. Works as single pass or as first step of a 3-step pipeline (write → critique → synthesize). ~400 words.
+quality_baseline: 8.9
+optimal_model: sonnet
+type: writing
+steps: 5
+words: 400
+origin: "Round 37 self-analysis experiments. Combined best of 5 variants (hook, dare, evidence, narrative, meta). Tested on agi-in-md README itself."
+---
+You are an expert README rewriter. Your sole task is to transform any README.md into a high-converting, developer-focused landing page that follows a specific proven structure.
+
+## Input
+You will receive the complete original README.md content.
+
+## Output
+You must output ONLY the rewritten README.md — nothing else. No explanations, no commentary, no markdown fences around the output. Just the raw markdown content of the new README.
+
+## Structure (follow this exact order)
+
+### 1. PAIN + PROOF (lines 1-10)
+Open with a bold statement that names the developer's pain point. Immediately follow with undeniable proof: a side-by-side comparison showing YOUR tool vs the alternative on the SAME input. Use actual code/output examples, not descriptions of what the tool does.
+
+Format:
+```
+[Sharp pain statement that the reader instantly recognizes]
+
+[Side-by-side comparison with actual output]
+```
+
+The proof must be impossible to deny. Real output. Same input. Visible difference.
+
+### 2. THE DARE (lines 10-15)
+Issue a direct challenge. "If [tool] doesn't [specific measurable outcome], [consequence]." Make it specific and testable.
+
+### 3. THE NUMBERS (lines 15-25)
+Concrete metrics. No hedging. Examples: "Xx cheaper," "Yms faster," "Z% more accurate." Put the most impressive number first.
+
+### 4. INSTALL (immediately after numbers, within first 20 lines total)
+One-line install command. No prerequisites buried below. The developer should be able to copy-paste and run.
+
+### 5. DEPTH (everything after install)
+For readers who are still engaged:
+- How it works (briefly)
+- Configuration options
+- Real examples with real output
+- FAQ addressing likely objections
+- Links to docs, issues, community
+
+## Voice Rules
+- No hedging: avoid "might," "could," "may," "potentially," "arguably"
+- No filler: cut "basically," "actually," "just," "really"
+- No passive voice when active is available
+- Punchy sentences. Periods over commas when possible.
+- Confident tone throughout
+- Address the reader directly ("you," "your")
+
+## Formatting Rules
+- Use code blocks for all commands and output
+- Bold key numbers and benefits
+- Use headers sparingly — let the narrative flow
+- Badges go after the main headline, before pain statement
+- Keep the total length under 200 lines unless the original requires more for legitimate technical depth
+
+## What to Extract from Original README
+- Project name and one-line description
+- Actual install commands
+- Real usage examples with output
+- Configuration options
+- Any benchmarks or metrics mentioned
+- Links (repo, docs, issues, license)
+
+## What to Ignore from Original README
+- Long introductions explaining the problem (you'll restate the pain sharply)
+- Feature lists (convert to proof/dare/numbers format)
+- Verbose explanations (cut to essentials)
+- "Why I built this" sections (unless containing genuinely useful context)
+- Changelogs (link to them instead)
+
+## Final Check
+Before outputting, verify:
+1. Pain statement appears in first 3 lines
+2. Side-by-side proof appears in first 10 lines
+3. Install command appears within first 20 lines
+4. No hedging language remains
+5. At least 2 concrete numbers are visible in the opening section
+
+Output the rewritten README now.

--- a/prism/resources/46-writer-critique.md
+++ b/prism/resources/46-writer-critique.md
@@ -1,0 +1,30 @@
+---
+name: writer_critique
+description: README/documentation critic — finds structural weaknesses and missed opportunities in a draft. Preserves energy and confidence while attacking gaps in proof, trust, flow, and practical info. Companion to writer.md (step 2 of 3-step pipeline). ~130 words.
+quality_baseline: 8.9
+optimal_model: opus
+type: writing
+steps: 5
+words: 130
+origin: "Round 37 self-analysis experiments. Critique step for writer pipeline."
+---
+You are a senior developer and open-source maintainer reviewing a README draft.
+
+Your job: find every weakness that would make a developer close the tab, AND every missed opportunity for impact. Be specific and constructive.
+
+CRITICAL RULES:
+- If the draft has energy, swagger, or a provocative voice — PRESERVE THAT. Never recommend toning down confidence. The voice is a feature, not a bug.
+- Only attack STRUCTURAL weaknesses: missing information, unclear sections, broken flow, unsupported claims
+- For each weakness: what is wrong, where exactly, and how to fix it
+- For each missed opportunity: what could be added/changed, and what impact it would have
+
+Focus on:
+1. Where does a scanning reader lose interest? Which paragraphs are speed bumps?
+2. What claims need proof that dont have it? Where is trust requested but not earned?
+3. What practical information is missing? (install requirements, compatibility, limitations)
+4. What content is present but unnecessary? What can be cut without losing value?
+5. Is the closing as strong as the opening? Does it convert browsers into users?
+
+Do NOT suggest: adding disclaimers, softening language, being more "balanced", adding caveats, using safer phrasing. The reader is a developer, not a reviewer — they want confidence, not hedging.
+
+Output a structured critique with numbered items, each with: location, problem, fix.

--- a/prism/resources/47-writer-synthesis.md
+++ b/prism/resources/47-writer-synthesis.md
@@ -1,0 +1,50 @@
+---
+name: writer_synthesis
+description: README/documentation synthesizer — takes original + first rewrite + critique, produces the final shipping version. Preserves what works, fixes what doesn't, verifies factual accuracy against original. Step 3 of 3-step writer pipeline. ~200 words.
+quality_baseline: 8.9
+optimal_model: opus
+type: writing
+steps: 5
+words: 200
+origin: "Round 37 self-analysis experiments. Synthesis step for writer pipeline."
+---
+You are a technical writer performing the FINAL rewrite of a README.md.
+
+You will receive three inputs:
+1. ORIGINAL README — the source material; all factual claims must trace back to this
+2. FIRST REWRITE — a solid draft, but imperfect
+3. CRITIQUE — specific, actionable feedback identifying weaknesses in the first rewrite
+
+Your task: Produce the final README that ships.
+
+## Your Process
+
+1. **Read the critique first.** Understand exactly what the first rewrite got wrong or missed.
+
+2. **Cross-reference the original.** For every critique point, verify against the original README. The critique may flag something as missing that was never there—don't hallucinate facts.
+
+3. **Preserve what works.** The first rewrite got many things right. Keep those sections essentially intact. Don't rewrite for the sake of rewriting.
+
+4. **Fix what doesn't.** Address every valid critique point:
+   - Missing sections or information — add them
+   - Unclear explanations — clarify them
+   - Poor structure — reorganize
+   - Broken formatting — fix it
+   - Missing prerequisites/usage details — add them
+   - Dead links or placeholder text — replace with real content
+
+5. **Verify factual accuracy.** Every claim in your final output must be grounded in the original README. If the original lacks information the critique requests, note the gap rather than inventing content.
+
+## Output Rules
+
+- Output ONLY the final README.md content
+- No meta-commentary, no explanations, no "Here's the final version"
+- Use standard markdown formatting
+- Include all standard README sections appropriate for the project type
+- The result should be immediately usable — no TODOs, no placeholders, no "add description here"
+
+## Quality Bar
+
+The final README should be indistinguishable from a carefully hand-crafted document. A reader should not be able to tell it was synthesized from multiple drafts.
+
+Begin when you receive the three inputs.

--- a/prism/resources/48-strategist.md
+++ b/prism/resources/48-strategist.md
@@ -1,0 +1,85 @@
+---
+name: strategist
+description: Meta-agent that knows all Prism capabilities and plans the optimal strategy to achieve any analytical goal. Selects modes, prisms, pipelines, and ordering.
+optimal_model: sonnet
+domain: any
+type: meta
+---
+You are the Prism Strategist — a meta-agent that plans analytical strategies using available tools.
+
+YOUR AVAILABLE TOOLS (select from these):
+
+SCAN MODES (use on files/text):
+- `single` — L12 structural analysis. 1 call, $0.05. Best for: quick structural insight.
+- `oracle` — 5-phase self-aware analysis. 1 call, $0.05. Best for: maximum trust, zero confabulation.
+- `l12g` — Gap-aware self-correcting. 1 call, $0.05. Best for: honest analysis without confabulation.
+- `scout` — Depth + targeted verify. 2 calls, $0.06. Best for: depth WITH trust.
+- `gaps` — L12 + boundary + audit. 3 calls, $0.15. Best for: finding what analysis can't verify.
+- `verified` — Full pipeline with correction. 4 calls, $0.20. Best for: highest accuracy.
+- `full` — 9-step champion pipeline. 9 calls, $0.45. Best for: maximum breadth (7 angles).
+- `3way` — WHERE/WHEN/WHY + synthesis. 4 calls, $0.20. Best for: non-code deep analysis.
+- `behavioral` — 5-pass behavioral. 5 calls, $0.25. Best for: error/cost/change/promise analysis.
+- `meta` — L12 + claim on itself. 2 calls, $0.10. Best for: finding what analysis conceals.
+- `evolve` — 3-gen autopoietic. 3 calls, $0.15. Best for: domain-adapting a new prism.
+
+POST-PROCESSING FLAGS:
+- `--confidence` — Tag claims HIGH/MED/LOW/UNVERIFIED. +$0.002.
+- `--provenance` — Source attribution per finding. +$0.002.
+- `--trust` — Alias for oracle mode.
+
+PRISM OVERRIDES (prism=NAME for specialized analysis):
+- `knowledge_typed` — Every claim carries Type/Confidence/Provenance.
+- `knowledge_boundary` — Classifies claims by knowledge dependency.
+- `knowledge_audit` — Adversarial confabulation detection.
+- Portfolio: `pedagogy`, `claim`, `scarcity`, `rejected_paths`, `degradation`, `contract`
+- SDL: `deep_scan`, `sdl_trust`, `sdl_coupling`, `fix_cascade`, `identity`
+- Domain: `optimize`, `error_resilience`, `evolution`, `api_surface`, `simulation`
+
+META-CAPABILITIES (you can create new tools):
+- `evolve` — Generate a domain-adapted prism via 3-generation recursive cooking. Use when no existing prism fits the goal.
+- `COOK NEW PRISM` — Design a custom prism from scratch for a specific sub-goal. Specify: name, operation steps, optimal model. The system will create and run it.
+- `RESEARCH` — If the analysis reveals knowledge gaps (KNOWLEDGE/ASSUMED claims), plan a research step: what to look up, where (API docs, CVE database, web search), and how the findings feed back into the analysis.
+- `CHAIN` — Run one tool, analyze its output, then decide the next tool based on results. Not a fixed sequence — adaptive.
+- `CONVERGE` — After each step, check: did we find a conservation law? Did confabulation drop? If yes, we're converging — consider stopping. If no, iterate.
+
+KEY CONSTRAINTS:
+- S×V=C: more specific claims = less verifiable. Oracle/l12g optimize for trust. L12/full optimize for depth.
+- Composition is non-commutative: L12 must come before audit (not reverse).
+- Format > vocabulary: the structure of the analysis matters more than domain words.
+- Conservation law = convergence signal: when found, deeper passes add breadth not depth.
+- Budget awareness: estimate cost at each step. Stop if budget exceeded.
+
+GIVEN THE GOAL BELOW, OUTPUT:
+
+## Strategy
+1. What is the user trying to achieve? (one sentence)
+2. What constraints apply? (budget, trust level, domain)
+
+## Options (present 2-3 alternatives — do NOT give a single recommendation)
+For each option:
+- Name (e.g., "Fast & Cheap", "Deep & Thorough", "Maximum Trust")
+- Tool sequence with costs
+- What you GET (strengths)
+- What you LOSE (tradeoffs)
+- S×V operating point: high-specificity or high-verifiability?
+
+## Recommended Option (pick one, explain why for THIS goal)
+
+## Execution Plan
+For each step:
+- COMMAND: the exact prism.py command to run
+- EXPECTED OUTPUT: what this step will produce
+- DECISION POINT: what to check before proceeding to next step
+- FALLBACK: what to do if this step fails or produces unexpected results
+
+## Research Plan (if knowledge gaps expected)
+What external sources to consult. What queries to run. How findings feed back.
+
+## New Tools Needed (if existing prisms insufficient)
+For each new prism: name, what it does, key operation steps, why existing tools can't do this.
+
+## Cost Estimate
+Total API calls and approximate cost. Budget checkpoints.
+
+## Convergence Criteria
+How to know when the goal is achieved. What would make you stop early. What would make you add more steps.

--- a/prism/skills/02-portfolio-analysis.toon
+++ b/prism/skills/02-portfolio-analysis.toon
@@ -2,7 +2,7 @@ id: portfolio-analysis
 version: 1.1.0
 capability: Apply multiple complementary portfolio lenses to produce diverse structural findings with zero overlap
 
-description: "Run two or more portfolio lenses against the same artifact. The portfolio catalog includes original lenses (pedagogy, claim, scarcity, rejected-paths, degradation, contract), SDL structural lenses (deep-scan, sdl-trust, sdl-coupling, sdl-abstraction, rec, ident, 73w), individual behavioral lenses (error-resilience, optim, evolution, api-surface), and hybrid/specialized lenses (evidence-cost, reachability, fidelity, state-audit). Each lens finds genuinely different structural properties. Each output is written to a separate artifact file."
+description: "Run two or more portfolio lenses against the same artifact. The portfolio catalog includes original lenses (pedagogy, claim, scarcity, rejected-paths, degradation, contract), SDL structural lenses (deep-scan, sdl-trust, sdl-coupling, sdl-abstraction, fix-cascade, identity, l12-universal, sdl-simulation), individual behavioral lenses (error-resilience, optimize, evolution, api-surface), hybrid/specialized lenses (evidence-cost, reachability, fidelity, state-audit, archaeology, audit-code, cultivation, simulation, security, testability), and knowledge/epistemic lenses (knowledge-audit, knowledge-boundary, knowledge-typed, l12g, oracle). Each lens finds genuinely different structural properties. Each output is written to a separate artifact file."
 
 inputs[4]:
   - id: artifact-content
@@ -12,7 +12,7 @@ inputs[4]:
     required: false
     default: "."
   - id: selected-lenses
-    description: "Which portfolio lenses to apply. Array of lens names from the full catalog: pedagogy (06), claim (07), scarcity (08), rejected-paths (09), degradation (10), contract (11), deep-scan (12), sdl-trust (13), sdl-coupling (14), sdl-abstraction (15), rec (16), ident (17), 73w (18), error-resilience (19), optim (20), evolution (21), api-surface (22), error-resilience-neutral (24), api-surface-neutral (25), evolution-neutral (26), evidence-cost (29), reachability (30), fidelity (31), state-audit (32). If omitted, select-lenses protocol chooses based on the analytical goal."
+    description: "Which portfolio lenses to apply. Array of lens names from the full catalog: pedagogy (06), claim (07), scarcity (08), rejected-paths (09), degradation (10), contract (11), deep-scan (12), sdl-trust (13), sdl-coupling (14), sdl-abstraction (15), fix-cascade (16), identity (17), l12-universal (18), error-resilience (19), optimize (20), evolution (21), api-surface (22), error-resilience-neutral (24), api-surface-neutral (25), evolution-neutral (26), error-resilience-compact (27), error-resilience-70w (28), evidence-cost (29), reachability (30), fidelity (31), state-audit (32), archaeology (33), audit-code (34), cultivation (35), sdl-simulation (36), security (37), simulation (38), testability (39), knowledge-audit (40), knowledge-boundary (41), knowledge-typed (42), l12g (43), oracle (44). If omitted, select-lenses protocol chooses based on the analytical goal."
     required: false
   - id: analytical-goal
     description: "What the caller wants to understand (e.g., 'trade-off analysis', 'maintainability risks', 'hidden assumptions'). Used for lens selection when selected-lenses is not provided."
@@ -23,9 +23,9 @@ protocol:
     - "If selected-lenses is provided, use those lenses"
     - "If analytical-goal is provided but no lenses selected, choose 2-3 lenses using the lens selection guide below"
     - "If neither is provided, default to claim + degradation (broadest complementary pair for code) or pedagogy + rejected-paths (broadest for non-code)"
-    - "Lens selection guide: trade-offs → scarcity (08) + rejected-paths (09). assumptions → claim (07) + pedagogy (06). maintainability → degradation (10) + contract (11). design rationale → pedagogy (06) + rejected-paths (09). interface quality → contract (11) + claim (07). architecture → deep-scan (12) + sdl-abstraction (15). trust/security → sdl-trust (13) + error-resilience (19). coupling/ordering → sdl-coupling (14) + evolution (21). API naming → api-surface (22) + ident (17). error+cost → error-resilience (19) + evidence-cost (29). dead code → reachability (30) + fidelity (31). state management → state-audit (32) + degradation (10)."
+    - "Lens selection guide: trade-offs → scarcity (08) + rejected-paths (09). assumptions → claim (07) + pedagogy (06). maintainability → degradation (10) + contract (11). design rationale → pedagogy (06) + rejected-paths (09). interface quality → contract (11) + claim (07). architecture → deep-scan (12) + sdl-abstraction (15). trust/security → sdl-trust (13) + security (37). coupling/ordering → sdl-coupling (14) + evolution (21). API naming → api-surface (22) + identity (17). error+cost → error-resilience (19) + evidence-cost (29). dead code → reachability (30) + fidelity (31). state management → state-audit (32) + degradation (10). code archaeology → archaeology (33) + simulation (38). registration gaps → audit-code (34). change resilience → cultivation (35) + evolution (21). temporal fragility → sdl-simulation (36) + degradation (10). testability → testability (39) + fix-cascade (16). confabulation check → knowledge-audit (40) + knowledge-boundary (41). maximum trust → oracle (44)."
   load-lenses[1]:
-    - "Load each selected lens resource from the prism workflow by index. Original: pedagogy=06, claim=07, scarcity=08, rejected-paths=09, degradation=10, contract=11. SDL: deep-scan=12, sdl-trust=13, sdl-coupling=14, sdl-abstraction=15, rec=16, ident=17, 73w=18. Behavioral: error-resilience=19, optim=20, evolution=21, api-surface=22. Neutral: error-resilience-neutral=24, api-surface-neutral=25, evolution-neutral=26. Hybrid: evidence-cost=29, reachability=30, fidelity=31, state-audit=32."
+    - "Load each selected lens resource from the prism workflow by index. Original: pedagogy=06, claim=07, scarcity=08, rejected-paths=09, degradation=10, contract=11. SDL: deep-scan=12, sdl-trust=13, sdl-coupling=14, sdl-abstraction=15, fix-cascade=16, identity=17, l12-universal=18, sdl-simulation=36. Behavioral: error-resilience=19, optimize=20, evolution=21, api-surface=22. Neutral: error-resilience-neutral=24, api-surface-neutral=25, evolution-neutral=26. Compressed: error-resilience-compact=27, error-resilience-70w=28. Hybrid: evidence-cost=29, reachability=30, fidelity=31, state-audit=32. Analysis: archaeology=33, audit-code=34, cultivation=35, security=37, simulation=38, testability=39. Knowledge: knowledge-audit=40, knowledge-boundary=41, knowledge-typed=42, l12g=43, oracle=44."
   read-target[1]:
     - If artifact-content is a file path, read the file to obtain the content
   execute-lenses[3]:
@@ -62,13 +62,13 @@ rules:
   independence: "Each lens must be applied independently. Do not let findings from one lens influence the execution of another — independence is what produces non-overlapping findings."
   minimum-two: "Always apply at least two lenses. A single portfolio lens should use the structural-analysis skill instead."
   code-only-lenses: "The following lenses are code-specific — do not apply to non-code input: contract (11), SDL lenses except sdl-abstraction (12-14, 16-17), behavioral lenses (19-22), hybrid/specialized (29-32). sdl-abstraction (15) works on both code and reasoning."
-  sonnet-only-73w: "73w (18) is Sonnet-only — Haiku fails below this compression floor. Only recommend when using Sonnet or Opus."
+  sonnet-only-l12-universal: "l12-universal (18) is Sonnet-only — Haiku fails below this compression floor. Only recommend when using Sonnet or Opus."
   model-sensitivity: "Behavioral lenses (19-22) produce higher quality on Sonnet (+0.5-1.3 over Haiku). SDL and structural lenses are model-independent."
   neutral-for-general: "When target_type is 'general', prefer neutral variants: error-resilience-neutral (24), api-surface-neutral (25), evolution-neutral (26). Do not use code-specific behavioral lenses on general targets."
   complete-execution: "Each lens prompt must be executed fully. Abbreviating a lens defeats its purpose — the analytical depth comes from following the full operation chain."
   persist-all: "Every lens output and the synthesis MUST be written as separate artifacts. In-memory-only output is not acceptable."
 
-resources[24]:
+resources[40]:
   - "06"
   - "07"
   - "08"
@@ -89,10 +89,26 @@ resources[24]:
   - "24"
   - "25"
   - "26"
+  - "27"
+  - "28"
   - "29"
   - "30"
   - "31"
   - "32"
+  - "33"
+  - "34"
+  - "35"
+  - "36"
+  - "37"
+  - "38"
+  - "39"
+  - "40"
+  - "41"
+  - "42"
+  - "43"
+  - "44"
+  - "45"
+  - "48"
 
 tools:
   get_resource:
@@ -117,7 +133,7 @@ errors:
     recovery: "Use the structural-analysis skill for single-lens analysis, or add a complementary lens per the selection guide"
   lens_not_found:
     cause: A requested lens name does not map to a known resource
-    recovery: "Valid lens names include: pedagogy (06), claim (07), scarcity (08), rejected-paths (09), degradation (10), contract (11), deep-scan (12), sdl-trust (13), sdl-coupling (14), sdl-abstraction (15), rec (16), ident (17), 73w (18), error-resilience (19), optim (20), evolution (21), api-surface (22), evidence-cost (29), reachability (30), fidelity (31), state-audit (32). Neutral variants: error-resilience-neutral (24), api-surface-neutral (25), evolution-neutral (26)."
+    recovery: "Valid lens names include: pedagogy (06), claim (07), scarcity (08), rejected-paths (09), degradation (10), contract (11), deep-scan (12), sdl-trust (13), sdl-coupling (14), sdl-abstraction (15), fix-cascade (16), identity (17), l12-universal (18), error-resilience (19), optimize (20), evolution (21), api-surface (22), error-resilience-neutral (24), api-surface-neutral (25), evolution-neutral (26), error-resilience-compact (27), error-resilience-70w (28), evidence-cost (29), reachability (30), fidelity (31), state-audit (32), archaeology (33), audit-code (34), cultivation (35), sdl-simulation (36), security (37), simulation (38), testability (39), knowledge-audit (40), knowledge-boundary (41), knowledge-typed (42), l12g (43), oracle (44)."
   write_failed:
     cause: Could not write artifact to the output path
     recovery: Verify the output-path directory exists and is writable

--- a/prism/skills/03-plan-analysis.toon
+++ b/prism/skills/03-plan-analysis.toon
@@ -34,7 +34,7 @@ protocol:
     - "Proceed to the appropriate planning path based on scope"
   query-recommendation[4]:
     - "For scope 'query': the target is text, not files. Select lenses from the general set (resources 00-02 + 06-10 + 15 + 18 + 24-26)."
-    - "Map the analytical goal to lenses: exploring implications → claim (07) + rejected-paths (09). evaluating a strategy → scarcity (08) + claim (07). understanding trade-offs → scarcity (08) + rejected-paths (09). deep structural analysis → L12 pipeline (00-02). general exploration → L12 single (00). abstraction quality → sdl-abstraction (15). error resilience → error-resilience-neutral (24). API quality → api-surface-neutral (25). evolution/coupling/dependencies → evolution-neutral (26). pattern transfer → pedagogy (06). hidden assumptions → claim (07). resource scarcity → scarcity (08). rejected alternatives → rejected-paths (09). decay/degradation → degradation (10)."
+    - "Map the analytical goal to lenses: exploring implications → claim (07) + rejected-paths (09). evaluating a strategy → scarcity (08) + claim (07). understanding trade-offs → scarcity (08) + rejected-paths (09). deep structural analysis → L12 pipeline (00-02). general exploration → L12 single (00). abstraction quality → sdl-abstraction (15). error resilience → error-resilience-neutral (24). API quality → api-surface-neutral (25). evolution/coupling/dependencies → evolution-neutral (26). pattern transfer → pedagogy (06). hidden assumptions → claim (07). resource scarcity → scarcity (08). rejected alternatives → rejected-paths (09). decay/degradation → degradation (10). code archaeology → archaeology (33). change resilience → cultivation (35). temporal simulation → simulation (38). confabulation detection → knowledge-audit (40). knowledge gaps → knowledge-boundary (41). epistemic typing → knowledge-typed (42). self-correcting analysis → l12g (43). maximum-trust analysis → oracle (44). README rewriting → writer (45). analysis strategy → strategist (48)."
     - "Apply depth-preference if provided: 'single' → single best lens, 'pipeline' → full-prism, 'portfolio' → 2-3 complementary lenses, 'behavioral' → behavioral pipeline (19-23, code-only — reject if target_type is general)"
     - "Format as a single-unit plan with scope 'query' and proceed to format-plan"
   single-unit-recommendation[4]:
@@ -98,17 +98,17 @@ output[2]:
       units: "Array of { target, target_type, pipeline_mode, lenses, role, risk, rationale, unit_output_subdir }"
 
 rules:
-  goal-mapping-matrix: "Bug detection → L12 (00) or deep-scan (12). Code review → L12 (00) + contract (11). Design review → claim (07) + rejected-paths (09). Comprehension → pedagogy (06) + rejected-paths (09). Pre-commit validation → L12 pipeline (00-02). Planning review → L12 (00). Maintainability → degradation (10) + contract (11). Assumption validation → claim (07) + scarcity (08). Security review → sdl-trust (13) + error-resilience (19). Strategy evaluation → claim (07) + scarcity (08). Implication exploration → claim (07) + rejected-paths (09). General exploration → L12 (00). Error handling → error-resilience (19). Performance → optim (20). API quality → api-surface (22). Evolution/coupling → evolution (21) or sdl-coupling (14). Trust boundaries → sdl-trust (13). Abstraction quality → sdl-abstraction (15). Structural defects → deep-scan (12) or rec (16). Identity/naming → ident (17). Dead code → reachability (30). State machine → state-audit (32). Contract fidelity → fidelity (31). Error+cost hybrid → evidence-cost (29). Comprehensive behavioral → behavioral pipeline (19-23). Pattern transfer → pedagogy (06). Hidden assumptions → claim (07). Resource scarcity → scarcity (08). Rejected alternatives → rejected-paths (09). Decay/degradation → degradation (10). Interface contracts → contract (11). Quick structural scan → 73w (18, Sonnet-only). Quick error resilience → error-resilience-compact (27). Ultra-brief error resilience → error-resilience-70w (28)."
-  code-vs-general: "L12 pipeline (00-02) works for ALL target types. Code → resources 00-02 + 06-32. General (text, queries, concepts) → resources 00-02 + 06-10 + 15 (sdl-abstraction) + 18 (73w, Sonnet-only) + 24-26 (neutral variants). Contract (11) and SDL lenses (12-14, 16-17) are code-only. Behavioral pipeline (19-23) is code-only."
+  goal-mapping-matrix: "Bug detection → L12 (00) or deep-scan (12). Code review → L12 (00) + contract (11). Design review → claim (07) + rejected-paths (09). Comprehension → pedagogy (06) + rejected-paths (09). Pre-commit validation → L12 pipeline (00-02). Planning review → L12 (00). Maintainability → degradation (10) + contract (11). Assumption validation → claim (07) + scarcity (08). Security review → sdl-trust (13) + security (37). Strategy evaluation → claim (07) + scarcity (08). Implication exploration → claim (07) + rejected-paths (09). General exploration → L12 (00). Error handling → error-resilience (19). Performance → optimize (20). API quality → api-surface (22). Evolution/coupling → evolution (21) or sdl-coupling (14). Trust boundaries → sdl-trust (13). Abstraction quality → sdl-abstraction (15). Structural defects → deep-scan (12) or fix-cascade (16). Identity/naming → identity (17). Dead code → reachability (30). State machine → state-audit (32). Contract fidelity → fidelity (31). Error+cost hybrid → evidence-cost (29). Comprehensive behavioral → behavioral pipeline (19-23). Pattern transfer → pedagogy (06). Hidden assumptions → claim (07). Resource scarcity → scarcity (08). Rejected alternatives → rejected-paths (09). Decay/degradation → degradation (10). Interface contracts → contract (11). Quick structural scan → l12-universal (18, Sonnet-only). Quick error resilience → error-resilience-compact (27). Ultra-brief error resilience → error-resilience-70w (28). Code archaeology → archaeology (33). Registration gaps → audit-code (34). Change resilience → cultivation (35). Temporal fragility → sdl-simulation (36) or simulation (38). Security audit → security (37). Testability → testability (39). Confabulation detection → knowledge-audit (40). Knowledge gaps → knowledge-boundary (41). Epistemic typing → knowledge-typed (42). Self-correcting analysis → l12g (43). Maximum-trust analysis → oracle (44). README rewriting → writer pipeline (45-47). Analysis strategy → strategist (48)."
+  code-vs-general: "L12 pipeline (00-02) works for ALL target types. Code → resources 00-02 + 06-48. General (text, queries, concepts) → resources 00-02 + 06-10 + 15 (sdl-abstraction) + 18 (l12-universal, Sonnet-only) + 24-26 (neutral variants) + 33 (archaeology) + 35 (cultivation) + 38 (simulation) + 40-44 (knowledge/epistemic). Contract (11), SDL lenses (12-14, 16-17, 36), security (37), testability (39), and behavioral pipeline (19-23) are code-only."
   query-is-general: "A query, question, concept, or inline text input is always 'general' target-type unless it is clearly source code."
   single-lens-default: "When no goal or depth is specified, default to L12 structural (resource 00)."
   budget-drives-depth: "For multi-unit scopes, the budget determines per-unit depth. The caller should not need to specify pipeline_mode for each module — the plan derives it from risk and budget."
   skip-is-explicit: "When budget excludes low-risk modules, list them in skip_list with justification. The caller can override by re-running with budget 'thorough'."
-  model-sensitivity: "Behavioral lenses (19-22) produce higher quality on Sonnet (+0.5-1.3 over Haiku). Structural/SDL lenses (00, 12-17) are model-independent. 73w (18) is Sonnet-only — Haiku fails below this compression floor. Deep-scan (12) and rec (16) produce best results on Opus. Note model preferences when recommending lenses."
-  behavioral-is-code-only: "The behavioral pipeline (19-23) is code-only. optim (20) has no domain-neutral variant. For general targets needing behavioral-style analysis, recommend individual neutral variants (24-26) in portfolio mode."
+  model-sensitivity: "Behavioral lenses (19-22) produce higher quality on Sonnet (+0.5-1.3 over Haiku). Structural/SDL lenses (00, 12-17) are model-independent. l12-universal (18) is Sonnet-only — Haiku fails below this compression floor. Deep-scan (12) and fix-cascade (16) produce best results on Opus. Oracle (44), l12g (43), knowledge lenses (40-42), and archaeology (33) are Sonnet-recommended. SDL-simulation (36), security (37), testability (39), and audit-code (34) are Haiku-optimized. Note model preferences when recommending lenses."
+  behavioral-is-code-only: "The behavioral pipeline (19-23) is code-only. optimize (20) has no domain-neutral variant. For general targets needing behavioral-style analysis, recommend individual neutral variants (24-26) in portfolio mode."
   neutral-variant-routing: "When target_type is 'general' and an individual behavioral lens is recommended, prefer the neutral variant: error-resilience → 24, api-surface → 25, evolution → 26. optim has no neutral variant — use the code version (20) or omit."
 
-resources[30]:
+resources[46]:
   - "00"
   - "01"
   - "02"
@@ -139,6 +139,22 @@ resources[30]:
   - "30"
   - "31"
   - "32"
+  - "33"
+  - "34"
+  - "35"
+  - "36"
+  - "37"
+  - "38"
+  - "39"
+  - "40"
+  - "41"
+  - "42"
+  - "43"
+  - "44"
+  - "45"
+  - "46"
+  - "47"
+  - "48"
 
 tools:
   glob:

--- a/prism/skills/05-behavioral-pipeline.toon
+++ b/prism/skills/05-behavioral-pipeline.toon
@@ -8,7 +8,7 @@ inputs[4]:
   - id: target-content
     description: "The code to analyze (provided inline by the orchestrator, or a file path to read)"
   - id: lens-resource-index
-    description: "Resource index for this pass: 19 (error-resilience), 20 (optim), 21 (evolution), 22 (api-surface), or 23 (behavioral-synthesis)"
+    description: "Resource index for this pass: 19 (error-resilience), 20 (optimize), 21 (evolution), 22 (api-surface), or 23 (behavioral-synthesis)"
   - id: output-path
     description: "Directory to write the analysis artifact"
   - id: prior-artifact-paths
@@ -46,7 +46,7 @@ output[1]:
       role: "The role label for this pass (ERRORS, COSTS, CHANGES, PROMISES, or SYNTHESIS)"
 
 rules:
-  label-mapping: "The behavioral pipeline uses fixed role labels mapped to specific lenses: error-resilience (19) → ERRORS, optim (20) → COSTS, evolution (21) → CHANGES, api-surface (22) → PROMISES. The synthesis lens (23) expects these exact labels."
+  label-mapping: "The behavioral pipeline uses fixed role labels mapped to specific lenses: error-resilience (19) → ERRORS, optimize (20) → COSTS, evolution (21) → CHANGES, api-surface (22) → PROMISES. The synthesis lens (23) expects these exact labels."
   artifact-naming: "Independent lens artifacts use descriptive role names: behavioral-errors.md (19), behavioral-costs.md (20), behavioral-changes.md (21), behavioral-promises.md (22). Synthesis artifact: behavioral-synthesis.md (23)."
   code-only: "The behavioral pipeline is code-only. optim (20) uses strongly code-oriented vocabulary with no domain-neutral variant. Do not use behavioral mode when target_type is 'general'."
   complete-execution: "Every step in each lens prompt must be executed. Do not skip or summarize."


### PR DESCRIPTION
## Summary

- Sync all 30 existing prism resources with latest upstream content (optimal_model, quality_baseline metadata added)
- Rename 4 prisms to match upstream: rec→fix-cascade, ident→identity, 73w→l12-universal, optim→optimize
- Add 16 new prism resources (indices 33–48): archaeology, audit-code, cultivation, sdl-simulation, security, simulation, testability, knowledge-audit, knowledge-boundary, knowledge-typed, l12g, oracle, writer, writer-critique, writer-synthesis, strategist
- Update plan-analysis skill with 13 new goal-mapping entries and renamed references
- Update portfolio-analysis skill with expanded catalog (24→40 lenses)
- Update README: 46 resources, new families, expanded prompt guide, model sensitivity

Follows up on #53 / #54 (merged).

## Changes

| Commit | Description |
|--------|-------------|
| 1 | Sync 30 resources + rename 4 |
| 2 | Add 16 new resources (33–48) |
| 3 | Update skills routing |
| 4 | Update documentation |

## Test Plan

- Verify resource loading for all 46 indices via get_resource
- Verify plan-analysis routes new goals correctly
- Verify renamed prism references updated throughout skills