### PR TITLE
Fix: Agents not utilizing template resources attached to skill responses

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -26,8 +26,8 @@ All workflow tools require `session_token` and explicit `workflow_id`. Each resp
 
 | Tool | Parameters | Description |
 |------|------------|-------------|
-| `get_skills` | `session_token`, `workflow_id`, `activity_id` | Get all skills and their referenced resources for an activity in one call |
-| `get_skill` | `session_token`, `workflow_id`, `skill_id` | Get a single skill with its referenced resources attached |
+| `get_skills` | `session_token`, `workflow_id`, `activity_id` | Get all skills and resources for an activity. Resources returned as structured array `[{index, id, version, content}]` |
+| `get_skill` | `session_token`, `workflow_id`, `skill_id` | Get a single skill with resources. Response: `{skill, resources: [{index, id, version, content}]}` |
 
 ### State Tools
 

--- a/docs/workflow-fidelity.md
+++ b/docs/workflow-fidelity.md
@@ -111,7 +111,7 @@ Beyond enforcement, the server reduces the context burden on agents:
 
 ### Batch Skill Loading
 
-`get_skills(workflow_id, activity_id)` returns all skills (primary + supporting) and their referenced resources for an activity in one call. This replaces multiple sequential `get_skill` and `get_resource` calls, reducing round-trips and context overhead.
+`get_skills(workflow_id, activity_id)` returns all skills and their referenced resources as a structured array. Each resource has `index`, `id`, `version`, and `content` fields — agents match resources by index or id, eliminating ambiguity. `get_skill` returns the same structured format for individual skill loads.
 
 ### Self-Describing Bootstrap
 

--- a/src/loaders/resource-loader.ts
+++ b/src/loaders/resource-loader.ts
@@ -212,6 +212,48 @@ export async function getResourceEntry(
   ) ?? null;
 }
 
