### PR TITLE
fix: enforce validation in skill and activity loaders

### DIFF
--- a/src/loaders/activity-loader.ts
+++ b/src/loaders/activity-loader.ts
@@ -114,10 +114,11 @@ async function readActivityFromWorkflow(
     
     const validation = safeValidateActivity(decoded);
     if (!validation.success) {
-      logWarn('Activity validation failed, using raw content', { activityId, workflowId, errors: validation.error.issues });
+      logWarn('Activity validation failed', { activityId, workflowId, errors: validation.error.issues });
+      return err(new ActivityNotFoundError(activityId, workflowId));
     }
     
-    const activity = validation.success ? validation.data : decoded;
+    const activity = validation.data;
     
     // Infer artifactPrefix from the activity filename index
     const parsedFilename = parseActivityFilename(matchingFile);
@@ -242,7 +243,11 @@ export async function readActivityIndex(workflowDir: string): Promise<Result<Act
       const decoded = decodeToon<Activity>(content);
       
       const validation = safeValidateActivity(decoded);
-      const activity = validation.success ? validation.data : decoded;
+      if (!validation.success) {
+        logWarn('Activity validation failed, skipping', { activityId: entry.id, workflowId: entry.workflowId, errors: validation.error.issues });
+        continue;
+      }
+      const activity = validation.data;
       
       const indexSkillParams: Record<string, string> = { skill_id: activity.skills.primary };
       if (entry.workflowId) indexSkillParams['workflow_id'] = entry.workflowId;

--- a/src/loaders/skill-loader.ts
+++ b/src/loaders/skill-loader.ts
@@ -5,7 +5,7 @@ import { type Result, ok, err } from '../result.js';
 import { SkillNotFoundError } from '../errors.js';
 import { logInfo, logWarn } from '../logging.js';
 import { decodeToon } from '../utils/toon.js';
-import type { Skill } from '../schema/skill.schema.js';
+import { type Skill, safeValidateSkill } from '../schema/skill.schema.js';
 import { parseActivityFilename as parseSkillFilename } from './filename-utils.js';
 
 /** The meta workflow contains universal skills */
@@ -75,7 +75,13 @@ async function tryLoadSkill(skillDir: string, skillId: string): Promise<Skill | 
 
   try {
     const content = await readFile(filePath, 'utf-8');
-    return decodeToon<Skill>(content);
+    const decoded = decodeToon<Skill>(content);
+    const validation = safeValidateSkill(decoded);
+    if (!validation.success) {
+      logWarn('Skill validation failed', { skillId, path: filePath, errors: validation.error.issues });
+      return null;
+    }
+    return validation.data;
   } catch (error) {
     logWarn('Failed to decode skill TOON', { skillId, path: filePath, error: error instanceof Error ? error.message : String(error) });
     return null;

--- a/src/schema/skill.schema.ts
+++ b/src/schema/skill.schema.ts
@@ -161,6 +161,7 @@ export const SkillSchema = z.object({
   status_values: z.record(z.string()).optional(),
   interpretation: InterpretationSchema.optional(),
   resumption: ResumptionSchema.optional(),
+  execution_pattern: ExecutionPatternSchema.optional(),
   rules: RulesDefinitionSchema.optional(),
   errors: z.record(ErrorDefinitionSchema).optional(),
   inputs: InputsDefinitionSchema.optional(),

--- a/tests/skill-loader.test.ts
+++ b/tests/skill-loader.test.ts
@@ -145,25 +145,32 @@ describe('skill-loader', () => {
       await rm(tempDir, { recursive: true, force: true });
     });
 
-    it('should handle non-skill TOON content without crashing', async () => {
+    it('should reject non-skill TOON content', async () => {
       await writeFile(join(tempDir, 'meta', 'skills', '01-not-a-skill.toon'), 'just a plain string', 'utf-8');
       const result = await readSkill('not-a-skill', tempDir);
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
     });
 
-    it('should handle empty TOON file without crashing', async () => {
+    it('should reject empty TOON file', async () => {
       await writeFile(join(tempDir, 'meta', 'skills', '01-empty-skill.toon'), '', 'utf-8');
       const result = await readSkill('empty-skill', tempDir);
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
     });
 
-    it('should handle TOON with minimal fields without crashing', async () => {
-      await writeFile(join(tempDir, 'meta', 'skills', '01-minimal.toon'), 'id: minimal\nversion: 1.0.0\n', 'utf-8');
+    it('should accept TOON with all required fields', async () => {
+      await writeFile(join(tempDir, 'meta', 'skills', '01-minimal.toon'), 'id: minimal\nversion: 1.0.0\ncapability: test capability\n', 'utf-8');
       const result = await readSkill('minimal', tempDir);
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.value.id).toBe('minimal');
+        expect(result.value.capability).toBe('test capability');
       }
+    });
+
+    it('should reject TOON missing required capability field', async () => {
+      await writeFile(join(tempDir, 'meta', 'skills', '01-incomplete.toon'), 'id: incomplete\nversion: 1.0.0\n', 'utf-8');
+      const result = await readSkill('incomplete', tempDir);
+      expect(result.success).toBe(false);
     });
 
     it('should return error for non-existent skill in temp directory', async () => {


### PR DESCRIPTION
## Summary

Enforce Zod validation in skill and activity loading paths, eliminating the validation bypass that allowed malformed TOON content through unchecked.

📐 [Engineering](https://github.com/m2ux/workflow-server/blob/engineering/artifacts/planning/2026-03-27-prism-audit-remediation/README.md)

---

## Motivation

The prism quality audit identified a self-concealing validation equilibrium: skill loading skipped Zod validation entirely, activity loading fell through to raw data on validation failure, and tests depended on undeclared schema properties that survived only because validation was bypassed. This PR breaks that equilibrium in controlled order.

---

## Changes

- **F-09** (MEDIUM) — Wire orphaned `ExecutionPatternSchema` into `SkillSchema` so production TOON data validates correctly
- **F-05** (MEDIUM) — Add `safeValidateSkill()` call in `tryLoadSkill()` — invalid skills now return `null` instead of unvalidated data
- **F-08** (MEDIUM) — Update skill-loader tests: malformed TOON content now correctly rejected; added test for missing required fields
- **F-06** (MEDIUM) — Fix `readActivityFromWorkflow()` to return `ActivityNotFoundError` on validation failure instead of serving raw data
- **F-07** (MEDIUM) — Fix `readActivityIndex()` to skip invalid activities instead of including them in the index

---

## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: validation enforcement, no new features
- [x] Update documentation (if relevant)
- [x] No new todos introduced

---

## 🔱 Fork Strategy

- [x] N/A

---

## 🗹 TODO before merging

- [x] Ready for review