### PR TITLE
fix: strict equality, meta schema, atomic key creation, test config

### DIFF
--- a/src/schema/condition.schema.ts
+++ b/src/schema/condition.schema.ts
@@ -61,8 +61,8 @@ function evaluateSimpleCondition(condition: SimpleCondition, variables: Record<s
   switch (condition.operator) {
     case 'exists': return value !== undefined && value !== null;
     case 'notExists': return value === undefined || value === null;
-    case '==': return value == condition.value;
-    case '!=': return value != condition.value;
+    case '==': return value === condition.value;
+    case '!=': return value !== condition.value;
     case '>': return typeof value === 'number' && typeof condition.value === 'number' && value > condition.value;
     case '<': return typeof value === 'number' && typeof condition.value === 'number' && value < condition.value;
     case '>=': return typeof value === 'number' && typeof condition.value === 'number' && value >= condition.value;

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,5 +1,6 @@
 import { randomBytes, createCipheriv, createDecipheriv, createHmac, timingSafeEqual } from 'node:crypto';
-import { readFile, writeFile, mkdir, rename } from 'node:fs/promises';
+import { readFile, writeFile, mkdir, open } from 'node:fs/promises';
+import { constants } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 
@@ -32,9 +33,16 @@ async function loadOrCreateKey(): Promise<Buffer> {
     if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
       const key = randomBytes(KEY_LENGTH);
       await mkdir(KEY_DIR, { recursive: true, mode: 0o700 });
-      const tmpFile = `${KEY_FILE}.${process.pid}.tmp`;
-      await writeFile(tmpFile, key, { mode: 0o600 });
-      await rename(tmpFile, KEY_FILE);
+      try {
+        const fh = await open(KEY_FILE, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, 0o600);
+        await fh.writeFile(key);
+        await fh.close();
+      } catch (writeErr: unknown) {
+        if (writeErr instanceof Error && 'code' in writeErr && (writeErr as NodeJS.ErrnoException).code === 'EEXIST') {
+          return readFile(KEY_FILE);
+        }
+        throw writeErr;
+      }
       return key;
     }
     throw err;

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import type { SessionPayload } from './session.js';
 import type { Workflow } from '../schema/workflow.schema.js';
 import { getValidTransitions, getActivity, getTransitionList } from '../loaders/workflow-loader.js';
@@ -184,4 +185,20 @@ export function buildErrorValidation(error: string, ...warnings: (string | null)
   result.status = 'error';
   result.errors = [error];
   return result;
+}
+
+export const ValidationResultSchema = z.object({
+  status: z.enum(['valid', 'warning', 'error']),
+  warnings: z.array(z.string()),
+  errors: z.array(z.string()).optional(),
+});
+
+export const MetaResponseSchema = z.object({
+  session_token: z.string(),
+  validation: ValidationResultSchema,
+});
+export type MetaResponse = z.infer<typeof MetaResponseSchema>;
+
+export function buildMeta(sessionToken: string, validation: ValidationResult): MetaResponse {
+  return { session_token: sessionToken, validation };
 }

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -19,6 +19,7 @@ describe('mcp-server integration', () => {
   beforeAll(async () => {
     const config = {
       workflowDir: resolve(import.meta.dirname, '../workflows'),
+      schemasDir: resolve(import.meta.dirname, '../schemas'),
       serverName: 'test-workflow-server',
       serverVersion: '1.0.0',
     };


### PR DESCRIPTION
## Summary

Fix condition evaluation semantics, add _meta response schema, eliminate key creation race condition, and complete test configuration.

📐 [Engineering](https://github.com/m2ux/workflow-server/blob/engineering/artifacts/planning/2026-03-27-prism-audit-remediation/README.md)

---

## Motivation

The prism quality audit identified four independent correctness issues: condition evaluation using loose equality (`==`) instead of the documented strict equality (`===`), ad-hoc `_meta` response construction with no shared schema, a TOCTOU race in cryptographic key file creation, and a missing `schemasDir` field in test configuration.

---

## Changes

- **F-04** (MEDIUM) — Replace `==` with `===` and `!=` with `!==` in `evaluateSimpleCondition()` to match JSON Schema documentation
- **F-12** (LOW) — Define `MetaResponseSchema` and `buildMeta()` helper in `validation.ts` for typed `_meta` response construction
- **F-14** (LOW) — Fix TOCTOU race in `loadOrCreateKey()` using `O_EXCL` flag for atomic file creation — concurrent processes now converge on a single key
- **F-15** (LOW) — Add `schemasDir` to test config in `mcp-server.test.ts`

---

## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: correctness fixes only
- [x] Update documentation (if relevant)
- [x] No new todos introduced

---

## 🔱 Fork Strategy

- [x] N/A

---

## 🗹 TODO before merging

- [x] Ready for review