### PR TITLE
Rename MCP entry-point tools and add session management (#59)

### DIFF
--- a/.cursor/rules/workflow-server.mdc
+++ b/.cursor/rules/workflow-server.mdc
@@ -6,9 +6,7 @@ alwaysApply: true
 # Overview
 
 For all workflow execution user requests use the workflow-server MCP server. Before use you *must*:
-1. Fetch the `workflow-server://schemas` resource to load TOON schema definitions
-2. Call `list_workflows` to discover available workflows and match the user's goal
-3. Call `start_session` with the chosen `workflow_id` to load agent guidelines and obtain an opaque session token
-4. Pass the session token to all subsequent tool calls and use the updated token from each response's `_meta.session_token`
+1. Call `list_workflows` to discover available workflows and match the user's goal
+2. Call `start_session` with the chosen `workflow_id`
 
-CRITICAL: When following the workflow you *must* respect workflow fidelity as defined in the TOON files' semantics
+The server response contains all further instructions including session protocol, behavioral rules, and workflow fidelity requirements.

--- a/.cursor/rules/workflow-server.mdc
+++ b/.cursor/rules/workflow-server.mdc
@@ -7,6 +7,8 @@ alwaysApply: true
 
 For all workflow execution user requests use the workflow-server MCP server. Before use you *must*:
 1. Fetch the `workflow-server://schemas` resource to load TOON schema definitions
-2. Call the `start_session` tool to load agent guidelines and obtain a session token
+2. Call `list_workflows` to discover available workflows and match the user's goal
+3. Call `start_session` with the chosen `workflow_id` to load agent guidelines and obtain an opaque session token
+4. Pass the session token to all subsequent tool calls and use the updated token from each response's `_meta.session_token`
 
 CRITICAL: When following the workflow you *must* respect workflow fidelity as defined in the TOON files' semantics

--- a/.cursor/rules/workflow-server.mdc
+++ b/.cursor/rules/workflow-server.mdc
@@ -7,6 +7,6 @@ alwaysApply: true
 
 For all workflow execution user requests use the workflow-server MCP server. Before use you *must*:
 1. Fetch the `workflow-server://schemas` resource to load TOON schema definitions
-2. Call the `get_rules` tool to load agent guidelines
+2. Call the `start_session` tool to load agent guidelines and obtain a session token
 
 CRITICAL: When following the workflow you *must* respect workflow fidelity as defined in the TOON files' semantics

--- a/.cursor/rules/workflow-server.mdc
+++ b/.cursor/rules/workflow-server.mdc
@@ -5,8 +5,4 @@ alwaysApply: true
 
 # Overview
 
-For all workflow execution user requests use the workflow-server MCP server. Before use you *must*:
-1. Call `list_workflows` to discover available workflows and match the user's goal
-2. Call `start_session` with the chosen `workflow_id`
-
-The server response contains all further instructions including session protocol, behavioral rules, and workflow fidelity requirements.
+For all workflow execution user requests, call the `help` tool on the workflow-server MCP server to learn the bootstrap procedure.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ This repo is an **MCP server** for AI agent workflow orchestration (TypeScript, 
 ## Boundaries
 
 - Do **not** modify server source (`src/`, `schemas/`) or workflow TOON/registry content unless the user explicitly asks.
-- When following workflows, respect workflow fidelity as defined in TOON files and the workflow-server rules (fetch `workflow-server://schemas`, call `get_rules`). See [docs/ide-setup.md](docs/ide-setup.md).
+- When following workflows, respect workflow fidelity as defined in TOON files and the workflow-server rules (fetch `workflow-server://schemas`, call `start_session`). See [docs/ide-setup.md](docs/ide-setup.md).
 
 ## Testing and PR instructions
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for AI
 Workflow Server uses a **Goal → Activity → Skill → Tools** architecture to guide AI agents through structured workflows.
 
 After initial setup of an always-applied [rule](docs/ide-setup.md), agents:
-1. **Match the user's goal** to an activity via `match_goal` (returns `quick_match` patterns and `next_action` guidance)
+1. **Discover workflows** via `list_workflows`, match the user's goal to a workflow, then call `start_session(workflow_id)` to get agent rules and an opaque session token
 2. **Load the primary skill** via `get_skill` to get tool orchestration patterns (execution order, state tracking, error recovery)
-3. **Execute workflow activities** using skill-directed tools (`get_workflow`, `get_workflow_activity`, `get_checkpoint`, `validate_transition`)
+3. **Execute workflow activities** using skill-directed tools (`get_workflow`, `get_workflow_activity`, `get_checkpoint`, `validate_transition`) — all tools derive workflow context from the session token
 
 This reduces context overhead and provides deterministic tool selection.
 

--- a/README.md
+++ b/README.md
@@ -15,31 +15,34 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for AI
 
 ## 🎯 Overview
 
-Workflow Server uses a **Goal → Activity → Skill → Tools** architecture to guide AI agents through structured workflows.
+Workflow Server guides AI agents through structured, multi-step workflows. A single always-applied [IDE rule](docs/ide-setup.md) bootstraps the agent — from there, the server handles workflow discovery, session management, and step-by-step navigation.
 
-After initial setup of an always-applied [rule](docs/ide-setup.md), agents:
-1. **Discover workflows** via `list_workflows`, match the user's goal to a workflow, then call `start_session(workflow_id)` to get agent rules and an opaque session token
-2. **Load the primary skill** via `get_skill` to get tool orchestration patterns (execution order, state tracking, error recovery)
-3. **Execute workflow activities** using skill-directed tools (`get_workflow`, `get_workflow_activity`, `get_checkpoint`, `validate_transition`) — all tools derive workflow context from the session token
+### How It Works
 
-This reduces context overhead and provides deterministic tool selection.
+1. **Discover** — The agent lists available workflows and selects one that matches the user's goal
+2. **Start session** — The server returns behavioral rules for the workflow and an opaque session token that tracks workflow state across all subsequent calls
+3. **Navigate** — Skills loaded from the server tell the agent which tools to call and in what order. The session token carries workflow context so individual tools need minimal parameters
+4. **Execute** — The agent works through activities (phases of a workflow), with checkpoints for user decisions and transitions governing the flow between activities
 
-### Execution Model
+### Architecture
 
-> Problem Domain:
-> ```
-> User Goal (complete a work package) → Activity (start-workflow, resume-workflow, ..)
-> ```
-> Solution Domain:
-> ```
-> Skill(s) (workflow-execution) → Tool(s) (validate_transition, get_workflow_activity, get_checkpoint, ..)
-> ```
+```
+User Goal → Workflow → Activity → Skill → Tools
+                         ↑                   |
+                         └───────────────────┘
+                           (transitions)
+```
+
+- **Workflows** define the overall process (e.g., implement a feature from issue to merged PR)
+- **Activities** are phases within a workflow (e.g., plan, implement, review, validate)
+- **Skills** provide tool orchestration patterns — which tools to call, in what order, what state to track
+- **Tools** are the MCP operations the agent invokes, all correlated by the session token
 
 ### Available Workflows
 
 | Workflow | Activities | Description |
 |----------|------------|-------------|
-| `work-package` | 11 | Single work package from issue to merged PR |
+| `work-package` | 14 | Single work package from issue to merged PR |
 | `work-packages` | 7 | Plan and coordinate multiple related work packages |
 
 ---

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for AI
 
 ---
 
-**[Quick Start](#-quick-start)** • **[Schema Guide](schemas/README.md)** • **[API Reference](docs/api-reference.md)** • **[Development](docs/development.md)** • **[Workflows](https://github.com/m2ux/workflow-server/tree/workflows)** • **[Engineering](https://github.com/m2ux/workflow-server/tree/engineering)**
+**[Quick Start](#-quick-start)** • **[Schema Guide](schemas/README.md)** • **[API Reference](docs/api-reference.md)** • **[Workflow Fidelity](docs/workflow-fidelity.md)** • **[Development](docs/development.md)** • **[Workflows](https://github.com/m2ux/workflow-server/tree/workflows)** • **[Engineering](https://github.com/m2ux/workflow-server/tree/engineering)**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for AI
 Workflow Server uses a **Goal → Activity → Skill → Tools** architecture to guide AI agents through structured workflows.
 
 After initial setup of an always-applied [rule](docs/ide-setup.md), agents:
-1. **Match the user's goal** to an activity via `get_activities` (returns `quick_match` patterns and `next_action` guidance)
+1. **Match the user's goal** to an activity via `match_goal` (returns `quick_match` patterns and `next_action` guidance)
 2. **Load the primary skill** via `get_skill` to get tool orchestration patterns (execution order, state tracking, error recovery)
 3. **Execute workflow activities** using skill-directed tools (`get_workflow`, `get_workflow_activity`, `get_checkpoint`, `validate_transition`)
 
@@ -104,7 +104,7 @@ Add the following to your IDE 'always-applied' rule-set (see [`docs/ide-setup.md
 ```
 For all workflow execution user requests use the workflow-server MCP server. Before use you *must*:
 1. Fetch the `workflow-server://schemas` resource to load TOON schema definitions
-2. Call the `get_rules` tool to load agent guidelines
+2. Call the `start_session` tool to load agent guidelines and obtain a session token
 
 CRITICAL: When following the workflow you *must* respect workflow fidelity as defined in the TOON files' semantics
 ```

--- a/SETUP.md
+++ b/SETUP.md
@@ -72,7 +72,7 @@ Add the following to your IDE rules (see [`docs/ide-setup.md`](docs/ide-setup.md
 ```
 For all workflow execution user requests use the workflow-server MCP server. Before use you *must*:
 1. Fetch the `workflow-server://schemas` resource to load TOON schema definitions
-2. Call the `get_rules` tool to load agent guidelines
+2. Call the `start_session` tool to load agent guidelines and obtain a session token
 
 CRITICAL: When following the workflow you *must* respect workflow fidelity as defined in the TOON files' semantics
 ```

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,45 +2,71 @@
 
 ## MCP Tools
 
-### Workflow Tools
+### Bootstrap Tools
 
 | Tool | Parameters | Description |
 |------|------------|-------------|
-| `list_workflows` | - | List all available workflow definitions with metadata |
-| `get_workflow` | `workflow_id` | Get complete workflow definition by ID |
-| `get_workflow_activity` | `workflow_id`, `activity_id` | Get details of a specific activity within a workflow |
-| `get_checkpoint` | `workflow_id`, `activity_id`, `checkpoint_id` | Get checkpoint details including options and effects |
-| `validate_transition` | `workflow_id`, `from_activity`, `to_activity` | Validate if a transition between activities is allowed |
+| `list_workflows` | - | List all available workflow definitions. Call before start_session to choose a workflow |
+| `start_session` | `workflow_id` | Start a workflow session. Returns agent rules, workflow metadata, and an opaque session token |
 | `health_check` | - | Check server health and available workflows |
 
-### Goal Matching & Session Tools
+### Workflow Tools
+
+All workflow tools require `session_token` (from `start_session`). Each response includes an updated token in `_meta.session_token`.
 
 | Tool | Parameters | Description |
 |------|------------|-------------|
-| `match_goal` | - | Match user goal to a workflow via activity index |
-| `start_session` | `workflow_version` | Start a workflow session — returns agent rules and a session token |
-| `get_activity` | `session_token`, `activity_id` | Get a specific workflow activity |
+| `get_workflow` | `session_token` | Get the complete workflow definition (workflow_id from token) |
+| `get_workflow_activity` | `session_token`, `activity_id` | Get activity details and update the session's current activity |
+| `get_checkpoint` | `session_token`, `checkpoint_id` | Get checkpoint details (activity_id from token) |
+| `validate_transition` | `session_token`, `from_activity`, `to_activity` | Validate if a transition between activities is allowed |
 
 ### Skill Tools
 
 | Tool | Parameters | Description |
 |------|------------|-------------|
-| `get_skills` | - | Get skill index - summary of all skills with capabilities |
-| `list_skills` | `workflow_id?` | List all skills (universal + workflow-specific if workflow_id provided) |
-| `get_skill` | `skill_id`, `workflow_id?` | Get a skill (checks workflow-specific first, then universal) |
+| `get_activity` | `session_token` | Get the current activity from the session (activity_id from token) |
+| `get_skills` | `session_token` | Get skill index — summary of all skills with capabilities |
+| `list_skills` | `session_token` | List all skills for the session workflow (universal + workflow-specific) |
+| `get_skill` | `session_token`, `skill_id` | Get a skill (checks workflow-specific first, then universal) |
 
 ### Resource Tools
 
 | Tool | Parameters | Description |
 |------|------------|-------------|
-| `list_workflow_resources` | `workflow_id` | List all resources for a workflow |
-| `get_resource` | `workflow_id`, `index` | Get content of a specific resource by index |
+| `list_workflow_resources` | `session_token` | List all resources for the session workflow |
+| `get_resource` | `session_token`, `index` | Get a specific resource by index |
 
 ### Discovery Tools
 
 | Tool | Parameters | Description |
 |------|------------|-------------|
-| `discover_resources` | - | Discover all available resources: workflows, resources, activities, skills |
+| `discover_resources` | `session_token` | Discover all available resources: workflows, resources, skills |
+
+### State Tools
+
+| Tool | Parameters | Description |
+|------|------------|-------------|
+| `save_state` | `session_token`, `state`, `planning_folder_path`, `description?` | Save workflow state (encrypts session token at rest) |
+| `restore_state` | `session_token`, `file_path` | Restore workflow state (decrypts session token) |
+
+## Session Token
+
+The session token is an opaque string returned by `start_session`. It encodes the current workflow, activity, and a sequence counter. Agents should treat it as an opaque value — pass it to every tool call and use the updated token from each response's `_meta.session_token`.
+
+### Lifecycle
+
+1. Call `list_workflows` to see available workflows
+2. Call `start_session(workflow_id)` to get rules + opaque token
+3. Pass `session_token` to every subsequent tool call
+4. Use the updated token from `_meta.session_token` in the next call
+5. The counter increments on every call, enabling staleness detection
+
+### Token exempt tools
+
+- `list_workflows` — pre-session bootstrap
+- `start_session` — creates the session
+- `health_check` — operational
 
 ## Activities
 
@@ -77,7 +103,7 @@ The `meta` workflow is the bootstrap workflow for the workflow-server. It contai
 
 ### Skill Resolution
 
-When calling `get_skill { skill_id, workflow_id }`:
+When calling `get_skill { skill_id }` (workflow_id is derived from the session token):
 1. First checks `{workflow_id}/skills/{NN}-{skill_id}.toon`
 2. Falls back to `meta/skills/{NN}-{skill_id}.toon` (universal)
 
@@ -96,7 +122,7 @@ Each skill provides:
 #### workflow-execution (universal)
 
 Primary skill for workflow navigation:
-- **Start**: `list_workflows` → `get_workflow` → `list_workflow_resources`
+- **Start**: `list_workflows` → `start_session` → `get_workflow` → `list_workflow_resources`
 - **Per-activity**: `get_workflow_activity` → `get_checkpoint` → `get_resource`
 - **Transitions**: `validate_transition`
 - **Triggers**: Suspend parent, execute child workflow, return to parent
@@ -104,7 +130,7 @@ Primary skill for workflow navigation:
 #### activity-resolution (universal)
 
 Bootstrap skill for agent initialization:
-- **Bootstrap**: `match_goal` → `start_session` → `get_activity`
+- **Bootstrap**: `list_workflows` → `start_session`
 - **Skill loading**: `get_skill`
 - **Discovery**: `discover_resources`
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -18,7 +18,7 @@ All workflow tools require `session_token` and explicit `workflow_id`. Each resp
 | Tool | Parameters | Description |
 |------|------------|-------------|
 | `get_workflow` | `session_token`, `workflow_id`, `summary?` | Get workflow definition. Use `summary=true` for lightweight metadata |
-| `get_activity` | `session_token`, `workflow_id`, `activity_id`, `step_manifest?` | Get activity details. Optional manifest validates previous activity's step completion |
+| `get_activity` | `session_token`, `workflow_id`, `activity_id`, `transition_condition?`, `step_manifest?` | Get activity details. Optional condition and manifest enable transition and step validation |
 | `next_activity` | `session_token`, `workflow_id` | Get possible next activities with transition conditions from current activity (token.act) |
 | `get_checkpoint` | `session_token`, `workflow_id`, `activity_id`, `checkpoint_id` | Get checkpoint details |
 | `validate_transition` | `session_token`, `workflow_id`, `from_activity`, `to_activity`, `step_manifest?` | Validate transition. Optional manifest validates from_activity's step completion |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -27,7 +27,8 @@ All workflow tools require `session_token` and explicit `workflow_id`. Each resp
 
 | Tool | Parameters | Description |
 |------|------------|-------------|
-| `get_skill` | `session_token`, `workflow_id`, `skill_id` | Get a skill (checks workflow-specific first, then universal) |
+| `get_skills` | `session_token`, `workflow_id`, `activity_id` | Get all skills for an activity (primary + supporting) in one call |
+| `get_skill` | `session_token`, `workflow_id`, `skill_id` | Get a single skill by ID |
 
 ### Resource Tools
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -17,8 +17,9 @@ All workflow tools require `session_token` and explicit `workflow_id`. Each resp
 
 | Tool | Parameters | Description |
 |------|------------|-------------|
-| `get_workflow` | `session_token`, `workflow_id` | Get the complete workflow definition |
+| `get_workflow` | `session_token`, `workflow_id`, `summary?` | Get workflow definition. Use `summary=true` for lightweight metadata |
 | `get_activity` | `session_token`, `workflow_id`, `activity_id`, `step_manifest?` | Get activity details. Optional manifest validates previous activity's step completion |
+| `next_activity` | `session_token`, `workflow_id` | Get possible next activities with transition conditions from current activity (token.act) |
 | `get_checkpoint` | `session_token`, `workflow_id`, `activity_id`, `checkpoint_id` | Get checkpoint details |
 | `validate_transition` | `session_token`, `workflow_id`, `from_activity`, `to_activity`, `step_manifest?` | Validate transition. Optional manifest validates from_activity's step completion |
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -28,14 +28,13 @@ All workflow tools require `session_token` and explicit `workflow_id`. Each resp
 | Tool | Parameters | Description |
 |------|------------|-------------|
 | `get_skills` | `session_token`, `workflow_id`, `activity_id` | Get all skills and their referenced resources for an activity in one call |
-| `get_skill` | `session_token`, `workflow_id`, `skill_id` | Get a single skill by ID |
+| `get_skill` | `session_token`, `workflow_id`, `skill_id` | Get a single skill with its referenced resources attached |
 
 ### Resource Tools
 
 | Tool | Parameters | Description |
 |------|------------|-------------|
-| `list_resources` | `session_token`, `workflow_id` | List all resources for a workflow |
-| `get_resource` | `session_token`, `workflow_id`, `index` | Get a specific resource by index |
+| `list_resources` | `session_token`, `workflow_id` | List all resources for a workflow (discovery only — resources are attached to skill responses) |
 
 ### Discovery Tools
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -30,12 +30,6 @@ All workflow tools require `session_token` and explicit `workflow_id`. Each resp
 | `get_skills` | `session_token`, `workflow_id`, `activity_id` | Get all skills and their referenced resources for an activity in one call |
 | `get_skill` | `session_token`, `workflow_id`, `skill_id` | Get a single skill with its referenced resources attached |
 
-### Resource Tools
-
-| Tool | Parameters | Description |
-|------|------------|-------------|
-| `list_resources` | `session_token`, `workflow_id` | List all resources for a workflow (discovery only — resources are attached to skill responses) |
-
 ### Discovery Tools
 
 | Tool | Parameters | Description |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -122,8 +122,8 @@ When calling `get_skill { workflow_id, skill_id }`:
 #### workflow-execution (universal)
 
 Primary skill for workflow navigation:
-- **Start**: `list_workflows` → `start_session` → `get_workflow` → `list_resources`
-- **Per-activity**: `get_activity` → `get_checkpoint` → `get_resource`
+- **Start**: `list_workflows` → `start_session` → `get_workflow`
+- **Per-activity**: `get_activity` → `get_skills` (includes skills + resources) → `get_checkpoint`
 - **Transitions**: `validate_transition`
 
 #### activity-resolution (universal)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -6,33 +6,34 @@
 
 | Tool | Parameters | Description |
 |------|------------|-------------|
-| `list_workflows` | - | List all available workflow definitions. Call before start_session to choose a workflow |
-| `start_session` | `workflow_id` | Start a workflow session. Returns agent rules, workflow metadata, and an opaque session token |
+| `help` | - | How to use this server. Returns bootstrap procedure and session protocol |
+| `list_workflows` | - | List all available workflow definitions |
+| `start_session` | `workflow_id` | Start a workflow session. Returns agent rules, workflow metadata, and opaque session token |
 | `health_check` | - | Check server health and available workflows |
 
 ### Workflow Tools
 
-All workflow tools require `session_token` (from `start_session`). Each response includes an updated token in `_meta.session_token`.
+All workflow tools require `session_token` and explicit `workflow_id`. Each response includes an updated token and validation result in `_meta`.
 
 | Tool | Parameters | Description |
 |------|------------|-------------|
-| `get_workflow` | `session_token` | Get the complete workflow definition (workflow_id from token) |
-| `get_activity` | `session_token`, `activity_id` | Get activity details and update the session's current activity |
-| `get_checkpoint` | `session_token`, `checkpoint_id` | Get checkpoint details (activity_id from token) |
-| `validate_transition` | `session_token`, `from_activity`, `to_activity` | Validate if a transition between activities is allowed |
+| `get_workflow` | `session_token`, `workflow_id` | Get the complete workflow definition |
+| `get_activity` | `session_token`, `workflow_id`, `activity_id` | Get activity details |
+| `get_checkpoint` | `session_token`, `workflow_id`, `activity_id`, `checkpoint_id` | Get checkpoint details |
+| `validate_transition` | `session_token`, `workflow_id`, `from_activity`, `to_activity` | Validate if a transition between activities is allowed |
 
 ### Skill Tools
 
 | Tool | Parameters | Description |
 |------|------------|-------------|
-| `get_skill` | `session_token`, `skill_id` | Get a skill (checks workflow-specific first, then universal) |
+| `get_skill` | `session_token`, `workflow_id`, `skill_id` | Get a skill (checks workflow-specific first, then universal) |
 
 ### Resource Tools
 
 | Tool | Parameters | Description |
 |------|------------|-------------|
-| `list_resources` | `session_token` | List all resources for the session workflow |
-| `get_resource` | `session_token`, `index` | Get a specific resource by index |
+| `list_resources` | `session_token`, `workflow_id` | List all resources for a workflow |
+| `get_resource` | `session_token`, `workflow_id`, `index` | Get a specific resource by index |
 
 ### Discovery Tools
 
@@ -49,72 +50,55 @@ All workflow tools require `session_token` (from `start_session`). Each response
 
 ## Session Token
 
-The session token is an opaque string returned by `start_session`. It encodes the current workflow, activity, and a sequence counter. Agents should treat it as an opaque value — pass it to every tool call and use the updated token from each response's `_meta.session_token`.
+The session token is an opaque string returned by `start_session`. It captures the context of each call (workflow, activity, skill) so the server can validate subsequent calls for consistency.
 
 ### Lifecycle
 
-1. Call `list_workflows` to see available workflows
-2. Call `start_session(workflow_id)` to get rules + opaque token
-3. Pass `session_token` to every subsequent tool call
-4. Use the updated token from `_meta.session_token` in the next call
-5. The counter increments on every call, enabling staleness detection
+1. Call `help` to learn the bootstrap procedure
+2. Call `list_workflows` to see available workflows
+3. Call `start_session(workflow_id)` to get rules + opaque token
+4. Pass `session_token` alongside explicit `workflow_id`/`activity_id` params to every subsequent tool call
+5. Use the updated token from `_meta.session_token` in the next call
 
-### Token exempt tools
+### Validation
 
-- `list_workflows` — pre-session bootstrap
-- `start_session` — creates the session
-- `health_check` — operational
+The server validates each call against the token's recorded state. Validation results are returned in `_meta.validation`:
 
-## Activities
+```json
+{
+  "_meta": {
+    "session_token": "<updated-token>",
+    "validation": {
+      "status": "valid",
+      "warnings": []
+    }
+  }
+}
+```
 
-Activities define user goals and map them to skills. They are the primary entry point for agent interaction.
+Validation checks:
+- **Workflow consistency** — the token's workflow matches the explicit `workflow_id`
+- **Activity transition** — the requested activity is a valid transition from the token's last activity
+- **Skill association** — the requested skill is declared by the current activity
+- **Version drift** — the workflow version hasn't changed since the session started
 
-| Activity | Problem | Primary Skill |
-|----------|---------|---------------|
-| `start-workflow` | Begin executing a new workflow | `workflow-execution` |
-| `resume-workflow` | Continue a previously started workflow | `workflow-execution` |
-| `end-workflow` | Complete and finalize a workflow | `workflow-execution` |
+Warnings do not block execution — the tool still returns its result. They enable agent self-correction.
+
+### Token-exempt tools
+
+- `help`, `list_workflows`, `start_session`, `health_check`
 
 ## Skills
 
-Skills provide structured guidance for agents to consistently execute workflows. Skills can be **universal** (apply globally) or **workflow-specific**.
-
-### Universal Skills
-
-Universal skills are stored in the `meta` workflow and apply to all workflows.
-
-| Skill | Location | Description |
-|-------|----------|-------------|
-| `activity-resolution` | `meta/skills/` | Bootstraps agent interaction by resolving user goals to activities and loading appropriate skills |
-| `workflow-execution` | `meta/skills/` | Guides agents through workflow execution with tool orchestration, state management, and error recovery |
-
-### Workflow-Specific Skills
-
-Workflow-specific skills are stored in each workflow's `skills/` directory. Currently no workflow-specific skills are defined.
-
-### The Meta Workflow
-
-The `meta` workflow is the bootstrap workflow for the workflow-server. It contains:
-- **Activities** (`meta/activities/`): All user activities for workflow operations
-- **Universal skills** (`meta/skills/`): Skills that apply to all workflows
+Skills provide structured guidance for agents to consistently execute workflows.
 
 ### Skill Resolution
 
-When calling `get_skill { skill_id }` (workflow_id is derived from the session token):
+When calling `get_skill { workflow_id, skill_id }`:
 1. First checks `{workflow_id}/skills/{NN}-{skill_id}.toon`
 2. Falls back to `meta/skills/{NN}-{skill_id}.toon` (universal)
 
-All skills use NN- indexed filenames (e.g., `00-activity-resolution.toon`, `01-workflow-execution.toon`).
-
-### Skill Contents
-
-Each skill provides:
-
-- **Execution pattern** - Tool sequence for workflow stages
-- **Tool guidance** - When to use each tool, parameters, what to preserve
-- **State management** - What to track in memory during execution (activity IDs, step indices)
-- **Interpretation rules** - How to evaluate transitions, checkpoints, decisions, triggers
-- **Error recovery** - Common error scenarios and recovery patterns
+### Key Skills
 
 #### workflow-execution (universal)
 
@@ -122,7 +106,6 @@ Primary skill for workflow navigation:
 - **Start**: `list_workflows` → `start_session` → `get_workflow` → `list_resources`
 - **Per-activity**: `get_activity` → `get_checkpoint` → `get_resource`
 - **Transitions**: `validate_transition`
-- **Triggers**: Suspend parent, execute child workflow, return to parent
 
 #### activity-resolution (universal)
 
@@ -135,26 +118,5 @@ Bootstrap skill for agent initialization:
 | Workflow | Activities | Description |
 |----------|------------|-------------|
 | `meta` | 3 | Bootstrap workflow - independent activities for workflow lifecycle |
-| `work-package` | 11 | Single work package from issue to merged PR |
+| `work-package` | 14 | Single work package from issue to merged PR |
 | `work-packages` | 7 | Plan and coordinate multiple related work packages |
-
-### Workflow Types
-
-**Sequential workflows** (e.g., `work-package`, `work-packages`):
-- Activities connected by transitions
-- Require `initialActivity`
-- Follow a defined flow
-
-**Independent activities** (e.g., `meta`):
-- Activities matched via recognition patterns
-- No transitions between activities
-- Each is a self-contained entry point
-
-### Cross-Workflow Triggering
-
-Activities can trigger other workflows using the `triggers` property. When triggered:
-1. Parent workflow state is suspended
-2. Child workflow executes to completion
-3. Parent workflow resumes with returned context
-
-Example: `work-packages` implementation activity triggers `work-package` for each planned package.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -27,7 +27,7 @@ All workflow tools require `session_token` and explicit `workflow_id`. Each resp
 
 | Tool | Parameters | Description |
 |------|------------|-------------|
-| `get_skills` | `session_token`, `workflow_id`, `activity_id` | Get all skills for an activity (primary + supporting) in one call |
+| `get_skills` | `session_token`, `workflow_id`, `activity_id` | Get all skills and their referenced resources for an activity in one call |
 | `get_skill` | `session_token`, `workflow_id`, `skill_id` | Get a single skill by ID |
 
 ### Resource Tools

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -25,7 +25,6 @@ All workflow tools require `session_token` (from `start_session`). Each response
 
 | Tool | Parameters | Description |
 |------|------------|-------------|
-| `get_activity` | `session_token` | Get the current activity from the session (activity_id from token) |
 | `get_skills` | `session_token` | Get skill index — summary of all skills with capabilities |
 | `list_skills` | `session_token` | List all skills for the session workflow (universal + workflow-specific) |
 | `get_skill` | `session_token`, `skill_id` | Get a skill (checks workflow-specific first, then universal) |
@@ -130,9 +129,8 @@ Primary skill for workflow navigation:
 #### activity-resolution (universal)
 
 Bootstrap skill for agent initialization:
-- **Bootstrap**: `list_workflows` → `start_session`
+- **Bootstrap**: `help` → `list_workflows` → `start_session`
 - **Skill loading**: `get_skill`
-- **Discovery**: `discover_resources`
 
 ## Available Workflows
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -13,18 +13,13 @@
 | `validate_transition` | `workflow_id`, `from_activity`, `to_activity` | Validate if a transition between activities is allowed |
 | `health_check` | - | Check server health and available workflows |
 
-### Activity Tools
+### Goal Matching & Session Tools
 
 | Tool | Parameters | Description |
 |------|------------|-------------|
-| `get_activities` | - | Get activity index - primary entry point for agents |
-| `get_activity` | `activity_id` | Get a specific workflow activity |
-
-### Rules Tools
-
-| Tool | Parameters | Description |
-|------|------------|-------------|
-| `get_rules` | - | Get global agent rules - behavioral guidelines for workflow execution |
+| `match_goal` | - | Match user goal to a workflow via activity index |
+| `start_session` | `workflow_version` | Start a workflow session — returns agent rules and a session token |
+| `get_activity` | `session_token`, `activity_id` | Get a specific workflow activity |
 
 ### Skill Tools
 
@@ -109,7 +104,7 @@ Primary skill for workflow navigation:
 #### activity-resolution (universal)
 
 Bootstrap skill for agent initialization:
-- **Bootstrap**: `get_activities` → `get_activity`
+- **Bootstrap**: `match_goal` → `start_session` → `get_activity`
 - **Skill loading**: `get_skill`
 - **Discovery**: `discover_resources`
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -25,8 +25,6 @@ All workflow tools require `session_token` (from `start_session`). Each response
 
 | Tool | Parameters | Description |
 |------|------------|-------------|
-| `get_skills` | `session_token` | Get skill index — summary of all skills with capabilities |
-| `list_skills` | `session_token` | List all skills for the session workflow (universal + workflow-specific) |
 | `get_skill` | `session_token`, `skill_id` | Get a skill (checks workflow-specific first, then universal) |
 
 ### Resource Tools

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -18,9 +18,9 @@ All workflow tools require `session_token` and explicit `workflow_id`. Each resp
 | Tool | Parameters | Description |
 |------|------------|-------------|
 | `get_workflow` | `session_token`, `workflow_id` | Get the complete workflow definition |
-| `get_activity` | `session_token`, `workflow_id`, `activity_id` | Get activity details |
+| `get_activity` | `session_token`, `workflow_id`, `activity_id`, `step_manifest?` | Get activity details. Optional manifest validates previous activity's step completion |
 | `get_checkpoint` | `session_token`, `workflow_id`, `activity_id`, `checkpoint_id` | Get checkpoint details |
-| `validate_transition` | `session_token`, `workflow_id`, `from_activity`, `to_activity` | Validate if a transition between activities is allowed |
+| `validate_transition` | `session_token`, `workflow_id`, `from_activity`, `to_activity`, `step_manifest?` | Validate transition. Optional manifest validates from_activity's step completion |
 
 ### Skill Tools
 
@@ -81,8 +81,25 @@ Validation checks:
 - **Activity transition** — the requested activity is a valid transition from the token's last activity
 - **Skill association** — the requested skill is declared by the current activity
 - **Version drift** — the workflow version hasn't changed since the session started
+- **Step completion** — when `step_manifest` is provided, validates all steps present, in order, with outputs
+- **HMAC integrity** — token signature is verified on every call (rejects fabricated/tampered tokens)
 
 Warnings do not block execution — the tool still returns its result. They enable agent self-correction.
+
+### Step Completion Manifest
+
+When transitioning between activities, agents can include a `step_manifest` parameter — a structured summary of completed steps from the previous activity:
+
+```json
+{
+  "step_manifest": [
+    { "step_id": "resolve-target", "output": "Target verified at /path" },
+    { "step_id": "initialize-target", "output": "Checked out main, pulled latest" }
+  ]
+}
+```
+
+The server validates: all required steps present, correct order, non-empty outputs. Missing manifest triggers a warning. All steps within an activity are required — optionality is handled at the activity level.
 
 ### Token-exempt tools
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -31,7 +31,7 @@ All workflow tools require `session_token` (from `start_session`). Each response
 
 | Tool | Parameters | Description |
 |------|------------|-------------|
-| `list_workflow_resources` | `session_token` | List all resources for the session workflow |
+| `list_resources` | `session_token` | List all resources for the session workflow |
 | `get_resource` | `session_token`, `index` | Get a specific resource by index |
 
 ### Discovery Tools
@@ -119,7 +119,7 @@ Each skill provides:
 #### workflow-execution (universal)
 
 Primary skill for workflow navigation:
-- **Start**: `list_workflows` → `start_session` → `get_workflow` → `list_workflow_resources`
+- **Start**: `list_workflows` → `start_session` → `get_workflow` → `list_resources`
 - **Per-activity**: `get_activity` → `get_checkpoint` → `get_resource`
 - **Transitions**: `validate_transition`
 - **Triggers**: Suspend parent, execute child workflow, return to parent

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -17,7 +17,7 @@ All workflow tools require `session_token` (from `start_session`). Each response
 | Tool | Parameters | Description |
 |------|------------|-------------|
 | `get_workflow` | `session_token` | Get the complete workflow definition (workflow_id from token) |
-| `get_workflow_activity` | `session_token`, `activity_id` | Get activity details and update the session's current activity |
+| `get_activity` | `session_token`, `activity_id` | Get activity details and update the session's current activity |
 | `get_checkpoint` | `session_token`, `checkpoint_id` | Get checkpoint details (activity_id from token) |
 | `validate_transition` | `session_token`, `from_activity`, `to_activity` | Validate if a transition between activities is allowed |
 
@@ -122,7 +122,7 @@ Each skill provides:
 
 Primary skill for workflow navigation:
 - **Start**: `list_workflows` → `start_session` → `get_workflow` → `list_workflow_resources`
-- **Per-activity**: `get_workflow_activity` → `get_checkpoint` → `get_resource`
+- **Per-activity**: `get_activity` → `get_checkpoint` → `get_resource`
 - **Transitions**: `validate_transition`
 - **Triggers**: Suspend parent, execute child workflow, return to parent
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -110,7 +110,7 @@ When calling `get_skill { workflow_id, skill_id }`:
 Primary skill for workflow navigation:
 - **Start**: `list_workflows` → `start_session` → `get_workflow`
 - **Per-activity**: `get_activity` → `get_skills` (includes skills + resources) → `get_checkpoint`
-- **Transitions**: `validate_transition`
+- **Transitions**: `next_activity`
 
 #### activity-resolution (universal)
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -30,12 +30,6 @@ All workflow tools require `session_token` and explicit `workflow_id`. Each resp
 | `get_skills` | `session_token`, `workflow_id`, `activity_id` | Get all skills and their referenced resources for an activity in one call |
 | `get_skill` | `session_token`, `workflow_id`, `skill_id` | Get a single skill with its referenced resources attached |
 
-### Discovery Tools
-
-| Tool | Parameters | Description |
-|------|------------|-------------|
-| `discover_resources` | `session_token` | Discover all available resources: workflows, resources, skills |
-
 ### State Tools
 
 | Tool | Parameters | Description |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -21,7 +21,6 @@ All workflow tools require `session_token` and explicit `workflow_id`. Each resp
 | `get_activity` | `session_token`, `workflow_id`, `activity_id`, `transition_condition?`, `step_manifest?` | Get activity details. Optional condition and manifest enable transition and step validation |
 | `next_activity` | `session_token`, `workflow_id` | Get possible next activities with transition conditions from current activity (token.act) |
 | `get_checkpoint` | `session_token`, `workflow_id`, `activity_id`, `checkpoint_id` | Get checkpoint details |
-| `validate_transition` | `session_token`, `workflow_id`, `from_activity`, `to_activity`, `step_manifest?` | Validate transition. Optional manifest validates from_activity's step completion |
 
 ### Skill Tools
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -197,7 +197,7 @@ Resources are stored in a `resources/` subdirectory within each workflow:
 1. Create `{NN}-{name}.toon` or `{NN}-{name}.md` in `workflows/{workflow-id}/resources/`
 2. Use sequential index (00, 01, 02, etc.)
 3. Resources are auto-discovered - no manifest update needed
-4. Access via: `get_resource { workflow_id: "{id}", index: "{NN}" }`
+4. Access via: `get_skill` or `get_skills` (resources are attached to skill responses)
 5. Commit to the `workflows` branch
 
 Note: For backwards compatibility, the loader also checks the `guides/` folder if `resources/` doesn't exist.

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -37,7 +37,7 @@ CRITICAL: When following the workflow you *must* respect workflow fidelity as de
 | `get_checkpoint` | Get checkpoint details (activity from token) |
 | `validate_transition` | Check if a transition is allowed |
 | `get_skill` | Get specific skill (workflow from token) |
-| `list_workflow_resources` | List resources for session workflow |
+| `list_resources` | List resources for session workflow |
 | `get_resource` | Get specific resource by index |
 | `discover_resources` | Discover all available resources |
 | `save_state` / `restore_state` | Persist/restore workflow state (encrypts token at rest) |

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -36,6 +36,5 @@ For all workflow execution user requests, call the `help` tool on the workflow-s
 | `validate_transition` | Check if a transition is allowed |
 | `get_skills` | Get all skills and their referenced resources for an activity in one call |
 | `get_skill` | Get a single skill with its referenced resources attached |
-| `discover_resources` | Discover all available resources |
 | `save_state` / `restore_state` | Persist/restore workflow state (encrypts token at rest) |
 | `health_check` | Server health (no token required) |

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -34,7 +34,8 @@ For all workflow execution user requests, call the `help` tool on the workflow-s
 | `next_activity` | Get possible next activities with transition conditions |
 | `get_checkpoint` | Get checkpoint details |
 | `validate_transition` | Check if a transition is allowed |
-| `get_skill` | Get specific skill |
+| `get_skills` | Get all skills for an activity (primary + supporting) in one call |
+| `get_skill` | Get a single skill by ID |
 | `list_resources` | List resources for a workflow |
 | `get_resource` | Get specific resource by index |
 | `discover_resources` | Discover all available resources |

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -35,9 +35,8 @@ For all workflow execution user requests, call the `help` tool on the workflow-s
 | `get_checkpoint` | Get checkpoint details |
 | `validate_transition` | Check if a transition is allowed |
 | `get_skills` | Get all skills and their referenced resources for an activity in one call |
-| `get_skill` | Get a single skill by ID |
-| `list_resources` | List resources for a workflow |
-| `get_resource` | Get specific resource by index |
+| `get_skill` | Get a single skill with its referenced resources attached |
+| `list_resources` | List resources for a workflow (discovery only) |
 | `discover_resources` | Discover all available resources |
 | `save_state` / `restore_state` | Persist/restore workflow state (encrypts token at rest) |
 | `health_check` | Server health (no token required) |

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -3,22 +3,18 @@
 Paste the following into your IDE rules location:
 
 ```
-For all workflow execution user requests use the workflow-server MCP server. Before use you *must*:
-1. Fetch the `workflow-server://schemas` resource to load TOON schema definitions
-2. Call the `start_session` tool to load agent guidelines and obtain a session token
-
-CRITICAL: When following the workflow you *must* respect workflow fidelity as defined in the TOON files' semantics
+For all workflow execution user requests, call the `help` tool on the workflow-server MCP server to learn the bootstrap procedure.
 ```
 
 ## How It Works
 
-1. **Fetch schemas** - Fetch `workflow-server://schemas` resource to load TOON schema definitions
+1. **Call help** - Learn the bootstrap procedure and session protocol
 2. **Discover workflows** - Call `list_workflows` to see available workflows and match the user's goal
 3. **Start session** - Call `start_session(workflow_id)` to load agent rules and obtain an opaque session token
-4. **Load workflow** - Call `get_workflow` (workflow_id from token) for the full definition
-5. **Load activity** - Call `get_activity { activity_id }` for detailed flow
-6. **Load skill** - Call `get_skill { skill_id }` referenced by the activity
-7. **Execute** - Follow the skill's tool orchestration and workflow interpretation guidance. Pass `session_token` to every call and use the updated token from `_meta.session_token`
+4. **Load workflow** - Call `get_workflow(workflow_id)` for the full definition
+5. **Load activity** - Call `get_activity(workflow_id, activity_id)` for detailed flow
+6. **Load skill** - Call `get_skill(workflow_id, skill_id)` referenced by the activity
+7. **Execute** - Follow the skill's tool orchestration guidance. Pass `session_token` and explicit `workflow_id`/`activity_id` to every call. Use the updated token from `_meta.session_token`. Check `_meta.validation` for warnings.
 
 ## Available Resources
 
@@ -30,14 +26,15 @@ CRITICAL: When following the workflow you *must* respect workflow fidelity as de
 
 | Tool | Purpose |
 |------|---------|
+| `help` | Bootstrap procedure and session protocol (no token required) |
 | `list_workflows` | List all workflows (no token required) |
 | `start_session` | Start session — returns rules, workflow metadata, and opaque token |
-| `get_workflow` | Get workflow definition (workflow_id from token) |
-| `get_activity` | Get activity details and update session activity |
-| `get_checkpoint` | Get checkpoint details (activity from token) |
+| `get_workflow` | Get workflow definition |
+| `get_activity` | Get activity details |
+| `get_checkpoint` | Get checkpoint details |
 | `validate_transition` | Check if a transition is allowed |
-| `get_skill` | Get specific skill (workflow from token) |
-| `list_resources` | List resources for session workflow |
+| `get_skill` | Get specific skill |
+| `list_resources` | List resources for a workflow |
 | `get_resource` | Get specific resource by index |
 | `discover_resources` | Discover all available resources |
 | `save_state` / `restore_state` | Persist/restore workflow state (encrypts token at rest) |

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -37,7 +37,6 @@ CRITICAL: When following the workflow you *must* respect workflow fidelity as de
 | `get_checkpoint` | Get checkpoint details (activity from token) |
 | `validate_transition` | Check if a transition is allowed |
 | `get_skill` | Get specific skill (workflow from token) |
-| `list_skills` | List skills for session workflow |
 | `list_workflow_resources` | List resources for session workflow |
 | `get_resource` | Get specific resource by index |
 | `discover_resources` | Discover all available resources |

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -29,8 +29,9 @@ For all workflow execution user requests, call the `help` tool on the workflow-s
 | `help` | Bootstrap procedure and session protocol (no token required) |
 | `list_workflows` | List all workflows (no token required) |
 | `start_session` | Start session — returns rules, workflow metadata, and opaque token |
-| `get_workflow` | Get workflow definition |
+| `get_workflow` | Get workflow definition (use summary=true for lightweight metadata) |
 | `get_activity` | Get activity details |
+| `next_activity` | Get possible next activities with transition conditions |
 | `get_checkpoint` | Get checkpoint details |
 | `validate_transition` | Check if a transition is allowed |
 | `get_skill` | Get specific skill |

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -36,7 +36,6 @@ For all workflow execution user requests, call the `help` tool on the workflow-s
 | `validate_transition` | Check if a transition is allowed |
 | `get_skills` | Get all skills and their referenced resources for an activity in one call |
 | `get_skill` | Get a single skill with its referenced resources attached |
-| `list_resources` | List resources for a workflow (discovery only) |
 | `discover_resources` | Discover all available resources |
 | `save_state` / `restore_state` | Persist/restore workflow state (encrypts token at rest) |
 | `health_check` | Server health (no token required) |

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -13,12 +13,12 @@ CRITICAL: When following the workflow you *must* respect workflow fidelity as de
 ## How It Works
 
 1. **Fetch schemas** - Fetch `workflow-server://schemas` resource to load TOON schema definitions
-2. **Start session** - Call `start_session` to load agent behavioral guidelines and obtain a session token
-3. **Match goal** - Call `match_goal` to get the activity index with `quick_match` patterns
-4. **Match user goal** - Use `quick_match` patterns to identify the appropriate activity
-5. **Load activity** - Call `get_activity { activity_id: "{id}" }` for detailed flow
-6. **Load skill** - Call `get_skill { skill_id: "{skill}" }` referenced by the activity
-7. **Execute** - Follow the skill's tool orchestration and workflow interpretation guidance
+2. **Discover workflows** - Call `list_workflows` to see available workflows and match the user's goal
+3. **Start session** - Call `start_session(workflow_id)` to load agent rules and obtain an opaque session token
+4. **Load workflow** - Call `get_workflow` (workflow_id from token) for the full definition
+5. **Load activity** - Call `get_workflow_activity { activity_id }` for detailed flow
+6. **Load skill** - Call `get_skill { skill_id }` referenced by the activity
+7. **Execute** - Follow the skill's tool orchestration and workflow interpretation guidance. Pass `session_token` to every call and use the updated token from `_meta.session_token`
 
 ## Available Resources
 
@@ -30,13 +30,17 @@ CRITICAL: When following the workflow you *must* respect workflow fidelity as de
 
 | Tool | Purpose |
 |------|---------|
-| `start_session` | Start session — returns agent guidelines and session token |
-| `match_goal` | Match user goal to a workflow via activity index |
-| `get_activity` | Get specific activity by ID |
-| `list_skills` | List available skills |
-| `get_skill` | Get specific skill by ID |
-| `list_workflows` | List all workflows |
-| `get_workflow` | Get workflow definition |
-| `list_workflow_resources` | List resources for a workflow |
+| `list_workflows` | List all workflows (no token required) |
+| `start_session` | Start session — returns rules, workflow metadata, and opaque token |
+| `get_workflow` | Get workflow definition (workflow_id from token) |
+| `get_workflow_activity` | Get activity details and update session activity |
+| `get_checkpoint` | Get checkpoint details (activity from token) |
+| `validate_transition` | Check if a transition is allowed |
+| `get_activity` | Get current activity from token |
+| `get_skill` | Get specific skill (workflow from token) |
+| `list_skills` | List skills for session workflow |
+| `list_workflow_resources` | List resources for session workflow |
 | `get_resource` | Get specific resource by index |
 | `discover_resources` | Discover all available resources |
+| `save_state` / `restore_state` | Persist/restore workflow state (encrypts token at rest) |
+| `health_check` | Server health (no token required) |

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -16,7 +16,7 @@ CRITICAL: When following the workflow you *must* respect workflow fidelity as de
 2. **Discover workflows** - Call `list_workflows` to see available workflows and match the user's goal
 3. **Start session** - Call `start_session(workflow_id)` to load agent rules and obtain an opaque session token
 4. **Load workflow** - Call `get_workflow` (workflow_id from token) for the full definition
-5. **Load activity** - Call `get_workflow_activity { activity_id }` for detailed flow
+5. **Load activity** - Call `get_activity { activity_id }` for detailed flow
 6. **Load skill** - Call `get_skill { skill_id }` referenced by the activity
 7. **Execute** - Follow the skill's tool orchestration and workflow interpretation guidance. Pass `session_token` to every call and use the updated token from `_meta.session_token`
 
@@ -33,7 +33,7 @@ CRITICAL: When following the workflow you *must* respect workflow fidelity as de
 | `list_workflows` | List all workflows (no token required) |
 | `start_session` | Start session — returns rules, workflow metadata, and opaque token |
 | `get_workflow` | Get workflow definition (workflow_id from token) |
-| `get_workflow_activity` | Get activity details and update session activity |
+| `get_activity` | Get activity details and update session activity |
 | `get_checkpoint` | Get checkpoint details (activity from token) |
 | `validate_transition` | Check if a transition is allowed |
 | `get_skill` | Get specific skill (workflow from token) |

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -5,7 +5,7 @@ Paste the following into your IDE rules location:
 ```
 For all workflow execution user requests use the workflow-server MCP server. Before use you *must*:
 1. Fetch the `workflow-server://schemas` resource to load TOON schema definitions
-2. Call the `get_rules` tool to load agent guidelines
+2. Call the `start_session` tool to load agent guidelines and obtain a session token
 
 CRITICAL: When following the workflow you *must* respect workflow fidelity as defined in the TOON files' semantics
 ```
@@ -13,8 +13,8 @@ CRITICAL: When following the workflow you *must* respect workflow fidelity as de
 ## How It Works
 
 1. **Fetch schemas** - Fetch `workflow-server://schemas` resource to load TOON schema definitions
-2. **Get rules** - Call `get_rules` to load agent behavioral guidelines
-3. **Get activities** - Call `get_activities` to get the activity index with `quick_match` patterns
+2. **Start session** - Call `start_session` to load agent behavioral guidelines and obtain a session token
+3. **Match goal** - Call `match_goal` to get the activity index with `quick_match` patterns
 4. **Match user goal** - Use `quick_match` patterns to identify the appropriate activity
 5. **Load activity** - Call `get_activity { activity_id: "{id}" }` for detailed flow
 6. **Load skill** - Call `get_skill { skill_id: "{skill}" }` referenced by the activity
@@ -30,8 +30,8 @@ CRITICAL: When following the workflow you *must* respect workflow fidelity as de
 
 | Tool | Purpose |
 |------|---------|
-| `get_rules` | Get agent behavioral guidelines |
-| `get_activities` | Get activity index - primary entry point |
+| `start_session` | Start session — returns agent guidelines and session token |
+| `match_goal` | Match user goal to a workflow via activity index |
 | `get_activity` | Get specific activity by ID |
 | `list_skills` | List available skills |
 | `get_skill` | Get specific skill by ID |

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -34,7 +34,7 @@ For all workflow execution user requests, call the `help` tool on the workflow-s
 | `next_activity` | Get possible next activities with transition conditions |
 | `get_checkpoint` | Get checkpoint details |
 | `validate_transition` | Check if a transition is allowed |
-| `get_skills` | Get all skills for an activity (primary + supporting) in one call |
+| `get_skills` | Get all skills and their referenced resources for an activity in one call |
 | `get_skill` | Get a single skill by ID |
 | `list_resources` | List resources for a workflow |
 | `get_resource` | Get specific resource by index |

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -33,7 +33,6 @@ For all workflow execution user requests, call the `help` tool on the workflow-s
 | `get_activity` | Get activity details |
 | `next_activity` | Get possible next activities with transition conditions |
 | `get_checkpoint` | Get checkpoint details |
-| `validate_transition` | Check if a transition is allowed |
 | `get_skills` | Get all skills and their referenced resources for an activity in one call |
 | `get_skill` | Get a single skill with its referenced resources attached |
 | `save_state` / `restore_state` | Persist/restore workflow state (encrypts token at rest) |

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -36,7 +36,6 @@ CRITICAL: When following the workflow you *must* respect workflow fidelity as de
 | `get_workflow_activity` | Get activity details and update session activity |
 | `get_checkpoint` | Get checkpoint details (activity from token) |
 | `validate_transition` | Check if a transition is allowed |
-| `get_activity` | Get current activity from token |
 | `get_skill` | Get specific skill (workflow from token) |
 | `list_skills` | List skills for session workflow |
 | `list_workflow_resources` | List resources for session workflow |

--- a/docs/workflow-fidelity.md
+++ b/docs/workflow-fidelity.md
@@ -9,7 +9,7 @@ AI agents executing multi-step workflows face two reliability challenges:
 1. **Context degradation** — as conversations grow, earlier instructions (including workflow definitions) fall out of the model's effective attention window, leading to skipped steps, wrong transitions, and hallucinated procedures
 2. **Behavioral drift** — without enforcement, agents may take shortcuts, skip checkpoints, or fabricate state rather than following the defined execution path
 
-The workflow server addresses these through three layers of enforcement, each operating at a different granularity.
+The workflow server addresses these through four layers of enforcement, each operating at a different granularity.
 
 ## Enforcement Layers
 
@@ -109,6 +109,10 @@ Beyond enforcement, the server reduces the context burden on agents:
 }
 ```
 
+### Batch Skill Loading
+
+`get_skills(workflow_id, activity_id)` returns all skills (primary + supporting) for an activity in one call, replacing multiple sequential `get_skill` calls. This reduces round-trips and context overhead from repeated tool exchanges.
+
 ### Self-Describing Bootstrap
 
 The `help` tool returns the complete bootstrap procedure and session protocol. Agents learn how to use the server from the server itself, reducing reliance on IDE-side configuration that may go stale.
@@ -120,6 +124,7 @@ When workflow state is persisted via `save_state`, the session token is encrypte
 ## Limitations
 
 - **Step execution is not provable** — the manifest validates that the agent *reported* each step, not that it *performed* the work. The output descriptions are agent-generated.
+- **Condition truth is not verified** — the server checks that a claimed condition maps to the target activity, but cannot verify whether the condition is actually true in the agent's state. Post-hoc audit via checkpoint logs is possible.
 - **Replay is not detected** — an agent could present an old valid token. The HMAC proves authenticity but not freshness (the server is stateless).
 - **Warnings are advisory** — a confused agent may ignore validation warnings. The enforcement is detection-oriented, not prevention-oriented.
 

--- a/docs/workflow-fidelity.md
+++ b/docs/workflow-fidelity.md
@@ -1,0 +1,115 @@
+# Workflow Fidelity Enforcement
+
+How the workflow server ensures agents follow workflows correctly.
+
+## The Problem
+
+AI agents executing multi-step workflows face two reliability challenges:
+
+1. **Context degradation** — as conversations grow, earlier instructions (including workflow definitions) fall out of the model's effective attention window, leading to skipped steps, wrong transitions, and hallucinated procedures
+2. **Behavioral drift** — without enforcement, agents may take shortcuts, skip checkpoints, or fabricate state rather than following the defined execution path
+
+The workflow server addresses these through three layers of enforcement, each operating at a different granularity.
+
+## Enforcement Layers
+
+```
+┌─────────────────────────────────────────────┐
+│  Layer 1: Token Integrity (HMAC)            │
+│  Every call — prevents fabrication           │
+├─────────────────────────────────────────────┤
+│  Layer 2: Cross-Activity Validation          │
+│  Between activities — checks consistency     │
+├─────────────────────────────────────────────┤
+│  Layer 3: Step Completion Manifest           │
+│  Within activities — verifies completeness   │
+└─────────────────────────────────────────────┘
+```
+
+### Layer 1: Token Integrity
+
+Every session token is HMAC-SHA256 signed using a server-held key (`~/.workflow-server/secret`). The token format is `<base64url-payload>.<hmac-signature>`.
+
+**What it enforces:**
+- Agents cannot fabricate tokens — the server rejects any token it didn't issue
+- Agents cannot tamper with token fields (workflow ID, activity, sequence counter) — modifying any field invalidates the signature
+- Each tool call produces a new token with an incremented counter, ensuring tokens are unique per exchange
+
+**How it works:** The server verifies the HMAC signature on every tool call before processing. Invalid signatures cause immediate rejection.
+
+### Layer 2: Cross-Activity Validation
+
+When an agent makes a tool call, the server compares the token's recorded state (from the previous call) against the current call's explicit parameters. Warnings are returned in `_meta.validation`.
+
+**Checks performed:**
+
+| Check | What it detects |
+|-------|----------------|
+| Workflow consistency | Agent switched workflows mid-session without starting a new session |
+| Activity transition | Agent jumped to an activity that isn't a valid transition from the previous one |
+| Skill association | Agent loaded a skill not declared by the current activity |
+| Version drift | Workflow definition changed on disk since the session started |
+
+**Design principle:** Warnings don't block execution — the tool still returns its result. This allows agents to self-correct rather than being hard-blocked, while making violations visible.
+
+### Layer 3: Step Completion Manifest
+
+When transitioning between activities, agents can include a `step_manifest` parameter — a structured summary of each step completed in the previous activity.
+
+```json
+{
+  "step_manifest": [
+    { "step_id": "resolve-target", "output": "Target verified at /path" },
+    { "step_id": "initialize-target", "output": "Checked out main" },
+    { "step_id": "detect-project-type", "output": "project_type=other" }
+  ]
+}
+```
+
+**What it enforces:**
+- All required steps are present (missing steps produce a warning)
+- Steps are in the correct order (out-of-order steps produce a warning)
+- Each step has a non-empty output description (empty outputs produce a warning)
+
+**Design constraint:** All steps within an activity are required. Optionality is handled at the activity level (via transition conditions), not at the step level. This simplifies enforcement — the validator checks for exact match against the expected step sequence.
+
+## Context Pressure Mitigation
+
+Beyond enforcement, the server reduces the context burden on agents:
+
+### Summary Mode
+
+`get_workflow(summary=true)` returns lightweight metadata (~2KB) instead of the full workflow definition (~13KB). The orchestrator gets rules, variables, and activity stubs without consuming its context window with step-level detail.
+
+### Server-Side Transition List
+
+`next_activity` returns the transition list for the current activity with human-readable conditions. The agent matches conditions against its state variables using a fresh list from the server, rather than referencing a workflow definition loaded many exchanges ago.
+
+```json
+{
+  "current_activity": "codebase-comprehension",
+  "transitions": [
+    { "to": "requirements-elicitation", "condition": "needs_elicitation == true" },
+    { "to": "implementation-analysis", "isDefault": true }
+  ]
+}
+```
+
+### Self-Describing Bootstrap
+
+The `help` tool returns the complete bootstrap procedure and session protocol. Agents learn how to use the server from the server itself, reducing reliance on IDE-side configuration that may go stale.
+
+## At-Rest Token Security
+
+When workflow state is persisted via `save_state`, the session token is encrypted using AES-256-GCM before writing to disk. `restore_state` decrypts it transparently. This prevents token extraction from state files.
+
+## Limitations
+
+- **Step execution is not provable** — the manifest validates that the agent *reported* each step, not that it *performed* the work. The output descriptions are agent-generated.
+- **Replay is not detected** — an agent could present an old valid token. The HMAC proves authenticity but not freshness (the server is stateless).
+- **Warnings are advisory** — a confused agent may ignore validation warnings. The enforcement is detection-oriented, not prevention-oriented.
+
+## Related
+
+- [API Reference](api-reference.md) — tool parameters and validation response format
+- [IDE Setup](ide-setup.md) — bootstrap configuration

--- a/docs/workflow-fidelity.md
+++ b/docs/workflow-fidelity.md
@@ -21,7 +21,10 @@ The workflow server addresses these through three layers of enforcement, each op
 │  Layer 2: Cross-Activity Validation          │
 │  Between activities — checks consistency     │
 ├─────────────────────────────────────────────┤
-│  Layer 3: Step Completion Manifest           │
+│  Layer 3: Transition Condition Tracking      │
+│  At transitions — verifies condition logic   │
+├─────────────────────────────────────────────┤
+│  Layer 4: Step Completion Manifest           │
 │  Within activities — verifies completeness   │
 └─────────────────────────────────────────────┘
 ```
@@ -52,7 +55,18 @@ When an agent makes a tool call, the server compares the token's recorded state 
 
 **Design principle:** Warnings don't block execution — the tool still returns its result. This allows agents to self-correct rather than being hard-blocked, while making violations visible.
 
-### Layer 3: Step Completion Manifest
+### Layer 3: Transition Condition Tracking
+
+When calling `get_activity` to transition to a new activity, agents can include a `transition_condition` parameter — the condition string (from `next_activity` output) that caused the transition.
+
+**What it enforces:**
+- The claimed condition actually maps to the target activity in the transition table
+- Default transitions are correctly reported (no false condition claims)
+- The condition is recorded in the HMAC-signed token, creating an immutable audit trail
+
+**What it cannot verify in real-time:** Whether the condition is actually true in the agent's state. However, conditions are typically set by user choices at checkpoints, which are logged. Post-hoc review can cross-reference claimed conditions against checkpoint responses.
+
+### Layer 4: Step Completion Manifest
 
 When transitioning between activities, agents can include a `step_manifest` parameter — a structured summary of each step completed in the previous activity.
 

--- a/docs/workflow-fidelity.md
+++ b/docs/workflow-fidelity.md
@@ -111,7 +111,7 @@ Beyond enforcement, the server reduces the context burden on agents:
 
 ### Batch Skill Loading
 
-`get_skills(workflow_id, activity_id)` returns all skills (primary + supporting) for an activity in one call, replacing multiple sequential `get_skill` calls. This reduces round-trips and context overhead from repeated tool exchanges.
+`get_skills(workflow_id, activity_id)` returns all skills (primary + supporting) and their referenced resources for an activity in one call. This replaces multiple sequential `get_skill` and `get_resource` calls, reducing round-trips and context overhead.
 
 ### Self-Describing Bootstrap
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1184,7 +1184,7 @@ The activity schema (`activity.schema.json`) defines unified activities that com
 **Independent Activities** (e.g., meta workflow):
 - Have `recognition` patterns for intent matching
 - No `transitions` to other activities
-- Matched via `get_activities` tool
+- Matched via `match_goal` tool
 
 **Sequential Activities** (e.g., work-package workflow):
 - Have `transitions` connecting them

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1184,7 +1184,7 @@ The activity schema (`activity.schema.json`) defines unified activities that com
 **Independent Activities** (e.g., meta workflow):
 - Have `recognition` patterns for intent matching
 - No `transitions` to other activities
-- Matched via `match_goal` tool
+- Matched via `list_workflows` and `start_session`
 
 **Sequential Activities** (e.g., work-package workflow):
 - Have `transitions` connecting them

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1399,14 +1399,14 @@ A minimal skill demonstrating key concepts:
   "capability": "Demonstrate skill schema structure",
   "description": "A minimal skill showing required and optional fields",
   "execution_pattern": {
-    "start": ["discover_resources"],
+    "start": ["list_workflows", "start_session"],
     "per_task": ["execute_task", "validate_result"]
   },
   "tools": {
-    "discover_resources": {
+    "list_workflows": {
       "when": "Beginning a new task",
       "params": "none",
-      "returns": "List of available resources"
+      "returns": "List of available workflows"
     },
     "execute_task": {
       "when": "Ready to perform work",
@@ -1421,7 +1421,7 @@ A minimal skill demonstrating key concepts:
     }
   },
   "flow": [
-    "1. Call discover_resources to understand context",
+    "1. Call list_workflows to understand available workflows",
     "2. Match task to available resources",
     "3. Call execute_task with appropriate parameters",
     "4. Call validate_result to confirm success"
@@ -1429,7 +1429,7 @@ A minimal skill demonstrating key concepts:
   "errors": {
     "resource_not_found": {
       "cause": "Requested resource does not exist",
-      "recovery": "Call discover_resources to see available options"
+      "recovery": "Call list_workflows to see available options"
     }
   }
 }

--- a/src/loaders/activity-loader.ts
+++ b/src/loaders/activity-loader.ts
@@ -269,9 +269,9 @@ export async function readActivityIndex(workflowDir: string): Promise<Result<Act
   
   const index: ActivityIndex = {
     description: 'Match user goal to an activity. Activities use skills to achieve outcomes.',
-    usage: 'Call the tool in next_action first (get_rules), then proceed to the matched activity.',
+    usage: 'Call the tool in next_action first (start_session), then proceed to the matched activity.',
     next_action: {
-      tool: 'get_rules',
+      tool: 'start_session',
       parameters: {},
     },
     activities,

--- a/src/loaders/workflow-loader.ts
+++ b/src/loaders/workflow-loader.ts
@@ -177,6 +177,45 @@ export function getValidTransitions(workflow: Workflow, fromActivityId: string):
   return [...new Set(transitions)];
 }
 
+export interface TransitionEntry {
+  to: string;
+  condition?: string | undefined;
+  isDefault?: boolean | undefined;
+}
+
+/** Get the transition list for an activity with human-readable conditions */
+export function getTransitionList(workflow: Workflow, fromActivityId: string): TransitionEntry[] {
+  const activity = getActivity(workflow, fromActivityId);
+  if (!activity) return [];
+
+  const entries: TransitionEntry[] = [];
+
+  for (const t of activity.transitions ?? []) {
+    entries.push({
+      to: t.to,
+      condition: t.condition ? conditionToString(t.condition) : undefined,
+      isDefault: t.isDefault || undefined,
+    });
+  }
+
+  return entries;
+}
+
+function conditionToString(condition: { type: string; variable?: string; operator?: string; value?: unknown; conditions?: unknown[]; condition?: unknown }): string {
+  switch (condition.type) {
+    case 'simple':
+      return `${condition.variable} ${condition.operator} ${JSON.stringify(condition.value)}`;
+    case 'and':
+      return (condition.conditions as Array<typeof condition>).map(c => conditionToString(c)).join(' AND ');
+    case 'or':
+      return (condition.conditions as Array<typeof condition>).map(c => conditionToString(c)).join(' OR ');
+    case 'not':
+      return `NOT (${conditionToString(condition.condition as typeof condition)})`;
+    default:
+      return String(condition);
+  }
+}
+
 /** Validate a transition between activities */
 export function validateTransition(workflow: Workflow, fromActivityId: string, toActivityId: string): { valid: boolean; reason?: string } {
   if (!getActivity(workflow, fromActivityId)) return { valid: false, reason: `Source activity not found: ${fromActivityId}` };

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,7 +19,7 @@ export function createServer(config: ServerConfig): McpServer {
   logInfo('Server configured', { 
     tools: [
       'help', 'list_workflows', 'get_workflow', 'validate_transition', 'get_activity', 'get_checkpoint', 'health_check',
-      'start_session', 'get_skills', 'list_skills', 'get_skill',
+      'start_session', 'get_skill',
       'list_workflow_resources', 'get_resource', 'discover_resources',
       'save_state', 'restore_state'
     ],

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,7 @@ export function createServer(config: ServerConfig): McpServer {
   registerSchemaResources(server, config);
   logInfo('Server configured', { 
     tools: [
-      'help', 'list_workflows', 'get_workflow', 'validate_transition', 'get_activity', 'get_checkpoint', 'next_activity', 'health_check',
+      'help', 'list_workflows', 'get_workflow', 'get_activity', 'get_checkpoint', 'next_activity', 'health_check',
       'start_session', 'get_skills', 'get_skill',
       'save_state', 'restore_state'
     ],

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,7 +20,7 @@ export function createServer(config: ServerConfig): McpServer {
     tools: [
       'help', 'list_workflows', 'get_workflow', 'validate_transition', 'get_activity', 'get_checkpoint', 'next_activity', 'health_check',
       'start_session', 'get_skills', 'get_skill',
-      'list_resources', 'discover_resources',
+      'discover_resources',
       'save_state', 'restore_state'
     ],
     resources: ['workflow-server://schemas']

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,7 +19,7 @@ export function createServer(config: ServerConfig): McpServer {
   logInfo('Server configured', { 
     tools: [
       'help', 'list_workflows', 'get_workflow', 'validate_transition', 'get_activity', 'get_checkpoint', 'next_activity', 'health_check',
-      'start_session', 'get_skill',
+      'start_session', 'get_skills', 'get_skill',
       'list_resources', 'get_resource', 'discover_resources',
       'save_state', 'restore_state'
     ],

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,7 +20,7 @@ export function createServer(config: ServerConfig): McpServer {
     tools: [
       'help', 'list_workflows', 'get_workflow', 'validate_transition', 'get_activity', 'get_checkpoint', 'health_check',
       'start_session', 'get_skill',
-      'list_workflow_resources', 'get_resource', 'discover_resources',
+      'list_resources', 'get_resource', 'discover_resources',
       'save_state', 'restore_state'
     ],
     resources: ['workflow-server://schemas']

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,7 +20,6 @@ export function createServer(config: ServerConfig): McpServer {
     tools: [
       'help', 'list_workflows', 'get_workflow', 'validate_transition', 'get_activity', 'get_checkpoint', 'next_activity', 'health_check',
       'start_session', 'get_skills', 'get_skill',
-      'discover_resources',
       'save_state', 'restore_state'
     ],
     resources: ['workflow-server://schemas']

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,7 @@ export function createServer(config: ServerConfig): McpServer {
   registerSchemaResources(server, config);
   logInfo('Server configured', { 
     tools: [
-      'help', 'list_workflows', 'get_workflow', 'validate_transition', 'get_activity', 'get_checkpoint', 'health_check',
+      'help', 'list_workflows', 'get_workflow', 'validate_transition', 'get_activity', 'get_checkpoint', 'next_activity', 'health_check',
       'start_session', 'get_skill',
       'list_resources', 'get_resource', 'discover_resources',
       'save_state', 'restore_state'

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,7 @@ export function createServer(config: ServerConfig): McpServer {
   registerSchemaResources(server, config);
   logInfo('Server configured', { 
     tools: [
-      'help', 'list_workflows', 'get_workflow', 'validate_transition', 'get_workflow_activity', 'get_checkpoint', 'health_check',
+      'help', 'list_workflows', 'get_workflow', 'validate_transition', 'get_activity', 'get_checkpoint', 'health_check',
       'start_session', 'get_skills', 'list_skills', 'get_skill',
       'list_workflow_resources', 'get_resource', 'discover_resources',
       'save_state', 'restore_state'

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,7 +19,7 @@ export function createServer(config: ServerConfig): McpServer {
   logInfo('Server configured', { 
     tools: [
       'list_workflows', 'get_workflow', 'validate_transition', 'get_workflow_activity', 'get_checkpoint', 'health_check',
-      'get_activities', 'get_activity', 'get_rules', 'get_skills', 'list_skills', 'get_skill',
+      'match_goal', 'get_activity', 'get_rules', 'get_skills', 'list_skills', 'get_skill',
       'list_workflow_resources', 'get_resource', 'discover_resources',
       'save_state', 'restore_state'
     ],

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,7 +19,7 @@ export function createServer(config: ServerConfig): McpServer {
   logInfo('Server configured', { 
     tools: [
       'list_workflows', 'get_workflow', 'validate_transition', 'get_workflow_activity', 'get_checkpoint', 'health_check',
-      'match_goal', 'get_activity', 'get_rules', 'get_skills', 'list_skills', 'get_skill',
+      'match_goal', 'get_activity', 'start_session', 'get_skills', 'list_skills', 'get_skill',
       'list_workflow_resources', 'get_resource', 'discover_resources',
       'save_state', 'restore_state'
     ],

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,7 @@ export function createServer(config: ServerConfig): McpServer {
   registerSchemaResources(server, config);
   logInfo('Server configured', { 
     tools: [
-      'list_workflows', 'get_workflow', 'validate_transition', 'get_workflow_activity', 'get_checkpoint', 'health_check',
+      'help', 'list_workflows', 'get_workflow', 'validate_transition', 'get_workflow_activity', 'get_checkpoint', 'health_check',
       'get_activity', 'start_session', 'get_skills', 'list_skills', 'get_skill',
       'list_workflow_resources', 'get_resource', 'discover_resources',
       'save_state', 'restore_state'

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,7 +19,7 @@ export function createServer(config: ServerConfig): McpServer {
   logInfo('Server configured', { 
     tools: [
       'help', 'list_workflows', 'get_workflow', 'validate_transition', 'get_workflow_activity', 'get_checkpoint', 'health_check',
-      'get_activity', 'start_session', 'get_skills', 'list_skills', 'get_skill',
+      'start_session', 'get_skills', 'list_skills', 'get_skill',
       'list_workflow_resources', 'get_resource', 'discover_resources',
       'save_state', 'restore_state'
     ],

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,7 +19,7 @@ export function createServer(config: ServerConfig): McpServer {
   logInfo('Server configured', { 
     tools: [
       'list_workflows', 'get_workflow', 'validate_transition', 'get_workflow_activity', 'get_checkpoint', 'health_check',
-      'match_goal', 'get_activity', 'start_session', 'get_skills', 'list_skills', 'get_skill',
+      'get_activity', 'start_session', 'get_skills', 'list_skills', 'get_skill',
       'list_workflow_resources', 'get_resource', 'discover_resources',
       'save_state', 'restore_state'
     ],

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,7 +20,7 @@ export function createServer(config: ServerConfig): McpServer {
     tools: [
       'help', 'list_workflows', 'get_workflow', 'validate_transition', 'get_activity', 'get_checkpoint', 'next_activity', 'health_check',
       'start_session', 'get_skills', 'get_skill',
-      'list_resources', 'get_resource', 'discover_resources',
+      'list_resources', 'discover_resources',
       'save_state', 'restore_state'
     ],
     resources: ['workflow-server://schemas']

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -5,7 +5,7 @@ import { withAuditLog } from '../logging.js';
 
 import { listWorkflows, loadWorkflow } from '../loaders/workflow-loader.js';
 import { listResources, readResourceRaw, listWorkflowsWithResources } from '../loaders/resource-loader.js';
-import { listSkills, listUniversalSkills, listWorkflowSkills, readSkill, readSkillIndex } from '../loaders/skill-loader.js';
+import { listUniversalSkills, listWorkflowSkills, readSkill } from '../loaders/skill-loader.js';
 import { readRules } from '../loaders/rules-loader.js';
 import { createSessionToken, decodeSessionToken, advanceToken, sessionTokenParam } from '../utils/session.js';
 
@@ -56,42 +56,6 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
   );
 
   // ============== Skill Tools ==============
-
-  server.tool(
-    'get_skills',
-    'Get the skill index - summary of all available skills with capabilities.',
-    { ...sessionTokenParam },
-    withAuditLog('get_skills', async ({ session_token }) => {
-      const result = await readSkillIndex(config.workflowDir);
-      if (!result.success) {
-        const skills = await listSkills(config.workflowDir);
-        return withAdvancedToken(
-          { content: [{ type: 'text' as const, text: JSON.stringify(skills, null, 2) }] },
-          session_token,
-        );
-      }
-      return withAdvancedToken(
-        { content: [{ type: 'text' as const, text: JSON.stringify(result.value, null, 2) }] },
-        session_token,
-      );
-    })
-  );
-
-  server.tool(
-    'list_skills',
-    'List all available skills - both universal and workflow-specific for the session workflow.',
-    { ...sessionTokenParam },
-    withAuditLog('list_skills', async ({ session_token }) => {
-      const { wf } = decodeSessionToken(session_token);
-      const workflowSkills = await listWorkflowSkills(config.workflowDir, wf);
-      const universalSkills = await listUniversalSkills(config.workflowDir);
-      const result = { universal: universalSkills, workflow: workflowSkills };
-      return withAdvancedToken(
-        { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] },
-        session_token,
-      );
-    })
-  );
 
   server.tool(
     'get_skill',
@@ -166,8 +130,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
         },
         universal_skills: {
           items: universalSkills.map(s => s.id),
-          tool: 'list_skills',
-          description: 'Universal skills (apply to all workflows)',
+          description: 'Universal skills (apply to all workflows). Load with get_skill.',
         },
         workflows: workflows.map(w => ({
           id: w.id, title: w.title,

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -5,7 +5,6 @@ import { withAuditLog } from '../logging.js';
 
 import { listWorkflows, loadWorkflow } from '../loaders/workflow-loader.js';
 import { listResources, readResourceRaw, listWorkflowsWithResources } from '../loaders/resource-loader.js';
-import { listActivities, readActivity, readActivityIndex } from '../loaders/activity-loader.js';
 import { listSkills, listUniversalSkills, listWorkflowSkills, readSkill, readSkillIndex } from '../loaders/skill-loader.js';
 import { readRules } from '../loaders/rules-loader.js';
 import { createSessionToken, decodeSessionToken, advanceToken, sessionTokenParam } from '../utils/session.js';
@@ -22,24 +21,6 @@ function withAdvancedToken(
 }
 
 export function registerResourceTools(server: McpServer, config: ServerConfig): void {
-
-  // ============== Activity Tools ==============
-
-  server.tool(
-    'get_activity',
-    'Get a specific activity by ID for detailed flow guidance',
-    { ...sessionTokenParam },
-    withAuditLog('get_activity', async ({ session_token }) => {
-      const { act } = decodeSessionToken(session_token);
-      if (!act) throw new Error('No activity set in session token');
-      const result = await readActivity(config.workflowDir, act);
-      if (!result.success) throw result.error;
-      return withAdvancedToken(
-        { content: [{ type: 'text' as const, text: JSON.stringify(result.value, null, 2) }] },
-        session_token,
-      );
-    })
-  );
 
   // ============== Session Tools ==============
 

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -135,30 +135,6 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
     })
   );
 
-  // ============== Resource Tools ==============
-
-  server.tool(
-    'list_resources',
-    'List all resources available for a workflow',
-    { ...sessionTokenParam, workflow_id: z.string().describe('Workflow ID') },
-    withAuditLog('list_resources', async ({ session_token, workflow_id }) => {
-      const token = await decodeSessionToken(session_token);
-      const resources = await listResources(config.workflowDir, workflow_id);
-      const result = resources.map(r => ({
-        index: r.index, name: r.name, title: r.title, format: r.format,
-      }));
-
-      const validation = buildValidation(
-        validateWorkflowConsistency(token, workflow_id),
-      );
-
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
-        _meta: { session_token: await advanceToken(session_token, { wf: workflow_id }), validation },
-      };
-    })
-  );
-
   // ============== Discovery Tool ==============
 
   server.tool(

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -3,7 +3,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ServerConfig } from '../config.js';
 import { withAuditLog } from '../logging.js';
 
-import { listWorkflows, loadWorkflow } from '../loaders/workflow-loader.js';
+import { listWorkflows, loadWorkflow, getActivity } from '../loaders/workflow-loader.js';
 import { listResources, readResourceRaw, listWorkflowsWithResources } from '../loaders/resource-loader.js';
 import { listUniversalSkills, listWorkflowSkills, readSkill } from '../loaders/skill-loader.js';
 import { readRules } from '../loaders/rules-loader.js';
@@ -47,8 +47,43 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
   // ============== Skill Tools ==============
 
   server.tool(
+    'get_skills',
+    'Get all skills for an activity in one call (primary + supporting). More efficient than multiple get_skill calls.',
+    {
+      ...sessionTokenParam,
+      workflow_id: z.string().describe('Workflow ID'),
+      activity_id: z.string().describe('Activity ID to load skills for'),
+    },
+    withAuditLog('get_skills', async ({ session_token, workflow_id, activity_id }) => {
+      const token = await decodeSessionToken(session_token);
+      const wfResult = await loadWorkflow(config.workflowDir, workflow_id);
+      if (!wfResult.success) throw wfResult.error;
+
+      const activity = getActivity(wfResult.value, activity_id);
+      if (!activity) throw new Error(`Activity not found: ${activity_id}`);
+
+      const skillIds = [activity.skills.primary, ...(activity.skills.supporting ?? [])];
+      const skills: Record<string, unknown> = {};
+      for (const sid of skillIds) {
+        const result = await readSkill(sid, config.workflowDir, workflow_id);
+        if (result.success) skills[sid] = result.value;
+      }
+
+      const validation = buildValidation(
+        validateWorkflowConsistency(token, workflow_id),
+        validateWorkflowVersion(token, wfResult.value),
+      );
+
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ activity_id, skills }, null, 2) }],
+        _meta: { session_token: await advanceToken(session_token, { wf: workflow_id, act: activity_id }), validation },
+      };
+    })
+  );
+
+  server.tool(
     'get_skill',
-    'Get a specific skill for tool orchestration guidance. Checks workflow-specific skills first, then universal.',
+    'Get a single skill by ID. For loading all skills for an activity at once, use get_skills instead.',
     {
       ...sessionTokenParam,
       workflow_id: z.string().describe('Workflow ID'),

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -48,7 +48,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
 
   server.tool(
     'get_skills',
-    'Get all skills for an activity in one call (primary + supporting). More efficient than multiple get_skill calls.',
+    'Get all skills and their associated resources for an activity in one call. Returns primary + supporting skills with full content, plus all resources referenced by those skills.',
     {
       ...sessionTokenParam,
       workflow_id: z.string().describe('Workflow ID'),
@@ -64,9 +64,23 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
 
       const skillIds = [activity.skills.primary, ...(activity.skills.supporting ?? [])];
       const skills: Record<string, unknown> = {};
+      const resourceIndices = new Set<string>();
+
       for (const sid of skillIds) {
         const result = await readSkill(sid, config.workflowDir, workflow_id);
-        if (result.success) skills[sid] = result.value;
+        if (result.success) {
+          skills[sid] = result.value;
+          const skillResources = (result.value as Record<string, unknown>)['resources'] as string[] | undefined;
+          if (skillResources) {
+            for (const idx of skillResources) resourceIndices.add(idx);
+          }
+        }
+      }
+
+      const resources: Record<string, string> = {};
+      for (const idx of resourceIndices) {
+        const result = await readResourceRaw(config.workflowDir, workflow_id, idx);
+        if (result.success) resources[idx] = result.value.content;
       }
 
       const validation = buildValidation(
@@ -75,7 +89,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
       );
 
       return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ activity_id, skills }, null, 2) }],
+        content: [{ type: 'text' as const, text: JSON.stringify({ activity_id, skills, resources }, null, 2) }],
         _meta: { session_token: await advanceToken(session_token, { wf: workflow_id, act: activity_id }), validation },
       };
     })

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -28,7 +28,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
       if (!rulesResult.success) throw rulesResult.error;
 
       const workflow = wfResult.value;
-      const token = createSessionToken(workflow_id, workflow.version ?? '0.0.0');
+      const token = await createSessionToken(workflow_id, workflow.version ?? '0.0.0');
 
       const response = {
         rules: rulesResult.value,
@@ -55,7 +55,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
       skill_id: z.string().describe('Skill ID (e.g., workflow-execution, activity-resolution)'),
     },
     withAuditLog('get_skill', async ({ session_token, workflow_id, skill_id }) => {
-      const token = decodeSessionToken(session_token);
+      const token = await decodeSessionToken(session_token);
       const result = await readSkill(skill_id, config.workflowDir, workflow_id);
       if (!result.success) throw result.error;
 
@@ -68,7 +68,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
 
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(result.value, null, 2) }],
-        _meta: { session_token: advanceToken(session_token, { wf: workflow_id, skill: skill_id }), validation },
+        _meta: { session_token: await advanceToken(session_token, { wf: workflow_id, skill: skill_id }), validation },
       };
     })
   );
@@ -80,7 +80,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
     'List all resources available for a workflow',
     { ...sessionTokenParam, workflow_id: z.string().describe('Workflow ID') },
     withAuditLog('list_resources', async ({ session_token, workflow_id }) => {
-      const token = decodeSessionToken(session_token);
+      const token = await decodeSessionToken(session_token);
       const resources = await listResources(config.workflowDir, workflow_id);
       const result = resources.map(r => ({
         index: r.index, name: r.name, title: r.title, format: r.format,
@@ -92,7 +92,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
 
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
-        _meta: { session_token: advanceToken(session_token, { wf: workflow_id }), validation },
+        _meta: { session_token: await advanceToken(session_token, { wf: workflow_id }), validation },
       };
     })
   );
@@ -106,7 +106,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
       index: z.string().describe('Resource index (e.g., 0, 00, 01)'),
     },
     withAuditLog('get_resource', async ({ session_token, workflow_id, index }) => {
-      const token = decodeSessionToken(session_token);
+      const token = await decodeSessionToken(session_token);
       const result = await readResourceRaw(config.workflowDir, workflow_id, index);
       if (!result.success) throw result.error;
 
@@ -116,7 +116,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
 
       return {
         content: [{ type: 'text' as const, text: result.value.content }],
-        _meta: { session_token: advanceToken(session_token, { wf: workflow_id }), validation },
+        _meta: { session_token: await advanceToken(session_token, { wf: workflow_id }), validation },
       };
     })
   );
@@ -128,6 +128,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
     'Discover all available resources: workflows, resources, skills',
     { ...sessionTokenParam },
     withAuditLog('discover_resources', async ({ session_token }) => {
+      await decodeSessionToken(session_token);
       const workflows = await listWorkflows(config.workflowDir);
       const workflowsWithResources = await listWorkflowsWithResources(config.workflowDir);
       const universalSkills = await listUniversalSkills(config.workflowDir);
@@ -161,7 +162,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
 
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(discovery, null, 2) }],
-        _meta: { session_token: advanceToken(session_token), validation: buildValidation() },
+        _meta: { session_token: await advanceToken(session_token), validation: buildValidation() },
       };
     })
   );

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -115,8 +115,21 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
         wfResult.success && token.act ? validateSkillAssociation(wfResult.value, token.act, skill_id) : null,
       );
 
+      const skillResources = (result.value as Record<string, unknown>)['resources'] as string[] | undefined;
+      const resources: Record<string, string> = {};
+      if (skillResources) {
+        for (const idx of skillResources) {
+          const resResult = await readResourceRaw(config.workflowDir, workflow_id, idx);
+          if (resResult.success) resources[idx] = resResult.value.content;
+        }
+      }
+
+      const response = Object.keys(resources).length > 0
+        ? { ...result.value as Record<string, unknown>, _resources: resources }
+        : result.value;
+
       return {
-        content: [{ type: 'text' as const, text: JSON.stringify(result.value, null, 2) }],
+        content: [{ type: 'text' as const, text: JSON.stringify(response, null, 2) }],
         _meta: { session_token: await advanceToken(session_token, { wf: workflow_id, skill: skill_id }), validation },
       };
     })
@@ -141,30 +154,6 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
 
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
-        _meta: { session_token: await advanceToken(session_token, { wf: workflow_id }), validation },
-      };
-    })
-  );
-
-  server.tool(
-    'get_resource',
-    'Get a specific resource by index',
-    {
-      ...sessionTokenParam,
-      workflow_id: z.string().describe('Workflow ID'),
-      index: z.string().describe('Resource index (e.g., 0, 00, 01)'),
-    },
-    withAuditLog('get_resource', async ({ session_token, workflow_id, index }) => {
-      const token = await decodeSessionToken(session_token);
-      const result = await readResourceRaw(config.workflowDir, workflow_id, index);
-      if (!result.success) throw result.error;
-
-      const validation = buildValidation(
-        validateWorkflowConsistency(token, workflow_id),
-      );
-
-      return {
-        content: [{ type: 'text' as const, text: result.value.content }],
         _meta: { session_token: await advanceToken(session_token, { wf: workflow_id }), validation },
       };
     })

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -3,41 +3,41 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ServerConfig } from '../config.js';
 import { withAuditLog } from '../logging.js';
 
-// Loaders
-import { listWorkflows } from '../loaders/workflow-loader.js';
+import { listWorkflows, loadWorkflow } from '../loaders/workflow-loader.js';
 import { listResources, readResourceRaw, listWorkflowsWithResources } from '../loaders/resource-loader.js';
 import { listActivities, readActivity, readActivityIndex } from '../loaders/activity-loader.js';
 import { listSkills, listUniversalSkills, listWorkflowSkills, readSkill, readSkillIndex } from '../loaders/skill-loader.js';
 import { readRules } from '../loaders/rules-loader.js';
-import { generateSessionToken, sessionTokenParam } from '../utils/session.js';
+import { createSessionToken, decodeSessionToken, advanceToken, sessionTokenParam } from '../utils/session.js';
+
+function withAdvancedToken(
+  result: { content: Array<{ type: 'text'; text: string }> },
+  token: string,
+  updates?: { act?: string },
+) {
+  return {
+    ...result,
+    _meta: { session_token: advanceToken(token, updates) },
+  };
+}
 
 export function registerResourceTools(server: McpServer, config: ServerConfig): void {
-  
+
   // ============== Activity Tools ==============
-  
-  server.tool(
-    'match_goal',
-    'Match a user goal to an available workflow. Returns quick_match patterns and an activity index for goal-to-workflow resolution.',
-    {},
-    withAuditLog('match_goal', async () => {
-      const result = await readActivityIndex(config.workflowDir);
-      if (!result.success) {
-        // Fall back to listing activities
-        const activities = await listActivities(config.workflowDir);
-        return { content: [{ type: 'text', text: JSON.stringify(activities, null, 2) }] };
-      }
-      return { content: [{ type: 'text', text: JSON.stringify(result.value, null, 2) }] };
-    })
-  );
 
   server.tool(
     'get_activity',
     'Get a specific activity by ID for detailed flow guidance',
-    { ...sessionTokenParam, activity_id: z.string().describe('Activity ID (e.g., start-workflow, resume-workflow)') },
-    withAuditLog('get_activity', async ({ activity_id }) => {
-      const result = await readActivity(config.workflowDir, activity_id);
+    { ...sessionTokenParam },
+    withAuditLog('get_activity', async ({ session_token }) => {
+      const { act } = decodeSessionToken(session_token);
+      if (!act) throw new Error('No activity set in session token');
+      const result = await readActivity(config.workflowDir, act);
       if (!result.success) throw result.error;
-      return { content: [{ type: 'text', text: JSON.stringify(result.value, null, 2) }] };
+      return withAdvancedToken(
+        { content: [{ type: 'text' as const, text: JSON.stringify(result.value, null, 2) }] },
+        session_token,
+      );
     })
   );
 
@@ -45,23 +45,32 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
 
   server.tool(
     'start_session',
-    'Start a workflow session. Returns agent behavioral rules and a session token for subsequent tool calls.',
+    'Start a workflow session. Accepts a workflow ID (from list_workflows). Returns agent rules, workflow metadata, and an opaque session token for all subsequent tool calls.',
     {
-      workflow_version: z.string().describe('Workflow version to embed in the session token (e.g., "3.4.0")'),
+      workflow_id: z.string().describe('Workflow ID to start a session for (e.g., "work-package")'),
     },
-    withAuditLog('start_session', async ({ workflow_version }) => {
-      const result = await readRules(config.workflowDir);
-      if (!result.success) throw result.error;
-      const token = generateSessionToken(workflow_version);
+    withAuditLog('start_session', async ({ workflow_id }) => {
+      const wfResult = await loadWorkflow(config.workflowDir, workflow_id);
+      if (!wfResult.success) throw wfResult.error;
+
+      const rulesResult = await readRules(config.workflowDir);
+      if (!rulesResult.success) throw rulesResult.error;
+
+      const workflow = wfResult.value;
+      const initialActivity = (workflow as Record<string, unknown>)['initialActivity'] as string | undefined;
+      const token = createSessionToken(workflow_id, workflow.version ?? '0.0.0', initialActivity ?? '');
+
       const response = {
-        rules: result.value,
-        session: {
-          token,
-          created_at: new Date().toISOString(),
-          server_version: config.serverVersion,
+        rules: rulesResult.value,
+        workflow: {
+          id: workflow.id,
+          version: workflow.version,
+          title: workflow.title,
+          description: workflow.description,
         },
+        session_token: token,
       };
-      return { content: [{ type: 'text', text: JSON.stringify(response, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify(response, null, 2) }] };
     })
   );
 
@@ -69,55 +78,55 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
 
   server.tool(
     'get_skills',
-    'Get the skill index - summary of all available skills with capabilities. Returns universal skills and workflow-specific skills grouped by workflow.',
+    'Get the skill index - summary of all available skills with capabilities.',
     { ...sessionTokenParam },
-    withAuditLog('get_skills', async () => {
+    withAuditLog('get_skills', async ({ session_token }) => {
       const result = await readSkillIndex(config.workflowDir);
       if (!result.success) {
-        // Fall back to listing skills
         const skills = await listSkills(config.workflowDir);
-        return { content: [{ type: 'text', text: JSON.stringify(skills, null, 2) }] };
+        return withAdvancedToken(
+          { content: [{ type: 'text' as const, text: JSON.stringify(skills, null, 2) }] },
+          session_token,
+        );
       }
-      return { content: [{ type: 'text', text: JSON.stringify(result.value, null, 2) }] };
+      return withAdvancedToken(
+        { content: [{ type: 'text' as const, text: JSON.stringify(result.value, null, 2) }] },
+        session_token,
+      );
     })
   );
 
   server.tool(
     'list_skills',
-    'List all available skills - both universal (from meta workflow) and workflow-specific. Optionally filter by workflow.',
-    { 
-      ...sessionTokenParam,
-      workflow_id: z.string().optional().describe('Optional workflow ID to filter workflow-specific skills')
-    },
-    withAuditLog('list_skills', async ({ workflow_id }) => {
-      if (workflow_id) {
-        // List skills for a specific workflow + universal skills
-        const workflowSkills = await listWorkflowSkills(config.workflowDir, workflow_id);
-        const universalSkills = await listUniversalSkills(config.workflowDir);
-        const result = {
-          universal: universalSkills,
-          workflow: workflowSkills,
-        };
-        return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-      }
-      // List all skills
-      const skills = await listSkills(config.workflowDir);
-      return { content: [{ type: 'text', text: JSON.stringify(skills, null, 2) }] };
+    'List all available skills - both universal and workflow-specific for the session workflow.',
+    { ...sessionTokenParam },
+    withAuditLog('list_skills', async ({ session_token }) => {
+      const { wf } = decodeSessionToken(session_token);
+      const workflowSkills = await listWorkflowSkills(config.workflowDir, wf);
+      const universalSkills = await listUniversalSkills(config.workflowDir);
+      const result = { universal: universalSkills, workflow: workflowSkills };
+      return withAdvancedToken(
+        { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] },
+        session_token,
+      );
     })
   );
 
   server.tool(
     'get_skill',
-    'Get a specific skill for tool orchestration guidance. Workflow-specific skills are checked first, then universal.',
-    { 
+    'Get a specific skill for tool orchestration guidance. Checks workflow-specific skills first, then universal.',
+    {
       ...sessionTokenParam,
       skill_id: z.string().describe('Skill ID (e.g., workflow-execution, activity-resolution)'),
-      workflow_id: z.string().optional().describe('Optional workflow ID to look for workflow-specific skill first')
     },
-    withAuditLog('get_skill', async ({ skill_id, workflow_id }) => {
-      const result = await readSkill(skill_id, config.workflowDir, workflow_id);
+    withAuditLog('get_skill', async ({ session_token, skill_id }) => {
+      const { wf } = decodeSessionToken(session_token);
+      const result = await readSkill(skill_id, config.workflowDir, wf);
       if (!result.success) throw result.error;
-      return { content: [{ type: 'text', text: JSON.stringify(result.value, null, 2) }] };
+      return withAdvancedToken(
+        { content: [{ type: 'text' as const, text: JSON.stringify(result.value, null, 2) }] },
+        session_token,
+      );
     })
   );
 
@@ -125,32 +134,36 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
 
   server.tool(
     'list_workflow_resources',
-    'List all resources available for a workflow',
-    { ...sessionTokenParam, workflow_id: z.string().describe('Workflow ID (e.g., work-package)') },
-    withAuditLog('list_workflow_resources', async ({ workflow_id }) => {
-      const resources = await listResources(config.workflowDir, workflow_id);
+    'List all resources available for the session workflow',
+    { ...sessionTokenParam },
+    withAuditLog('list_workflow_resources', async ({ session_token }) => {
+      const { wf } = decodeSessionToken(session_token);
+      const resources = await listResources(config.workflowDir, wf);
       const result = resources.map(r => ({
-        index: r.index,
-        name: r.name,
-        title: r.title,
-        format: r.format,
+        index: r.index, name: r.name, title: r.title, format: r.format,
       }));
-      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      return withAdvancedToken(
+        { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] },
+        session_token,
+      );
     })
   );
 
   server.tool(
     'get_resource',
-    'Get a specific resource by index',
-    { 
+    'Get a specific resource by index from the session workflow',
+    {
       ...sessionTokenParam,
-      workflow_id: z.string().describe('Workflow ID (e.g., work-package)'),
-      index: z.string().describe('Resource index (e.g., 0, 00, 01)')
+      index: z.string().describe('Resource index (e.g., 0, 00, 01)'),
     },
-    withAuditLog('get_resource', async ({ workflow_id, index }) => {
-      const result = await readResourceRaw(config.workflowDir, workflow_id, index);
+    withAuditLog('get_resource', async ({ session_token, index }) => {
+      const { wf } = decodeSessionToken(session_token);
+      const result = await readResourceRaw(config.workflowDir, wf, index);
       if (!result.success) throw result.error;
-      return { content: [{ type: 'text', text: result.value.content }] };
+      return withAdvancedToken(
+        { content: [{ type: 'text' as const, text: result.value.content }] },
+        session_token,
+      );
     })
   );
 
@@ -158,17 +171,17 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
 
   server.tool(
     'discover_resources',
-    'Discover all available resources: workflows, resources, activities, skills',
+    'Discover all available resources: workflows, resources, skills',
     { ...sessionTokenParam },
-    withAuditLog('discover_resources', async () => {
+    withAuditLog('discover_resources', async ({ session_token }) => {
       const workflows = await listWorkflows(config.workflowDir);
       const workflowsWithResources = await listWorkflowsWithResources(config.workflowDir);
       const universalSkills = await listUniversalSkills(config.workflowDir);
-      
+
       const discovery: Record<string, unknown> = {
-        activities: {
-          tool: 'match_goal',
-          description: 'Match user goal to a workflow via activity index',
+        bootstrap: {
+          tool: 'list_workflows',
+          description: 'List available workflows, then call start_session with the chosen workflow_id',
         },
         universal_skills: {
           items: universalSkills.map(s => s.id),
@@ -176,36 +189,27 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
           description: 'Universal skills (apply to all workflows)',
         },
         workflows: workflows.map(w => ({
-          id: w.id,
-          title: w.title,
-          tool: `get_workflow { workflow_id: "${w.id}" }`,
+          id: w.id, title: w.title,
         })),
       };
-      
-      // Add workflow-specific resources
+
       for (const workflowId of workflowsWithResources) {
         const resources = await listResources(config.workflowDir, workflowId);
         const workflowSkills = await listWorkflowSkills(config.workflowDir, workflowId);
-        
+
         const workflowDiscovery: Record<string, unknown> = {
-          resources: {
-            count: resources.length,
-            tool: `list_workflow_resources { workflow_id: "${workflowId}" }`,
-          },
+          resources: { count: resources.length },
         };
-        
         if (workflowSkills.length > 0) {
-          workflowDiscovery['skills'] = {
-            items: workflowSkills.map(s => s.id),
-            tool: `list_skills { workflow_id: "${workflowId}" }`,
-            get: `get_skill { skill_id: "...", workflow_id: "${workflowId}" }`,
-          };
+          workflowDiscovery['skills'] = { items: workflowSkills.map(s => s.id) };
         }
-        
         discovery[workflowId] = workflowDiscovery;
       }
-      
-      return { content: [{ type: 'text', text: JSON.stringify(discovery, null, 2) }] };
+
+      return withAdvancedToken(
+        { content: [{ type: 'text' as const, text: JSON.stringify(discovery, null, 2) }] },
+        session_token,
+      );
     })
   );
 }

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -78,10 +78,10 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
   // ============== Resource Tools ==============
 
   server.tool(
-    'list_workflow_resources',
+    'list_resources',
     'List all resources available for the session workflow',
     { ...sessionTokenParam },
-    withAuditLog('list_workflow_resources', async ({ session_token }) => {
+    withAuditLog('list_resources', async ({ session_token }) => {
       const { wf } = decodeSessionToken(session_token);
       const resources = await listResources(config.workflowDir, wf);
       const result = resources.map(r => ({

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -9,7 +9,7 @@ import { listResources, readResourceRaw, listWorkflowsWithResources } from '../l
 import { listActivities, readActivity, readActivityIndex } from '../loaders/activity-loader.js';
 import { listSkills, listUniversalSkills, listWorkflowSkills, readSkill, readSkillIndex } from '../loaders/skill-loader.js';
 import { readRules } from '../loaders/rules-loader.js';
-import { generateSessionToken } from '../utils/session.js';
+import { generateSessionToken, sessionTokenParam } from '../utils/session.js';
 
 export function registerResourceTools(server: McpServer, config: ServerConfig): void {
   
@@ -33,7 +33,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
   server.tool(
     'get_activity',
     'Get a specific activity by ID for detailed flow guidance',
-    { activity_id: z.string().describe('Activity ID (e.g., start-workflow, resume-workflow)') },
+    { ...sessionTokenParam, activity_id: z.string().describe('Activity ID (e.g., start-workflow, resume-workflow)') },
     withAuditLog('get_activity', async ({ activity_id }) => {
       const result = await readActivity(config.workflowDir, activity_id);
       if (!result.success) throw result.error;
@@ -70,7 +70,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
   server.tool(
     'get_skills',
     'Get the skill index - summary of all available skills with capabilities. Returns universal skills and workflow-specific skills grouped by workflow.',
-    {},
+    { ...sessionTokenParam },
     withAuditLog('get_skills', async () => {
       const result = await readSkillIndex(config.workflowDir);
       if (!result.success) {
@@ -86,6 +86,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
     'list_skills',
     'List all available skills - both universal (from meta workflow) and workflow-specific. Optionally filter by workflow.',
     { 
+      ...sessionTokenParam,
       workflow_id: z.string().optional().describe('Optional workflow ID to filter workflow-specific skills')
     },
     withAuditLog('list_skills', async ({ workflow_id }) => {
@@ -109,6 +110,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
     'get_skill',
     'Get a specific skill for tool orchestration guidance. Workflow-specific skills are checked first, then universal.',
     { 
+      ...sessionTokenParam,
       skill_id: z.string().describe('Skill ID (e.g., workflow-execution, activity-resolution)'),
       workflow_id: z.string().optional().describe('Optional workflow ID to look for workflow-specific skill first')
     },
@@ -124,7 +126,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
   server.tool(
     'list_workflow_resources',
     'List all resources available for a workflow',
-    { workflow_id: z.string().describe('Workflow ID (e.g., work-package)') },
+    { ...sessionTokenParam, workflow_id: z.string().describe('Workflow ID (e.g., work-package)') },
     withAuditLog('list_workflow_resources', async ({ workflow_id }) => {
       const resources = await listResources(config.workflowDir, workflow_id);
       const result = resources.map(r => ({
@@ -141,6 +143,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
     'get_resource',
     'Get a specific resource by index',
     { 
+      ...sessionTokenParam,
       workflow_id: z.string().describe('Workflow ID (e.g., work-package)'),
       index: z.string().describe('Resource index (e.g., 0, 00, 01)')
     },
@@ -156,7 +159,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
   server.tool(
     'discover_resources',
     'Discover all available resources: workflows, resources, activities, skills',
-    {},
+    { ...sessionTokenParam },
     withAuditLog('discover_resources', async () => {
       const workflows = await listWorkflows(config.workflowDir);
       const workflowsWithResources = await listWorkflowsWithResources(config.workflowDir);

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -15,10 +15,10 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
   // ============== Activity Tools ==============
   
   server.tool(
-    'get_activities',
-    'Get the activity index - the primary entry point for workflow execution. Returns quick_match patterns to identify user activity.',
+    'match_goal',
+    'Match a user goal to an available workflow. Returns quick_match patterns and an activity index for goal-to-workflow resolution.',
     {},
-    withAuditLog('get_activities', async () => {
+    withAuditLog('match_goal', async () => {
       const result = await readActivityIndex(config.workflowDir);
       if (!result.success) {
         // Fall back to listing activities
@@ -152,8 +152,8 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
       
       const discovery: Record<string, unknown> = {
         activities: {
-          tool: 'get_activities',
-          description: 'Activity index - primary entry point for workflow execution',
+          tool: 'match_goal',
+          description: 'Match user goal to a workflow via activity index',
         },
         universal_skills: {
           items: universalSkills.map(s => s.id),

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -9,6 +9,7 @@ import { listResources, readResourceRaw, listWorkflowsWithResources } from '../l
 import { listActivities, readActivity, readActivityIndex } from '../loaders/activity-loader.js';
 import { listSkills, listUniversalSkills, listWorkflowSkills, readSkill, readSkillIndex } from '../loaders/skill-loader.js';
 import { readRules } from '../loaders/rules-loader.js';
+import { generateSessionToken } from '../utils/session.js';
 
 export function registerResourceTools(server: McpServer, config: ServerConfig): void {
   
@@ -40,16 +41,27 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
     })
   );
 
-  // ============== Rules Tools ==============
+  // ============== Session Tools ==============
 
   server.tool(
-    'get_rules',
-    'Get global agent rules - behavioral guidelines that apply to all workflow executions. Call this after get_activities and before executing any workflow.',
-    {},
-    withAuditLog('get_rules', async () => {
+    'start_session',
+    'Start a workflow session. Returns agent behavioral rules and a session token for subsequent tool calls.',
+    {
+      workflow_version: z.string().describe('Workflow version to embed in the session token (e.g., "3.4.0")'),
+    },
+    withAuditLog('start_session', async ({ workflow_version }) => {
       const result = await readRules(config.workflowDir);
       if (!result.success) throw result.error;
-      return { content: [{ type: 'text', text: JSON.stringify(result.value, null, 2) }] };
+      const token = generateSessionToken(workflow_version);
+      const response = {
+        rules: result.value,
+        session: {
+          token,
+          created_at: new Date().toISOString(),
+          server_version: config.serverVersion,
+        },
+      };
+      return { content: [{ type: 'text', text: JSON.stringify(response, null, 2) }] };
     })
   );
 

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -8,17 +8,7 @@ import { listResources, readResourceRaw, listWorkflowsWithResources } from '../l
 import { listUniversalSkills, listWorkflowSkills, readSkill } from '../loaders/skill-loader.js';
 import { readRules } from '../loaders/rules-loader.js';
 import { createSessionToken, decodeSessionToken, advanceToken, sessionTokenParam } from '../utils/session.js';
-
-function withAdvancedToken(
-  result: { content: Array<{ type: 'text'; text: string }> },
-  token: string,
-  updates?: { act?: string },
-) {
-  return {
-    ...result,
-    _meta: { session_token: advanceToken(token, updates) },
-  };
-}
+import { buildValidation, validateWorkflowConsistency, validateWorkflowVersion, validateSkillAssociation } from '../utils/validation.js';
 
 export function registerResourceTools(server: McpServer, config: ServerConfig): void {
 
@@ -38,8 +28,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
       if (!rulesResult.success) throw rulesResult.error;
 
       const workflow = wfResult.value;
-      const initialActivity = (workflow as Record<string, unknown>)['initialActivity'] as string | undefined;
-      const token = createSessionToken(workflow_id, workflow.version ?? '0.0.0', initialActivity ?? '');
+      const token = createSessionToken(workflow_id, workflow.version ?? '0.0.0');
 
       const response = {
         rules: rulesResult.value,
@@ -62,16 +51,25 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
     'Get a specific skill for tool orchestration guidance. Checks workflow-specific skills first, then universal.',
     {
       ...sessionTokenParam,
+      workflow_id: z.string().describe('Workflow ID'),
       skill_id: z.string().describe('Skill ID (e.g., workflow-execution, activity-resolution)'),
     },
-    withAuditLog('get_skill', async ({ session_token, skill_id }) => {
-      const { wf } = decodeSessionToken(session_token);
-      const result = await readSkill(skill_id, config.workflowDir, wf);
+    withAuditLog('get_skill', async ({ session_token, workflow_id, skill_id }) => {
+      const token = decodeSessionToken(session_token);
+      const result = await readSkill(skill_id, config.workflowDir, workflow_id);
       if (!result.success) throw result.error;
-      return withAdvancedToken(
-        { content: [{ type: 'text' as const, text: JSON.stringify(result.value, null, 2) }] },
-        session_token,
+
+      const wfResult = await loadWorkflow(config.workflowDir, workflow_id);
+      const validation = buildValidation(
+        validateWorkflowConsistency(token, workflow_id),
+        wfResult.success ? validateWorkflowVersion(token, wfResult.value) : null,
+        wfResult.success && token.act ? validateSkillAssociation(wfResult.value, token.act, skill_id) : null,
       );
+
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result.value, null, 2) }],
+        _meta: { session_token: advanceToken(session_token, { wf: workflow_id, skill: skill_id }), validation },
+      };
     })
   );
 
@@ -79,36 +77,47 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
 
   server.tool(
     'list_resources',
-    'List all resources available for the session workflow',
-    { ...sessionTokenParam },
-    withAuditLog('list_resources', async ({ session_token }) => {
-      const { wf } = decodeSessionToken(session_token);
-      const resources = await listResources(config.workflowDir, wf);
+    'List all resources available for a workflow',
+    { ...sessionTokenParam, workflow_id: z.string().describe('Workflow ID') },
+    withAuditLog('list_resources', async ({ session_token, workflow_id }) => {
+      const token = decodeSessionToken(session_token);
+      const resources = await listResources(config.workflowDir, workflow_id);
       const result = resources.map(r => ({
         index: r.index, name: r.name, title: r.title, format: r.format,
       }));
-      return withAdvancedToken(
-        { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] },
-        session_token,
+
+      const validation = buildValidation(
+        validateWorkflowConsistency(token, workflow_id),
       );
+
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+        _meta: { session_token: advanceToken(session_token, { wf: workflow_id }), validation },
+      };
     })
   );
 
   server.tool(
     'get_resource',
-    'Get a specific resource by index from the session workflow',
+    'Get a specific resource by index',
     {
       ...sessionTokenParam,
+      workflow_id: z.string().describe('Workflow ID'),
       index: z.string().describe('Resource index (e.g., 0, 00, 01)'),
     },
-    withAuditLog('get_resource', async ({ session_token, index }) => {
-      const { wf } = decodeSessionToken(session_token);
-      const result = await readResourceRaw(config.workflowDir, wf, index);
+    withAuditLog('get_resource', async ({ session_token, workflow_id, index }) => {
+      const token = decodeSessionToken(session_token);
+      const result = await readResourceRaw(config.workflowDir, workflow_id, index);
       if (!result.success) throw result.error;
-      return withAdvancedToken(
-        { content: [{ type: 'text' as const, text: result.value.content }] },
-        session_token,
+
+      const validation = buildValidation(
+        validateWorkflowConsistency(token, workflow_id),
       );
+
+      return {
+        content: [{ type: 'text' as const, text: result.value.content }],
+        _meta: { session_token: advanceToken(session_token, { wf: workflow_id }), validation },
+      };
     })
   );
 
@@ -150,10 +159,10 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
         discovery[workflowId] = workflowDiscovery;
       }
 
-      return withAdvancedToken(
-        { content: [{ type: 'text' as const, text: JSON.stringify(discovery, null, 2) }] },
-        session_token,
-      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(discovery, null, 2) }],
+        _meta: { session_token: advanceToken(session_token), validation: buildValidation() },
+      };
     })
   );
 }

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -3,9 +3,9 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ServerConfig } from '../config.js';
 import { withAuditLog } from '../logging.js';
 
-import { listWorkflows, loadWorkflow, getActivity } from '../loaders/workflow-loader.js';
-import { listResources, readResourceRaw, listWorkflowsWithResources } from '../loaders/resource-loader.js';
-import { listUniversalSkills, listWorkflowSkills, readSkill } from '../loaders/skill-loader.js';
+import { loadWorkflow, getActivity } from '../loaders/workflow-loader.js';
+import { readResourceRaw } from '../loaders/resource-loader.js';
+import { readSkill } from '../loaders/skill-loader.js';
 import { readRules } from '../loaders/rules-loader.js';
 import { createSessionToken, decodeSessionToken, advanceToken, sessionTokenParam } from '../utils/session.js';
 import { buildValidation, validateWorkflowConsistency, validateWorkflowVersion, validateSkillAssociation } from '../utils/validation.js';
@@ -135,49 +135,4 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
     })
   );
 
-  // ============== Discovery Tool ==============
-
-  server.tool(
-    'discover_resources',
-    'Discover all available resources: workflows, resources, skills',
-    { ...sessionTokenParam },
-    withAuditLog('discover_resources', async ({ session_token }) => {
-      await decodeSessionToken(session_token);
-      const workflows = await listWorkflows(config.workflowDir);
-      const workflowsWithResources = await listWorkflowsWithResources(config.workflowDir);
-      const universalSkills = await listUniversalSkills(config.workflowDir);
-
-      const discovery: Record<string, unknown> = {
-        bootstrap: {
-          tool: 'list_workflows',
-          description: 'List available workflows, then call start_session with the chosen workflow_id',
-        },
-        universal_skills: {
-          items: universalSkills.map(s => s.id),
-          description: 'Universal skills (apply to all workflows). Load with get_skill.',
-        },
-        workflows: workflows.map(w => ({
-          id: w.id, title: w.title,
-        })),
-      };
-
-      for (const workflowId of workflowsWithResources) {
-        const resources = await listResources(config.workflowDir, workflowId);
-        const workflowSkills = await listWorkflowSkills(config.workflowDir, workflowId);
-
-        const workflowDiscovery: Record<string, unknown> = {
-          resources: { count: resources.length },
-        };
-        if (workflowSkills.length > 0) {
-          workflowDiscovery['skills'] = { items: workflowSkills.map(s => s.id) };
-        }
-        discovery[workflowId] = workflowDiscovery;
-      }
-
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify(discovery, null, 2) }],
-        _meta: { session_token: await advanceToken(session_token), validation: buildValidation() },
-      };
-    })
-  );
 }

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -7,6 +7,7 @@ import type { StateSaveFile } from '../schema/state.schema.js';
 import { decodeToon, encodeToon } from '../utils/toon.js';
 import { withAuditLog } from '../logging.js';
 import { sessionTokenParam } from '../utils/session.js';
+import { getOrCreateServerKey, encryptToken, decryptToken } from '../utils/crypto.js';
 
 const STATE_FILENAME = 'workflow-state.toon';
 
@@ -32,6 +33,12 @@ export function registerStateTools(server: McpServer): void {
         throw new Error(`State validation failed: ${stateResult.error.issues.map(i => `${i.path.join('.')}: ${i.message}`).join('; ')}`);
       }
       const state = stateResult.data;
+
+      if (typeof state.variables['session_token'] === 'string') {
+        const key = await getOrCreateServerKey();
+        state.variables['session_token'] = encryptToken(state.variables['session_token'] as string, key);
+        state.variables['_session_token_encrypted'] = true;
+      }
 
       const saveFile: StateSaveFile = {
         id: generateSaveId(),
@@ -76,7 +83,15 @@ export function registerStateTools(server: McpServer): void {
       if (!result.success) {
         throw new Error(`State file validation failed: ${result.error.issues.map(i => `${i.path.join('.')}: ${i.message}`).join('; ')}`);
       }
-      return { content: [{ type: 'text' as const, text: JSON.stringify(result.data, null, 2) }] };
+
+      const restored = result.data;
+      if (restored.state.variables['_session_token_encrypted'] && typeof restored.state.variables['session_token'] === 'string') {
+        const key = await getOrCreateServerKey();
+        restored.state.variables['session_token'] = decryptToken(restored.state.variables['session_token'] as string, key);
+        delete restored.state.variables['_session_token_encrypted'];
+      }
+
+      return { content: [{ type: 'text' as const, text: JSON.stringify(restored, null, 2) }] };
     }),
   );
 }

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -28,7 +28,7 @@ export function registerStateTools(server: McpServer): void {
       description: z.string().optional().describe('Human-readable description of the save point'),
     },
     withAuditLog('save_state', async ({ session_token, state: stateJson, planning_folder_path, description }) => {
-      decodeSessionToken(session_token);
+      await decodeSessionToken(session_token);
 
       const parsed = JSON.parse(stateJson);
       const stateResult = NestedWorkflowStateSchema.safeParse(parsed);
@@ -70,7 +70,7 @@ export function registerStateTools(server: McpServer): void {
       };
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(summary, null, 2) }],
-        _meta: { session_token: advanceToken(session_token), validation: buildValidation() },
+        _meta: { session_token: await advanceToken(session_token), validation: buildValidation() },
       };
     }),
   );
@@ -83,7 +83,7 @@ export function registerStateTools(server: McpServer): void {
       file_path: z.string().describe('Path to the workflow-state.toon file'),
     },
     withAuditLog('restore_state', async ({ session_token, file_path }) => {
-      decodeSessionToken(session_token);
+      await decodeSessionToken(session_token);
 
       const content = await readFile(file_path, 'utf-8');
       const decoded = decodeToon<Record<string, unknown>>(content);
@@ -101,7 +101,7 @@ export function registerStateTools(server: McpServer): void {
 
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(restored, null, 2) }],
-        _meta: { session_token: advanceToken(session_token), validation: buildValidation() },
+        _meta: { session_token: await advanceToken(session_token), validation: buildValidation() },
       };
     }),
   );

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -6,7 +6,8 @@ import { NestedWorkflowStateSchema, StateSaveFileSchema } from '../schema/state.
 import type { StateSaveFile } from '../schema/state.schema.js';
 import { decodeToon, encodeToon } from '../utils/toon.js';
 import { withAuditLog } from '../logging.js';
-import { advanceToken, sessionTokenParam } from '../utils/session.js';
+import { decodeSessionToken, advanceToken, sessionTokenParam } from '../utils/session.js';
+import { buildValidation } from '../utils/validation.js';
 import { getOrCreateServerKey, encryptToken, decryptToken } from '../utils/crypto.js';
 
 const STATE_FILENAME = 'workflow-state.toon';
@@ -27,6 +28,8 @@ export function registerStateTools(server: McpServer): void {
       description: z.string().optional().describe('Human-readable description of the save point'),
     },
     withAuditLog('save_state', async ({ session_token, state: stateJson, planning_folder_path, description }) => {
+      decodeSessionToken(session_token);
+
       const parsed = JSON.parse(stateJson);
       const stateResult = NestedWorkflowStateSchema.safeParse(parsed);
       if (!stateResult.success) {
@@ -67,7 +70,7 @@ export function registerStateTools(server: McpServer): void {
       };
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(summary, null, 2) }],
-        _meta: { session_token: advanceToken(session_token) },
+        _meta: { session_token: advanceToken(session_token), validation: buildValidation() },
       };
     }),
   );
@@ -80,6 +83,8 @@ export function registerStateTools(server: McpServer): void {
       file_path: z.string().describe('Path to the workflow-state.toon file'),
     },
     withAuditLog('restore_state', async ({ session_token, file_path }) => {
+      decodeSessionToken(session_token);
+
       const content = await readFile(file_path, 'utf-8');
       const decoded = decodeToon<Record<string, unknown>>(content);
       const result = StateSaveFileSchema.safeParse(decoded);
@@ -96,7 +101,7 @@ export function registerStateTools(server: McpServer): void {
 
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(restored, null, 2) }],
-        _meta: { session_token: advanceToken(session_token) },
+        _meta: { session_token: advanceToken(session_token), validation: buildValidation() },
       };
     }),
   );

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -6,6 +6,7 @@ import { NestedWorkflowStateSchema, StateSaveFileSchema } from '../schema/state.
 import type { StateSaveFile } from '../schema/state.schema.js';
 import { decodeToon, encodeToon } from '../utils/toon.js';
 import { withAuditLog } from '../logging.js';
+import { sessionTokenParam } from '../utils/session.js';
 
 const STATE_FILENAME = 'workflow-state.toon';
 
@@ -19,6 +20,7 @@ export function registerStateTools(server: McpServer): void {
     'save_state',
     'Save workflow execution state to a TOON file in the planning folder for cross-session resumption. Accepts the state as a JSON string with support for nested child workflow states in triggeredWorkflows.',
     {
+      ...sessionTokenParam,
       state: z.string().describe('Workflow state as a JSON string (validated against NestedWorkflowStateSchema)'),
       planning_folder_path: z.string().describe('Absolute or relative path to the planning folder'),
       description: z.string().optional().describe('Human-readable description of the save point'),
@@ -64,6 +66,7 @@ export function registerStateTools(server: McpServer): void {
     'restore_state',
     'Restore workflow execution state from a previously saved TOON file. Returns the full nested state object for resumption.',
     {
+      ...sessionTokenParam,
       file_path: z.string().describe('Path to the workflow-state.toon file'),
     },
     withAuditLog('restore_state', async ({ file_path }) => {

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -6,7 +6,7 @@ import { NestedWorkflowStateSchema, StateSaveFileSchema } from '../schema/state.
 import type { StateSaveFile } from '../schema/state.schema.js';
 import { decodeToon, encodeToon } from '../utils/toon.js';
 import { withAuditLog } from '../logging.js';
-import { sessionTokenParam } from '../utils/session.js';
+import { advanceToken, sessionTokenParam } from '../utils/session.js';
 import { getOrCreateServerKey, encryptToken, decryptToken } from '../utils/crypto.js';
 
 const STATE_FILENAME = 'workflow-state.toon';
@@ -19,14 +19,14 @@ function generateSaveId(): string {
 export function registerStateTools(server: McpServer): void {
   server.tool(
     'save_state',
-    'Save workflow execution state to a TOON file in the planning folder for cross-session resumption. Accepts the state as a JSON string with support for nested child workflow states in triggeredWorkflows.',
+    'Save workflow execution state to a TOON file in the planning folder for cross-session resumption.',
     {
       ...sessionTokenParam,
       state: z.string().describe('Workflow state as a JSON string (validated against NestedWorkflowStateSchema)'),
       planning_folder_path: z.string().describe('Absolute or relative path to the planning folder'),
       description: z.string().optional().describe('Human-readable description of the save point'),
     },
-    withAuditLog('save_state', async ({ state: stateJson, planning_folder_path, description }) => {
+    withAuditLog('save_state', async ({ session_token, state: stateJson, planning_folder_path, description }) => {
       const parsed = JSON.parse(stateJson);
       const stateResult = NestedWorkflowStateSchema.safeParse(parsed);
       if (!stateResult.success) {
@@ -65,7 +65,10 @@ export function registerStateTools(server: McpServer): void {
         triggeredWorkflows: state.triggeredWorkflows.length,
         status: state.status,
       };
-      return { content: [{ type: 'text' as const, text: JSON.stringify(summary, null, 2) }] };
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(summary, null, 2) }],
+        _meta: { session_token: advanceToken(session_token) },
+      };
     }),
   );
 
@@ -76,7 +79,7 @@ export function registerStateTools(server: McpServer): void {
       ...sessionTokenParam,
       file_path: z.string().describe('Path to the workflow-state.toon file'),
     },
-    withAuditLog('restore_state', async ({ file_path }) => {
+    withAuditLog('restore_state', async ({ session_token, file_path }) => {
       const content = await readFile(file_path, 'utf-8');
       const decoded = decodeToon<Record<string, unknown>>(content);
       const result = StateSaveFileSchema.safeParse(decoded);
@@ -91,7 +94,10 @@ export function registerStateTools(server: McpServer): void {
         delete restored.state.variables['_session_token_encrypted'];
       }
 
-      return { content: [{ type: 'text' as const, text: JSON.stringify(restored, null, 2) }] };
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(restored, null, 2) }],
+        _meta: { session_token: advanceToken(session_token) },
+      };
     }),
   );
 }

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -4,7 +4,7 @@ import type { ServerConfig } from '../config.js';
 import { listWorkflows, loadWorkflow, getActivity, getCheckpoint, validateTransition, getTransitionList } from '../loaders/workflow-loader.js';
 import { withAuditLog } from '../logging.js';
 import { decodeSessionToken, advanceToken, sessionTokenParam } from '../utils/session.js';
-import { buildValidation, validateWorkflowConsistency, validateWorkflowVersion, validateActivityTransition, validateStepManifest } from '../utils/validation.js';
+import { buildValidation, validateWorkflowConsistency, validateWorkflowVersion, validateActivityTransition, validateStepManifest, validateTransitionCondition } from '../utils/validation.js';
 import type { StepManifestEntry } from '../utils/validation.js';
 
 const stepManifestSchema = z.array(z.object({
@@ -98,9 +98,10 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       ...sessionTokenParam,
       workflow_id: z.string().describe('Workflow ID'),
       activity_id: z.string().describe('Activity ID to load'),
+      transition_condition: z.string().optional().describe('The condition that caused this transition (from next_activity output). Enables server-side validation of condition-activity consistency.'),
       step_manifest: stepManifestSchema,
     },
-    withAuditLog('get_activity', async ({ session_token, workflow_id, activity_id, step_manifest }) => {
+    withAuditLog('get_activity', async ({ session_token, workflow_id, activity_id, transition_condition, step_manifest }) => {
       const token = await decodeSessionToken(session_token);
       const result = await loadWorkflow(config.workflowDir, workflow_id);
       if (!result.success) throw result.error;
@@ -115,16 +116,21 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
         manifestWarnings.push(`No step_manifest provided for previous activity '${token.act}'. Include a manifest to enable step completion validation.`);
       }
 
+      const condWarning = (transition_condition !== undefined && token.act)
+        ? validateTransitionCondition(token, result.value, activity_id, transition_condition)
+        : null;
+
       const validation = buildValidation(
         validateWorkflowConsistency(token, workflow_id),
         validateActivityTransition(token, result.value, activity_id),
         validateWorkflowVersion(token, result.value),
+        condWarning,
         ...manifestWarnings,
       );
 
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(activity, null, 2) }],
-        _meta: { session_token: await advanceToken(session_token, { wf: workflow_id, act: activity_id }), validation },
+        _meta: { session_token: await advanceToken(session_token, { wf: workflow_id, act: activity_id, cond: transition_condition ?? '' }), validation },
       };
     }));
 

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -4,6 +4,7 @@ import type { ServerConfig } from '../config.js';
 import { listWorkflows, loadWorkflow, getActivity, getCheckpoint, validateTransition } from '../loaders/workflow-loader.js';
 import { withAuditLog } from '../logging.js';
 import { decodeSessionToken, advanceToken, sessionTokenParam } from '../utils/session.js';
+import { buildValidation, validateWorkflowConsistency, validateWorkflowVersion, validateActivityTransition } from '../utils/validation.js';
 
 export function registerWorkflowTools(server: McpServer, config: ServerConfig): void {
 
@@ -27,10 +28,10 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
           },
         },
         session_protocol: {
-          token_usage: 'Pass the session_token to ALL subsequent tool calls. It encodes workflow context so you do not need to pass workflow_id or activity_id separately.',
+          token_usage: 'Pass the session_token to all subsequent tool calls alongside explicit workflow_id and activity_id parameters. The token enables server-side validation of call consistency.',
           token_update: 'Every tool response includes an updated token in _meta.session_token. Use the updated token for the next call.',
           token_opacity: 'Treat the token as opaque. Do not attempt to parse, decode, or fabricate tokens.',
-          staleness: 'The token includes a counter that increments on each call. Stale tokens indicate missed exchanges.',
+          validation: 'The server validates each call against the token: workflow consistency, activity transition validity, skill-activity association, and version drift. Warnings are returned in _meta.validation.',
           exempt_tools: ['help', 'list_workflows', 'start_session', 'health_check'],
         },
         available_workflows: workflows.map(w => ({ id: w.id, title: w.title, version: w.version })),
@@ -40,61 +41,94 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
 
   server.tool('list_workflows', 'List all available workflow definitions. Call this after help to choose a workflow.', {},
     withAuditLog('list_workflows', async () => ({
-      content: [{ type: 'text', text: JSON.stringify(await listWorkflows(config.workflowDir), null, 2) }],
+      content: [{ type: 'text' as const, text: JSON.stringify(await listWorkflows(config.workflowDir), null, 2) }],
     })));
 
-  server.tool('get_workflow', 'Get the complete workflow definition for the session workflow',
-    { ...sessionTokenParam },
-    withAuditLog('get_workflow', async ({ session_token }) => {
-      const { wf } = decodeSessionToken(session_token);
-      const result = await loadWorkflow(config.workflowDir, wf);
+  server.tool('get_workflow', 'Get the complete workflow definition by ID',
+    { ...sessionTokenParam, workflow_id: z.string().describe('Workflow ID (e.g., "work-package")') },
+    withAuditLog('get_workflow', async ({ session_token, workflow_id }) => {
+      const token = decodeSessionToken(session_token);
+      const result = await loadWorkflow(config.workflowDir, workflow_id);
       if (!result.success) throw result.error;
+
+      const validation = buildValidation(
+        validateWorkflowConsistency(token, workflow_id),
+        validateWorkflowVersion(token, result.value),
+      );
+
       const content: Array<{ type: 'text'; text: string }> = [];
       if (config.schemaPreamble) {
         content.push({ type: 'text', text: config.schemaPreamble });
       }
       content.push({ type: 'text', text: JSON.stringify(result.value, null, 2) });
-      return { content, _meta: { session_token: advanceToken(session_token) } };
+      return { content, _meta: { session_token: advanceToken(session_token, { wf: workflow_id }), validation } };
     }));
 
-  server.tool('validate_transition', 'Validate if a transition between activities is allowed',
-    { ...sessionTokenParam, from_activity: z.string(), to_activity: z.string() },
-    withAuditLog('validate_transition', async ({ session_token, from_activity, to_activity }) => {
-      const { wf } = decodeSessionToken(session_token);
-      const result = await loadWorkflow(config.workflowDir, wf);
-      if (!result.success) throw result.error;
-      return {
-        content: [{ type: 'text', text: JSON.stringify(validateTransition(result.value, from_activity, to_activity), null, 2) }],
-        _meta: { session_token: advanceToken(session_token) },
-      };
-    }));
-
-  server.tool('get_activity', 'Get details of a specific activity within the session workflow',
-    { ...sessionTokenParam, activity_id: z.string().describe('Activity ID to load (also updates the session activity)') },
-    withAuditLog('get_activity', async ({ session_token, activity_id }) => {
-      const { wf } = decodeSessionToken(session_token);
-      const result = await loadWorkflow(config.workflowDir, wf);
+  server.tool('get_activity', 'Get details of a specific activity within a workflow',
+    {
+      ...sessionTokenParam,
+      workflow_id: z.string().describe('Workflow ID'),
+      activity_id: z.string().describe('Activity ID to load'),
+    },
+    withAuditLog('get_activity', async ({ session_token, workflow_id, activity_id }) => {
+      const token = decodeSessionToken(session_token);
+      const result = await loadWorkflow(config.workflowDir, workflow_id);
       if (!result.success) throw result.error;
       const activity = getActivity(result.value, activity_id);
       if (!activity) throw new Error(`Activity not found: ${activity_id}`);
+
+      const validation = buildValidation(
+        validateWorkflowConsistency(token, workflow_id),
+        validateActivityTransition(token, result.value, activity_id),
+        validateWorkflowVersion(token, result.value),
+      );
+
       return {
-        content: [{ type: 'text', text: JSON.stringify(activity, null, 2) }],
-        _meta: { session_token: advanceToken(session_token, { act: activity_id }) },
+        content: [{ type: 'text' as const, text: JSON.stringify(activity, null, 2) }],
+        _meta: { session_token: advanceToken(session_token, { wf: workflow_id, act: activity_id }), validation },
       };
     }));
 
-  server.tool('get_checkpoint', 'Get checkpoint details for the current session activity',
-    { ...sessionTokenParam, checkpoint_id: z.string() },
-    withAuditLog('get_checkpoint', async ({ session_token, checkpoint_id }) => {
-      const { wf, act } = decodeSessionToken(session_token);
-      if (!act) throw new Error('No activity set in session token');
-      const result = await loadWorkflow(config.workflowDir, wf);
+  server.tool('get_checkpoint', 'Get checkpoint details for an activity',
+    {
+      ...sessionTokenParam,
+      workflow_id: z.string().describe('Workflow ID'),
+      activity_id: z.string().describe('Activity ID containing the checkpoint'),
+      checkpoint_id: z.string().describe('Checkpoint ID'),
+    },
+    withAuditLog('get_checkpoint', async ({ session_token, workflow_id, activity_id, checkpoint_id }) => {
+      const token = decodeSessionToken(session_token);
+      const result = await loadWorkflow(config.workflowDir, workflow_id);
       if (!result.success) throw result.error;
-      const checkpoint = getCheckpoint(result.value, act, checkpoint_id);
+      const checkpoint = getCheckpoint(result.value, activity_id, checkpoint_id);
       if (!checkpoint) throw new Error(`Checkpoint not found: ${checkpoint_id}`);
+
+      const validation = buildValidation(
+        validateWorkflowConsistency(token, workflow_id),
+        validateWorkflowVersion(token, result.value),
+      );
+
       return {
-        content: [{ type: 'text', text: JSON.stringify(checkpoint, null, 2) }],
-        _meta: { session_token: advanceToken(session_token) },
+        content: [{ type: 'text' as const, text: JSON.stringify(checkpoint, null, 2) }],
+        _meta: { session_token: advanceToken(session_token, { wf: workflow_id, act: activity_id }), validation },
+      };
+    }));
+
+  server.tool('validate_transition', 'Validate if a transition between activities is allowed',
+    { ...sessionTokenParam, workflow_id: z.string(), from_activity: z.string(), to_activity: z.string() },
+    withAuditLog('validate_transition', async ({ session_token, workflow_id, from_activity, to_activity }) => {
+      const token = decodeSessionToken(session_token);
+      const result = await loadWorkflow(config.workflowDir, workflow_id);
+      if (!result.success) throw result.error;
+
+      const validation = buildValidation(
+        validateWorkflowConsistency(token, workflow_id),
+        validateWorkflowVersion(token, result.value),
+      );
+
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(validateTransition(result.value, from_activity, to_activity), null, 2) }],
+        _meta: { session_token: advanceToken(session_token, { wf: workflow_id }), validation },
       };
     }));
 
@@ -102,7 +136,7 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
     withAuditLog('health_check', async () => {
       const workflows = await listWorkflows(config.workflowDir);
       return {
-        content: [{ type: 'text', text: JSON.stringify({
+        content: [{ type: 'text' as const, text: JSON.stringify({
           status: 'healthy', server: config.serverName, version: config.serverVersion,
           workflows_available: workflows.length, uptime_seconds: Math.floor(process.uptime()),
         }, null, 2) }],

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ServerConfig } from '../config.js';
-import { listWorkflows, loadWorkflow, getActivity, getCheckpoint, validateTransition } from '../loaders/workflow-loader.js';
+import { listWorkflows, loadWorkflow, getActivity, getCheckpoint, validateTransition, getTransitionList } from '../loaders/workflow-loader.js';
 import { withAuditLog } from '../logging.js';
 import { decodeSessionToken, advanceToken, sessionTokenParam } from '../utils/session.js';
 import { buildValidation, validateWorkflowConsistency, validateWorkflowVersion, validateActivityTransition, validateStepManifest } from '../utils/validation.js';
@@ -51,9 +51,13 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       content: [{ type: 'text' as const, text: JSON.stringify(await listWorkflows(config.workflowDir), null, 2) }],
     })));
 
-  server.tool('get_workflow', 'Get the complete workflow definition by ID',
-    { ...sessionTokenParam, workflow_id: z.string().describe('Workflow ID (e.g., "work-package")') },
-    withAuditLog('get_workflow', async ({ session_token, workflow_id }) => {
+  server.tool('get_workflow', 'Get a workflow definition. Use summary=true for lightweight metadata (rules, variables, activity stubs) to reduce context usage.',
+    {
+      ...sessionTokenParam,
+      workflow_id: z.string().describe('Workflow ID (e.g., "work-package")'),
+      summary: z.boolean().optional().default(false).describe('If true, returns lightweight summary instead of full definition'),
+    },
+    withAuditLog('get_workflow', async ({ session_token, workflow_id, summary }) => {
       const token = await decodeSessionToken(session_token);
       const result = await loadWorkflow(config.workflowDir, workflow_id);
       if (!result.success) throw result.error;
@@ -67,7 +71,24 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       if (config.schemaPreamble) {
         content.push({ type: 'text', text: config.schemaPreamble });
       }
-      content.push({ type: 'text', text: JSON.stringify(result.value, null, 2) });
+
+      if (summary) {
+        const wf = result.value;
+        const summaryData = {
+          id: wf.id,
+          version: wf.version,
+          title: wf.title,
+          description: wf.description,
+          rules: wf.rules,
+          variables: wf.variables,
+          initialActivity: (wf as Record<string, unknown>)['initialActivity'],
+          activities: wf.activities.map(a => ({ id: a.id, name: a.name, required: a.required })),
+        };
+        content.push({ type: 'text', text: JSON.stringify(summaryData, null, 2) });
+      } else {
+        content.push({ type: 'text', text: JSON.stringify(result.value, null, 2) });
+      }
+
       return { content, _meta: { session_token: await advanceToken(session_token, { wf: workflow_id }), validation } };
     }));
 
@@ -152,6 +173,31 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
 
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(validateTransition(result.value, from_activity, to_activity), null, 2) }],
+        _meta: { session_token: await advanceToken(session_token, { wf: workflow_id }), validation },
+      };
+    }));
+
+  server.tool('next_activity', 'Get the list of possible next activities with their transition conditions. Returns transitions from the current activity (token.act) so the agent can match conditions against its state variables.',
+    { ...sessionTokenParam, workflow_id: z.string().describe('Workflow ID') },
+    withAuditLog('next_activity', async ({ session_token, workflow_id }) => {
+      const token = await decodeSessionToken(session_token);
+      if (!token.act) throw new Error('No current activity in session token. Call get_activity first.');
+
+      const result = await loadWorkflow(config.workflowDir, workflow_id);
+      if (!result.success) throw result.error;
+
+      const transitions = getTransitionList(result.value, token.act);
+      const validation = buildValidation(
+        validateWorkflowConsistency(token, workflow_id),
+        validateWorkflowVersion(token, result.value),
+      );
+
+      const response = {
+        current_activity: token.act,
+        transitions,
+      };
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(response, null, 2) }],
         _meta: { session_token: await advanceToken(session_token, { wf: workflow_id }), validation },
       };
     }));

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -69,9 +69,9 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       };
     }));
 
-  server.tool('get_workflow_activity', 'Get details of a specific activity within the session workflow',
+  server.tool('get_activity', 'Get details of a specific activity within the session workflow',
     { ...sessionTokenParam, activity_id: z.string().describe('Activity ID to load (also updates the session activity)') },
-    withAuditLog('get_workflow_activity', async ({ session_token, activity_id }) => {
+    withAuditLog('get_activity', async ({ session_token, activity_id }) => {
       const { wf } = decodeSessionToken(session_token);
       const result = await loadWorkflow(config.workflowDir, wf);
       if (!result.success) throw result.error;

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ServerConfig } from '../config.js';
-import { listWorkflows, loadWorkflow, getActivity, getCheckpoint, validateTransition, getTransitionList } from '../loaders/workflow-loader.js';
+import { listWorkflows, loadWorkflow, getActivity, getCheckpoint, getTransitionList } from '../loaders/workflow-loader.js';
 import { withAuditLog } from '../logging.js';
 import { decodeSessionToken, advanceToken, sessionTokenParam } from '../utils/session.js';
 import { buildValidation, validateWorkflowConsistency, validateWorkflowVersion, validateActivityTransition, validateStepManifest, validateTransitionCondition } from '../utils/validation.js';
@@ -156,31 +156,6 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(checkpoint, null, 2) }],
         _meta: { session_token: await advanceToken(session_token, { wf: workflow_id, act: activity_id }), validation },
-      };
-    }));
-
-  server.tool('validate_transition', 'Validate if a transition between activities is allowed',
-    { ...sessionTokenParam, workflow_id: z.string(), from_activity: z.string(), to_activity: z.string(), step_manifest: stepManifestSchema },
-    withAuditLog('validate_transition', async ({ session_token, workflow_id, from_activity, to_activity, step_manifest }) => {
-      const token = await decodeSessionToken(session_token);
-      const result = await loadWorkflow(config.workflowDir, workflow_id);
-      if (!result.success) throw result.error;
-
-      const manifestWarnings: (string | null)[] = [];
-      if (step_manifest) {
-        const mw = validateStepManifest(step_manifest as StepManifestEntry[], result.value, from_activity);
-        manifestWarnings.push(...mw);
-      }
-
-      const validation = buildValidation(
-        validateWorkflowConsistency(token, workflow_id),
-        validateWorkflowVersion(token, result.value),
-        ...manifestWarnings,
-      );
-
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify(validateTransition(result.value, from_activity, to_activity), null, 2) }],
-        _meta: { session_token: await advanceToken(session_token, { wf: workflow_id }), validation },
       };
     }));
 

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -55,7 +55,7 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
     {
       ...sessionTokenParam,
       workflow_id: z.string().describe('Workflow ID (e.g., "work-package")'),
-      summary: z.boolean().optional().default(false).describe('If true, returns lightweight summary instead of full definition'),
+      summary: z.boolean().optional().default(true).describe('Returns lightweight summary by default. Set to false for the full definition.'),
     },
     withAuditLog('get_workflow', async ({ session_token, workflow_id, summary }) => {
       const token = await decodeSessionToken(session_token);

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -3,12 +3,13 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ServerConfig } from '../config.js';
 import { listWorkflows, loadWorkflow, getActivity, getCheckpoint, validateTransition } from '../loaders/workflow-loader.js';
 import { withAuditLog } from '../logging.js';
+import { sessionTokenParam } from '../utils/session.js';
 
 export function registerWorkflowTools(server: McpServer, config: ServerConfig): void {
-  server.tool('list_workflows', 'List all available workflow definitions', {},
+  server.tool('list_workflows', 'List all available workflow definitions', { ...sessionTokenParam },
     withAuditLog('list_workflows', async () => ({ content: [{ type: 'text', text: JSON.stringify(await listWorkflows(config.workflowDir), null, 2) }] })));
 
-  server.tool('get_workflow', 'Get a complete workflow definition by ID', { workflow_id: z.string() },
+  server.tool('get_workflow', 'Get a complete workflow definition by ID', { ...sessionTokenParam, workflow_id: z.string() },
     withAuditLog('get_workflow', async ({ workflow_id }) => {
       const result = await loadWorkflow(config.workflowDir, workflow_id);
       if (!result.success) throw result.error;
@@ -21,14 +22,14 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
     }));
 
   server.tool('validate_transition', 'Validate if a transition between activities is allowed',
-    { workflow_id: z.string(), from_activity: z.string(), to_activity: z.string() },
+    { ...sessionTokenParam, workflow_id: z.string(), from_activity: z.string(), to_activity: z.string() },
     withAuditLog('validate_transition', async ({ workflow_id, from_activity, to_activity }) => {
       const result = await loadWorkflow(config.workflowDir, workflow_id);
       if (!result.success) throw result.error;
       return { content: [{ type: 'text', text: JSON.stringify(validateTransition(result.value, from_activity, to_activity), null, 2) }] };
     }));
 
-  server.tool('get_workflow_activity', 'Get details of a specific activity within a workflow', { workflow_id: z.string(), activity_id: z.string() },
+  server.tool('get_workflow_activity', 'Get details of a specific activity within a workflow', { ...sessionTokenParam, workflow_id: z.string(), activity_id: z.string() },
     withAuditLog('get_workflow_activity', async ({ workflow_id, activity_id }) => {
       const result = await loadWorkflow(config.workflowDir, workflow_id);
       if (!result.success) throw result.error;
@@ -37,7 +38,7 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       return { content: [{ type: 'text', text: JSON.stringify(activity, null, 2) }] };
     }));
 
-  server.tool('get_checkpoint', 'Get checkpoint details', { workflow_id: z.string(), activity_id: z.string(), checkpoint_id: z.string() },
+  server.tool('get_checkpoint', 'Get checkpoint details', { ...sessionTokenParam, workflow_id: z.string(), activity_id: z.string(), checkpoint_id: z.string() },
     withAuditLog('get_checkpoint', async ({ workflow_id, activity_id, checkpoint_id }) => {
       const result = await loadWorkflow(config.workflowDir, workflow_id);
       if (!result.success) throw result.error;

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -47,7 +47,7 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
   server.tool('get_workflow', 'Get the complete workflow definition by ID',
     { ...sessionTokenParam, workflow_id: z.string().describe('Workflow ID (e.g., "work-package")') },
     withAuditLog('get_workflow', async ({ session_token, workflow_id }) => {
-      const token = decodeSessionToken(session_token);
+      const token = await decodeSessionToken(session_token);
       const result = await loadWorkflow(config.workflowDir, workflow_id);
       if (!result.success) throw result.error;
 
@@ -61,7 +61,7 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
         content.push({ type: 'text', text: config.schemaPreamble });
       }
       content.push({ type: 'text', text: JSON.stringify(result.value, null, 2) });
-      return { content, _meta: { session_token: advanceToken(session_token, { wf: workflow_id }), validation } };
+      return { content, _meta: { session_token: await advanceToken(session_token, { wf: workflow_id }), validation } };
     }));
 
   server.tool('get_activity', 'Get details of a specific activity within a workflow',
@@ -71,7 +71,7 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       activity_id: z.string().describe('Activity ID to load'),
     },
     withAuditLog('get_activity', async ({ session_token, workflow_id, activity_id }) => {
-      const token = decodeSessionToken(session_token);
+      const token = await decodeSessionToken(session_token);
       const result = await loadWorkflow(config.workflowDir, workflow_id);
       if (!result.success) throw result.error;
       const activity = getActivity(result.value, activity_id);
@@ -85,7 +85,7 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
 
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(activity, null, 2) }],
-        _meta: { session_token: advanceToken(session_token, { wf: workflow_id, act: activity_id }), validation },
+        _meta: { session_token: await advanceToken(session_token, { wf: workflow_id, act: activity_id }), validation },
       };
     }));
 
@@ -97,7 +97,7 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       checkpoint_id: z.string().describe('Checkpoint ID'),
     },
     withAuditLog('get_checkpoint', async ({ session_token, workflow_id, activity_id, checkpoint_id }) => {
-      const token = decodeSessionToken(session_token);
+      const token = await decodeSessionToken(session_token);
       const result = await loadWorkflow(config.workflowDir, workflow_id);
       if (!result.success) throw result.error;
       const checkpoint = getCheckpoint(result.value, activity_id, checkpoint_id);
@@ -110,14 +110,14 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
 
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(checkpoint, null, 2) }],
-        _meta: { session_token: advanceToken(session_token, { wf: workflow_id, act: activity_id }), validation },
+        _meta: { session_token: await advanceToken(session_token, { wf: workflow_id, act: activity_id }), validation },
       };
     }));
 
   server.tool('validate_transition', 'Validate if a transition between activities is allowed',
     { ...sessionTokenParam, workflow_id: z.string(), from_activity: z.string(), to_activity: z.string() },
     withAuditLog('validate_transition', async ({ session_token, workflow_id, from_activity, to_activity }) => {
-      const token = decodeSessionToken(session_token);
+      const token = await decodeSessionToken(session_token);
       const result = await loadWorkflow(config.workflowDir, workflow_id);
       if (!result.success) throw result.error;
 
@@ -128,7 +128,7 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
 
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(validateTransition(result.value, from_activity, to_activity), null, 2) }],
-        _meta: { session_token: advanceToken(session_token, { wf: workflow_id }), validation },
+        _meta: { session_token: await advanceToken(session_token, { wf: workflow_id }), validation },
       };
     }));
 

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -3,53 +3,78 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ServerConfig } from '../config.js';
 import { listWorkflows, loadWorkflow, getActivity, getCheckpoint, validateTransition } from '../loaders/workflow-loader.js';
 import { withAuditLog } from '../logging.js';
-import { sessionTokenParam } from '../utils/session.js';
+import { decodeSessionToken, advanceToken, sessionTokenParam } from '../utils/session.js';
 
 export function registerWorkflowTools(server: McpServer, config: ServerConfig): void {
-  server.tool('list_workflows', 'List all available workflow definitions', { ...sessionTokenParam },
-    withAuditLog('list_workflows', async () => ({ content: [{ type: 'text', text: JSON.stringify(await listWorkflows(config.workflowDir), null, 2) }] })));
 
-  server.tool('get_workflow', 'Get a complete workflow definition by ID', { ...sessionTokenParam, workflow_id: z.string() },
-    withAuditLog('get_workflow', async ({ workflow_id }) => {
-      const result = await loadWorkflow(config.workflowDir, workflow_id);
+  server.tool('list_workflows', 'List all available workflow definitions. Call this before start_session to choose a workflow.', {},
+    withAuditLog('list_workflows', async () => ({
+      content: [{ type: 'text', text: JSON.stringify(await listWorkflows(config.workflowDir), null, 2) }],
+    })));
+
+  server.tool('get_workflow', 'Get the complete workflow definition for the session workflow',
+    { ...sessionTokenParam },
+    withAuditLog('get_workflow', async ({ session_token }) => {
+      const { wf } = decodeSessionToken(session_token);
+      const result = await loadWorkflow(config.workflowDir, wf);
       if (!result.success) throw result.error;
       const content: Array<{ type: 'text'; text: string }> = [];
       if (config.schemaPreamble) {
         content.push({ type: 'text', text: config.schemaPreamble });
       }
       content.push({ type: 'text', text: JSON.stringify(result.value, null, 2) });
-      return { content };
+      return { content, _meta: { session_token: advanceToken(session_token) } };
     }));
 
   server.tool('validate_transition', 'Validate if a transition between activities is allowed',
-    { ...sessionTokenParam, workflow_id: z.string(), from_activity: z.string(), to_activity: z.string() },
-    withAuditLog('validate_transition', async ({ workflow_id, from_activity, to_activity }) => {
-      const result = await loadWorkflow(config.workflowDir, workflow_id);
+    { ...sessionTokenParam, from_activity: z.string(), to_activity: z.string() },
+    withAuditLog('validate_transition', async ({ session_token, from_activity, to_activity }) => {
+      const { wf } = decodeSessionToken(session_token);
+      const result = await loadWorkflow(config.workflowDir, wf);
       if (!result.success) throw result.error;
-      return { content: [{ type: 'text', text: JSON.stringify(validateTransition(result.value, from_activity, to_activity), null, 2) }] };
+      return {
+        content: [{ type: 'text', text: JSON.stringify(validateTransition(result.value, from_activity, to_activity), null, 2) }],
+        _meta: { session_token: advanceToken(session_token) },
+      };
     }));
 
-  server.tool('get_workflow_activity', 'Get details of a specific activity within a workflow', { ...sessionTokenParam, workflow_id: z.string(), activity_id: z.string() },
-    withAuditLog('get_workflow_activity', async ({ workflow_id, activity_id }) => {
-      const result = await loadWorkflow(config.workflowDir, workflow_id);
+  server.tool('get_workflow_activity', 'Get details of a specific activity within the session workflow',
+    { ...sessionTokenParam, activity_id: z.string().describe('Activity ID to load (also updates the session activity)') },
+    withAuditLog('get_workflow_activity', async ({ session_token, activity_id }) => {
+      const { wf } = decodeSessionToken(session_token);
+      const result = await loadWorkflow(config.workflowDir, wf);
       if (!result.success) throw result.error;
       const activity = getActivity(result.value, activity_id);
       if (!activity) throw new Error(`Activity not found: ${activity_id}`);
-      return { content: [{ type: 'text', text: JSON.stringify(activity, null, 2) }] };
+      return {
+        content: [{ type: 'text', text: JSON.stringify(activity, null, 2) }],
+        _meta: { session_token: advanceToken(session_token, { act: activity_id }) },
+      };
     }));
 
-  server.tool('get_checkpoint', 'Get checkpoint details', { ...sessionTokenParam, workflow_id: z.string(), activity_id: z.string(), checkpoint_id: z.string() },
-    withAuditLog('get_checkpoint', async ({ workflow_id, activity_id, checkpoint_id }) => {
-      const result = await loadWorkflow(config.workflowDir, workflow_id);
+  server.tool('get_checkpoint', 'Get checkpoint details for the current session activity',
+    { ...sessionTokenParam, checkpoint_id: z.string() },
+    withAuditLog('get_checkpoint', async ({ session_token, checkpoint_id }) => {
+      const { wf, act } = decodeSessionToken(session_token);
+      if (!act) throw new Error('No activity set in session token');
+      const result = await loadWorkflow(config.workflowDir, wf);
       if (!result.success) throw result.error;
-      const checkpoint = getCheckpoint(result.value, activity_id, checkpoint_id);
+      const checkpoint = getCheckpoint(result.value, act, checkpoint_id);
       if (!checkpoint) throw new Error(`Checkpoint not found: ${checkpoint_id}`);
-      return { content: [{ type: 'text', text: JSON.stringify(checkpoint, null, 2) }] };
+      return {
+        content: [{ type: 'text', text: JSON.stringify(checkpoint, null, 2) }],
+        _meta: { session_token: advanceToken(session_token) },
+      };
     }));
 
   server.tool('health_check', 'Check server health', {},
     withAuditLog('health_check', async () => {
       const workflows = await listWorkflows(config.workflowDir);
-      return { content: [{ type: 'text', text: JSON.stringify({ status: 'healthy', server: config.serverName, version: config.serverVersion, workflows_available: workflows.length, uptime_seconds: Math.floor(process.uptime()) }, null, 2) }] };
+      return {
+        content: [{ type: 'text', text: JSON.stringify({
+          status: 'healthy', server: config.serverName, version: config.serverVersion,
+          workflows_available: workflows.length, uptime_seconds: Math.floor(process.uptime()),
+        }, null, 2) }],
+      };
     }));
 }

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -4,7 +4,14 @@ import type { ServerConfig } from '../config.js';
 import { listWorkflows, loadWorkflow, getActivity, getCheckpoint, validateTransition } from '../loaders/workflow-loader.js';
 import { withAuditLog } from '../logging.js';
 import { decodeSessionToken, advanceToken, sessionTokenParam } from '../utils/session.js';
-import { buildValidation, validateWorkflowConsistency, validateWorkflowVersion, validateActivityTransition } from '../utils/validation.js';
+import { buildValidation, validateWorkflowConsistency, validateWorkflowVersion, validateActivityTransition, validateStepManifest } from '../utils/validation.js';
+import type { StepManifestEntry } from '../utils/validation.js';
+
+const stepManifestSchema = z.array(z.object({
+  step_id: z.string(),
+  output: z.string(),
+})).optional().describe('Step completion manifest from the previous activity. Each entry reports a step ID and its output summary.');
+
 
 export function registerWorkflowTools(server: McpServer, config: ServerConfig): void {
 
@@ -69,18 +76,28 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       ...sessionTokenParam,
       workflow_id: z.string().describe('Workflow ID'),
       activity_id: z.string().describe('Activity ID to load'),
+      step_manifest: stepManifestSchema,
     },
-    withAuditLog('get_activity', async ({ session_token, workflow_id, activity_id }) => {
+    withAuditLog('get_activity', async ({ session_token, workflow_id, activity_id, step_manifest }) => {
       const token = await decodeSessionToken(session_token);
       const result = await loadWorkflow(config.workflowDir, workflow_id);
       if (!result.success) throw result.error;
       const activity = getActivity(result.value, activity_id);
       if (!activity) throw new Error(`Activity not found: ${activity_id}`);
 
+      const manifestWarnings: (string | null)[] = [];
+      if (step_manifest && token.act) {
+        const mw = validateStepManifest(step_manifest as StepManifestEntry[], result.value, token.act);
+        manifestWarnings.push(...mw);
+      } else if (!step_manifest && token.act) {
+        manifestWarnings.push(`No step_manifest provided for previous activity '${token.act}'. Include a manifest to enable step completion validation.`);
+      }
+
       const validation = buildValidation(
         validateWorkflowConsistency(token, workflow_id),
         validateActivityTransition(token, result.value, activity_id),
         validateWorkflowVersion(token, result.value),
+        ...manifestWarnings,
       );
 
       return {
@@ -115,15 +132,22 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
     }));
 
   server.tool('validate_transition', 'Validate if a transition between activities is allowed',
-    { ...sessionTokenParam, workflow_id: z.string(), from_activity: z.string(), to_activity: z.string() },
-    withAuditLog('validate_transition', async ({ session_token, workflow_id, from_activity, to_activity }) => {
+    { ...sessionTokenParam, workflow_id: z.string(), from_activity: z.string(), to_activity: z.string(), step_manifest: stepManifestSchema },
+    withAuditLog('validate_transition', async ({ session_token, workflow_id, from_activity, to_activity, step_manifest }) => {
       const token = await decodeSessionToken(session_token);
       const result = await loadWorkflow(config.workflowDir, workflow_id);
       if (!result.success) throw result.error;
 
+      const manifestWarnings: (string | null)[] = [];
+      if (step_manifest) {
+        const mw = validateStepManifest(step_manifest as StepManifestEntry[], result.value, from_activity);
+        manifestWarnings.push(...mw);
+      }
+
       const validation = buildValidation(
         validateWorkflowConsistency(token, workflow_id),
         validateWorkflowVersion(token, result.value),
+        ...manifestWarnings,
       );
 
       return {

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -39,6 +39,7 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
           token_update: 'Every tool response includes an updated token in _meta.session_token. Use the updated token for the next call.',
           token_opacity: 'Treat the token as opaque. Do not attempt to parse, decode, or fabricate tokens.',
           validation: 'The server validates each call against the token: workflow consistency, activity transition validity, skill-activity association, and version drift. Warnings are returned in _meta.validation.',
+          efficiency: 'Use get_skills(workflow_id, activity_id) to load all skills for an activity in one call instead of multiple get_skill calls.',
           exempt_tools: ['help', 'list_workflows', 'start_session', 'health_check'],
         },
         available_workflows: workflows.map(w => ({ id: w.id, title: w.title, version: w.version })),

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -7,7 +7,38 @@ import { decodeSessionToken, advanceToken, sessionTokenParam } from '../utils/se
 
 export function registerWorkflowTools(server: McpServer, config: ServerConfig): void {
 
-  server.tool('list_workflows', 'List all available workflow definitions. Call this before start_session to choose a workflow.', {},
+  server.tool('help', 'How to use this server. Call this first. Returns the bootstrap procedure and session protocol.', {},
+    withAuditLog('help', async () => {
+      const workflows = await listWorkflows(config.workflowDir);
+      const guide = {
+        server: config.serverName,
+        version: config.serverVersion,
+        bootstrap: {
+          step_1: {
+            action: 'Call list_workflows to discover available workflows',
+            tool: 'list_workflows',
+            note: 'Match the user goal to a workflow from the returned list',
+          },
+          step_2: {
+            action: 'Call start_session with the chosen workflow_id',
+            tool: 'start_session',
+            params: { workflow_id: '<chosen workflow ID>' },
+            returns: 'Agent behavioral rules, workflow metadata, and an opaque session token',
+          },
+        },
+        session_protocol: {
+          token_usage: 'Pass the session_token to ALL subsequent tool calls. It encodes workflow context so you do not need to pass workflow_id or activity_id separately.',
+          token_update: 'Every tool response includes an updated token in _meta.session_token. Use the updated token for the next call.',
+          token_opacity: 'Treat the token as opaque. Do not attempt to parse, decode, or fabricate tokens.',
+          staleness: 'The token includes a counter that increments on each call. Stale tokens indicate missed exchanges.',
+          exempt_tools: ['help', 'list_workflows', 'start_session', 'health_check'],
+        },
+        available_workflows: workflows.map(w => ({ id: w.id, title: w.title, version: w.version })),
+      };
+      return { content: [{ type: 'text' as const, text: JSON.stringify(guide, null, 2) }] };
+    }));
+
+  server.tool('list_workflows', 'List all available workflow definitions. Call this after help to choose a workflow.', {},
     withAuditLog('list_workflows', async () => ({
       content: [{ type: 'text', text: JSON.stringify(await listWorkflows(config.workflowDir), null, 2) }],
     })));

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,0 +1,44 @@
+import { randomBytes, createCipheriv, createDecipheriv } from 'node:crypto';
+import { readFile, writeFile, mkdir, chmod } from 'node:fs/promises';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { existsSync } from 'node:fs';
+
+const KEY_DIR = join(homedir(), '.workflow-server');
+const KEY_FILE = join(KEY_DIR, 'secret');
+const KEY_LENGTH = 32; // 256 bits
+const IV_LENGTH = 12;  // GCM standard
+const AUTH_TAG_LENGTH = 16;
+const ALGORITHM = 'aes-256-gcm';
+
+export async function getOrCreateServerKey(): Promise<Buffer> {
+  if (existsSync(KEY_FILE)) {
+    return readFile(KEY_FILE);
+  }
+
+  const key = randomBytes(KEY_LENGTH);
+  await mkdir(KEY_DIR, { recursive: true, mode: 0o700 });
+  await writeFile(KEY_FILE, key, { mode: 0o600 });
+  return key;
+}
+
+export function encryptToken(token: string, key: Buffer): string {
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
+  const encrypted = Buffer.concat([cipher.update(token, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return `${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted.toString('hex')}`;
+}
+
+export function decryptToken(encrypted: string, key: Buffer): string {
+  const parts = encrypted.split(':');
+  if (parts.length !== 3) throw new Error('Invalid encrypted token format');
+
+  const iv = Buffer.from(parts[0]!, 'hex');
+  const authTag = Buffer.from(parts[1]!, 'hex');
+  const ciphertext = Buffer.from(parts[2]!, 'hex');
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
+  decipher.setAuthTag(authTag);
+  return decipher.update(ciphertext) + decipher.final('utf8');
+}

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,4 +1,4 @@
-import { randomBytes, createCipheriv, createDecipheriv } from 'node:crypto';
+import { randomBytes, createCipheriv, createDecipheriv, createHmac } from 'node:crypto';
 import { readFile, writeFile, mkdir, chmod } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
@@ -41,4 +41,18 @@ export function decryptToken(encrypted: string, key: Buffer): string {
   const decipher = createDecipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
   decipher.setAuthTag(authTag);
   return decipher.update(ciphertext) + decipher.final('utf8');
+}
+
+export function hmacSign(payload: string, key: Buffer): string {
+  return createHmac('sha256', key).update(payload).digest('hex');
+}
+
+export function hmacVerify(payload: string, signature: string, key: Buffer): boolean {
+  const expected = hmacSign(payload, key);
+  if (expected.length !== signature.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < expected.length; i++) {
+    mismatch |= expected.charCodeAt(i) ^ signature.charCodeAt(i);
+  }
+  return mismatch === 0;
 }

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,0 +1,24 @@
+import { randomUUID } from 'node:crypto';
+import { z } from 'zod';
+
+/**
+ * Token format: <workflow-version>_<unix-epoch-seconds>_<8-hex-chars>
+ * Example: 3.4.0_1711300000_a3b2c1d4
+ */
+const SESSION_TOKEN_PATTERN = /^[\d.]+_\d+_[0-9a-f]{8}$/;
+
+export function generateSessionToken(workflowVersion: string): string {
+  const epoch = Math.floor(Date.now() / 1000);
+  const hex = randomUUID().replace(/-/g, '').substring(0, 8);
+  return `${workflowVersion}_${epoch}_${hex}`;
+}
+
+export function validateSessionToken(token: string): boolean {
+  return SESSION_TOKEN_PATTERN.test(token);
+}
+
+export const sessionTokenParam = {
+  session_token: z.string()
+    .regex(SESSION_TOKEN_PATTERN, 'Invalid session token format')
+    .describe('Session token from start_session'),
+};

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -3,9 +3,16 @@ import { z } from 'zod';
 export interface SessionPayload {
   wf: string;
   act: string;
+  skill: string;
   v: string;
   seq: number;
   ts: number;
+}
+
+export interface SessionAdvance {
+  wf?: string;
+  act?: string;
+  skill?: string;
 }
 
 function encode(payload: SessionPayload): string {
@@ -18,8 +25,8 @@ function decode(token: string): SessionPayload {
     const json = Buffer.from(token, 'base64url').toString('utf8');
     const parsed = JSON.parse(json) as Record<string, unknown>;
     if (typeof parsed['wf'] !== 'string' || typeof parsed['act'] !== 'string' ||
-        typeof parsed['v'] !== 'string' || typeof parsed['seq'] !== 'number' ||
-        typeof parsed['ts'] !== 'number') {
+        typeof parsed['skill'] !== 'string' || typeof parsed['v'] !== 'string' ||
+        typeof parsed['seq'] !== 'number' || typeof parsed['ts'] !== 'number') {
       throw new Error('Missing or invalid token fields');
     }
     return parsed as unknown as SessionPayload;
@@ -29,10 +36,11 @@ function decode(token: string): SessionPayload {
   }
 }
 
-export function createSessionToken(workflowId: string, workflowVersion: string, initialActivity?: string): string {
+export function createSessionToken(workflowId: string, workflowVersion: string): string {
   return encode({
     wf: workflowId,
-    act: initialActivity ?? '',
+    act: '',
+    skill: '',
     v: workflowVersion,
     seq: 0,
     ts: Math.floor(Date.now() / 1000),
@@ -43,10 +51,12 @@ export function decodeSessionToken(token: string): SessionPayload {
   return decode(token);
 }
 
-export function advanceToken(token: string, updates?: { act?: string }): string {
+export function advanceToken(token: string, updates?: SessionAdvance): string {
   const payload = decode(token);
   payload.seq += 1;
+  if (updates?.wf !== undefined) payload.wf = updates.wf;
   if (updates?.act !== undefined) payload.act = updates.act;
+  if (updates?.skill !== undefined) payload.skill = updates.skill;
   return encode(payload);
 }
 

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { getOrCreateServerKey, hmacSign, hmacVerify } from './crypto.js';
 
 export interface SessionPayload {
   wf: string;
@@ -15,14 +16,28 @@ export interface SessionAdvance {
   skill?: string;
 }
 
-function encode(payload: SessionPayload): string {
+async function encode(payload: SessionPayload): Promise<string> {
   const json = JSON.stringify(payload);
-  return Buffer.from(json, 'utf8').toString('base64url');
+  const b64 = Buffer.from(json, 'utf8').toString('base64url');
+  const key = await getOrCreateServerKey();
+  const sig = hmacSign(b64, key);
+  return `${b64}.${sig}`;
 }
 
-function decode(token: string): SessionPayload {
+async function decode(token: string): Promise<SessionPayload> {
+  const dotIndex = token.lastIndexOf('.');
+  if (dotIndex === -1) throw new Error('Invalid session token: missing signature');
+
+  const b64 = token.substring(0, dotIndex);
+  const sig = token.substring(dotIndex + 1);
+
+  const key = await getOrCreateServerKey();
+  if (!hmacVerify(b64, sig, key)) {
+    throw new Error('Invalid session token: signature verification failed');
+  }
+
   try {
-    const json = Buffer.from(token, 'base64url').toString('utf8');
+    const json = Buffer.from(b64, 'base64url').toString('utf8');
     const parsed = JSON.parse(json) as Record<string, unknown>;
     if (typeof parsed['wf'] !== 'string' || typeof parsed['act'] !== 'string' ||
         typeof parsed['skill'] !== 'string' || typeof parsed['v'] !== 'string' ||
@@ -36,7 +51,7 @@ function decode(token: string): SessionPayload {
   }
 }
 
-export function createSessionToken(workflowId: string, workflowVersion: string): string {
+export async function createSessionToken(workflowId: string, workflowVersion: string): Promise<string> {
   return encode({
     wf: workflowId,
     act: '',
@@ -47,12 +62,12 @@ export function createSessionToken(workflowId: string, workflowVersion: string):
   });
 }
 
-export function decodeSessionToken(token: string): SessionPayload {
+export async function decodeSessionToken(token: string): Promise<SessionPayload> {
   return decode(token);
 }
 
-export function advanceToken(token: string, updates?: SessionAdvance): string {
-  const payload = decode(token);
+export async function advanceToken(token: string, updates?: SessionAdvance): Promise<string> {
+  const payload = await decode(token);
   payload.seq += 1;
   if (updates?.wf !== undefined) payload.wf = updates.wf;
   if (updates?.act !== undefined) payload.act = updates.act;

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -5,6 +5,7 @@ export interface SessionPayload {
   wf: string;
   act: string;
   skill: string;
+  cond: string;
   v: string;
   seq: number;
   ts: number;
@@ -14,6 +15,7 @@ export interface SessionAdvance {
   wf?: string;
   act?: string;
   skill?: string;
+  cond?: string;
 }
 
 async function encode(payload: SessionPayload): Promise<string> {
@@ -40,8 +42,9 @@ async function decode(token: string): Promise<SessionPayload> {
     const json = Buffer.from(b64, 'base64url').toString('utf8');
     const parsed = JSON.parse(json) as Record<string, unknown>;
     if (typeof parsed['wf'] !== 'string' || typeof parsed['act'] !== 'string' ||
-        typeof parsed['skill'] !== 'string' || typeof parsed['v'] !== 'string' ||
-        typeof parsed['seq'] !== 'number' || typeof parsed['ts'] !== 'number') {
+        typeof parsed['skill'] !== 'string' || typeof parsed['cond'] !== 'string' ||
+        typeof parsed['v'] !== 'string' || typeof parsed['seq'] !== 'number' ||
+        typeof parsed['ts'] !== 'number') {
       throw new Error('Missing or invalid token fields');
     }
     return parsed as unknown as SessionPayload;
@@ -56,6 +59,7 @@ export async function createSessionToken(workflowId: string, workflowVersion: st
     wf: workflowId,
     act: '',
     skill: '',
+    cond: '',
     v: workflowVersion,
     seq: 0,
     ts: Math.floor(Date.now() / 1000),
@@ -72,6 +76,7 @@ export async function advanceToken(token: string, updates?: SessionAdvance): Pro
   if (updates?.wf !== undefined) payload.wf = updates.wf;
   if (updates?.act !== undefined) payload.act = updates.act;
   if (updates?.skill !== undefined) payload.skill = updates.skill;
+  if (updates?.cond !== undefined) payload.cond = updates.cond;
   return encode(payload);
 }
 

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,24 +1,57 @@
-import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 
-/**
- * Token format: <workflow-version>_<unix-epoch-seconds>_<8-hex-chars>
- * Example: 3.4.0_1711300000_a3b2c1d4
- */
-const SESSION_TOKEN_PATTERN = /^[\d.]+_\d+_[0-9a-f]{8}$/;
-
-export function generateSessionToken(workflowVersion: string): string {
-  const epoch = Math.floor(Date.now() / 1000);
-  const hex = randomUUID().replace(/-/g, '').substring(0, 8);
-  return `${workflowVersion}_${epoch}_${hex}`;
+export interface SessionPayload {
+  wf: string;
+  act: string;
+  v: string;
+  seq: number;
+  ts: number;
 }
 
-export function validateSessionToken(token: string): boolean {
-  return SESSION_TOKEN_PATTERN.test(token);
+function encode(payload: SessionPayload): string {
+  const json = JSON.stringify(payload);
+  return Buffer.from(json, 'utf8').toString('base64url');
+}
+
+function decode(token: string): SessionPayload {
+  try {
+    const json = Buffer.from(token, 'base64url').toString('utf8');
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    if (typeof parsed['wf'] !== 'string' || typeof parsed['act'] !== 'string' ||
+        typeof parsed['v'] !== 'string' || typeof parsed['seq'] !== 'number' ||
+        typeof parsed['ts'] !== 'number') {
+      throw new Error('Missing or invalid token fields');
+    }
+    return parsed as unknown as SessionPayload;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`Invalid session token: ${msg}`);
+  }
+}
+
+export function createSessionToken(workflowId: string, workflowVersion: string, initialActivity?: string): string {
+  return encode({
+    wf: workflowId,
+    act: initialActivity ?? '',
+    v: workflowVersion,
+    seq: 0,
+    ts: Math.floor(Date.now() / 1000),
+  });
+}
+
+export function decodeSessionToken(token: string): SessionPayload {
+  return decode(token);
+}
+
+export function advanceToken(token: string, updates?: { act?: string }): string {
+  const payload = decode(token);
+  payload.seq += 1;
+  if (updates?.act !== undefined) payload.act = updates.act;
+  return encode(payload);
 }
 
 export const sessionTokenParam = {
   session_token: z.string()
-    .regex(SESSION_TOKEN_PATTERN, 'Invalid session token format')
-    .describe('Session token from start_session'),
+    .min(1, 'Session token is required')
+    .describe('Opaque session token from start_session'),
 };

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -60,6 +60,52 @@ export function validateWorkflowVersion(token: SessionPayload, workflow: Workflo
   return null;
 }
 
+export interface StepManifestEntry {
+  step_id: string;
+  output: string;
+}
+
+export function validateStepManifest(
+  manifest: StepManifestEntry[],
+  workflow: Workflow,
+  activityId: string,
+): string[] {
+  const activity = getActivity(workflow, activityId);
+  if (!activity) return [`Cannot validate manifest: activity '${activityId}' not found`];
+
+  const steps = (activity as Record<string, unknown>)['steps'] as Array<{ id: string }> | undefined;
+  if (!steps || steps.length === 0) return [];
+
+  const expectedIds = steps.map(s => s.id);
+  const manifestIds = manifest.map(m => m.step_id);
+  const warnings: string[] = [];
+
+  const missing = expectedIds.filter(id => !manifestIds.includes(id));
+  if (missing.length > 0) {
+    warnings.push(`Missing steps in manifest: [${missing.join(', ')}]`);
+  }
+
+  const unexpected = manifestIds.filter(id => !expectedIds.includes(id));
+  if (unexpected.length > 0) {
+    warnings.push(`Unexpected steps in manifest: [${unexpected.join(', ')}]`);
+  }
+
+  for (let i = 0; i < manifestIds.length && i < expectedIds.length; i++) {
+    if (manifestIds[i] !== expectedIds[i]) {
+      warnings.push(`Step order mismatch at position ${i}: expected '${expectedIds[i]}' but got '${manifestIds[i]}'`);
+      break;
+    }
+  }
+
+  for (const entry of manifest) {
+    if (!entry.output || entry.output.trim().length === 0) {
+      warnings.push(`Step '${entry.step_id}' has empty output`);
+    }
+  }
+
+  return warnings;
+}
+
 export function buildValidation(...warnings: (string | null)[]): ValidationResult {
   const result = emptyValidation();
   for (const w of warnings) {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,72 @@
+import type { SessionPayload } from './session.js';
+import type { Workflow } from '../schema/workflow.schema.js';
+import { getValidTransitions, getActivity } from '../loaders/workflow-loader.js';
+
+export interface ValidationResult {
+  status: 'valid' | 'warning';
+  warnings: string[];
+}
+
+function emptyValidation(): ValidationResult {
+  return { status: 'valid', warnings: [] };
+}
+
+export function validateWorkflowConsistency(token: SessionPayload, workflowId: string): string | null {
+  if (token.wf && token.wf !== workflowId) {
+    return `Workflow mismatch: session was on '${token.wf}' but call targets '${workflowId}'. Start a new session for a different workflow.`;
+  }
+  return null;
+}
+
+export function validateActivityTransition(token: SessionPayload, workflow: Workflow, activityId: string): string | null {
+  if (!token.act) return null;
+  if (token.act === activityId) return null;
+
+  const valid = getValidTransitions(workflow, token.act);
+  if (valid.length === 0) return null;
+
+  if (!valid.includes(activityId)) {
+    return `Activity '${activityId}' is not a direct transition from '${token.act}'. Valid transitions: [${valid.join(', ')}]`;
+  }
+  return null;
+}
+
+export function validateSkillAssociation(workflow: Workflow, activityId: string, skillId: string): string | null {
+  if (!activityId) return null;
+
+  const activity = getActivity(workflow, activityId);
+  if (!activity) return null;
+
+  const skills = activity.skills;
+  if (!skills) return null;
+
+  const declared: string[] = [];
+  if (typeof skills === 'object' && 'primary' in skills) {
+    declared.push((skills as { primary: string }).primary);
+    const supporting = (skills as { supporting?: string[] }).supporting;
+    if (supporting) declared.push(...supporting);
+  }
+
+  if (declared.length > 0 && !declared.includes(skillId)) {
+    return `Skill '${skillId}' is not declared by activity '${activityId}'. Declared skills: [${declared.join(', ')}]`;
+  }
+  return null;
+}
+
+export function validateWorkflowVersion(token: SessionPayload, workflow: Workflow): string | null {
+  if (token.v && workflow.version && token.v !== workflow.version) {
+    return `Workflow version drift: session started with v${token.v} but current definition is v${workflow.version}. Workflow may have changed mid-session.`;
+  }
+  return null;
+}
+
+export function buildValidation(...warnings: (string | null)[]): ValidationResult {
+  const result = emptyValidation();
+  for (const w of warnings) {
+    if (w) {
+      result.warnings.push(w);
+      result.status = 'warning';
+    }
+  }
+  return result;
+}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,6 +1,6 @@
 import type { SessionPayload } from './session.js';
 import type { Workflow } from '../schema/workflow.schema.js';
-import { getValidTransitions, getActivity } from '../loaders/workflow-loader.js';
+import { getValidTransitions, getActivity, getTransitionList } from '../loaders/workflow-loader.js';
 
 export interface ValidationResult {
   status: 'valid' | 'warning';
@@ -104,6 +104,35 @@ export function validateStepManifest(
   }
 
   return warnings;
+}
+
+export function validateTransitionCondition(token: SessionPayload, workflow: Workflow, activityId: string, claimedCondition: string): string | null {
+  if (!token.act) return null;
+  if (token.act === activityId) return null;
+
+  const transitions = getTransitionList(workflow, token.act);
+  if (transitions.length === 0) return null;
+
+  const matchingTransition = transitions.find(t => t.to === activityId);
+  if (!matchingTransition) return null;
+
+  if (claimedCondition === '' || claimedCondition === 'default') {
+    if (matchingTransition.isDefault) return null;
+    if (matchingTransition.condition) {
+      return `Transition to '${activityId}' requires condition '${matchingTransition.condition}' but agent claimed default transition.`;
+    }
+    return null;
+  }
+
+  if (matchingTransition.isDefault && !matchingTransition.condition) {
+    return `Transition to '${activityId}' is the default (no condition) but agent claimed condition '${claimedCondition}'.`;
+  }
+
+  if (matchingTransition.condition && matchingTransition.condition !== claimedCondition) {
+    return `Condition mismatch for transition to '${activityId}': workflow defines '${matchingTransition.condition}' but agent claimed '${claimedCondition}'.`;
+  }
+
+  return null;
 }
 
 export function buildValidation(...warnings: (string | null)[]): ValidationResult {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -284,18 +284,6 @@ describe('mcp-server integration', () => {
     });
   });
 
-  describe('tool: discover_resources', () => {
-    it('should return bootstrap info in discovery', async () => {
-      const result = await client.callTool({
-        name: 'discover_resources',
-        arguments: { session_token: sessionToken },
-      });
-      const discovery = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
-      expect(discovery.bootstrap).toBeDefined();
-      expect(discovery.bootstrap.tool).toBe('list_workflows');
-    });
-  });
-
   // ============== Batch Skill Loading ==============
 
   describe('tool: get_skills', () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -198,10 +198,10 @@ describe('mcp-server integration', () => {
     });
   });
 
-  describe('tool: get_workflow_activity', () => {
+  describe('tool: get_activity', () => {
     it('should get activity and update token act field', async () => {
       const result = await client.callTool({
-        name: 'get_workflow_activity',
+        name: 'get_activity',
         arguments: { session_token: sessionToken, activity_id: 'start-work-package' },
       });
 
@@ -218,7 +218,7 @@ describe('mcp-server integration', () => {
 
     it('should return error for non-existent activity', async () => {
       const result = await client.callTool({
-        name: 'get_workflow_activity',
+        name: 'get_activity',
         arguments: { session_token: sessionToken, activity_id: 'non-existent' },
       });
       expect(result.isError).toBe(true);
@@ -228,7 +228,7 @@ describe('mcp-server integration', () => {
   describe('tool: get_checkpoint', () => {
     it('should get checkpoint using activity from token', async () => {
       const actResult = await client.callTool({
-        name: 'get_workflow_activity',
+        name: 'get_activity',
         arguments: { session_token: sessionToken, activity_id: 'start-work-package' },
       });
       const actMeta = actResult._meta as Record<string, unknown>;

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -141,7 +141,7 @@ describe('mcp-server integration', () => {
 
     it('should reject tool call without session_token', async () => {
       const result = await client.callTool({
-        name: 'get_activity',
+        name: 'get_workflow',
         arguments: {},
       });
       expect(result.isError).toBe(true);
@@ -288,23 +288,6 @@ describe('mcp-server integration', () => {
   });
 
   // ============== Resource Tools ==============
-
-  describe('tool: get_activity', () => {
-    it('should get activity from token act field', async () => {
-      const actResult = await client.callTool({
-        name: 'get_workflow_activity',
-        arguments: { session_token: sessionToken, activity_id: 'start-work-package' },
-      });
-      const actMeta = actResult._meta as Record<string, unknown>;
-      const tokenWithAct = actMeta['session_token'] as string;
-
-      const result = await client.callTool({
-        name: 'get_activity',
-        arguments: { session_token: tokenWithAct },
-      });
-      expect(result.isError).toBeFalsy();
-    });
-  });
 
   describe('tool: get_skill', () => {
     it('should get skill using workflow from token', async () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -269,27 +269,18 @@ describe('mcp-server integration', () => {
     });
   });
 
-  describe('tool: list_resources', () => {
-    it('should list resources with explicit workflow_id', async () => {
+  describe('resources attached to skills', () => {
+    it('get_skill should include referenced resources in _resources', async () => {
       const result = await client.callTool({
-        name: 'list_resources',
-        arguments: { session_token: sessionToken, workflow_id: 'work-package' },
+        name: 'get_skill',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', skill_id: 'create-issue' },
       });
-      const resources = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
-      expect(Array.isArray(resources)).toBe(true);
-      expect(resources.length).toBeGreaterThan(0);
-    });
-  });
-
-  describe('tool: get_resource', () => {
-    it('should get resource with explicit workflow_id', async () => {
-      const result = await client.callTool({
-        name: 'get_resource',
-        arguments: { session_token: sessionToken, workflow_id: 'work-package', index: '01' },
-      });
-      const content = (result.content[0] as { type: 'text'; text: string }).text;
-      expect(content).toBeDefined();
-      expect(content.length).toBeGreaterThan(0);
+      expect(result.isError).toBeFalsy();
+      const skill = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      if (skill.resources && skill.resources.length > 0) {
+        expect(skill._resources).toBeDefined();
+        expect(Object.keys(skill._resources).length).toBeGreaterThan(0);
+      }
     });
   });
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -217,35 +217,6 @@ describe('mcp-server integration', () => {
     });
   });
 
-  describe('tool: validate_transition', () => {
-    it('should validate allowed transition', async () => {
-      const result = await client.callTool({
-        name: 'validate_transition',
-        arguments: {
-          session_token: sessionToken,
-          workflow_id: 'work-package',
-          from_activity: 'start-work-package',
-          to_activity: 'design-philosophy',
-        },
-      });
-      const validation = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
-      expect(validation.valid).toBe(true);
-    });
-
-    it('should reject invalid transition', async () => {
-      const result = await client.callTool({
-        name: 'validate_transition',
-        arguments: {
-          session_token: sessionToken,
-          workflow_id: 'work-package',
-          from_activity: 'start-work-package',
-          to_activity: 'complete',
-        },
-      });
-      const validation = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
-      expect(validation.valid).toBe(false);
-    });
-  });
 
   describe('tool: health_check', () => {
     it('should return healthy status', async () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -347,7 +347,7 @@ describe('mcp-server integration', () => {
       expect(validation.warnings.some((w: string) => w.includes('not a direct transition'))).toBe(true);
     });
 
-    it('should not warn on valid activity transition', async () => {
+    it('should not warn on valid activity transition with manifest', async () => {
       const actResult = await client.callTool({
         name: 'get_activity',
         arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
@@ -355,9 +355,12 @@ describe('mcp-server integration', () => {
       const actMeta = actResult._meta as Record<string, unknown>;
       const tokenAfterStart = actMeta['session_token'] as string;
 
+      const actContent = JSON.parse((actResult.content[0] as { type: 'text'; text: string }).text);
+      const manifest = actContent.steps.map((s: { id: string }) => ({ step_id: s.id, output: 'completed' }));
+
       const result = await client.callTool({
         name: 'get_activity',
-        arguments: { session_token: tokenAfterStart, workflow_id: 'work-package', activity_id: 'design-philosophy' },
+        arguments: { session_token: tokenAfterStart, workflow_id: 'work-package', activity_id: 'design-philosophy', step_manifest: manifest },
       });
       expect(result.isError).toBeFalsy();
       const meta = result._meta as Record<string, unknown>;
@@ -380,6 +383,99 @@ describe('mcp-server integration', () => {
       expect(result.isError).toBeFalsy();
       const workflow = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
       expect(workflow.id).toBe('work-package');
+    });
+  });
+
+  // ============== Step Manifest ==============
+
+  describe('step completion manifest', () => {
+    it('should warn when no manifest provided for previous activity', async () => {
+      const actResult = await client.callTool({
+        name: 'get_activity',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
+      });
+      const actMeta = actResult._meta as Record<string, unknown>;
+      const tokenAfterAct = actMeta['session_token'] as string;
+
+      const result = await client.callTool({
+        name: 'get_activity',
+        arguments: { session_token: tokenAfterAct, workflow_id: 'work-package', activity_id: 'design-philosophy' },
+      });
+      const meta = result._meta as Record<string, unknown>;
+      const validation = meta['validation'] as { status: string; warnings: string[] };
+      expect(validation.status).toBe('warning');
+      expect(validation.warnings.some((w: string) => w.includes('No step_manifest'))).toBe(true);
+    });
+
+    it('should warn on missing steps in manifest', async () => {
+      const actResult = await client.callTool({
+        name: 'get_activity',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
+      });
+      const actMeta = actResult._meta as Record<string, unknown>;
+      const tokenAfterAct = actMeta['session_token'] as string;
+
+      const result = await client.callTool({
+        name: 'get_activity',
+        arguments: {
+          session_token: tokenAfterAct,
+          workflow_id: 'work-package',
+          activity_id: 'design-philosophy',
+          step_manifest: [{ step_id: 'resolve-target', output: 'done' }],
+        },
+      });
+      const meta = result._meta as Record<string, unknown>;
+      const validation = meta['validation'] as { status: string; warnings: string[] };
+      expect(validation.status).toBe('warning');
+      expect(validation.warnings.some((w: string) => w.includes('Missing steps'))).toBe(true);
+    });
+
+    it('should warn on wrong step order in manifest', async () => {
+      const actResult = await client.callTool({
+        name: 'get_activity',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
+      });
+      const actMeta = actResult._meta as Record<string, unknown>;
+      const tokenAfterAct = actMeta['session_token'] as string;
+
+      const actContent = JSON.parse((actResult.content[0] as { type: 'text'; text: string }).text);
+      const reversedManifest = actContent.steps.map((s: { id: string }) => ({ step_id: s.id, output: 'done' })).reverse();
+
+      const result = await client.callTool({
+        name: 'get_activity',
+        arguments: {
+          session_token: tokenAfterAct,
+          workflow_id: 'work-package',
+          activity_id: 'design-philosophy',
+          step_manifest: reversedManifest,
+        },
+      });
+      const meta = result._meta as Record<string, unknown>;
+      const validation = meta['validation'] as { status: string; warnings: string[] };
+      expect(validation.status).toBe('warning');
+      expect(validation.warnings.some((w: string) => w.includes('order mismatch'))).toBe(true);
+    });
+
+    it('manifest validation should not block execution', async () => {
+      const actResult = await client.callTool({
+        name: 'get_activity',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
+      });
+      const actMeta = actResult._meta as Record<string, unknown>;
+      const tokenAfterAct = actMeta['session_token'] as string;
+
+      const result = await client.callTool({
+        name: 'get_activity',
+        arguments: {
+          session_token: tokenAfterAct,
+          workflow_id: 'work-package',
+          activity_id: 'design-philosophy',
+          step_manifest: [{ step_id: 'fake-step', output: 'done' }],
+        },
+      });
+      expect(result.isError).toBeFalsy();
+      const activity = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(activity.id).toBe('design-philosophy');
     });
   });
 });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -305,6 +305,50 @@ describe('mcp-server integration', () => {
     });
   });
 
+  // ============== Batch Skill Loading ==============
+
+  describe('tool: get_skills', () => {
+    it('should return all skills for an activity in one call', async () => {
+      const result = await client.callTool({
+        name: 'get_skills',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
+      });
+      expect(result.isError).toBeFalsy();
+
+      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(response.activity_id).toBe('start-work-package');
+      expect(response.skills).toBeDefined();
+      expect(response.skills['create-issue']).toBeDefined();
+    });
+
+    it('should include primary and supporting skills', async () => {
+      const result = await client.callTool({
+        name: 'get_skills',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
+      });
+      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const skillIds = Object.keys(response.skills);
+      expect(skillIds.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should return updated token in _meta', async () => {
+      const result = await client.callTool({
+        name: 'get_skills',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
+      });
+      const meta = result._meta as Record<string, unknown>;
+      expect(meta['session_token']).toBeDefined();
+    });
+
+    it('should error for non-existent activity', async () => {
+      const result = await client.callTool({
+        name: 'get_skills',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'non-existent' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
   // ============== Validation ==============
 
   describe('token validation', () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -430,6 +430,104 @@ describe('mcp-server integration', () => {
     });
   });
 
+  // ============== Transition Condition Tracking ==============
+
+  describe('transition condition validation', () => {
+    it('should accept correct condition-activity pairing', async () => {
+      const actResult = await client.callTool({
+        name: 'get_activity',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'codebase-comprehension' },
+      });
+      const actMeta = actResult._meta as Record<string, unknown>;
+      const tokenAtComprehension = actMeta['session_token'] as string;
+
+      const result = await client.callTool({
+        name: 'get_activity',
+        arguments: {
+          session_token: tokenAtComprehension,
+          workflow_id: 'work-package',
+          activity_id: 'requirements-elicitation',
+          transition_condition: 'needs_elicitation == true',
+        },
+      });
+      expect(result.isError).toBeFalsy();
+      const meta = result._meta as Record<string, unknown>;
+      const validation = meta['validation'] as { status: string; warnings: string[] };
+      const condWarnings = validation.warnings.filter((w: string) => w.includes('Condition mismatch') || w.includes('condition'));
+      expect(condWarnings).toHaveLength(0);
+    });
+
+    it('should warn on mismatched condition for activity', async () => {
+      const actResult = await client.callTool({
+        name: 'get_activity',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'codebase-comprehension' },
+      });
+      const actMeta = actResult._meta as Record<string, unknown>;
+      const tokenAtComprehension = actMeta['session_token'] as string;
+
+      const result = await client.callTool({
+        name: 'get_activity',
+        arguments: {
+          session_token: tokenAtComprehension,
+          workflow_id: 'work-package',
+          activity_id: 'requirements-elicitation',
+          transition_condition: 'skip_optional_activities == true',
+        },
+      });
+      expect(result.isError).toBeFalsy();
+      const meta = result._meta as Record<string, unknown>;
+      const validation = meta['validation'] as { status: string; warnings: string[] };
+      expect(validation.status).toBe('warning');
+      expect(validation.warnings.some((w: string) => w.includes('Condition mismatch'))).toBe(true);
+    });
+
+    it('should accept default transition with empty condition', async () => {
+      const actResult = await client.callTool({
+        name: 'get_activity',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
+      });
+      const actMeta = actResult._meta as Record<string, unknown>;
+      const tokenAtStart = actMeta['session_token'] as string;
+
+      const result = await client.callTool({
+        name: 'get_activity',
+        arguments: {
+          session_token: tokenAtStart,
+          workflow_id: 'work-package',
+          activity_id: 'design-philosophy',
+          transition_condition: 'default',
+        },
+      });
+      expect(result.isError).toBeFalsy();
+      const meta = result._meta as Record<string, unknown>;
+      const validation = meta['validation'] as { status: string; warnings: string[] };
+      const condWarnings = validation.warnings.filter((w: string) => w.includes('condition') || w.includes('Condition'));
+      expect(condWarnings).toHaveLength(0);
+    });
+
+    it('condition should not block execution', async () => {
+      const actResult = await client.callTool({
+        name: 'get_activity',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'codebase-comprehension' },
+      });
+      const actMeta = actResult._meta as Record<string, unknown>;
+      const tokenAtComprehension = actMeta['session_token'] as string;
+
+      const result = await client.callTool({
+        name: 'get_activity',
+        arguments: {
+          session_token: tokenAtComprehension,
+          workflow_id: 'work-package',
+          activity_id: 'requirements-elicitation',
+          transition_condition: 'wrong_condition == true',
+        },
+      });
+      expect(result.isError).toBeFalsy();
+      const activity = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(activity.id).toBe('requirements-elicitation');
+    });
+  });
+
   // ============== Step Manifest ==============
 
   describe('step completion manifest', () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -568,7 +568,7 @@ describe('mcp-server integration', () => {
   // ============== Workflow Summary Mode ==============
 
   describe('tool: get_workflow (summary mode)', () => {
-    it('should return lightweight summary when summary=true', async () => {
+    it('should return lightweight summary by default', async () => {
       const result = await client.callTool({
         name: 'get_workflow',
         arguments: { session_token: sessionToken, workflow_id: 'work-package', summary: true },

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -478,4 +478,136 @@ describe('mcp-server integration', () => {
       expect(activity.id).toBe('design-philosophy');
     });
   });
+
+  // ============== Next Activity ==============
+
+  describe('tool: next_activity', () => {
+    it('should return transition list for current activity', async () => {
+      const actResult = await client.callTool({
+        name: 'get_activity',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
+      });
+      const actMeta = actResult._meta as Record<string, unknown>;
+      const tokenWithAct = actMeta['session_token'] as string;
+
+      const result = await client.callTool({
+        name: 'next_activity',
+        arguments: { session_token: tokenWithAct, workflow_id: 'work-package' },
+      });
+      expect(result.isError).toBeFalsy();
+
+      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(response.current_activity).toBe('start-work-package');
+      expect(response.transitions).toBeDefined();
+      expect(Array.isArray(response.transitions)).toBe(true);
+      expect(response.transitions.length).toBeGreaterThan(0);
+      expect(response.transitions[0].to).toBeDefined();
+    });
+
+    it('should include conditions as readable strings', async () => {
+      const actResult = await client.callTool({
+        name: 'get_activity',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'codebase-comprehension' },
+      });
+      const actMeta = actResult._meta as Record<string, unknown>;
+      const tokenWithAct = actMeta['session_token'] as string;
+
+      const result = await client.callTool({
+        name: 'next_activity',
+        arguments: { session_token: tokenWithAct, workflow_id: 'work-package' },
+      });
+      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const conditional = response.transitions.find((t: { condition?: string }) => t.condition);
+      expect(conditional).toBeDefined();
+      expect(typeof conditional.condition).toBe('string');
+    });
+
+    it('should mark default transitions', async () => {
+      const actResult = await client.callTool({
+        name: 'get_activity',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
+      });
+      const actMeta = actResult._meta as Record<string, unknown>;
+      const tokenWithAct = actMeta['session_token'] as string;
+
+      const result = await client.callTool({
+        name: 'next_activity',
+        arguments: { session_token: tokenWithAct, workflow_id: 'work-package' },
+      });
+      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const defaultTransition = response.transitions.find((t: { isDefault?: boolean }) => t.isDefault);
+      expect(defaultTransition).toBeDefined();
+    });
+
+    it('should error when no activity in token', async () => {
+      const result = await client.callTool({
+        name: 'next_activity',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package' },
+      });
+      expect(result.isError).toBe(true);
+    });
+
+    it('should return updated token in _meta', async () => {
+      const actResult = await client.callTool({
+        name: 'get_activity',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
+      });
+      const actMeta = actResult._meta as Record<string, unknown>;
+      const tokenWithAct = actMeta['session_token'] as string;
+
+      const result = await client.callTool({
+        name: 'next_activity',
+        arguments: { session_token: tokenWithAct, workflow_id: 'work-package' },
+      });
+      const meta = result._meta as Record<string, unknown>;
+      expect(meta['session_token']).toBeDefined();
+      expect(meta['session_token']).not.toBe(tokenWithAct);
+    });
+  });
+
+  // ============== Workflow Summary Mode ==============
+
+  describe('tool: get_workflow (summary mode)', () => {
+    it('should return lightweight summary when summary=true', async () => {
+      const result = await client.callTool({
+        name: 'get_workflow',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', summary: true },
+      });
+      expect(result.isError).toBeFalsy();
+
+      const wf = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(wf.id).toBe('work-package');
+      expect(wf.version).toBe('3.4.0');
+      expect(wf.rules).toBeDefined();
+      expect(wf.variables).toBeDefined();
+      expect(wf.activities).toBeDefined();
+      expect(wf.activities[0].id).toBeDefined();
+      expect(wf.activities[0].steps).toBeUndefined();
+      expect(wf.activities[0].checkpoints).toBeUndefined();
+    });
+
+    it('summary should be smaller than full definition', async () => {
+      const fullResult = await client.callTool({
+        name: 'get_workflow',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', summary: false },
+      });
+      const summaryResult = await client.callTool({
+        name: 'get_workflow',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', summary: true },
+      });
+
+      const fullSize = (fullResult.content[0] as { type: 'text'; text: string }).text.length;
+      const summarySize = (summaryResult.content[0] as { type: 'text'; text: string }).text.length;
+      expect(summarySize).toBeLessThan(fullSize / 2);
+    });
+
+    it('should return full definition when summary=false', async () => {
+      const result = await client.callTool({
+        name: 'get_workflow',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', summary: false },
+      });
+      const wf = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(wf.activities[0].steps).toBeDefined();
+    });
+  });
 });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -20,7 +20,7 @@ describe('mcp-server integration', () => {
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 
     await server.connect(serverTransport);
-    
+
     client = new Client({ name: 'test-client', version: '1.0.0' }, {});
     await client.connect(clientTransport);
 
@@ -31,79 +31,110 @@ describe('mcp-server integration', () => {
 
     const sessionResult = await client.callTool({
       name: 'start_session',
-      arguments: { workflow_version: '3.4.0' },
+      arguments: { workflow_id: 'work-package' },
     });
     const sessionResponse = JSON.parse((sessionResult.content[0] as { type: 'text'; text: string }).text);
-    sessionToken = sessionResponse.session.token;
+    sessionToken = sessionResponse.session_token;
   });
 
   afterAll(async () => {
     await closeTransport();
   });
 
-  // ============== Session & Bootstrap Tools ==============
+  // ============== Bootstrap Flow ==============
 
-  describe('tool: start_session', () => {
-    it('should return rules and session with token', async () => {
+  describe('bootstrap flow: list_workflows -> start_session', () => {
+    it('list_workflows should not require session_token', async () => {
+      const result = await client.callTool({ name: 'list_workflows', arguments: {} });
+      expect(result.isError).toBeFalsy();
+
+      const workflows = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(Array.isArray(workflows)).toBe(true);
+      expect(workflows.length).toBeGreaterThanOrEqual(2);
+
+      const ids = workflows.map((w: { id: string }) => w.id);
+      expect(ids).toContain('work-package');
+      expect(ids).toContain('meta');
+    });
+
+    it('start_session should return rules, workflow metadata, and opaque token', async () => {
       const result = await client.callTool({
         name: 'start_session',
-        arguments: { workflow_version: '3.4.0' },
+        arguments: { workflow_id: 'work-package' },
       });
+      expect(result.isError).toBeFalsy();
 
       const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
 
       expect(response.rules).toBeDefined();
       expect(response.rules.id).toBe('agent-rules');
       expect(response.rules.sections).toBeDefined();
-      expect(response.session).toBeDefined();
-      expect(response.session.token).toBeDefined();
-      expect(response.session.created_at).toBeDefined();
-      expect(response.session.server_version).toBe('1.0.0');
+
+      expect(response.workflow).toBeDefined();
+      expect(response.workflow.id).toBe('work-package');
+      expect(response.workflow.version).toBe('3.4.0');
+
+      expect(response.session_token).toBeDefined();
+      expect(typeof response.session_token).toBe('string');
+      expect(response.session_token.length).toBeGreaterThan(10);
     });
 
-    it('should return token matching structured format', async () => {
+    it('start_session should reject unknown workflow_id', async () => {
       const result = await client.callTool({
         name: 'start_session',
-        arguments: { workflow_version: '3.4.0' },
+        arguments: { workflow_id: 'non-existent' },
       });
-
-      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
-      expect(response.session.token).toMatch(/^[\d.]+_\d+_[0-9a-f]{8}$/);
-      expect(response.session.token).toMatch(/^3\.4\.0_/);
+      expect(result.isError).toBe(true);
     });
 
-    it('should work without session_token (exempt)', async () => {
+    it('start_session should not require session_token (exempt)', async () => {
       const result = await client.callTool({
         name: 'start_session',
-        arguments: { workflow_version: '1.0.0' },
+        arguments: { workflow_id: 'meta' },
       });
       expect(result.isError).toBeFalsy();
     });
   });
 
-  describe('tool: match_goal', () => {
-    it('should return activity index', async () => {
-      const result = await client.callTool({ name: 'match_goal', arguments: {} });
-      
-      const index = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
-      
-      expect(index.description).toBeDefined();
-      expect(index.activities).toBeDefined();
-      expect(index.activities.length).toBeGreaterThanOrEqual(3);
-      expect(index.quick_match).toBeDefined();
+  // ============== Session Token Lifecycle ==============
+
+  describe('session token lifecycle', () => {
+    it('token should be opaque (not readable JSON)', async () => {
+      expect(sessionToken).not.toContain('{');
+      expect(sessionToken).not.toContain('workflow');
     });
 
-    it('should reference start_session in next_action', async () => {
-      const result = await client.callTool({ name: 'match_goal', arguments: {} });
-
-      const index = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
-
-      expect(index.next_action).toBeDefined();
-      expect(index.next_action.tool).toBe('start_session');
+    it('tools should return updated token in _meta', async () => {
+      const result = await client.callTool({
+        name: 'get_workflow',
+        arguments: { session_token: sessionToken },
+      });
+      expect(result.isError).toBeFalsy();
+      const meta = result._meta as Record<string, unknown> | undefined;
+      expect(meta).toBeDefined();
+      expect(meta!['session_token']).toBeDefined();
+      expect(typeof meta!['session_token']).toBe('string');
+      expect(meta!['session_token']).not.toBe(sessionToken);
     });
 
-    it('should work without session_token (exempt)', async () => {
-      const result = await client.callTool({ name: 'match_goal', arguments: {} });
+    it('should reject tool call without session_token', async () => {
+      const result = await client.callTool({
+        name: 'get_activity',
+        arguments: {},
+      });
+      expect(result.isError).toBe(true);
+    });
+
+    it('should reject tool call with invalid session_token', async () => {
+      const result = await client.callTool({
+        name: 'get_workflow',
+        arguments: { session_token: 'not-a-valid-token' },
+      });
+      expect(result.isError).toBe(true);
+    });
+
+    it('health_check should not require session_token', async () => {
+      const result = await client.callTool({ name: 'health_check', arguments: {} });
       expect(result.isError).toBeFalsy();
     });
   });
@@ -120,129 +151,74 @@ describe('mcp-server integration', () => {
       const result = await client.callTool({ name: 'get_rules', arguments: {} });
       expect(result.isError).toBe(true);
     });
-  });
 
-  // ============== Session Token Enforcement ==============
-
-  describe('session_token enforcement', () => {
-    it('should reject tool call without session_token', async () => {
-      const result = await client.callTool({
-        name: 'get_activity',
-        arguments: { activity_id: 'start-workflow' },
-      });
+    it('should reject match_goal (removed)', async () => {
+      const result = await client.callTool({ name: 'match_goal', arguments: { prompt: 'test' } });
       expect(result.isError).toBe(true);
     });
-
-    it('should reject tool call with malformed session_token', async () => {
-      const result = await client.callTool({
-        name: 'get_activity',
-        arguments: { session_token: 'invalid-token', activity_id: 'start-workflow' },
-      });
-      expect(result.isError).toBe(true);
-    });
-
-    it('should accept tool call with valid session_token', async () => {
-      const result = await client.callTool({
-        name: 'get_activity',
-        arguments: { session_token: sessionToken, activity_id: 'start-workflow' },
-      });
-      expect(result.isError).toBeFalsy();
-    });
-
-    it('should not require session_token for health_check', async () => {
-      const result = await client.callTool({ name: 'health_check', arguments: {} });
-      expect(result.isError).toBeFalsy();
-    });
   });
 
-  // ============== Workflow Tools (with session_token) ==============
-
-  describe('tool: list_workflows', () => {
-    it('should list available workflows', async () => {
-      const result = await client.callTool({ name: 'list_workflows', arguments: { session_token: sessionToken } });
-      
-      expect(result.content).toBeDefined();
-      expect(result.content[0]).toHaveProperty('type', 'text');
-      
-      const workflows = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
-      expect(Array.isArray(workflows)).toBe(true);
-      expect(workflows.length).toBeGreaterThanOrEqual(2);
-      
-      const ids = workflows.map((w: { id: string }) => w.id);
-      expect(ids).toContain('work-package');
-      expect(ids).toContain('meta');
-    });
-  });
+  // ============== Workflow Tools ==============
 
   describe('tool: get_workflow', () => {
-    it('should get work-package workflow', async () => {
+    it('should get workflow using workflow_id from token', async () => {
       const result = await client.callTool({
         name: 'get_workflow',
-        arguments: { session_token: sessionToken, workflow_id: 'work-package' },
+        arguments: { session_token: sessionToken },
       });
-      
+
       expect(result.content).toBeDefined();
       const workflow = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
-      
+
       expect(workflow.id).toBe('work-package');
       expect(workflow.version).toBe('3.4.0');
       expect(workflow.activities).toHaveLength(14);
-      expect(workflow.initialActivity).toBe('start-work-package');
-    });
-
-    it('should return error for non-existent workflow', async () => {
-      const result = await client.callTool({
-        name: 'get_workflow',
-        arguments: { session_token: sessionToken, workflow_id: 'non-existent' },
-      });
-      
-      expect(result.isError).toBe(true);
-      expect((result.content[0] as { type: 'text'; text: string }).text).toContain('not found');
     });
   });
 
   describe('tool: get_workflow_activity', () => {
-    it('should get specific activity from workflow', async () => {
+    it('should get activity and update token act field', async () => {
       const result = await client.callTool({
         name: 'get_workflow_activity',
-        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
+        arguments: { session_token: sessionToken, activity_id: 'start-work-package' },
       });
-      
+
       const activity = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
-      
       expect(activity.id).toBe('start-work-package');
       expect(activity.name).toBe('Start Work Package');
       expect(activity.checkpoints).toBeDefined();
       expect(activity.checkpoints.length).toBeGreaterThan(0);
+
+      const meta = result._meta as Record<string, unknown> | undefined;
+      expect(meta).toBeDefined();
+      expect(meta!['session_token']).toBeDefined();
     });
 
     it('should return error for non-existent activity', async () => {
       const result = await client.callTool({
         name: 'get_workflow_activity',
-        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'non-existent' },
+        arguments: { session_token: sessionToken, activity_id: 'non-existent' },
       });
-      
       expect(result.isError).toBe(true);
-      expect((result.content[0] as { type: 'text'; text: string }).text).toContain('not found');
     });
   });
 
   describe('tool: get_checkpoint', () => {
-    it('should get specific checkpoint', async () => {
+    it('should get checkpoint using activity from token', async () => {
+      const actResult = await client.callTool({
+        name: 'get_workflow_activity',
+        arguments: { session_token: sessionToken, activity_id: 'start-work-package' },
+      });
+      const actMeta = actResult._meta as Record<string, unknown>;
+      const updatedToken = actMeta['session_token'] as string;
+
       const result = await client.callTool({
         name: 'get_checkpoint',
-        arguments: {
-          session_token: sessionToken,
-          workflow_id: 'work-package',
-          activity_id: 'start-work-package',
-          checkpoint_id: 'issue-verification',
-        },
+        arguments: { session_token: updatedToken, checkpoint_id: 'issue-verification' },
       });
-      
+
       const checkpoint = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
-      
       expect(checkpoint.id).toBe('issue-verification');
-      expect(checkpoint.name).toBe('Issue Verification Checkpoint');
       expect(checkpoint.options).toBeDefined();
       expect(checkpoint.options.length).toBeGreaterThan(0);
     });
@@ -254,12 +230,11 @@ describe('mcp-server integration', () => {
         name: 'validate_transition',
         arguments: {
           session_token: sessionToken,
-          workflow_id: 'work-package',
           from_activity: 'start-work-package',
           to_activity: 'design-philosophy',
         },
       });
-      
+
       const validation = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
       expect(validation.valid).toBe(true);
     });
@@ -269,107 +244,98 @@ describe('mcp-server integration', () => {
         name: 'validate_transition',
         arguments: {
           session_token: sessionToken,
-          workflow_id: 'work-package',
           from_activity: 'start-work-package',
           to_activity: 'complete',
         },
       });
-      
+
       const validation = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
       expect(validation.valid).toBe(false);
-      expect(validation.reason).toContain('No valid transition');
     });
   });
 
   describe('tool: health_check', () => {
     it('should return healthy status', async () => {
       const result = await client.callTool({ name: 'health_check', arguments: {} });
-      
+
       const health = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
-      
       expect(health.status).toBe('healthy');
       expect(health.server).toBe('test-workflow-server');
       expect(health.workflows_available).toBeGreaterThanOrEqual(2);
-      expect(health.uptime_seconds).toBeGreaterThanOrEqual(0);
     });
   });
 
-  // ============== Resource Tools (with session_token) ==============
+  // ============== Resource Tools ==============
 
   describe('tool: get_activity', () => {
-    it('should return specific activity', async () => {
+    it('should get activity from token act field', async () => {
+      const actResult = await client.callTool({
+        name: 'get_workflow_activity',
+        arguments: { session_token: sessionToken, activity_id: 'start-work-package' },
+      });
+      const actMeta = actResult._meta as Record<string, unknown>;
+      const tokenWithAct = actMeta['session_token'] as string;
+
       const result = await client.callTool({
         name: 'get_activity',
-        arguments: { session_token: sessionToken, activity_id: 'start-workflow' },
+        arguments: { session_token: tokenWithAct },
       });
-      
-      const activity = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
-      
-      expect(activity.id).toBe('start-workflow');
-      expect(activity.skills).toBeDefined();
-      expect(activity.skills.primary).toBe('workflow-execution');
+      expect(result.isError).toBeFalsy();
     });
   });
 
   describe('tool: get_skill', () => {
-    it('should return specific skill', async () => {
+    it('should get skill using workflow from token', async () => {
       const result = await client.callTool({
         name: 'get_skill',
         arguments: { session_token: sessionToken, skill_id: 'workflow-execution' },
       });
-      
+
       const skill = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
-      
       expect(skill.id).toBe('workflow-execution');
       expect(skill.capability).toBeDefined();
-      expect(skill.tools).toBeDefined();
     });
   });
 
   describe('tool: list_workflow_resources', () => {
-    it('should list resources for a workflow', async () => {
+    it('should list resources using workflow from token', async () => {
       const result = await client.callTool({
         name: 'list_workflow_resources',
-        arguments: { session_token: sessionToken, workflow_id: 'work-package' },
+        arguments: { session_token: sessionToken },
       });
-      
+
       const resources = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
-      
       expect(Array.isArray(resources)).toBe(true);
       expect(resources.length).toBeGreaterThan(0);
       expect(resources[0]).toHaveProperty('index');
-      expect(resources[0]).toHaveProperty('name');
     });
   });
 
   describe('tool: get_resource', () => {
-    it('should get specific resource', async () => {
+    it('should get resource using workflow from token', async () => {
       const result = await client.callTool({
         name: 'get_resource',
-        arguments: { session_token: sessionToken, workflow_id: 'work-package', index: '01' },
+        arguments: { session_token: sessionToken, index: '01' },
       });
-      
+
       const content = (result.content[0] as { type: 'text'; text: string }).text;
-      
       expect(content).toBeDefined();
-      expect(content).toContain('id:');
-      expect(content.includes('title:') || content.includes('# ')).toBe(true);
+      expect(content.length).toBeGreaterThan(0);
     });
   });
 
   // ============== Discovery Tool ==============
 
   describe('tool: discover_resources', () => {
-    it('should reference match_goal in discovery output', async () => {
+    it('should reference list_workflows bootstrap in discovery', async () => {
       const result = await client.callTool({
         name: 'discover_resources',
         arguments: { session_token: sessionToken },
       });
 
       const discovery = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
-
-      expect(discovery.activities).toBeDefined();
-      expect(discovery.activities.tool).toBe('match_goal');
+      expect(discovery.bootstrap).toBeDefined();
+      expect(discovery.bootstrap.tool).toBe('list_workflows');
     });
   });
 });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -18,7 +18,6 @@ describe('mcp-server integration', () => {
 
     const server = createServer(config);
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-
     await server.connect(serverTransport);
 
     client = new Client({ name: 'test-client', version: '1.0.0' }, {});
@@ -41,108 +40,86 @@ describe('mcp-server integration', () => {
     await closeTransport();
   });
 
-  // ============== Bootstrap Flow ==============
+  // ============== Bootstrap Tools ==============
 
   describe('tool: help', () => {
     it('should return bootstrap procedure and session protocol', async () => {
       const result = await client.callTool({ name: 'help', arguments: {} });
       expect(result.isError).toBeFalsy();
-
       const guide = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
-
       expect(guide.bootstrap).toBeDefined();
       expect(guide.bootstrap.step_1.tool).toBe('list_workflows');
       expect(guide.bootstrap.step_2.tool).toBe('start_session');
       expect(guide.session_protocol).toBeDefined();
-      expect(guide.session_protocol.exempt_tools).toContain('help');
-      expect(guide.available_workflows).toBeDefined();
+      expect(guide.session_protocol.validation).toBeDefined();
       expect(guide.available_workflows.length).toBeGreaterThanOrEqual(2);
-    });
-
-    it('should not require session_token', async () => {
-      const result = await client.callTool({ name: 'help', arguments: {} });
-      expect(result.isError).toBeFalsy();
     });
   });
 
-  describe('bootstrap flow: list_workflows -> start_session', () => {
-    it('list_workflows should not require session_token', async () => {
+  describe('tool: list_workflows', () => {
+    it('should not require session_token', async () => {
       const result = await client.callTool({ name: 'list_workflows', arguments: {} });
       expect(result.isError).toBeFalsy();
-
       const workflows = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
       expect(Array.isArray(workflows)).toBe(true);
-      expect(workflows.length).toBeGreaterThanOrEqual(2);
-
       const ids = workflows.map((w: { id: string }) => w.id);
       expect(ids).toContain('work-package');
       expect(ids).toContain('meta');
     });
+  });
 
-    it('start_session should return rules, workflow metadata, and opaque token', async () => {
+  describe('tool: start_session', () => {
+    it('should return rules, workflow metadata, and opaque token', async () => {
       const result = await client.callTool({
         name: 'start_session',
         arguments: { workflow_id: 'work-package' },
       });
       expect(result.isError).toBeFalsy();
-
       const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
-
       expect(response.rules).toBeDefined();
       expect(response.rules.id).toBe('agent-rules');
-      expect(response.rules.sections).toBeDefined();
-
-      expect(response.workflow).toBeDefined();
       expect(response.workflow.id).toBe('work-package');
-      expect(response.workflow.version).toBe('3.4.0');
-
       expect(response.session_token).toBeDefined();
       expect(typeof response.session_token).toBe('string');
-      expect(response.session_token.length).toBeGreaterThan(10);
     });
 
-    it('start_session should reject unknown workflow_id', async () => {
+    it('should reject unknown workflow_id', async () => {
       const result = await client.callTool({
         name: 'start_session',
         arguments: { workflow_id: 'non-existent' },
       });
       expect(result.isError).toBe(true);
     });
-
-    it('start_session should not require session_token (exempt)', async () => {
-      const result = await client.callTool({
-        name: 'start_session',
-        arguments: { workflow_id: 'meta' },
-      });
-      expect(result.isError).toBeFalsy();
-    });
   });
 
   // ============== Session Token Lifecycle ==============
 
   describe('session token lifecycle', () => {
-    it('token should be opaque (not readable JSON)', async () => {
+    it('token should be opaque', async () => {
       expect(sessionToken).not.toContain('{');
       expect(sessionToken).not.toContain('workflow');
     });
 
-    it('tools should return updated token in _meta', async () => {
+    it('tools should return updated token and validation in _meta', async () => {
       const result = await client.callTool({
         name: 'get_workflow',
-        arguments: { session_token: sessionToken },
+        arguments: { session_token: sessionToken, workflow_id: 'work-package' },
       });
       expect(result.isError).toBeFalsy();
       const meta = result._meta as Record<string, unknown> | undefined;
       expect(meta).toBeDefined();
       expect(meta!['session_token']).toBeDefined();
-      expect(typeof meta!['session_token']).toBe('string');
       expect(meta!['session_token']).not.toBe(sessionToken);
+      expect(meta!['validation']).toBeDefined();
+      const validation = meta!['validation'] as { status: string; warnings: string[] };
+      expect(validation.status).toBe('valid');
+      expect(validation.warnings).toHaveLength(0);
     });
 
     it('should reject tool call without session_token', async () => {
       const result = await client.callTool({
         name: 'get_workflow',
-        arguments: {},
+        arguments: { workflow_id: 'work-package' },
       });
       expect(result.isError).toBe(true);
     });
@@ -150,7 +127,7 @@ describe('mcp-server integration', () => {
     it('should reject tool call with invalid session_token', async () => {
       const result = await client.callTool({
         name: 'get_workflow',
-        arguments: { session_token: 'not-a-valid-token' },
+        arguments: { session_token: 'not-valid', workflow_id: 'work-package' },
       });
       expect(result.isError).toBe(true);
     });
@@ -164,17 +141,17 @@ describe('mcp-server integration', () => {
   // ============== Old Tool Names Removed ==============
 
   describe('old tool names removed', () => {
-    it('should reject get_activities (removed)', async () => {
+    it('should reject get_activities', async () => {
       const result = await client.callTool({ name: 'get_activities', arguments: {} });
       expect(result.isError).toBe(true);
     });
 
-    it('should reject get_rules (removed)', async () => {
+    it('should reject get_rules', async () => {
       const result = await client.callTool({ name: 'get_rules', arguments: {} });
       expect(result.isError).toBe(true);
     });
 
-    it('should reject match_goal (removed)', async () => {
+    it('should reject match_goal', async () => {
       const result = await client.callTool({ name: 'match_goal', arguments: { prompt: 'test' } });
       expect(result.isError).toBe(true);
     });
@@ -183,65 +160,59 @@ describe('mcp-server integration', () => {
   // ============== Workflow Tools ==============
 
   describe('tool: get_workflow', () => {
-    it('should get workflow using workflow_id from token', async () => {
+    it('should get workflow with explicit workflow_id', async () => {
       const result = await client.callTool({
         name: 'get_workflow',
-        arguments: { session_token: sessionToken },
+        arguments: { session_token: sessionToken, workflow_id: 'work-package' },
       });
-
       expect(result.content).toBeDefined();
       const workflow = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
-
       expect(workflow.id).toBe('work-package');
       expect(workflow.version).toBe('3.4.0');
-      expect(workflow.activities).toHaveLength(14);
+    });
+
+    it('should return error for non-existent workflow', async () => {
+      const result = await client.callTool({
+        name: 'get_workflow',
+        arguments: { session_token: sessionToken, workflow_id: 'non-existent' },
+      });
+      expect(result.isError).toBe(true);
     });
   });
 
   describe('tool: get_activity', () => {
-    it('should get activity and update token act field', async () => {
+    it('should get activity with explicit params', async () => {
       const result = await client.callTool({
         name: 'get_activity',
-        arguments: { session_token: sessionToken, activity_id: 'start-work-package' },
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
       });
-
       const activity = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
       expect(activity.id).toBe('start-work-package');
       expect(activity.name).toBe('Start Work Package');
-      expect(activity.checkpoints).toBeDefined();
-      expect(activity.checkpoints.length).toBeGreaterThan(0);
-
-      const meta = result._meta as Record<string, unknown> | undefined;
-      expect(meta).toBeDefined();
-      expect(meta!['session_token']).toBeDefined();
     });
 
     it('should return error for non-existent activity', async () => {
       const result = await client.callTool({
         name: 'get_activity',
-        arguments: { session_token: sessionToken, activity_id: 'non-existent' },
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'non-existent' },
       });
       expect(result.isError).toBe(true);
     });
   });
 
   describe('tool: get_checkpoint', () => {
-    it('should get checkpoint using activity from token', async () => {
-      const actResult = await client.callTool({
-        name: 'get_activity',
-        arguments: { session_token: sessionToken, activity_id: 'start-work-package' },
-      });
-      const actMeta = actResult._meta as Record<string, unknown>;
-      const updatedToken = actMeta['session_token'] as string;
-
+    it('should get checkpoint with explicit params', async () => {
       const result = await client.callTool({
         name: 'get_checkpoint',
-        arguments: { session_token: updatedToken, checkpoint_id: 'issue-verification' },
+        arguments: {
+          session_token: sessionToken,
+          workflow_id: 'work-package',
+          activity_id: 'start-work-package',
+          checkpoint_id: 'issue-verification',
+        },
       });
-
       const checkpoint = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
       expect(checkpoint.id).toBe('issue-verification');
-      expect(checkpoint.options).toBeDefined();
       expect(checkpoint.options.length).toBeGreaterThan(0);
     });
   });
@@ -252,11 +223,11 @@ describe('mcp-server integration', () => {
         name: 'validate_transition',
         arguments: {
           session_token: sessionToken,
+          workflow_id: 'work-package',
           from_activity: 'start-work-package',
           to_activity: 'design-philosophy',
         },
       });
-
       const validation = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
       expect(validation.valid).toBe(true);
     });
@@ -266,11 +237,11 @@ describe('mcp-server integration', () => {
         name: 'validate_transition',
         arguments: {
           session_token: sessionToken,
+          workflow_id: 'work-package',
           from_activity: 'start-work-package',
           to_activity: 'complete',
         },
       });
-
       const validation = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
       expect(validation.valid).toBe(false);
     });
@@ -279,10 +250,8 @@ describe('mcp-server integration', () => {
   describe('tool: health_check', () => {
     it('should return healthy status', async () => {
       const result = await client.callTool({ name: 'health_check', arguments: {} });
-
       const health = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
       expect(health.status).toBe('healthy');
-      expect(health.server).toBe('test-workflow-server');
       expect(health.workflows_available).toBeGreaterThanOrEqual(2);
     });
   });
@@ -290,57 +259,127 @@ describe('mcp-server integration', () => {
   // ============== Resource Tools ==============
 
   describe('tool: get_skill', () => {
-    it('should get skill using workflow from token', async () => {
+    it('should get skill with explicit workflow_id', async () => {
       const result = await client.callTool({
         name: 'get_skill',
-        arguments: { session_token: sessionToken, skill_id: 'workflow-execution' },
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', skill_id: 'create-issue' },
       });
-
       const skill = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
-      expect(skill.id).toBe('workflow-execution');
-      expect(skill.capability).toBeDefined();
+      expect(skill.id).toBe('create-issue');
     });
   });
 
   describe('tool: list_resources', () => {
-    it('should list resources using workflow from token', async () => {
+    it('should list resources with explicit workflow_id', async () => {
       const result = await client.callTool({
         name: 'list_resources',
-        arguments: { session_token: sessionToken },
+        arguments: { session_token: sessionToken, workflow_id: 'work-package' },
       });
-
       const resources = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
       expect(Array.isArray(resources)).toBe(true);
       expect(resources.length).toBeGreaterThan(0);
-      expect(resources[0]).toHaveProperty('index');
     });
   });
 
   describe('tool: get_resource', () => {
-    it('should get resource using workflow from token', async () => {
+    it('should get resource with explicit workflow_id', async () => {
       const result = await client.callTool({
         name: 'get_resource',
-        arguments: { session_token: sessionToken, index: '01' },
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', index: '01' },
       });
-
       const content = (result.content[0] as { type: 'text'; text: string }).text;
       expect(content).toBeDefined();
       expect(content.length).toBeGreaterThan(0);
     });
   });
 
-  // ============== Discovery Tool ==============
-
   describe('tool: discover_resources', () => {
-    it('should reference list_workflows bootstrap in discovery', async () => {
+    it('should return bootstrap info in discovery', async () => {
       const result = await client.callTool({
         name: 'discover_resources',
         arguments: { session_token: sessionToken },
       });
-
       const discovery = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
       expect(discovery.bootstrap).toBeDefined();
       expect(discovery.bootstrap.tool).toBe('list_workflows');
+    });
+  });
+
+  // ============== Validation ==============
+
+  describe('token validation', () => {
+    it('should warn on workflow mismatch', async () => {
+      const metaSession = await client.callTool({
+        name: 'start_session',
+        arguments: { workflow_id: 'meta' },
+      });
+      const metaResponse = JSON.parse((metaSession.content[0] as { type: 'text'; text: string }).text);
+      const metaToken = metaResponse.session_token;
+
+      const result = await client.callTool({
+        name: 'get_workflow',
+        arguments: { session_token: metaToken, workflow_id: 'work-package' },
+      });
+      expect(result.isError).toBeFalsy();
+      const meta = result._meta as Record<string, unknown>;
+      const validation = meta['validation'] as { status: string; warnings: string[] };
+      expect(validation.status).toBe('warning');
+      expect(validation.warnings.length).toBeGreaterThan(0);
+      expect(validation.warnings[0]).toContain('Workflow mismatch');
+    });
+
+    it('should warn on invalid activity transition', async () => {
+      const actResult = await client.callTool({
+        name: 'get_activity',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
+      });
+      const actMeta = actResult._meta as Record<string, unknown>;
+      const tokenAfterStart = actMeta['session_token'] as string;
+
+      const result = await client.callTool({
+        name: 'get_activity',
+        arguments: { session_token: tokenAfterStart, workflow_id: 'work-package', activity_id: 'complete' },
+      });
+      expect(result.isError).toBeFalsy();
+      const meta = result._meta as Record<string, unknown>;
+      const validation = meta['validation'] as { status: string; warnings: string[] };
+      expect(validation.status).toBe('warning');
+      expect(validation.warnings.some((w: string) => w.includes('not a direct transition'))).toBe(true);
+    });
+
+    it('should not warn on valid activity transition', async () => {
+      const actResult = await client.callTool({
+        name: 'get_activity',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
+      });
+      const actMeta = actResult._meta as Record<string, unknown>;
+      const tokenAfterStart = actMeta['session_token'] as string;
+
+      const result = await client.callTool({
+        name: 'get_activity',
+        arguments: { session_token: tokenAfterStart, workflow_id: 'work-package', activity_id: 'design-philosophy' },
+      });
+      expect(result.isError).toBeFalsy();
+      const meta = result._meta as Record<string, unknown>;
+      const validation = meta['validation'] as { status: string; warnings: string[] };
+      expect(validation.status).toBe('valid');
+    });
+
+    it('warnings should not block execution', async () => {
+      const metaSession = await client.callTool({
+        name: 'start_session',
+        arguments: { workflow_id: 'meta' },
+      });
+      const metaResponse = JSON.parse((metaSession.content[0] as { type: 'text'; text: string }).text);
+      const metaToken = metaResponse.session_token;
+
+      const result = await client.callTool({
+        name: 'get_workflow',
+        arguments: { session_token: metaToken, workflow_id: 'work-package' },
+      });
+      expect(result.isError).toBeFalsy();
+      const workflow = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(workflow.id).toBe('work-package');
     });
   });
 });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -302,10 +302,10 @@ describe('mcp-server integration', () => {
     });
   });
 
-  describe('tool: list_workflow_resources', () => {
+  describe('tool: list_resources', () => {
     it('should list resources using workflow from token', async () => {
       const result = await client.callTool({
-        name: 'list_workflow_resources',
+        name: 'list_resources',
         arguments: { session_token: sessionToken },
       });
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -43,6 +43,28 @@ describe('mcp-server integration', () => {
 
   // ============== Bootstrap Flow ==============
 
+  describe('tool: help', () => {
+    it('should return bootstrap procedure and session protocol', async () => {
+      const result = await client.callTool({ name: 'help', arguments: {} });
+      expect(result.isError).toBeFalsy();
+
+      const guide = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+
+      expect(guide.bootstrap).toBeDefined();
+      expect(guide.bootstrap.step_1.tool).toBe('list_workflows');
+      expect(guide.bootstrap.step_2.tool).toBe('start_session');
+      expect(guide.session_protocol).toBeDefined();
+      expect(guide.session_protocol.exempt_tools).toContain('help');
+      expect(guide.available_workflows).toBeDefined();
+      expect(guide.available_workflows.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('should not require session_token', async () => {
+      const result = await client.callTool({ name: 'help', arguments: {} });
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
   describe('bootstrap flow: list_workflows -> start_session', () => {
     it('list_workflows should not require session_token', async () => {
       const result = await client.callTool({ name: 'list_workflows', arguments: {} });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -7,6 +7,7 @@ import { resolve } from 'node:path';
 describe('mcp-server integration', () => {
   let client: Client;
   let closeTransport: () => Promise<void>;
+  let sessionToken: string;
 
   beforeAll(async () => {
     const config = {
@@ -27,15 +28,138 @@ describe('mcp-server integration', () => {
       await client.close();
       await server.close();
     };
+
+    const sessionResult = await client.callTool({
+      name: 'start_session',
+      arguments: { workflow_version: '3.4.0' },
+    });
+    const sessionResponse = JSON.parse((sessionResult.content[0] as { type: 'text'; text: string }).text);
+    sessionToken = sessionResponse.session.token;
   });
 
   afterAll(async () => {
     await closeTransport();
   });
 
+  // ============== Session & Bootstrap Tools ==============
+
+  describe('tool: start_session', () => {
+    it('should return rules and session with token', async () => {
+      const result = await client.callTool({
+        name: 'start_session',
+        arguments: { workflow_version: '3.4.0' },
+      });
+
+      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+
+      expect(response.rules).toBeDefined();
+      expect(response.rules.id).toBe('agent-rules');
+      expect(response.rules.sections).toBeDefined();
+      expect(response.session).toBeDefined();
+      expect(response.session.token).toBeDefined();
+      expect(response.session.created_at).toBeDefined();
+      expect(response.session.server_version).toBe('1.0.0');
+    });
+
+    it('should return token matching structured format', async () => {
+      const result = await client.callTool({
+        name: 'start_session',
+        arguments: { workflow_version: '3.4.0' },
+      });
+
+      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(response.session.token).toMatch(/^[\d.]+_\d+_[0-9a-f]{8}$/);
+      expect(response.session.token).toMatch(/^3\.4\.0_/);
+    });
+
+    it('should work without session_token (exempt)', async () => {
+      const result = await client.callTool({
+        name: 'start_session',
+        arguments: { workflow_version: '1.0.0' },
+      });
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  describe('tool: match_goal', () => {
+    it('should return activity index', async () => {
+      const result = await client.callTool({ name: 'match_goal', arguments: {} });
+      
+      const index = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      
+      expect(index.description).toBeDefined();
+      expect(index.activities).toBeDefined();
+      expect(index.activities.length).toBeGreaterThanOrEqual(3);
+      expect(index.quick_match).toBeDefined();
+    });
+
+    it('should reference start_session in next_action', async () => {
+      const result = await client.callTool({ name: 'match_goal', arguments: {} });
+
+      const index = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+
+      expect(index.next_action).toBeDefined();
+      expect(index.next_action.tool).toBe('start_session');
+    });
+
+    it('should work without session_token (exempt)', async () => {
+      const result = await client.callTool({ name: 'match_goal', arguments: {} });
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  // ============== Old Tool Names Removed ==============
+
+  describe('old tool names removed', () => {
+    it('should reject get_activities (removed)', async () => {
+      const result = await client.callTool({ name: 'get_activities', arguments: {} });
+      expect(result.isError).toBe(true);
+    });
+
+    it('should reject get_rules (removed)', async () => {
+      const result = await client.callTool({ name: 'get_rules', arguments: {} });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  // ============== Session Token Enforcement ==============
+
+  describe('session_token enforcement', () => {
+    it('should reject tool call without session_token', async () => {
+      const result = await client.callTool({
+        name: 'get_activity',
+        arguments: { activity_id: 'start-workflow' },
+      });
+      expect(result.isError).toBe(true);
+    });
+
+    it('should reject tool call with malformed session_token', async () => {
+      const result = await client.callTool({
+        name: 'get_activity',
+        arguments: { session_token: 'invalid-token', activity_id: 'start-workflow' },
+      });
+      expect(result.isError).toBe(true);
+    });
+
+    it('should accept tool call with valid session_token', async () => {
+      const result = await client.callTool({
+        name: 'get_activity',
+        arguments: { session_token: sessionToken, activity_id: 'start-workflow' },
+      });
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('should not require session_token for health_check', async () => {
+      const result = await client.callTool({ name: 'health_check', arguments: {} });
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  // ============== Workflow Tools (with session_token) ==============
+
   describe('tool: list_workflows', () => {
     it('should list available workflows', async () => {
-      const result = await client.callTool({ name: 'list_workflows', arguments: {} });
+      const result = await client.callTool({ name: 'list_workflows', arguments: { session_token: sessionToken } });
       
       expect(result.content).toBeDefined();
       expect(result.content[0]).toHaveProperty('type', 'text');
@@ -54,7 +178,7 @@ describe('mcp-server integration', () => {
     it('should get work-package workflow', async () => {
       const result = await client.callTool({
         name: 'get_workflow',
-        arguments: { workflow_id: 'work-package' },
+        arguments: { session_token: sessionToken, workflow_id: 'work-package' },
       });
       
       expect(result.content).toBeDefined();
@@ -69,7 +193,7 @@ describe('mcp-server integration', () => {
     it('should return error for non-existent workflow', async () => {
       const result = await client.callTool({
         name: 'get_workflow',
-        arguments: { workflow_id: 'non-existent' },
+        arguments: { session_token: sessionToken, workflow_id: 'non-existent' },
       });
       
       expect(result.isError).toBe(true);
@@ -81,7 +205,7 @@ describe('mcp-server integration', () => {
     it('should get specific activity from workflow', async () => {
       const result = await client.callTool({
         name: 'get_workflow_activity',
-        arguments: { workflow_id: 'work-package', activity_id: 'start-work-package' },
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
       });
       
       const activity = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
@@ -95,7 +219,7 @@ describe('mcp-server integration', () => {
     it('should return error for non-existent activity', async () => {
       const result = await client.callTool({
         name: 'get_workflow_activity',
-        arguments: { workflow_id: 'work-package', activity_id: 'non-existent' },
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'non-existent' },
       });
       
       expect(result.isError).toBe(true);
@@ -108,6 +232,7 @@ describe('mcp-server integration', () => {
       const result = await client.callTool({
         name: 'get_checkpoint',
         arguments: {
+          session_token: sessionToken,
           workflow_id: 'work-package',
           activity_id: 'start-work-package',
           checkpoint_id: 'issue-verification',
@@ -128,6 +253,7 @@ describe('mcp-server integration', () => {
       const result = await client.callTool({
         name: 'validate_transition',
         arguments: {
+          session_token: sessionToken,
           workflow_id: 'work-package',
           from_activity: 'start-work-package',
           to_activity: 'design-philosophy',
@@ -142,6 +268,7 @@ describe('mcp-server integration', () => {
       const result = await client.callTool({
         name: 'validate_transition',
         arguments: {
+          session_token: sessionToken,
           workflow_id: 'work-package',
           from_activity: 'start-work-package',
           to_activity: 'complete',
@@ -167,24 +294,13 @@ describe('mcp-server integration', () => {
     });
   });
 
-  describe('tool: get_activities', () => {
-    it('should return activity index', async () => {
-      const result = await client.callTool({ name: 'get_activities', arguments: {} });
-      
-      const index = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
-      
-      expect(index.description).toBeDefined();
-      expect(index.activities).toBeDefined();
-      expect(index.activities.length).toBeGreaterThanOrEqual(3);
-      expect(index.quick_match).toBeDefined();
-    });
-  });
+  // ============== Resource Tools (with session_token) ==============
 
   describe('tool: get_activity', () => {
     it('should return specific activity', async () => {
       const result = await client.callTool({
         name: 'get_activity',
-        arguments: { activity_id: 'start-workflow' },
+        arguments: { session_token: sessionToken, activity_id: 'start-workflow' },
       });
       
       const activity = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
@@ -199,7 +315,7 @@ describe('mcp-server integration', () => {
     it('should return specific skill', async () => {
       const result = await client.callTool({
         name: 'get_skill',
-        arguments: { skill_id: 'workflow-execution' },
+        arguments: { session_token: sessionToken, skill_id: 'workflow-execution' },
       });
       
       const skill = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
@@ -214,7 +330,7 @@ describe('mcp-server integration', () => {
     it('should list resources for a workflow', async () => {
       const result = await client.callTool({
         name: 'list_workflow_resources',
-        arguments: { workflow_id: 'work-package' },
+        arguments: { session_token: sessionToken, workflow_id: 'work-package' },
       });
       
       const resources = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
@@ -230,17 +346,30 @@ describe('mcp-server integration', () => {
     it('should get specific resource', async () => {
       const result = await client.callTool({
         name: 'get_resource',
-        arguments: { workflow_id: 'work-package', index: '01' },
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', index: '01' },
       });
       
-      // get_resource returns raw content (TOON or markdown format)
       const content = (result.content[0] as { type: 'text'; text: string }).text;
       
       expect(content).toBeDefined();
-      // Resource content should contain id (in YAML frontmatter or TOON format)
       expect(content).toContain('id:');
-      // Markdown format uses heading for title, TOON uses title: field
       expect(content.includes('title:') || content.includes('# ')).toBe(true);
+    });
+  });
+
+  // ============== Discovery Tool ==============
+
+  describe('tool: discover_resources', () => {
+    it('should reference match_goal in discovery output', async () => {
+      const result = await client.callTool({
+        name: 'discover_resources',
+        arguments: { session_token: sessionToken },
+      });
+
+      const discovery = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+
+      expect(discovery.activities).toBeDefined();
+      expect(discovery.activities.tool).toBe('match_goal');
     });
   });
 });

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -4,35 +4,20 @@ import { createSessionToken, decodeSessionToken, advanceToken } from '../src/uti
 describe('session token utilities', () => {
   describe('createSessionToken', () => {
     it('should create a base64url-encoded token', () => {
-      const token = createSessionToken('work-package', '3.4.0', 'start-work-package');
+      const token = createSessionToken('work-package', '3.4.0');
       expect(typeof token).toBe('string');
       expect(token.length).toBeGreaterThan(10);
       expect(token).not.toContain('{');
       expect(token).not.toContain(' ');
     });
 
-    it('should encode workflow_id and version', () => {
+    it('should encode workflow_id, version, and empty defaults', () => {
       const token = createSessionToken('work-package', '3.4.0');
       const payload = decodeSessionToken(token);
       expect(payload.wf).toBe('work-package');
       expect(payload.v).toBe('3.4.0');
-    });
-
-    it('should set initial activity when provided', () => {
-      const token = createSessionToken('work-package', '3.4.0', 'start-work-package');
-      const payload = decodeSessionToken(token);
-      expect(payload.act).toBe('start-work-package');
-    });
-
-    it('should default activity to empty string', () => {
-      const token = createSessionToken('work-package', '3.4.0');
-      const payload = decodeSessionToken(token);
       expect(payload.act).toBe('');
-    });
-
-    it('should set seq to 0', () => {
-      const token = createSessionToken('work-package', '3.4.0');
-      const payload = decodeSessionToken(token);
+      expect(payload.skill).toBe('');
       expect(payload.seq).toBe(0);
     });
 
@@ -48,11 +33,10 @@ describe('session token utilities', () => {
 
   describe('decodeSessionToken', () => {
     it('should decode a valid token', () => {
-      const token = createSessionToken('meta', '1.0.0', 'start-workflow');
+      const token = createSessionToken('meta', '1.0.0');
       const payload = decodeSessionToken(token);
       expect(payload.wf).toBe('meta');
       expect(payload.v).toBe('1.0.0');
-      expect(payload.act).toBe('start-workflow');
       expect(payload.seq).toBe(0);
     });
 
@@ -88,20 +72,36 @@ describe('session token utilities', () => {
     });
 
     it('should update act when provided', () => {
-      const token = createSessionToken('work-package', '3.4.0', 'start-work-package');
+      const token = createSessionToken('work-package', '3.4.0');
       const advanced = advanceToken(token, { act: 'design-philosophy' });
       const payload = decodeSessionToken(advanced);
       expect(payload.act).toBe('design-philosophy');
       expect(payload.seq).toBe(1);
     });
 
-    it('should preserve fields when not updating act', () => {
-      const token = createSessionToken('work-package', '3.4.0', 'start-work-package');
-      const advanced = advanceToken(token);
+    it('should update skill when provided', () => {
+      const token = createSessionToken('work-package', '3.4.0');
+      const advanced = advanceToken(token, { skill: 'create-issue' });
       const payload = decodeSessionToken(advanced);
+      expect(payload.skill).toBe('create-issue');
+    });
+
+    it('should update wf when provided', () => {
+      const token = createSessionToken('work-package', '3.4.0');
+      const advanced = advanceToken(token, { wf: 'meta' });
+      const payload = decodeSessionToken(advanced);
+      expect(payload.wf).toBe('meta');
+    });
+
+    it('should preserve fields when not updating', () => {
+      const token = createSessionToken('work-package', '3.4.0');
+      const step1 = advanceToken(token, { act: 'start-work-package', skill: 'create-issue' });
+      const step2 = advanceToken(step1);
+      const payload = decodeSessionToken(step2);
       expect(payload.wf).toBe('work-package');
-      expect(payload.v).toBe('3.4.0');
       expect(payload.act).toBe('start-work-package');
+      expect(payload.skill).toBe('create-issue');
+      expect(payload.seq).toBe(2);
     });
 
     it('should produce different token strings', () => {

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { generateSessionToken, validateSessionToken } from '../src/utils/session.js';
+import { encryptToken, decryptToken } from '../src/utils/crypto.js';
+import { randomBytes } from 'node:crypto';
+
+describe('session token utilities', () => {
+  describe('generateSessionToken', () => {
+    it('should produce token matching structured format', () => {
+      const token = generateSessionToken('3.4.0');
+      expect(token).toMatch(/^[\d.]+_\d+_[0-9a-f]{8}$/);
+    });
+
+    it('should embed the workflow version as prefix', () => {
+      const token = generateSessionToken('2.1.0');
+      expect(token.startsWith('2.1.0_')).toBe(true);
+    });
+
+    it('should produce unique tokens on successive calls', () => {
+      const tokens = new Set(Array.from({ length: 10 }, () => generateSessionToken('1.0.0')));
+      expect(tokens.size).toBe(10);
+    });
+
+    it('should embed a recent epoch timestamp', () => {
+      const before = Math.floor(Date.now() / 1000);
+      const token = generateSessionToken('1.0.0');
+      const after = Math.floor(Date.now() / 1000);
+      const epoch = parseInt(token.split('_')[1]!, 10);
+      expect(epoch).toBeGreaterThanOrEqual(before);
+      expect(epoch).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe('validateSessionToken', () => {
+    it('should accept valid tokens', () => {
+      expect(validateSessionToken('3.4.0_1711300000_a3b2c1d4')).toBe(true);
+      expect(validateSessionToken('1.0.0_1700000000_00000000')).toBe(true);
+      expect(validateSessionToken('10.20.30_9999999999_abcdef01')).toBe(true);
+    });
+
+    it('should reject tokens without version prefix', () => {
+      expect(validateSessionToken('_1711300000_a3b2c1d4')).toBe(false);
+    });
+
+    it('should reject tokens with wrong separators', () => {
+      expect(validateSessionToken('3.4.0-1711300000-a3b2c1d4')).toBe(false);
+    });
+
+    it('should reject tokens with short hex part', () => {
+      expect(validateSessionToken('3.4.0_1711300000_a3b2c1')).toBe(false);
+    });
+
+    it('should reject tokens with non-hex characters', () => {
+      expect(validateSessionToken('3.4.0_1711300000_g3b2c1d4')).toBe(false);
+    });
+
+    it('should reject empty string', () => {
+      expect(validateSessionToken('')).toBe(false);
+    });
+
+    it('should reject tokens with extra segments', () => {
+      expect(validateSessionToken('3.4.0_1711300000_a3b2c1d4_extra')).toBe(false);
+    });
+  });
+});
+
+describe('token encryption', () => {
+  const testKey = randomBytes(32);
+  const testToken = '3.4.0_1711300000_a3b2c1d4';
+
+  describe('encryptToken / decryptToken', () => {
+    it('should produce ciphertext different from plaintext', () => {
+      const encrypted = encryptToken(testToken, testKey);
+      expect(encrypted).not.toBe(testToken);
+    });
+
+    it('should round-trip: decrypt(encrypt(token)) returns original', () => {
+      const encrypted = encryptToken(testToken, testKey);
+      const decrypted = decryptToken(encrypted, testKey);
+      expect(decrypted).toBe(testToken);
+    });
+
+    it('should produce different ciphertext for same input (random IV)', () => {
+      const a = encryptToken(testToken, testKey);
+      const b = encryptToken(testToken, testKey);
+      expect(a).not.toBe(b);
+    });
+
+    it('should fail with wrong key', () => {
+      const encrypted = encryptToken(testToken, testKey);
+      const wrongKey = randomBytes(32);
+      expect(() => decryptToken(encrypted, wrongKey)).toThrow();
+    });
+
+    it('should fail with malformed encrypted string', () => {
+      expect(() => decryptToken('not-valid', testKey)).toThrow();
+    });
+  });
+});

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,98 +1,127 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { generateSessionToken, validateSessionToken } from '../src/utils/session.js';
-import { encryptToken, decryptToken } from '../src/utils/crypto.js';
-import { randomBytes } from 'node:crypto';
+import { describe, it, expect } from 'vitest';
+import { createSessionToken, decodeSessionToken, advanceToken } from '../src/utils/session.js';
 
 describe('session token utilities', () => {
-  describe('generateSessionToken', () => {
-    it('should produce token matching structured format', () => {
-      const token = generateSessionToken('3.4.0');
-      expect(token).toMatch(/^[\d.]+_\d+_[0-9a-f]{8}$/);
+  describe('createSessionToken', () => {
+    it('should create a base64url-encoded token', () => {
+      const token = createSessionToken('work-package', '3.4.0', 'start-work-package');
+      expect(typeof token).toBe('string');
+      expect(token.length).toBeGreaterThan(10);
+      expect(token).not.toContain('{');
+      expect(token).not.toContain(' ');
     });
 
-    it('should embed the workflow version as prefix', () => {
-      const token = generateSessionToken('2.1.0');
-      expect(token.startsWith('2.1.0_')).toBe(true);
+    it('should encode workflow_id and version', () => {
+      const token = createSessionToken('work-package', '3.4.0');
+      const payload = decodeSessionToken(token);
+      expect(payload.wf).toBe('work-package');
+      expect(payload.v).toBe('3.4.0');
     });
 
-    it('should produce unique tokens on successive calls', () => {
-      const tokens = new Set(Array.from({ length: 10 }, () => generateSessionToken('1.0.0')));
-      expect(tokens.size).toBe(10);
+    it('should set initial activity when provided', () => {
+      const token = createSessionToken('work-package', '3.4.0', 'start-work-package');
+      const payload = decodeSessionToken(token);
+      expect(payload.act).toBe('start-work-package');
     });
 
-    it('should embed a recent epoch timestamp', () => {
+    it('should default activity to empty string', () => {
+      const token = createSessionToken('work-package', '3.4.0');
+      const payload = decodeSessionToken(token);
+      expect(payload.act).toBe('');
+    });
+
+    it('should set seq to 0', () => {
+      const token = createSessionToken('work-package', '3.4.0');
+      const payload = decodeSessionToken(token);
+      expect(payload.seq).toBe(0);
+    });
+
+    it('should set ts to current epoch seconds', () => {
       const before = Math.floor(Date.now() / 1000);
-      const token = generateSessionToken('1.0.0');
+      const token = createSessionToken('work-package', '3.4.0');
       const after = Math.floor(Date.now() / 1000);
-      const epoch = parseInt(token.split('_')[1]!, 10);
-      expect(epoch).toBeGreaterThanOrEqual(before);
-      expect(epoch).toBeLessThanOrEqual(after);
+      const payload = decodeSessionToken(token);
+      expect(payload.ts).toBeGreaterThanOrEqual(before);
+      expect(payload.ts).toBeLessThanOrEqual(after);
     });
   });
 
-  describe('validateSessionToken', () => {
-    it('should accept valid tokens', () => {
-      expect(validateSessionToken('3.4.0_1711300000_a3b2c1d4')).toBe(true);
-      expect(validateSessionToken('1.0.0_1700000000_00000000')).toBe(true);
-      expect(validateSessionToken('10.20.30_9999999999_abcdef01')).toBe(true);
+  describe('decodeSessionToken', () => {
+    it('should decode a valid token', () => {
+      const token = createSessionToken('meta', '1.0.0', 'start-workflow');
+      const payload = decodeSessionToken(token);
+      expect(payload.wf).toBe('meta');
+      expect(payload.v).toBe('1.0.0');
+      expect(payload.act).toBe('start-workflow');
+      expect(payload.seq).toBe(0);
     });
 
-    it('should reject tokens without version prefix', () => {
-      expect(validateSessionToken('_1711300000_a3b2c1d4')).toBe(false);
+    it('should throw on garbage input', () => {
+      expect(() => decodeSessionToken('not-valid')).toThrow('Invalid session token');
     });
 
-    it('should reject tokens with wrong separators', () => {
-      expect(validateSessionToken('3.4.0-1711300000-a3b2c1d4')).toBe(false);
+    it('should throw on empty string', () => {
+      expect(() => decodeSessionToken('')).toThrow();
     });
 
-    it('should reject tokens with short hex part', () => {
-      expect(validateSessionToken('3.4.0_1711300000_a3b2c1')).toBe(false);
-    });
-
-    it('should reject tokens with non-hex characters', () => {
-      expect(validateSessionToken('3.4.0_1711300000_g3b2c1d4')).toBe(false);
-    });
-
-    it('should reject empty string', () => {
-      expect(validateSessionToken('')).toBe(false);
-    });
-
-    it('should reject tokens with extra segments', () => {
-      expect(validateSessionToken('3.4.0_1711300000_a3b2c1d4_extra')).toBe(false);
+    it('should throw on valid base64 with wrong structure', () => {
+      const bad = Buffer.from(JSON.stringify({ foo: 'bar' })).toString('base64url');
+      expect(() => decodeSessionToken(bad)).toThrow('Missing or invalid token fields');
     });
   });
-});
 
-describe('token encryption', () => {
-  const testKey = randomBytes(32);
-  const testToken = '3.4.0_1711300000_a3b2c1d4';
-
-  describe('encryptToken / decryptToken', () => {
-    it('should produce ciphertext different from plaintext', () => {
-      const encrypted = encryptToken(testToken, testKey);
-      expect(encrypted).not.toBe(testToken);
+  describe('advanceToken', () => {
+    it('should increment seq by 1', () => {
+      const token = createSessionToken('work-package', '3.4.0');
+      const advanced = advanceToken(token);
+      const payload = decodeSessionToken(advanced);
+      expect(payload.seq).toBe(1);
     });
 
-    it('should round-trip: decrypt(encrypt(token)) returns original', () => {
-      const encrypted = encryptToken(testToken, testKey);
-      const decrypted = decryptToken(encrypted, testKey);
-      expect(decrypted).toBe(testToken);
+    it('should increment cumulatively', () => {
+      let token = createSessionToken('work-package', '3.4.0');
+      token = advanceToken(token);
+      token = advanceToken(token);
+      token = advanceToken(token);
+      const payload = decodeSessionToken(token);
+      expect(payload.seq).toBe(3);
     });
 
-    it('should produce different ciphertext for same input (random IV)', () => {
-      const a = encryptToken(testToken, testKey);
-      const b = encryptToken(testToken, testKey);
-      expect(a).not.toBe(b);
+    it('should update act when provided', () => {
+      const token = createSessionToken('work-package', '3.4.0', 'start-work-package');
+      const advanced = advanceToken(token, { act: 'design-philosophy' });
+      const payload = decodeSessionToken(advanced);
+      expect(payload.act).toBe('design-philosophy');
+      expect(payload.seq).toBe(1);
     });
 
-    it('should fail with wrong key', () => {
-      const encrypted = encryptToken(testToken, testKey);
-      const wrongKey = randomBytes(32);
-      expect(() => decryptToken(encrypted, wrongKey)).toThrow();
+    it('should preserve fields when not updating act', () => {
+      const token = createSessionToken('work-package', '3.4.0', 'start-work-package');
+      const advanced = advanceToken(token);
+      const payload = decodeSessionToken(advanced);
+      expect(payload.wf).toBe('work-package');
+      expect(payload.v).toBe('3.4.0');
+      expect(payload.act).toBe('start-work-package');
     });
 
-    it('should fail with malformed encrypted string', () => {
-      expect(() => decryptToken('not-valid', testKey)).toThrow();
+    it('should produce different token strings', () => {
+      const token = createSessionToken('work-package', '3.4.0');
+      const advanced = advanceToken(token);
+      expect(advanced).not.toBe(token);
+    });
+  });
+
+  describe('token opacity', () => {
+    it('token should not contain readable workflow id', () => {
+      const token = createSessionToken('work-package', '3.4.0');
+      expect(token).not.toContain('work-package');
+      expect(token).not.toContain('3.4.0');
+    });
+
+    it('token should not look like JSON', () => {
+      const token = createSessionToken('work-package', '3.4.0');
+      expect(token).not.toContain('{');
+      expect(token).not.toContain('"');
     });
   });
 });

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -3,17 +3,17 @@ import { createSessionToken, decodeSessionToken, advanceToken } from '../src/uti
 
 describe('session token utilities', () => {
   describe('createSessionToken', () => {
-    it('should create a base64url-encoded token', () => {
-      const token = createSessionToken('work-package', '3.4.0');
+    it('should create an HMAC-signed opaque token', async () => {
+      const token = await createSessionToken('work-package', '3.4.0');
       expect(typeof token).toBe('string');
       expect(token.length).toBeGreaterThan(10);
+      expect(token).toContain('.');
       expect(token).not.toContain('{');
-      expect(token).not.toContain(' ');
     });
 
-    it('should encode workflow_id, version, and empty defaults', () => {
-      const token = createSessionToken('work-package', '3.4.0');
-      const payload = decodeSessionToken(token);
+    it('should encode workflow_id, version, and empty defaults', async () => {
+      const token = await createSessionToken('work-package', '3.4.0');
+      const payload = await decodeSessionToken(token);
       expect(payload.wf).toBe('work-package');
       expect(payload.v).toBe('3.4.0');
       expect(payload.act).toBe('');
@@ -21,107 +21,119 @@ describe('session token utilities', () => {
       expect(payload.seq).toBe(0);
     });
 
-    it('should set ts to current epoch seconds', () => {
+    it('should set ts to current epoch seconds', async () => {
       const before = Math.floor(Date.now() / 1000);
-      const token = createSessionToken('work-package', '3.4.0');
+      const token = await createSessionToken('work-package', '3.4.0');
       const after = Math.floor(Date.now() / 1000);
-      const payload = decodeSessionToken(token);
+      const payload = await decodeSessionToken(token);
       expect(payload.ts).toBeGreaterThanOrEqual(before);
       expect(payload.ts).toBeLessThanOrEqual(after);
     });
   });
 
   describe('decodeSessionToken', () => {
-    it('should decode a valid token', () => {
-      const token = createSessionToken('meta', '1.0.0');
-      const payload = decodeSessionToken(token);
+    it('should decode a valid token', async () => {
+      const token = await createSessionToken('meta', '1.0.0');
+      const payload = await decodeSessionToken(token);
       expect(payload.wf).toBe('meta');
       expect(payload.v).toBe('1.0.0');
       expect(payload.seq).toBe(0);
     });
 
-    it('should throw on garbage input', () => {
-      expect(() => decodeSessionToken('not-valid')).toThrow('Invalid session token');
+    it('should throw on garbage input', async () => {
+      await expect(decodeSessionToken('not-valid')).rejects.toThrow('Invalid session token');
     });
 
-    it('should throw on empty string', () => {
-      expect(() => decodeSessionToken('')).toThrow();
+    it('should throw on empty string', async () => {
+      await expect(decodeSessionToken('')).rejects.toThrow();
     });
 
-    it('should throw on valid base64 with wrong structure', () => {
-      const bad = Buffer.from(JSON.stringify({ foo: 'bar' })).toString('base64url');
-      expect(() => decodeSessionToken(bad)).toThrow('Missing or invalid token fields');
+    it('should throw on valid base64 with wrong structure', async () => {
+      const bad = Buffer.from(JSON.stringify({ foo: 'bar' })).toString('base64url') + '.fakesig';
+      await expect(decodeSessionToken(bad)).rejects.toThrow('signature verification failed');
+    });
+
+    it('should throw on tampered payload', async () => {
+      const token = await createSessionToken('work-package', '3.4.0');
+      const [, sig] = token.split('.');
+      const tampered = Buffer.from(JSON.stringify({ wf: 'hacked', act: '', skill: '', v: '1.0.0', seq: 0, ts: 0 })).toString('base64url');
+      await expect(decodeSessionToken(`${tampered}.${sig}`)).rejects.toThrow('signature verification failed');
     });
   });
 
   describe('advanceToken', () => {
-    it('should increment seq by 1', () => {
-      const token = createSessionToken('work-package', '3.4.0');
-      const advanced = advanceToken(token);
-      const payload = decodeSessionToken(advanced);
+    it('should increment seq by 1', async () => {
+      const token = await createSessionToken('work-package', '3.4.0');
+      const advanced = await advanceToken(token);
+      const payload = await decodeSessionToken(advanced);
       expect(payload.seq).toBe(1);
     });
 
-    it('should increment cumulatively', () => {
-      let token = createSessionToken('work-package', '3.4.0');
-      token = advanceToken(token);
-      token = advanceToken(token);
-      token = advanceToken(token);
-      const payload = decodeSessionToken(token);
+    it('should increment cumulatively', async () => {
+      let token = await createSessionToken('work-package', '3.4.0');
+      token = await advanceToken(token);
+      token = await advanceToken(token);
+      token = await advanceToken(token);
+      const payload = await decodeSessionToken(token);
       expect(payload.seq).toBe(3);
     });
 
-    it('should update act when provided', () => {
-      const token = createSessionToken('work-package', '3.4.0');
-      const advanced = advanceToken(token, { act: 'design-philosophy' });
-      const payload = decodeSessionToken(advanced);
+    it('should update act when provided', async () => {
+      const token = await createSessionToken('work-package', '3.4.0');
+      const advanced = await advanceToken(token, { act: 'design-philosophy' });
+      const payload = await decodeSessionToken(advanced);
       expect(payload.act).toBe('design-philosophy');
       expect(payload.seq).toBe(1);
     });
 
-    it('should update skill when provided', () => {
-      const token = createSessionToken('work-package', '3.4.0');
-      const advanced = advanceToken(token, { skill: 'create-issue' });
-      const payload = decodeSessionToken(advanced);
+    it('should update skill when provided', async () => {
+      const token = await createSessionToken('work-package', '3.4.0');
+      const advanced = await advanceToken(token, { skill: 'create-issue' });
+      const payload = await decodeSessionToken(advanced);
       expect(payload.skill).toBe('create-issue');
     });
 
-    it('should update wf when provided', () => {
-      const token = createSessionToken('work-package', '3.4.0');
-      const advanced = advanceToken(token, { wf: 'meta' });
-      const payload = decodeSessionToken(advanced);
-      expect(payload.wf).toBe('meta');
-    });
-
-    it('should preserve fields when not updating', () => {
-      const token = createSessionToken('work-package', '3.4.0');
-      const step1 = advanceToken(token, { act: 'start-work-package', skill: 'create-issue' });
-      const step2 = advanceToken(step1);
-      const payload = decodeSessionToken(step2);
+    it('should preserve fields when not updating', async () => {
+      const token = await createSessionToken('work-package', '3.4.0');
+      const step1 = await advanceToken(token, { act: 'start-work-package', skill: 'create-issue' });
+      const step2 = await advanceToken(step1);
+      const payload = await decodeSessionToken(step2);
       expect(payload.wf).toBe('work-package');
       expect(payload.act).toBe('start-work-package');
       expect(payload.skill).toBe('create-issue');
       expect(payload.seq).toBe(2);
     });
 
-    it('should produce different token strings', () => {
-      const token = createSessionToken('work-package', '3.4.0');
-      const advanced = advanceToken(token);
+    it('should produce different token strings', async () => {
+      const token = await createSessionToken('work-package', '3.4.0');
+      const advanced = await advanceToken(token);
       expect(advanced).not.toBe(token);
+    });
+
+    it('advanced token should have valid HMAC', async () => {
+      const token = await createSessionToken('work-package', '3.4.0');
+      const advanced = await advanceToken(token);
+      const payload = await decodeSessionToken(advanced);
+      expect(payload.seq).toBe(1);
     });
   });
 
-  describe('token opacity', () => {
-    it('token should not contain readable workflow id', () => {
-      const token = createSessionToken('work-package', '3.4.0');
-      expect(token).not.toContain('work-package');
-      expect(token).not.toContain('3.4.0');
+  describe('token opacity and HMAC', () => {
+    it('token should not contain readable workflow id', async () => {
+      const token = await createSessionToken('work-package', '3.4.0');
+      const b64Part = token.split('.')[0]!;
+      expect(b64Part).not.toContain('work-package');
     });
 
-    it('token should not look like JSON', () => {
-      const token = createSessionToken('work-package', '3.4.0');
-      expect(token).not.toContain('{');
-      expect(token).not.toContain('"');
+    it('token should contain a dot separator (payload.signature)', async () => {
+      const token = await createSessionToken('work-package', '3.4.0');
+      expect(token.split('.').length).toBe(2);
+    });
+
+    it('should reject token with modified signature', async () => {
+      const token = await createSessionToken('work-package', '3.4.0');
+      const corrupted = token.slice(0, -4) + 'dead';
+      await expect(decodeSessionToken(corrupted)).rejects.toThrow('signature verification failed');
     });
   });
 });

--- a/tests/skill-loader.test.ts
+++ b/tests/skill-loader.test.ts
@@ -86,7 +86,7 @@ describe('skill-loader', () => {
         expect(skill.tools).toBeDefined();
         expect(skill.tools['list_workflows']).toBeDefined();
         expect(skill.tools['get_workflow']).toBeDefined();
-        expect(skill.tools['get_workflow_activity']).toBeDefined();
+        expect(skill.tools['get_activity']).toBeDefined();
         expect(skill.tools['get_checkpoint']).toBeDefined();
         expect(skill.tools['validate_transition']).toBeDefined();
         

--- a/tests/skill-loader.test.ts
+++ b/tests/skill-loader.test.ts
@@ -88,7 +88,7 @@ describe('skill-loader', () => {
         expect(skill.tools['get_workflow']).toBeDefined();
         expect(skill.tools['get_activity']).toBeDefined();
         expect(skill.tools['get_checkpoint']).toBeDefined();
-        expect(skill.tools['validate_transition']).toBeDefined();
+        expect(skill.tools['next_activity']).toBeDefined();
         
         // Check state reference (structure now in state.schema.json, behavior in state-management skill)
         expect(skill.state).toBeDefined();


### PR DESCRIPTION
## Summary

Comprehensive session management redesign for the workflow-server MCP API.

### Session Token
- HMAC-SHA256 signed opaque token (base64url payload + signature)
- Captures previous call state for server-side validation
- Tools accept explicit `workflow_id`/`activity_id` alongside the token
- Token encrypted at rest via AES-256-GCM in state files

### 4-Layer Workflow Fidelity Enforcement
1. **HMAC integrity** — prevents token fabrication/tampering
2. **Cross-activity validation** — workflow consistency, activity transition, skill association, version drift
3. **Transition condition tracking** — validates claimed condition maps to target activity
4. **Step completion manifest** — validates all steps completed in order

### Context Pressure Mitigation
- `next_activity` — returns transition list with conditions (server-side, fresh from disk)
- `get_workflow(summary=true)` — default lightweight metadata (~2KB vs ~13KB)
- `get_skills` — batch loads all skills + referenced resources for an activity
- `get_skill` — attaches referenced resources in `_resources` field

### Tool Surface (17 → 11)
| Category | Tools |
|----------|-------|
| Bootstrap | `help`, `list_workflows`, `start_session`, `health_check` |
| Workflow | `get_workflow`, `get_activity`, `next_activity`, `get_checkpoint` |
| Skills | `get_skills`, `get_skill` |
| State | `save_state`, `restore_state` |

**Removed**: `match_goal`, `get_activities`, `get_rules`, `get_skills` (old index), `list_skills`, `get_resource`, `list_resources`, `list_workflow_resources`, `discover_resources`, `validate_transition`

### Other Changes
- `help` tool — self-describing bootstrap procedure
- IDE rule slimmed to single line
- Session protocol in server-delivered meta rules
- All workflow `.toon` files updated (49+ files)
- New documentation: [Workflow Fidelity](docs/workflow-fidelity.md)

### Stats
- 48 commits, 22 files changed, +1602/-446
- 149 tests passing, typecheck clean

Closes #59