### PR TITLE
docs: documentation alignment (WP-12)

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -166,6 +166,8 @@ erDiagram
         string message
         Condition condition
         boolean blocking
+        string defaultOption
+        integer autoAdvanceMs
     }
     
     CheckpointOption {
@@ -300,7 +302,7 @@ A step represents an individual task within an activity.
 
 #### Checkpoint
 
-A checkpoint is a blocking decision point requiring user input.
+A checkpoint is a decision point requiring user input. Checkpoints block by default but can be non-blocking with auto-advance.
 
 | Field       | Type               | Purpose                                             |
 | ----------- | ------------------ | --------------------------------------------------- |
@@ -310,7 +312,9 @@ A checkpoint is a blocking decision point requiring user input.
 | `condition` | Condition          | Condition that must be true to present; if false, skip |
 | `options`   | CheckpointOption[] | Available choices                                   |
 | `required`  | boolean            | Whether checkpoint must be answered                 |
-| `blocking`  | boolean            | Always true - checkpoints block progress            |
+| `blocking`  | boolean            | Whether this checkpoint blocks progress (default: true). Non-blocking checkpoints support `defaultOption` and `autoAdvanceMs` for auto-advance. |
+| `defaultOption` | string          | Option ID to auto-select when `autoAdvanceMs` elapses. Only meaningful when `blocking` is false. |
+| `autoAdvanceMs` | integer         | Milliseconds to wait before auto-selecting `defaultOption`. Only meaningful when `blocking` is false and `defaultOption` is set. |
 
 #### Decision
 
@@ -377,7 +381,7 @@ An action performed during workflow execution.
 
 | Field     | Type   | Purpose                             |
 | --------- | ------ | ----------------------------------- |
-| `action`  | enum   | "log", "validate", "set", or "emit" |
+| `action`  | enum   | "log", "validate", "set", "emit", or "message" |
 | `target`  | string | Target of the action                |
 | `message` | string | Message content                     |
 | `value`   | any    | Value for set/emit actions          |


### PR DESCRIPTION
## Summary

Align `schemas/README.md` documentation with actual schema behavior — correct the checkpoint `blocking` description and add the missing `message` action to the action enum.

🎫 [Issue](https://github.com/m2ux/workflow-server/issues/67)  📐 [Engineering](https://github.com/m2ux/workflow-server/blob/engineering/artifacts/planning/2026-03-27-audit-remediation/README.md)

---

## Motivation

The README states checkpoint `blocking` is "Always true" while the schema defines it as `default: true` with `autoAdvanceMs` and `defaultOption` properties supporting non-blocking operation. The README Action enum lists 4 values while the schema defines 5, omitting `message`. Anyone reading only the README encounters constraints that don't match the actual schema.

---

## Changes

**Implementation (coming next):**
- Update checkpoint `blocking` documentation to describe non-blocking support (QC-063)
- Add `message` to the Action enum documentation (QC-064)

---

## 📌 Submission Checklist

- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: not applicable
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] No new todos introduced

---

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other
- [x] N/A

---

## 🗹 TODO before merging

- [ ] Ready for review