### PR TITLE
fix: test infrastructure (WP-09)

### DIFF
--- a/tests/activity-loader.test.ts
+++ b/tests/activity-loader.test.ts
@@ -1,8 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { listActivities, readActivity, readActivityIndex } from '../src/loaders/activity-loader.js';
-import { join } from 'node:path';
+import { resolve, join } from 'node:path';
+import { mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 
-const WORKFLOW_DIR = join(process.cwd(), 'workflows');
+const WORKFLOW_DIR = resolve(import.meta.dirname, '../workflows');
 
 describe('activity-loader', () => {
   describe('listActivities', () => {
@@ -99,6 +101,39 @@ describe('activity-loader', () => {
         expect(result.value.next_action.parameters).toBeDefined();
         expect(result.value.next_action.parameters.skill_id).toBe(result.value.skills.primary);
       }
+    });
+  });
+
+  describe('malformed TOON handling', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await import('node:fs/promises').then(fs =>
+        fs.mkdtemp(join(tmpdir(), 'activity-test-'))
+      );
+      await mkdir(join(tempDir, 'meta', 'activities'), { recursive: true });
+    });
+
+    afterEach(async () => {
+      await rm(tempDir, { recursive: true, force: true });
+    });
+
+    it('should return error for malformed TOON content', async () => {
+      await writeFile(join(tempDir, 'meta', 'activities', '01-broken.toon'), 'this is not valid TOON {{{', 'utf-8');
+      const result = await readActivity(tempDir, 'broken');
+      expect(result.success).toBe(false);
+    });
+
+    it('should return error for empty TOON file', async () => {
+      await writeFile(join(tempDir, 'meta', 'activities', '01-empty-activity.toon'), '', 'utf-8');
+      const result = await readActivity(tempDir, 'empty-activity');
+      expect(result.success).toBe(false);
+    });
+
+    it('should return error for TOON with missing required fields', async () => {
+      await writeFile(join(tempDir, 'meta', 'activities', '01-incomplete.toon'), 'id: incomplete\n', 'utf-8');
+      const result = await readActivity(tempDir, 'incomplete');
+      expect(result.success).toBe(false);
     });
   });
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,8 +1,15 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { createServer } from '../src/server.js';
 import { resolve } from 'node:path';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseToolResponse(result: { content: unknown[] }): any {
+  return JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+}
+
+const SEMVER_RE = /^\d+\.\d+\.\d+$/;
 
 describe('mcp-server integration', () => {
   let client: Client;
@@ -27,13 +34,14 @@ describe('mcp-server integration', () => {
       await client.close();
       await server.close();
     };
+  });
 
+  beforeEach(async () => {
     const sessionResult = await client.callTool({
       name: 'start_session',
       arguments: { workflow_id: 'work-package' },
     });
-    const sessionResponse = JSON.parse((sessionResult.content[0] as { type: 'text'; text: string }).text);
-    sessionToken = sessionResponse.session_token;
+    sessionToken = parseToolResponse(sessionResult).session_token;
   });
 
   afterAll(async () => {
@@ -46,7 +54,7 @@ describe('mcp-server integration', () => {
     it('should return bootstrap procedure and session protocol', async () => {
       const result = await client.callTool({ name: 'help', arguments: {} });
       expect(result.isError).toBeFalsy();
-      const guide = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const guide = parseToolResponse(result);
       expect(guide.bootstrap).toBeDefined();
       expect(guide.bootstrap.step_1.tool).toBe('list_workflows');
       expect(guide.bootstrap.step_2.tool).toBe('start_session');
@@ -60,7 +68,7 @@ describe('mcp-server integration', () => {
     it('should not require session_token', async () => {
       const result = await client.callTool({ name: 'list_workflows', arguments: {} });
       expect(result.isError).toBeFalsy();
-      const workflows = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const workflows = parseToolResponse(result);
       expect(Array.isArray(workflows)).toBe(true);
       const ids = workflows.map((w: { id: string }) => w.id);
       expect(ids).toContain('work-package');
@@ -75,7 +83,7 @@ describe('mcp-server integration', () => {
         arguments: { workflow_id: 'work-package' },
       });
       expect(result.isError).toBeFalsy();
-      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const response = parseToolResponse(result);
       expect(response.rules).toBeDefined();
       expect(response.rules.id).toBe('agent-rules');
       expect(response.workflow.id).toBe('work-package');
@@ -106,7 +114,7 @@ describe('mcp-server integration', () => {
         arguments: { session_token: sessionToken, workflow_id: 'work-package' },
       });
       expect(result.isError).toBeFalsy();
-      const meta = result._meta as Record<string, unknown> | undefined;
+      const meta = result._meta as Record<string, unknown>;
       expect(meta).toBeDefined();
       expect(meta!['session_token']).toBeDefined();
       expect(meta!['session_token']).not.toBe(sessionToken);
@@ -144,16 +152,22 @@ describe('mcp-server integration', () => {
     it('should reject get_activities', async () => {
       const result = await client.callTool({ name: 'get_activities', arguments: {} });
       expect(result.isError).toBe(true);
+      expect(result.content.length).toBeGreaterThan(0);
+      expect((result.content[0] as { type: string; text: string }).text).toBeTruthy();
     });
 
     it('should reject get_rules', async () => {
       const result = await client.callTool({ name: 'get_rules', arguments: {} });
       expect(result.isError).toBe(true);
+      expect(result.content.length).toBeGreaterThan(0);
+      expect((result.content[0] as { type: string; text: string }).text).toBeTruthy();
     });
 
     it('should reject match_goal', async () => {
       const result = await client.callTool({ name: 'match_goal', arguments: { prompt: 'test' } });
       expect(result.isError).toBe(true);
+      expect(result.content.length).toBeGreaterThan(0);
+      expect((result.content[0] as { type: string; text: string }).text).toBeTruthy();
     });
   });
 
@@ -166,9 +180,9 @@ describe('mcp-server integration', () => {
         arguments: { session_token: sessionToken, workflow_id: 'work-package' },
       });
       expect(result.content).toBeDefined();
-      const workflow = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const workflow = parseToolResponse(result);
       expect(workflow.id).toBe('work-package');
-      expect(workflow.version).toBe('3.4.0');
+      expect(workflow.version).toMatch(SEMVER_RE);
     });
 
     it('should return error for non-existent workflow', async () => {
@@ -186,7 +200,7 @@ describe('mcp-server integration', () => {
         name: 'next_activity',
         arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
       });
-      const activity = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const activity = parseToolResponse(result);
       expect(activity.id).toBe('start-work-package');
       expect(activity.name).toBe('Start Work Package');
     });
@@ -211,7 +225,7 @@ describe('mcp-server integration', () => {
           checkpoint_id: 'issue-verification',
         },
       });
-      const checkpoint = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const checkpoint = parseToolResponse(result);
       expect(checkpoint.id).toBe('issue-verification');
       expect(checkpoint.options.length).toBeGreaterThan(0);
     });
@@ -221,7 +235,7 @@ describe('mcp-server integration', () => {
   describe('tool: health_check', () => {
     it('should return healthy status', async () => {
       const result = await client.callTool({ name: 'health_check', arguments: {} });
-      const health = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const health = parseToolResponse(result);
       expect(health.status).toBe('healthy');
       expect(health.workflows_available).toBeGreaterThanOrEqual(2);
     });
@@ -235,7 +249,7 @@ describe('mcp-server integration', () => {
         name: 'get_skill',
         arguments: { session_token: sessionToken, workflow_id: 'work-package', skill_id: 'create-issue' },
       });
-      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const response = parseToolResponse(result);
       expect(response.skill).toBeDefined();
       expect(response.skill.id).toBe('create-issue');
       expect(response.resources).toBeDefined();
@@ -250,7 +264,7 @@ describe('mcp-server integration', () => {
         arguments: { session_token: sessionToken, workflow_id: 'work-package', skill_id: 'create-issue' },
       });
       expect(result.isError).toBeFalsy();
-      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const response = parseToolResponse(result);
       expect(response.resources.length).toBeGreaterThan(0);
       const resource = response.resources[0];
       expect(resource.index).toBeDefined();
@@ -266,13 +280,15 @@ describe('mcp-server integration', () => {
         arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
       });
       expect(result.isError).toBeFalsy();
-      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const response = parseToolResponse(result);
       expect(Array.isArray(response.resources)).toBe(true);
       if (response.resources.length > 0) {
         expect(response.resources[0].index).toBeDefined();
         expect(response.resources[0].id).toBeDefined();
         expect(response.resources[0].content).toBeDefined();
       }
+      const meta = result._meta as Record<string, unknown>;
+      expect(meta['session_token']).toBeDefined();
     });
 
     it('resource content should not contain frontmatter', async () => {
@@ -280,7 +296,7 @@ describe('mcp-server integration', () => {
         name: 'get_skill',
         arguments: { session_token: sessionToken, workflow_id: 'work-package', skill_id: 'create-issue' },
       });
-      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const response = parseToolResponse(result);
       for (const resource of response.resources) {
         expect(resource.content).not.toMatch(/^---/);
       }
@@ -297,10 +313,12 @@ describe('mcp-server integration', () => {
       });
       expect(result.isError).toBeFalsy();
 
-      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const response = parseToolResponse(result);
       expect(response.activity_id).toBe('start-work-package');
       expect(response.skills).toBeDefined();
       expect(response.skills['create-issue']).toBeDefined();
+      const meta = result._meta as Record<string, unknown>;
+      expect(meta['session_token']).toBeDefined();
     });
 
     it('should include primary and supporting skills', async () => {
@@ -308,7 +326,7 @@ describe('mcp-server integration', () => {
         name: 'get_skills',
         arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
       });
-      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const response = parseToolResponse(result);
       const skillIds = Object.keys(response.skills);
       expect(skillIds.length).toBeGreaterThanOrEqual(1);
     });
@@ -339,8 +357,7 @@ describe('mcp-server integration', () => {
         name: 'start_session',
         arguments: { workflow_id: 'meta' },
       });
-      const metaResponse = JSON.parse((metaSession.content[0] as { type: 'text'; text: string }).text);
-      const metaToken = metaResponse.session_token;
+      const metaToken = parseToolResponse(metaSession).session_token;
 
       const result = await client.callTool({
         name: 'get_workflow',
@@ -381,7 +398,7 @@ describe('mcp-server integration', () => {
       const actMeta = actResult._meta as Record<string, unknown>;
       const tokenAfterStart = actMeta['session_token'] as string;
 
-      const actContent = JSON.parse((actResult.content[0] as { type: 'text'; text: string }).text);
+      const actContent = parseToolResponse(actResult);
       const manifest = actContent.steps.map((s: { id: string }) => ({ step_id: s.id, output: 'completed' }));
 
       const result = await client.callTool({
@@ -399,15 +416,14 @@ describe('mcp-server integration', () => {
         name: 'start_session',
         arguments: { workflow_id: 'meta' },
       });
-      const metaResponse = JSON.parse((metaSession.content[0] as { type: 'text'; text: string }).text);
-      const metaToken = metaResponse.session_token;
+      const metaToken = parseToolResponse(metaSession).session_token;
 
       const result = await client.callTool({
         name: 'get_workflow',
         arguments: { session_token: metaToken, workflow_id: 'work-package' },
       });
       expect(result.isError).toBeFalsy();
-      const workflow = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const workflow = parseToolResponse(result);
       expect(workflow.id).toBe('work-package');
     });
   });
@@ -505,7 +521,7 @@ describe('mcp-server integration', () => {
         },
       });
       expect(result.isError).toBeFalsy();
-      const activity = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const activity = parseToolResponse(result);
       expect(activity.id).toBe('requirements-elicitation');
     });
   });
@@ -562,7 +578,7 @@ describe('mcp-server integration', () => {
       const actMeta = actResult._meta as Record<string, unknown>;
       const tokenAfterAct = actMeta['session_token'] as string;
 
-      const actContent = JSON.parse((actResult.content[0] as { type: 'text'; text: string }).text);
+      const actContent = parseToolResponse(actResult);
       const reversedManifest = actContent.steps.map((s: { id: string }) => ({ step_id: s.id, output: 'done' })).reverse();
 
       const result = await client.callTool({
@@ -598,7 +614,7 @@ describe('mcp-server integration', () => {
         },
       });
       expect(result.isError).toBeFalsy();
-      const activity = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const activity = parseToolResponse(result);
       expect(activity.id).toBe('design-philosophy');
     });
   });
@@ -620,7 +636,7 @@ describe('mcp-server integration', () => {
       });
       expect(result.isError).toBeFalsy();
 
-      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const response = parseToolResponse(result);
       expect(response.current_activity).toBe('start-work-package');
       expect(response.transitions).toBeDefined();
       expect(Array.isArray(response.transitions)).toBe(true);
@@ -640,7 +656,7 @@ describe('mcp-server integration', () => {
         name: 'get_activities',
         arguments: { session_token: tokenWithAct, workflow_id: 'work-package' },
       });
-      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const response = parseToolResponse(result);
       const conditional = response.transitions.find((t: { condition?: string }) => t.condition);
       expect(conditional).toBeDefined();
       expect(typeof conditional.condition).toBe('string');
@@ -658,7 +674,7 @@ describe('mcp-server integration', () => {
         name: 'get_activities',
         arguments: { session_token: tokenWithAct, workflow_id: 'work-package' },
       });
-      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const response = parseToolResponse(result);
       const defaultTransition = response.transitions.find((t: { isDefault?: boolean }) => t.isDefault);
       expect(defaultTransition).toBeDefined();
     });
@@ -699,9 +715,9 @@ describe('mcp-server integration', () => {
       });
       expect(result.isError).toBeFalsy();
 
-      const wf = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const wf = parseToolResponse(result);
       expect(wf.id).toBe('work-package');
-      expect(wf.version).toBe('3.4.0');
+      expect(wf.version).toMatch(SEMVER_RE);
       expect(wf.rules).toBeDefined();
       expect(wf.variables).toBeDefined();
       expect(wf.activities).toBeDefined();
@@ -730,7 +746,7 @@ describe('mcp-server integration', () => {
         name: 'get_workflow',
         arguments: { session_token: sessionToken, workflow_id: 'work-package', summary: false },
       });
-      const wf = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const wf = parseToolResponse(result);
       expect(wf.activities[0].steps).toBeDefined();
     });
   });