+export interface StructuredResource {
+  index: string;
+  id: string;
+  version: string;
+  content: string;
+}
+
+function parseFrontmatter(raw: string): { id: string; version: string; content: string } {
+  const fmMatch = raw.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
+  if (!fmMatch) return { id: '', version: '', content: raw };
+
+  const frontmatter = fmMatch[1] ?? '';
+  const body = (fmMatch[2] ?? '').trim();
+
+  const idMatch = frontmatter.match(/^id:\s*(.+)$/m);
+  const versionMatch = frontmatter.match(/^version:\s*(.+)$/m);
+
+  return {
+    id: idMatch?.[1]?.trim() ?? '',
+    version: versionMatch?.[1]?.trim() ?? '',
+    content: body,
+  };
+}
+
+/**
+ * Read a resource by index and return structured metadata + content.
+ * Parses frontmatter (id, version) and returns body separately.
+ */
+export async function readResourceStructured(
+  workflowDir: string,
+  workflowId: string,
+  resourceIndex: string,
+): Promise<Result<StructuredResource, ResourceNotFoundError>> {
+  const rawResult = await readResourceRaw(workflowDir, workflowId, resourceIndex);
+  if (!rawResult.success) return rawResult;
+
+  const { id, version, content } = parseFrontmatter(rawResult.value.content);
+  const normalizedIndex = resourceIndex.padStart(2, '0');
+
+  return ok({ index: normalizedIndex, id, version, content });
+}
+
 /**
  * List all workflows that contain resources.
  * Scans {workflowDir}/ for subdirectories containing a resources/ subdirectory with resource files.

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -4,11 +4,24 @@ import type { ServerConfig } from '../config.js';
 import { withAuditLog } from '../logging.js';
 
 import { loadWorkflow, getActivity } from '../loaders/workflow-loader.js';
-import { readResourceRaw } from '../loaders/resource-loader.js';
+import { readResourceStructured } from '../loaders/resource-loader.js';
+import type { StructuredResource } from '../loaders/resource-loader.js';
 import { readSkill } from '../loaders/skill-loader.js';
 import { readRules } from '../loaders/rules-loader.js';
 import { createSessionToken, decodeSessionToken, advanceToken, sessionTokenParam } from '../utils/session.js';
 import { buildValidation, validateWorkflowConsistency, validateWorkflowVersion, validateSkillAssociation } from '../utils/validation.js';
+
+async function loadSkillResources(workflowDir: string, workflowId: string, skillValue: unknown): Promise<StructuredResource[]> {
+  const skillResources = (skillValue as Record<string, unknown>)['resources'] as string[] | undefined;
+  if (!skillResources) return [];
+
+  const resources: StructuredResource[] = [];
+  for (const idx of skillResources) {
+    const result = await readResourceStructured(workflowDir, workflowId, idx);
+    if (result.success) resources.push(result.value);
+  }
+  return resources;
+}
 
 export function registerResourceTools(server: McpServer, config: ServerConfig): void {
 
@@ -48,7 +61,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
 
   server.tool(
     'get_skills',
-    'Get all skills and their associated resources for an activity in one call. Returns primary + supporting skills with full content, plus all resources referenced by those skills.',
+    'Get all skills and their associated resources for an activity in one call. Resources are returned as a structured array with index, id, version, and content fields.',
     {
       ...sessionTokenParam,
       workflow_id: z.string().describe('Workflow ID'),
@@ -64,23 +77,21 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
 
       const skillIds = [activity.skills.primary, ...(activity.skills.supporting ?? [])];
       const skills: Record<string, unknown> = {};
-      const resourceIndices = new Set<string>();
+      const allResources: StructuredResource[] = [];
+      const seenIndices = new Set<string>();
 
       for (const sid of skillIds) {
         const result = await readSkill(sid, config.workflowDir, workflow_id);
         if (result.success) {
           skills[sid] = result.value;
-          const skillResources = (result.value as Record<string, unknown>)['resources'] as string[] | undefined;
-          if (skillResources) {
-            for (const idx of skillResources) resourceIndices.add(idx);
+          const resources = await loadSkillResources(config.workflowDir, workflow_id, result.value);
+          for (const r of resources) {
+            if (!seenIndices.has(r.index)) {
+              seenIndices.add(r.index);
+              allResources.push(r);
+            }
           }
         }
-      }
-
-      const resources: Record<string, string> = {};
-      for (const idx of resourceIndices) {
-        const result = await readResourceRaw(config.workflowDir, workflow_id, idx);
-        if (result.success) resources[idx] = result.value.content;
       }
 
       const validation = buildValidation(
@@ -89,7 +100,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
       );
 
       return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ activity_id, skills, resources }, null, 2) }],
+        content: [{ type: 'text' as const, text: JSON.stringify({ activity_id, skills, resources: allResources }, null, 2) }],
         _meta: { session_token: await advanceToken(session_token, { wf: workflow_id, act: activity_id }), validation },
       };
     })
@@ -97,7 +108,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
 
   server.tool(
     'get_skill',
-    'Get a single skill by ID. For loading all skills for an activity at once, use get_skills instead.',
+    'Get a single skill with its referenced resources. Resources are returned as a structured array with index, id, version, and content fields.',
     {
       ...sessionTokenParam,
       workflow_id: z.string().describe('Workflow ID'),
@@ -115,18 +126,12 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
         wfResult.success && token.act ? validateSkillAssociation(wfResult.value, token.act, skill_id) : null,
       );
 
-      const skillResources = (result.value as Record<string, unknown>)['resources'] as string[] | undefined;
-      const resources: Record<string, string> = {};
-      if (skillResources) {
-        for (const idx of skillResources) {
-          const resResult = await readResourceRaw(config.workflowDir, workflow_id, idx);
-          if (resResult.success) resources[idx] = resResult.value.content;
-        }
-      }
+      const resources = await loadSkillResources(config.workflowDir, workflow_id, result.value);
 
-      const response = Object.keys(resources).length > 0
-        ? { ...result.value as Record<string, unknown>, _resources: resources }
-        : result.value;
+      const response = {
+        skill: result.value,
+        resources,
+      };
 
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(response, null, 2) }],

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -235,22 +235,54 @@ describe('mcp-server integration', () => {
         name: 'get_skill',
         arguments: { session_token: sessionToken, workflow_id: 'work-package', skill_id: 'create-issue' },
       });
-      const skill = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
-      expect(skill.id).toBe('create-issue');
+      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(response.skill).toBeDefined();
+      expect(response.skill.id).toBe('create-issue');
+      expect(response.resources).toBeDefined();
+      expect(Array.isArray(response.resources)).toBe(true);
     });
   });
 
-  describe('resources attached to skills', () => {
-    it('get_skill should include referenced resources in _resources', async () => {
+  describe('structured resources in skill responses', () => {
+    it('get_skill should return structured resources with index/id/version/content', async () => {
       const result = await client.callTool({
         name: 'get_skill',
         arguments: { session_token: sessionToken, workflow_id: 'work-package', skill_id: 'create-issue' },
       });
       expect(result.isError).toBeFalsy();
-      const skill = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
-      if (skill.resources && skill.resources.length > 0) {
-        expect(skill._resources).toBeDefined();
-        expect(Object.keys(skill._resources).length).toBeGreaterThan(0);
+      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(response.resources.length).toBeGreaterThan(0);
+      const resource = response.resources[0];
+      expect(resource.index).toBeDefined();
+      expect(resource.id).toBeDefined();
+      expect(resource.version).toBeDefined();
+      expect(resource.content).toBeDefined();
+      expect(resource.content.length).toBeGreaterThan(0);
+    });
+
+    it('get_skills should return structured resources array', async () => {
+      const result = await client.callTool({
+        name: 'get_skills',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
+      });
+      expect(result.isError).toBeFalsy();
+      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(Array.isArray(response.resources)).toBe(true);
+      if (response.resources.length > 0) {
+        expect(response.resources[0].index).toBeDefined();
+        expect(response.resources[0].id).toBeDefined();
+        expect(response.resources[0].content).toBeDefined();
+      }
+    });
+
+    it('resource content should not contain frontmatter', async () => {
+      const result = await client.callTool({
+        name: 'get_skill',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', skill_id: 'create-issue' },
+      });
+      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      for (const resource of response.resources) {
+        expect(resource.content).not.toMatch(/^---/);
       }
     });
   });


### PR DESCRIPTION
## Summary

Fixes agents not utilizing template resources attached to skill responses:

1. Restructured `get_skill` response to `{ skill, resources: [{ index, id, version, content }] }`
2. `get_skills` uses the same structured array format
3. Resource frontmatter parsed — agents get clean content with metadata
4. Replaced 44 "Load resource" → "Use attached resource" in TOON files
5. Removed 42 `note_resources` tool entries
6. Added RESOURCE USAGE global rule to `meta/rules.toon`
7. Updated execute-activity skill protocol for workers

## Validation

- `npm run typecheck` — clean
- `npm test` — 151/151 passed
- `npm run build` — clean

Closes #61