@@ -738,23 +754,12 @@ describe('mcp-server integration', () => {
   // ============== Trace Integration ==============
 
   describe('trace lifecycle', () => {
-    let traceSessionToken: string;
-
-    beforeAll(async () => {
-      const sessionResult = await client.callTool({
-        name: 'start_session',
-        arguments: { workflow_id: 'work-package' },
-      });
-      const sessionResponse = JSON.parse((sessionResult.content[0] as { type: 'text'; text: string }).text);
-      traceSessionToken = sessionResponse.session_token;
-    });
-
     it('start_session initializes trace (IT-6)', async () => {
       const result = await client.callTool({
         name: 'get_trace',
-        arguments: { session_token: traceSessionToken },
+        arguments: { session_token: sessionToken },
       });
-      const trace = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const trace = parseToolResponse(result);
       expect(trace.source).toBe('memory');
       expect(trace.events.length).toBeGreaterThanOrEqual(1);
       expect(trace.events[0].name).toBe('start_session');
@@ -763,35 +768,38 @@ describe('mcp-server integration', () => {
     it('next_activity returns _meta.trace_token (IT-7)', async () => {
       const result = await client.callTool({
         name: 'next_activity',
-        arguments: { session_token: traceSessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
       });
       const meta = result._meta as Record<string, unknown>;
-      traceSessionToken = meta['session_token'] as string;
       expect(meta['trace_token']).toBeDefined();
       expect(typeof meta['trace_token']).toBe('string');
       expect((meta['trace_token'] as string).length).toBeGreaterThan(10);
     });
 
     it('get_trace without tokens returns in-memory trace (IT-13)', async () => {
+      await client.callTool({
+        name: 'next_activity',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
+      });
       const result = await client.callTool({
         name: 'get_trace',
-        arguments: { session_token: traceSessionToken },
+        arguments: { session_token: sessionToken },
       });
-      const meta = result._meta as Record<string, unknown>;
-      traceSessionToken = meta['session_token'] as string;
-      const trace = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const trace = parseToolResponse(result);
       expect(trace.source).toBe('memory');
       expect(trace.events.length).toBeGreaterThan(0);
     });
 
     it('trace events have compressed field names (IT-10)', async () => {
+      await client.callTool({
+        name: 'next_activity',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
+      });
       const result = await client.callTool({
         name: 'get_trace',
-        arguments: { session_token: traceSessionToken },
+        arguments: { session_token: sessionToken },
       });
-      const meta = result._meta as Record<string, unknown>;
-      traceSessionToken = meta['session_token'] as string;
-      const trace = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const trace = parseToolResponse(result);
       const event = trace.events[0];
       expect(event.ts).toBeDefined();
       expect(event.ms).toBeDefined();
@@ -801,24 +809,22 @@ describe('mcp-server integration', () => {
     });
 
     it('session_token not in trace events (IT-15)', async () => {
+      await client.callTool({
+        name: 'next_activity',
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
+      });
       const result = await client.callTool({
         name: 'get_trace',
-        arguments: { session_token: traceSessionToken },
+        arguments: { session_token: sessionToken },
       });
-      const meta = result._meta as Record<string, unknown>;
-      traceSessionToken = meta['session_token'] as string;
       const traceText = (result.content[0] as { type: 'text'; text: string }).text;
       expect(traceText).not.toContain('session_token');
     });
 
     it('get_trace excludes itself from trace (IT-14)', async () => {
-      const result = await client.callTool({
-        name: 'get_trace',
-        arguments: { session_token: traceSessionToken },
-      });
-      const meta = result._meta as Record<string, unknown>;
-      traceSessionToken = meta['session_token'] as string;
-      const trace = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      await client.callTool({ name: 'get_trace', arguments: { session_token: sessionToken } });
+      const result = await client.callTool({ name: 'get_trace', arguments: { session_token: sessionToken } });
+      const trace = parseToolResponse(result);
       const traceNames = trace.events.map((e: { name: string }) => e.name);
       expect(traceNames).not.toContain('get_trace');
     });
@@ -827,57 +833,49 @@ describe('mcp-server integration', () => {
       try {
         await client.callTool({
           name: 'next_activity',
-          arguments: { session_token: traceSessionToken, workflow_id: 'work-package', activity_id: 'nonexistent-activity' },
+          arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'nonexistent-activity' },
         });
       } catch { /* expected */ }
 
       const result = await client.callTool({
         name: 'get_trace',
-        arguments: { session_token: traceSessionToken },
+        arguments: { session_token: sessionToken },
       });
-      const meta = result._meta as Record<string, unknown>;
-      traceSessionToken = meta['session_token'] as string;
-      const trace = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const trace = parseToolResponse(result);
       const errorEvents = trace.events.filter((e: { s: string }) => e.s === 'error');
       expect(errorEvents.length).toBeGreaterThan(0);
       expect(errorEvents[0].err).toBeDefined();
     });
 
     it('accumulated trace tokens resolve via get_trace (IT-8)', async () => {
-      const session2 = await client.callTool({
-        name: 'start_session',
-        arguments: { workflow_id: 'work-package' },
-      });
-      let tok = JSON.parse((session2.content[0] as { type: 'text'; text: string }).text).session_token as string;
-
       await client.callTool({
         name: 'get_skills',
-        arguments: { session_token: tok, workflow_id: 'work-package', activity_id: 'start-work-package' },
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
       });
 
       const act1 = await client.callTool({
         name: 'next_activity',
-        arguments: { session_token: tok, workflow_id: 'work-package', activity_id: 'start-work-package' },
+        arguments: { session_token: sessionToken, workflow_id: 'work-package', activity_id: 'start-work-package' },
       });
       const meta1 = act1._meta as Record<string, unknown>;
-      tok = meta1['session_token'] as string;
+      const updatedToken = meta1['session_token'] as string;
       const traceToken1 = meta1['trace_token'] as string;
       expect(traceToken1).toBeDefined();
 
       const act2 = await client.callTool({
         name: 'next_activity',
-        arguments: { session_token: tok, workflow_id: 'work-package', activity_id: 'design-philosophy' },
+        arguments: { session_token: updatedToken, workflow_id: 'work-package', activity_id: 'design-philosophy' },
       });
       const meta2 = act2._meta as Record<string, unknown>;
-      tok = meta2['session_token'] as string;
+      const updatedToken2 = meta2['session_token'] as string;
       const traceToken2 = meta2['trace_token'] as string;
       expect(traceToken2).toBeDefined();
 
       const resolved = await client.callTool({
         name: 'get_trace',
-        arguments: { session_token: tok, trace_tokens: [traceToken1, traceToken2] },
+        arguments: { session_token: updatedToken2, trace_tokens: [traceToken1, traceToken2] },
       });
-      const trace = JSON.parse((resolved.content[0] as { type: 'text'; text: string }).text);
+      const trace = parseToolResponse(resolved);
       expect(trace.source).toBe('tokens');
       expect(trace.event_count).toBeGreaterThanOrEqual(2);
     });
@@ -885,26 +883,18 @@ describe('mcp-server integration', () => {
     it('invalid trace token handled gracefully (IT-19)', async () => {
       const result = await client.callTool({
         name: 'get_trace',
-        arguments: { session_token: traceSessionToken, trace_tokens: ['invalid.token.here'] },
+        arguments: { session_token: sessionToken, trace_tokens: ['invalid.token.here'] },
       });
-      const meta = result._meta as Record<string, unknown>;
-      traceSessionToken = meta['session_token'] as string;
-      const trace = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      const trace = parseToolResponse(result);
       expect(trace.token_errors).toBeDefined();
       expect(trace.token_errors.length).toBeGreaterThan(0);
     });
 
     it('activity_manifest accepted without error (IT-3)', async () => {
-      const session3 = await client.callTool({
-        name: 'start_session',
-        arguments: { workflow_id: 'work-package' },
-      });
-      const tok3 = JSON.parse((session3.content[0] as { type: 'text'; text: string }).text).session_token as string;
-
       const result = await client.callTool({
         name: 'next_activity',
         arguments: {
-          session_token: tok3,
+          session_token: sessionToken,
           workflow_id: 'work-package',
           activity_id: 'start-work-package',
           activity_manifest: [
@@ -913,6 +903,65 @@ describe('mcp-server integration', () => {
         },
       });
       expect(result.isError).toBeFalsy();
+    });
+  });
+
+  // ============== Concurrent Session Isolation ==============
+
+  describe('concurrent session isolation', () => {
+    it('operations on one session should not affect another', async () => {
+      const s1 = await client.callTool({
+        name: 'start_session',
+        arguments: { workflow_id: 'work-package' },
+      });
+      const s2 = await client.callTool({
+        name: 'start_session',
+        arguments: { workflow_id: 'work-package' },
+      });
+
+      const token1 = parseToolResponse(s1).session_token as string;
+      const token2 = parseToolResponse(s2).session_token as string;
+
+      const act1 = await client.callTool({
+        name: 'next_activity',
+        arguments: { session_token: token1, workflow_id: 'work-package', activity_id: 'design-philosophy' },
+      });
+      const act2 = await client.callTool({
+        name: 'next_activity',
+        arguments: { session_token: token2, workflow_id: 'work-package', activity_id: 'start-work-package' },
+      });
+
+      expect(act1.isError).toBeFalsy();
+      expect(act2.isError).toBeFalsy();
+      expect(parseToolResponse(act1).id).toBe('design-philosophy');
+      expect(parseToolResponse(act2).id).toBe('start-work-package');
+    });
+
+    it('traces from different sessions should be isolated', async () => {
+      const s1 = await client.callTool({
+        name: 'start_session',
+        arguments: { workflow_id: 'work-package' },
+      });
+      const s2 = await client.callTool({
+        name: 'start_session',
+        arguments: { workflow_id: 'work-package' },
+      });
+
+      const token1 = parseToolResponse(s1).session_token as string;
+      const token2 = parseToolResponse(s2).session_token as string;
+
+      await client.callTool({
+        name: 'next_activity',
+        arguments: { session_token: token1, workflow_id: 'work-package', activity_id: 'start-work-package' },
+      });
+
+      const trace2 = await client.callTool({
+        name: 'get_trace',
+        arguments: { session_token: token2 },
+      });
+      const traceData = parseToolResponse(trace2);
+      const names = traceData.events.map((e: { name: string }) => e.name);
+      expect(names).not.toContain('next_activity');
     });
   });
 });

--- a/tests/rules-loader.test.ts
+++ b/tests/rules-loader.test.ts
@@ -1,57 +1,58 @@
-import { describe, it, expect } from 'vitest';
-import { join } from 'node:path';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { resolve } from 'node:path';
 import { readRules, readRulesRaw } from '../src/loaders/rules-loader.js';
 
-const WORKFLOW_DIR = join(process.cwd(), 'workflows');
+const WORKFLOW_DIR = resolve(import.meta.dirname, '../workflows');
 
 describe('rules-loader', () => {
   describe('readRules', () => {
-    it('should load global rules from meta/rules.toon', async () => {
-      const result = await readRules(WORKFLOW_DIR);
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.value.id).toBe('agent-rules');
-        expect(result.value.version).toBeDefined();
-        expect(result.value.title).toBeDefined();
-        expect(result.value.description).toBeDefined();
+    let rulesResult: Awaited<ReturnType<typeof readRules>>;
+
+    beforeAll(async () => {
+      rulesResult = await readRules(WORKFLOW_DIR);
+    });
+
+    it('should load global rules from meta/rules.toon', () => {
+      expect(rulesResult.success).toBe(true);
+      if (rulesResult.success) {
+        expect(rulesResult.value.id).toBe('agent-rules');
+        expect(rulesResult.value.version).toBeDefined();
+        expect(rulesResult.value.title).toBeDefined();
+        expect(rulesResult.value.description).toBeDefined();
       }
     });
 
-    it('should have sections array with rule categories', async () => {
-      const result = await readRules(WORKFLOW_DIR);
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(Array.isArray(result.value.sections)).toBe(true);
-        expect(result.value.sections.length).toBeGreaterThan(0);
+    it('should have sections array with rule categories', () => {
+      expect(rulesResult.success).toBe(true);
+      if (rulesResult.success) {
+        expect(Array.isArray(rulesResult.value.sections)).toBe(true);
+        expect(rulesResult.value.sections.length).toBeGreaterThan(0);
       }
     });
 
-    it('should include code-modification section', async () => {
-      const result = await readRules(WORKFLOW_DIR);
-      expect(result.success).toBe(true);
-      if (result.success) {
-        const codeModSection = result.value.sections.find(s => s.id === 'code-modification');
+    it('should include code-modification section', () => {
+      expect(rulesResult.success).toBe(true);
+      if (rulesResult.success) {
+        const codeModSection = rulesResult.value.sections.find(s => s.id === 'code-modification');
         expect(codeModSection).toBeDefined();
         expect(codeModSection?.title).toBe('Code Modification Boundaries');
         expect(codeModSection?.priority).toBe('critical');
       }
     });
 
-    it('should include version-control section with GitHub CLI guidance', async () => {
-      const result = await readRules(WORKFLOW_DIR);
-      expect(result.success).toBe(true);
-      if (result.success) {
-        const githubSection = result.value.sections.find(s => s.id === 'github-cli');
+    it('should include version-control section with GitHub CLI guidance', () => {
+      expect(rulesResult.success).toBe(true);
+      if (rulesResult.success) {
+        const githubSection = rulesResult.value.sections.find(s => s.id === 'github-cli');
         expect(githubSection).toBeDefined();
         expect(githubSection?.title).toBe('GitHub CLI Usage');
       }
     });
 
-    it('should include precedence statement', async () => {
-      const result = await readRules(WORKFLOW_DIR);
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.value.precedence).toContain('Workflow-specific rules override');
+    it('should include precedence statement', () => {
+      expect(rulesResult.success).toBe(true);
+      if (rulesResult.success) {
+        expect(rulesResult.value.precedence).toContain('Workflow-specific rules override');
       }
     });
 

--- a/tests/schema-loader.test.ts
+++ b/tests/schema-loader.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { join } from 'node:path';
+import { resolve } from 'node:path';
 import { readAllSchemas, listSchemaIds } from '../src/loaders/schema-loader.js';
 
-const SCHEMAS_DIR = join(process.cwd(), 'schemas');
+const SCHEMAS_DIR = resolve(import.meta.dirname, '../schemas');
 
 describe('schema-loader', () => {
   describe('listSchemaIds', () => {
@@ -13,7 +13,7 @@ describe('schema-loader', () => {
       expect(ids).toContain('condition');
       expect(ids).toContain('skill');
       expect(ids).toContain('state');
-      expect(ids.length).toBe(5);
+      expect(ids.length).toBeGreaterThanOrEqual(5);
     });
   });
 

--- a/tests/schema-validation.test.ts
+++ b/tests/schema-validation.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { resolve } from 'node:path';
 import {
   WorkflowSchema,
   safeValidateWorkflow,
@@ -9,8 +10,13 @@ import {
   StepSchema,
   DecisionSchema,
   LoopSchema,
+  safeValidateActivity,
 } from '../src/schema/activity.schema.js';
 import { ConditionSchema } from '../src/schema/condition.schema.js';
+import { loadWorkflow } from '../src/loaders/workflow-loader.js';
+import { readActivity } from '../src/loaders/activity-loader.js';
+
+const WORKFLOW_DIR = resolve(import.meta.dirname, '../workflows');
 
 describe('schema-validation', () => {
   describe('ConditionSchema', () => {
@@ -257,6 +263,37 @@ describe('schema-validation', () => {
       };
       const result = ActivitySchema.safeParse(activity);
       expect(result.success).toBe(true);
+    });
+  });
+
+  describe('loader schema integration', () => {
+    it('loaded workflow should pass WorkflowSchema validation', async () => {
+      const result = await loadWorkflow(WORKFLOW_DIR, 'work-package');
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const validation = safeValidateWorkflow(result.value);
+        expect(validation.success).toBe(true);
+      }
+    });
+
+    it('loaded activity should pass ActivitySchema validation', async () => {
+      const result = await readActivity(WORKFLOW_DIR, 'start-workflow');
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const validation = safeValidateActivity(result.value);
+        expect(validation.success).toBe(true);
+      }
+    });
+
+    it('loaded workflow activities should all pass ActivitySchema', async () => {
+      const result = await loadWorkflow(WORKFLOW_DIR, 'work-package');
+      expect(result.success).toBe(true);
+      if (result.success) {
+        for (const activity of result.value.activities) {
+          const validation = ActivitySchema.safeParse(activity);
+          expect(validation.success, `Activity ${activity.id} failed schema validation`).toBe(true);
+        }
+      }
     });
   });
 

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -55,8 +55,9 @@ describe('session token utilities', () => {
 
     it('should throw on tampered payload', async () => {
       const token = await createSessionToken('work-package', '3.4.0');
+      const payload = await decodeSessionToken(token);
       const [, sig] = token.split('.');
-      const tampered = Buffer.from(JSON.stringify({ wf: 'hacked', act: '', skill: '', cond: '', v: '1.0.0', seq: 0, ts: 0, sid: 'fake', aid: '' })).toString('base64url');
+      const tampered = Buffer.from(JSON.stringify({ ...payload, wf: 'hacked' })).toString('base64url');
       await expect(decodeSessionToken(`${tampered}.${sig}`)).rejects.toThrow('signature verification failed');
     });
   });

--- a/tests/skill-loader.test.ts
+++ b/tests/skill-loader.test.ts
@@ -1,8 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { listSkills, listUniversalSkills, readSkill, readSkillIndex } from '../src/loaders/skill-loader.js';
-import { join } from 'node:path';
+import { resolve, join } from 'node:path';
+import { mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 
-const WORKFLOW_DIR = join(process.cwd(), 'workflows');
+const WORKFLOW_DIR = resolve(import.meta.dirname, '../workflows');
 
 describe('skill-loader', () => {
   describe('listUniversalSkills', () => {
@@ -125,6 +127,50 @@ describe('skill-loader', () => {
           expect(errorInfo.cause, `${errorName} should have 'cause' field`).toBeDefined();
           expect(errorInfo.recovery, `${errorName} should have 'recovery' field`).toBeDefined();
         }
+      }
+    });
+  });
+
+  describe('malformed TOON handling', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await import('node:fs/promises').then(fs =>
+        fs.mkdtemp(join(tmpdir(), 'skill-test-'))
+      );
+      await mkdir(join(tempDir, 'meta', 'skills'), { recursive: true });
+    });
+
+    afterEach(async () => {
+      await rm(tempDir, { recursive: true, force: true });
+    });
+
+    it('should handle non-skill TOON content without crashing', async () => {
+      await writeFile(join(tempDir, 'meta', 'skills', '01-not-a-skill.toon'), 'just a plain string', 'utf-8');
+      const result = await readSkill('not-a-skill', tempDir);
+      expect(result.success).toBe(true);
+    });
+
+    it('should handle empty TOON file without crashing', async () => {
+      await writeFile(join(tempDir, 'meta', 'skills', '01-empty-skill.toon'), '', 'utf-8');
+      const result = await readSkill('empty-skill', tempDir);
+      expect(result.success).toBe(true);
+    });
+
+    it('should handle TOON with minimal fields without crashing', async () => {
+      await writeFile(join(tempDir, 'meta', 'skills', '01-minimal.toon'), 'id: minimal\nversion: 1.0.0\n', 'utf-8');
+      const result = await readSkill('minimal', tempDir);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.value.id).toBe('minimal');
+      }
+    });
+
+    it('should return error for non-existent skill in temp directory', async () => {
+      const result = await readSkill('does-not-exist', tempDir);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.name).toBe('SkillNotFoundError');
       }
     });
   });

--- a/tests/state-persistence.test.ts
+++ b/tests/state-persistence.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { readFile, rm, mkdir } from 'node:fs/promises';
+import { readFile, writeFile, rm, mkdir } from 'node:fs/promises';
 import { join, resolve, sep } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -187,7 +187,7 @@ describe('state-persistence', () => {
         sessionTokenEncrypted: false,
         state,
       };
-      const encoded = encodeToon(saveFile as unknown as Record<string, unknown>);
+      const encoded = encodeToon(saveFile);
       const decoded = decodeToon<Record<string, unknown>>(encoded);
       expect(decoded).toEqual(saveFile);
     });
@@ -245,7 +245,7 @@ describe('state-persistence', () => {
           }],
         },
       };
-      const encoded = encodeToon(saveFile as unknown as Record<string, unknown>);
+      const encoded = encodeToon(saveFile);
       const decoded = decodeToon<Record<string, unknown>>(encoded);
       expect(decoded).toEqual(saveFile);
     });
@@ -262,9 +262,8 @@ describe('state-persistence', () => {
         state,
       };
       const filePath = join(TEST_DIR, 'workflow-state.toon');
-      const encoded = encodeToon(saveFile as unknown as Record<string, unknown>);
-      const { writeFile: wf } = await import('node:fs/promises');
-      await wf(filePath, encoded, 'utf-8');
+      const encoded = encodeToon(saveFile);
+      await writeFile(filePath, encoded, 'utf-8');
 
       const content = await readFile(filePath, 'utf-8');
       const decoded = decodeToon<Record<string, unknown>>(content);

--- a/tests/trace.test.ts
+++ b/tests/trace.test.ts
@@ -163,9 +163,11 @@ describe('trace token encode/decode', () => {
 
   it('rejects tampered payload (UT-10)', async () => {
     const token = await createTraceToken(samplePayload);
-    const [b64] = token.split('.');
-    const tampered = `${b64}x.${token.split('.')[1]}`;
-    await expect(decodeTraceToken(tampered)).rejects.toThrow('signature verification failed');
+    const [b64, sig] = token.split('.');
+    const decoded = JSON.parse(Buffer.from(b64!, 'base64url').toString());
+    decoded.n = 999;
+    const tamperedB64 = Buffer.from(JSON.stringify(decoded)).toString('base64url');
+    await expect(decodeTraceToken(`${tamperedB64}.${sig}`)).rejects.toThrow('signature verification failed');
   });
 
   it('rejects invalid HMAC (UT-11)', async () => {

--- a/tests/workflow-loader.test.ts
+++ b/tests/workflow-loader.test.ts
@@ -33,7 +33,7 @@ describe('workflow-loader', () => {
       
       expect(workPackage).toBeDefined();
       expect(workPackage?.title).toBe('Work Package Implementation Workflow');
-      expect(workPackage?.version).toBe('3.4.0');
+      expect(workPackage?.version).toMatch(/^\d+\.\d+\.\d+$/);
     });
   });
 
@@ -44,7 +44,7 @@ describe('workflow-loader', () => {
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.value.id).toBe('work-package');
-        expect(result.value.activities.length).toBe(14);
+        expect(result.value.activities.length).toBeGreaterThanOrEqual(14);
         expect(result.value.initialActivity).toBe('start-work-package');
       }
     });


### PR DESCRIPTION
## Summary

Fix test infrastructure — eliminate shared mutable state causing cascading failures, add malformed TOON data tests, extract repeated helper patterns, and decouple test assertions from mutable workflow data values.

🎫 [Issue](https://github.com/m2ux/workflow-server/issues/67)  📐 [Engineering](https://github.com/m2ux/workflow-server/blob/engineering/artifacts/planning/2026-03-27-audit-remediation/README.md)

---

## Motivation

Shared mutable `sessionToken` variables in `mcp-server.test.ts` cause a single test failure to cascade into all subsequent tests. The trace lifecycle test block has the same sequential dependency pattern. No tests exercise malformed TOON data paths — if the parser silently swallows field errors, the test suite won't detect it. `JSON.parse((result.content[0] as ...).text)` is repeated ~30 times with unsafe casts. Test assertions use hardcoded version strings and activity counts that break on data changes unrelated to code quality.

---

## Changes

**Implementation (coming next):**
- Scope `sessionToken` per test or `beforeEach` block (QC-016)
- Add malformed TOON fixture tests for parse-error paths (QC-017)
- Fix trace lifecycle sequential dependencies (QC-018)
- Replace hardcoded version/count assertions with structural checks (QC-070, QC-071, QC-072)
- Extract `parseToolResponse` helper (QC-073)
- Standardize path resolution on `import.meta.dirname` (QC-076)
- Address remaining test findings (QC-074, QC-075, QC-077, QC-078, QC-128–QC-133)

---

## 📌 Submission Checklist

- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: not applicable
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] No new todos introduced

---

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other
- [x] N/A

---

## 🗹 TODO before merging

- [ ] Ready for review