### PR TITLE
fix: resolve behavioral prism findings — correctness, diagnostics, and performance

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -44,5 +44,5 @@ export class ActivityNotFoundError extends Error {
 
 export class RulesNotFoundError extends Error {
   readonly code: ErrorCode = ERROR_CODES.RULES_NOT_FOUND;
-  constructor() { super('Global rules not found'); this.name = 'RulesNotFoundError'; }
+  constructor(message?: string) { super(message ?? 'Global rules not found'); this.name = 'RulesNotFoundError'; }
 }

--- a/src/loaders/activity-loader.ts
+++ b/src/loaders/activity-loader.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { type Result, ok, err } from '../result.js';
 import { ActivityNotFoundError } from '../errors.js';
 import { logInfo, logWarn } from '../logging.js';
-import { decodeToon } from '../utils/toon.js';
+import { decodeToonRaw } from '../utils/toon.js';
 import { type Activity, safeValidateActivity } from '../schema/activity.schema.js';
 import { parseActivityFilename } from './filename-utils.js';
 
@@ -111,7 +111,7 @@ async function readActivityFromWorkflow(
     
     const filePath = join(activityDir, matchingFile);
     const content = await readFile(filePath, 'utf-8');
-    const decoded = decodeToon<Activity>(content);
+    const decoded = decodeToonRaw(content);
     
     const validation = safeValidateActivity(decoded);
     if (!validation.success) {
@@ -242,10 +242,10 @@ export async function readActivityIndex(workflowDir: string): Promise<Result<Act
     
     try {
       const content = await readFile(filePath, 'utf-8');
-      const decoded = decodeToon<Activity>(content);
+      const decoded = decodeToonRaw(content);
       
       const validation = safeValidateActivity(decoded);
-      const activity = validation.success ? validation.data : decoded;
+      const activity = validation.success ? validation.data : decoded as Activity;
       
       const indexSkillParams: Record<string, string> = { skill_id: activity.skills.primary };
       if (entry.workflowId) indexSkillParams['workflow_id'] = entry.workflowId;

--- a/src/loaders/activity-loader.ts
+++ b/src/loaders/activity-loader.ts
@@ -47,7 +47,8 @@ async function findWorkflowsWithActivities(workflowDir: string): Promise<string[
     }
     
     return workflowIds.sort();
-  } catch {
+  } catch (error) {
+    logWarn('Failed to list workflows with activities', { workflowDir, error: error instanceof Error ? error.message : String(error) });
     return [];
   }
 }
@@ -114,10 +115,11 @@ async function readActivityFromWorkflow(
     
     const validation = safeValidateActivity(decoded);
     if (!validation.success) {
-      logWarn('Activity validation failed, using raw content', { activityId, workflowId, errors: validation.error.issues });
+      logWarn('Activity validation failed', { activityId, workflowId, errors: validation.error.issues });
+      return err(new ActivityNotFoundError(activityId, workflowId));
     }
     
-    const activity = validation.success ? validation.data : decoded;
+    const activity = validation.data;
     
     // Infer artifactPrefix from the activity filename index
     const parsedFilename = parseActivityFilename(matchingFile);
@@ -191,7 +193,8 @@ async function listActivitiesFromWorkflow(workflowDir: string, workflowId: strin
       })
       .filter((entry): entry is ActivityEntry => entry !== null)
       .sort((a, b) => a.index.localeCompare(b.index));
-  } catch { 
+  } catch (error) {
+    logWarn('Failed to list activities', { workflowId, error: error instanceof Error ? error.message : String(error) });
     return []; 
   }
 }
@@ -265,8 +268,8 @@ export async function readActivityIndex(workflowDir: string): Promise<Result<Act
           quick_match[pattern.toLowerCase()] = activity.id;
         }
       }
-    } catch {
-      logWarn('Failed to load activity for index', { activityId: entry.id, workflowId: entry.workflowId });
+    } catch (error) {
+      logWarn('Failed to load activity for index', { activityId: entry.id, workflowId: entry.workflowId, error: error instanceof Error ? error.message : String(error) });
     }
   }
   

--- a/src/loaders/resource-loader.ts
+++ b/src/loaders/resource-loader.ts
@@ -5,6 +5,9 @@ import { type Result, ok, err } from '../result.js';
 import { ResourceNotFoundError } from '../errors.js';
 import { logInfo, logError, logWarn } from '../logging.js';
 import { decodeToon } from '../utils/toon.js';
+import { ResourceSchema, type Resource } from '../schema/resource.schema.js';
+
+export type { Resource };
 
 export interface ResourceEntry { 
   index: string;  // e.g., "00", "01"
@@ -12,15 +15,6 @@ export interface ResourceEntry {
   title: string;  // e.g., "Start Here"
   path: string;   // e.g., "resources/00-start-here.toon"
   format: 'toon' | 'markdown';
-}
-
-export interface Resource {
-  id: string;
-  version?: string;
-  title: string;
-  purpose?: string;
-  sections?: unknown[];
-  [key: string]: unknown;
 }
 
 /** Normalize a resource index to a consistent width for comparison. */
@@ -104,7 +98,7 @@ export async function readResource(
         const filePath = join(resourceDir, file);
         const content = await readFile(filePath, 'utf-8');
         logInfo('Resource loaded', { workflowId, resourceIndex, path: filePath, format: 'toon' });
-        return ok(decodeToon<Resource>(content));
+        return ok(decodeToon(content, ResourceSchema));
       }
       if (!mdFallback) mdFallback = file;
     }

--- a/src/loaders/resource-loader.ts
+++ b/src/loaders/resource-loader.ts
@@ -210,7 +210,8 @@ export async function listResources(workflowDir: string, workflowId: string): Pr
     resources.sort((a, b) => parseInt(a.index, 10) - parseInt(b.index, 10));
     
     return resources;
-  } catch { 
+  } catch (error) {
+    logWarn('Failed to list resources', { workflowId, error: error instanceof Error ? error.message : String(error) });
     return []; 
   }
 }
@@ -298,7 +299,8 @@ export async function listWorkflowsWithResources(workflowDir: string): Promise<s
     }
     
     return workflows.sort();
-  } catch {
+  } catch (error) {
+    logWarn('Failed to list workflows with resources', { workflowDir, error: error instanceof Error ? error.message : String(error) });
     return [];
   }
 }

--- a/src/loaders/rules-loader.ts
+++ b/src/loaders/rules-loader.ts
@@ -1,10 +1,27 @@
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { z } from 'zod';
 import { type Result, ok, err } from '../result.js';
 import { RulesNotFoundError } from '../errors.js';
 import { logInfo, logWarn } from '../logging.js';
 import { decodeToon } from '../utils/toon.js';
+
+const RulesSectionSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  priority: z.string().optional(),
+  rules: z.array(z.string()).optional(),
+}).passthrough();
+
+const RulesSchema = z.object({
+  id: z.string(),
+  version: z.string(),
+  title: z.string(),
+  description: z.string(),
+  precedence: z.string(),
+  sections: z.array(RulesSectionSchema),
+});
 
 /** The meta workflow contains global rules */
 const META_WORKFLOW_ID = 'meta';
@@ -40,12 +57,19 @@ export async function readRules(workflowDir: string): Promise<Result<Rules, Rule
   
   try {
     const content = await readFile(rulesPath, 'utf-8');
-    const rules = decodeToon<Rules>(content);
-    logInfo('Rules loaded', { path: rulesPath, sectionCount: rules.sections?.length ?? 0 });
+    const decoded = decodeToon<unknown>(content);
+    const result = RulesSchema.safeParse(decoded);
+    if (!result.success) {
+      const issues = result.error.issues.map(i => `${i.path.join('.')}: ${i.message}`).join('; ');
+      logWarn('Rules validation failed', { path: rulesPath, issues });
+      return err(new RulesNotFoundError(`Rules file exists but failed validation: ${issues}`));
+    }
+    const rules = result.data as Rules;
+    logInfo('Rules loaded', { path: rulesPath, sectionCount: rules.sections.length });
     return ok(rules);
   } catch (error) {
     logWarn('Rules parse error', { path: rulesPath, error: String(error) });
-    return err(new RulesNotFoundError());
+    return err(new RulesNotFoundError(`Rules file exists but could not be parsed: ${error instanceof Error ? error.message : String(error)}`));
   }
 }
 
@@ -63,7 +87,8 @@ export async function readRulesRaw(workflowDir: string): Promise<Result<string, 
     const content = await readFile(rulesPath, 'utf-8');
     logInfo('Rules loaded (raw)', { path: rulesPath });
     return ok(content);
-  } catch {
-    return err(new RulesNotFoundError());
+  } catch (error) {
+    logWarn('Failed to read rules file', { path: rulesPath, error: error instanceof Error ? error.message : String(error) });
+    return err(new RulesNotFoundError(`Failed to read rules file: ${error instanceof Error ? error.message : String(error)}`));
   }
 }

--- a/src/loaders/rules-loader.ts
+++ b/src/loaders/rules-loader.ts
@@ -1,49 +1,17 @@
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { z } from 'zod';
 import { type Result, ok, err } from '../result.js';
 import { RulesNotFoundError } from '../errors.js';
 import { logInfo, logWarn } from '../logging.js';
-import { decodeToon } from '../utils/toon.js';
+import { decodeToonRaw } from '../utils/toon.js';
+import { RulesSchema, type Rules, type RulesSection } from '../schema/rules.schema.js';
 
-const RulesSectionSchema = z.object({
-  id: z.string(),
-  title: z.string(),
-  priority: z.string().optional(),
-  rules: z.array(z.string()).optional(),
-}).passthrough();
-
-const RulesSchema = z.object({
-  id: z.string(),
-  version: z.string(),
-  title: z.string(),
-  description: z.string(),
-  precedence: z.string(),
-  sections: z.array(RulesSectionSchema),
-});
+export type { Rules, RulesSection };
 
 /** The meta workflow contains global rules */
 const META_WORKFLOW_ID = 'meta';
 const RULES_FILE = 'rules.toon';
-
-export interface RulesSection {
-  id: string;
-  title: string;
-  priority?: string;
-  rules?: string[];
-  content?: string;
-  [key: string]: unknown;
-}
-
-export interface Rules {
-  id: string;
-  version: string;
-  title: string;
-  description: string;
-  precedence: string;
-  sections: RulesSection[];
-}
 
 /**
  * Read global agent rules from meta/rules.toon
@@ -57,7 +25,7 @@ export async function readRules(workflowDir: string): Promise<Result<Rules, Rule
   
   try {
     const content = await readFile(rulesPath, 'utf-8');
-    const decoded = decodeToon<unknown>(content);
+    const decoded = decodeToonRaw(content);
     const result = RulesSchema.safeParse(decoded);
     if (!result.success) {
       const issues = result.error.issues.map(i => `${i.path.join('.')}: ${i.message}`).join('; ');

--- a/src/loaders/skill-loader.ts
+++ b/src/loaders/skill-loader.ts
@@ -6,6 +6,7 @@ import { SkillNotFoundError } from '../errors.js';
 import { logInfo, logWarn } from '../logging.js';
 import { decodeToon } from '../utils/toon.js';
 import type { Skill } from '../schema/skill.schema.js';
+import { safeValidateSkill } from '../schema/skill.schema.js';
 import { parseActivityFilename as parseSkillFilename } from './filename-utils.js';
 
 /** The meta workflow contains universal skills */
@@ -30,7 +31,8 @@ async function findSkillFile(skillDir: string, skillId: string): Promise<string 
       return parsed && parsed.id === skillId;
     });
     return matchingFile ? join(skillDir, matchingFile) : null;
-  } catch {
+  } catch (error) {
+    logWarn('Failed to read skill directory', { skillDir, error: error instanceof Error ? error.message : String(error) });
     return null;
   }
 }
@@ -63,19 +65,26 @@ async function findWorkflowsWithSkills(workflowDir: string): Promise<string[]> {
     }
 
     return workflowIds.sort();
-  } catch {
+  } catch (error) {
+    logWarn('Failed to list workflows with skills', { workflowDir, error: error instanceof Error ? error.message : String(error) });
     return [];
   }
 }
 
-/** Try to load a skill from a specific directory, returning the parsed Skill or null */
+/** Try to load a skill from a specific directory, returning the validated Skill or null */
 async function tryLoadSkill(skillDir: string, skillId: string): Promise<Skill | null> {
   const filePath = await findSkillFile(skillDir, skillId);
   if (!filePath) return null;
 
   try {
     const content = await readFile(filePath, 'utf-8');
-    return decodeToon<Skill>(content);
+    const decoded = decodeToon<unknown>(content);
+    const result = safeValidateSkill(decoded);
+    if (!result.success) {
+      logWarn('Skill validation failed', { skillId, path: filePath, errors: result.error.issues.map(i => `${i.path.join('.')}: ${i.message}`) });
+      return null;
+    }
+    return result.data;
   } catch (error) {
     logWarn('Failed to decode skill TOON', { skillId, path: filePath, error: error instanceof Error ? error.message : String(error) });
     return null;
@@ -144,7 +153,8 @@ export async function listUniversalSkills(workflowDir: string): Promise<SkillEnt
       })
       .filter((entry): entry is SkillEntry => entry !== null)
       .sort((a, b) => a.index.localeCompare(b.index));
-  } catch { 
+  } catch (error) {
+    logWarn('Failed to list universal skills', { error: error instanceof Error ? error.message : String(error) });
     return []; 
   }
 }
@@ -169,7 +179,8 @@ export async function listWorkflowSkills(workflowDir: string, workflowId: string
     }
     
     return entries.sort((a, b) => a.index.localeCompare(b.index));
-  } catch { 
+  } catch (error) {
+    logWarn('Failed to list workflow skills', { workflowId, error: error instanceof Error ? error.message : String(error) });
     return []; 
   }
 }
@@ -195,8 +206,8 @@ export async function listSkills(workflowDir: string): Promise<SkillEntry[]> {
           skills.push(...workflowSkills);
         }
       }
-    } catch {
-      // Ignore errors
+    } catch (error) {
+      logWarn('Failed to enumerate workflow skill directories', { workflowDir, error: error instanceof Error ? error.message : String(error) });
     }
   }
   
@@ -279,8 +290,8 @@ export async function readSkillIndex(workflowDir: string): Promise<Result<SkillI
           }
         }
       }
-    } catch {
-      // Ignore errors
+    } catch (error) {
+      logWarn('Failed to build skill index', { workflowDir, error: error instanceof Error ? error.message : String(error) });
     }
   }
   

--- a/src/loaders/skill-loader.ts
+++ b/src/loaders/skill-loader.ts
@@ -4,7 +4,7 @@ import { join, basename } from 'node:path';
 import { type Result, ok, err } from '../result.js';
 import { SkillNotFoundError } from '../errors.js';
 import { logInfo, logWarn } from '../logging.js';
-import { decodeToon } from '../utils/toon.js';
+import { decodeToonRaw } from '../utils/toon.js';
 import type { Skill } from '../schema/skill.schema.js';
 import { safeValidateSkill } from '../schema/skill.schema.js';
 import { parseActivityFilename as parseSkillFilename } from './filename-utils.js';
@@ -78,7 +78,7 @@ async function tryLoadSkill(skillDir: string, skillId: string): Promise<Skill | 
 
   try {
     const content = await readFile(filePath, 'utf-8');
-    const decoded = decodeToon<unknown>(content);
+    const decoded = decodeToonRaw(content);
     const result = safeValidateSkill(decoded);
     if (!result.success) {
       logWarn('Skill validation failed', { skillId, path: filePath, errors: result.error.issues.map(i => `${i.path.join('.')}: ${i.message}`) });

--- a/src/loaders/workflow-loader.ts
+++ b/src/loaders/workflow-loader.ts
@@ -151,7 +151,7 @@ export async function listWorkflows(workflowDir: string): Promise<WorkflowManife
     
     return manifests;
   } catch (error) {
-    logWarn('Failed to list workflows', { workflowDir, error: error instanceof Error ? error.message : String(error) });
+    logWarn('Failed to list workflows', { workflowDir, error: error instanceof Error ? error.message : String(error), code: error instanceof Error && 'code' in error ? (error as NodeJS.ErrnoException).code : undefined });
     return [];
   }
 }
@@ -189,6 +189,7 @@ export function getTransitionList(workflow: Workflow, fromActivityId: string): T
   if (!activity) return [];
 
   const entries: TransitionEntry[] = [];
+  const seen = new Set<string>();
 
   for (const t of activity.transitions ?? []) {
     entries.push({
@@ -196,6 +197,25 @@ export function getTransitionList(workflow: Workflow, fromActivityId: string): T
       condition: t.condition ? conditionToString(t.condition) : undefined,
       isDefault: t.isDefault || undefined,
     });
+    seen.add(t.to);
+  }
+
+  for (const d of activity.decisions ?? []) {
+    for (const b of d.branches) {
+      if (b.transitionTo && !seen.has(b.transitionTo)) {
+        entries.push({ to: b.transitionTo, condition: b.condition ? conditionToString(b.condition) : undefined, isDefault: b.isDefault || undefined });
+        seen.add(b.transitionTo);
+      }
+    }
+  }
+
+  for (const c of activity.checkpoints ?? []) {
+    for (const o of c.options) {
+      if (o.effect?.transitionTo && !seen.has(o.effect.transitionTo)) {
+        entries.push({ to: o.effect.transitionTo, condition: `checkpoint:${c.id}:${o.id}` });
+        seen.add(o.effect.transitionTo);
+      }
+    }
   }
 
   return entries;

--- a/src/loaders/workflow-loader.ts
+++ b/src/loaders/workflow-loader.ts
@@ -6,7 +6,7 @@ import { type Activity, safeValidateActivity } from '../schema/activity.schema.j
 import { type Result, ok, err } from '../result.js';
 import { WorkflowNotFoundError, WorkflowValidationError } from '../errors.js';
 import { logInfo, logError, logWarn } from '../logging.js';
-import { decodeToon } from '../utils/toon.js';
+import { decodeToonRaw } from '../utils/toon.js';
 import { parseActivityFilename } from './filename-utils.js';
 
 export interface WorkflowManifestEntry { id: string; title: string; version: string; description?: string | undefined; }
@@ -37,7 +37,7 @@ async function loadActivitiesFromDir(activitiesPath: string): Promise<Activity[]
     
     try {
       const content = await readFile(join(activitiesPath, file), 'utf-8');
-      const decoded = decodeToon<Activity>(content);
+      const decoded = decodeToonRaw(content);
       
       const validation = safeValidateActivity(decoded);
       if (!validation.success) {
@@ -81,7 +81,7 @@ export async function loadWorkflow(workflowDir: string, workflowId: string): Pro
   
   try {
     const content = await readFile(filePath, 'utf-8');
-    const rawWorkflow = decodeToon<RawWorkflow>(content);
+    const rawWorkflow = decodeToonRaw(content) as RawWorkflow;
     
     // Load activities from directory if not inline
     // Default to 'activities/' subfolder, or use activitiesDir if specified
@@ -139,7 +139,7 @@ export async function listWorkflows(workflowDir: string): Promise<WorkflowManife
       if (toonPath) {
         try {
           const content = await readFile(toonPath, 'utf-8');
-          const raw = decodeToon<RawWorkflow>(content);
+          const raw = decodeToonRaw(content) as RawWorkflow;
           if (raw.id && raw.title && raw.version) {
             manifests.push({ id: raw.id, title: raw.title, version: raw.version, description: raw.description });
           }

--- a/src/schema/condition.schema.ts
+++ b/src/schema/condition.schema.ts
@@ -56,6 +56,12 @@ function getVariableValue(path: string, variables: Record<string, unknown>): unk
   return current;
 }
 
+function toNumber(v: unknown): number | undefined {
+  if (typeof v === 'number') return v;
+  if (typeof v === 'string') { const n = Number(v); return Number.isFinite(n) ? n : undefined; }
+  return undefined;
+}
+
 function evaluateSimpleCondition(condition: SimpleCondition, variables: Record<string, unknown>): boolean {
   const value = getVariableValue(condition.variable, variables);
   switch (condition.operator) {
@@ -63,10 +69,10 @@ function evaluateSimpleCondition(condition: SimpleCondition, variables: Record<s
     case 'notExists': return value === undefined || value === null;
     case '==': return value === condition.value;
     case '!=': return value !== condition.value;
-    case '>': return typeof value === 'number' && typeof condition.value === 'number' && value > condition.value;
-    case '<': return typeof value === 'number' && typeof condition.value === 'number' && value < condition.value;
-    case '>=': return typeof value === 'number' && typeof condition.value === 'number' && value >= condition.value;
-    case '<=': return typeof value === 'number' && typeof condition.value === 'number' && value <= condition.value;
+    case '>': { const a = toNumber(value), b = toNumber(condition.value); return a !== undefined && b !== undefined && a > b; }
+    case '<': { const a = toNumber(value), b = toNumber(condition.value); return a !== undefined && b !== undefined && a < b; }
+    case '>=': { const a = toNumber(value), b = toNumber(condition.value); return a !== undefined && b !== undefined && a >= b; }
+    case '<=': { const a = toNumber(value), b = toNumber(condition.value); return a !== undefined && b !== undefined && a <= b; }
   }
 }
 

--- a/src/schema/resource.schema.ts
+++ b/src/schema/resource.schema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const ResourceSchema = z.object({
+  id: z.string(),
+  version: z.string().optional(),
+  title: z.string(),
+  purpose: z.string().optional(),
+  sections: z.array(z.unknown()).optional(),
+}).passthrough();
+
+export type Resource = z.infer<typeof ResourceSchema>;

--- a/src/schema/rules.schema.ts
+++ b/src/schema/rules.schema.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+export const RulesSectionSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  priority: z.string().optional(),
+  rules: z.array(z.string()).optional(),
+}).passthrough();
+
+export const RulesSchema = z.object({
+  id: z.string(),
+  version: z.string(),
+  title: z.string(),
+  description: z.string(),
+  precedence: z.string(),
+  sections: z.array(RulesSectionSchema),
+});
+
+export type RulesSection = z.infer<typeof RulesSectionSchema> & {
+  content?: string;
+  [key: string]: unknown;
+};
+
+export type Rules = z.infer<typeof RulesSchema>;

--- a/src/schema/skill.schema.ts
+++ b/src/schema/skill.schema.ts
@@ -167,7 +167,7 @@ export const SkillSchema = z.object({
   protocol: ProtocolDefinitionSchema.optional(),
   output: OutputDefinitionSchema.optional(),
   resources: z.array(z.string()).optional().describe('Resource indices or IDs this skill depends on (e.g. 02, 04, 08)'),
-});
+}).passthrough();
 export type Skill = z.infer<typeof SkillSchema>;
 
 export function validateSkill(data: unknown): Skill { return SkillSchema.parse(data); }

--- a/src/schema/skill.schema.ts
+++ b/src/schema/skill.schema.ts
@@ -21,17 +21,6 @@ export const ErrorDefinitionSchema = z.object({
 });
 export type ErrorDefinition = z.infer<typeof ErrorDefinitionSchema>;
 
-export const ExecutionPatternSchema = z.object({
-  start: z.array(z.string()).optional(),
-  bootstrap: z.array(z.string()).optional(),
-  per_activity: z.array(z.string()).optional(),
-  skill_loading: z.array(z.string()).optional(),
-  discovery: z.array(z.string()).optional(),
-  transitions: z.array(z.string()).optional(),
-  artifacts: z.array(z.string()).optional(),
-});
-export type ExecutionPattern = z.infer<typeof ExecutionPatternSchema>;
-
 export const ArchitectureSchema = z.object({
   principle: z.string().optional(),
   layers: z.array(z.string()).optional(),
@@ -167,7 +156,7 @@ export const SkillSchema = z.object({
   protocol: ProtocolDefinitionSchema.optional(),
   output: OutputDefinitionSchema.optional(),
   resources: z.array(z.string()).optional().describe('Resource indices or IDs this skill depends on (e.g. 02, 04, 08)'),
-}).passthrough();
+}).strict();
 export type Skill = z.infer<typeof SkillSchema>;
 
 export function validateSkill(data: unknown): Skill { return SkillSchema.parse(data); }

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -73,7 +73,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
         session_token: token,
       };
       return {
-        content: [{ type: 'text' as const, text: JSON.stringify(response, null, 2) }],
+        content: [{ type: 'text' as const, text: JSON.stringify(response) }],
         _meta: { session_token: token },
       };
     })
@@ -132,7 +132,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
       if (duplicateIndices.length > 0) responseBody['duplicate_resource_indices'] = duplicateIndices;
 
       return {
-        content: [{ type: 'text' as const, text: JSON.stringify(responseBody, null, 2) }],
+        content: [{ type: 'text' as const, text: JSON.stringify(responseBody) }],
         _meta: { session_token: await advanceToken(session_token, { wf: workflow_id, act: activity_id }), validation },
       };
     }, traceOpts)
@@ -166,7 +166,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
       };
 
       return {
-        content: [{ type: 'text' as const, text: JSON.stringify(response, null, 2) }],
+        content: [{ type: 'text' as const, text: JSON.stringify(response) }],
         _meta: { session_token: await advanceToken(session_token, { wf: workflow_id, skill: skill_id }), validation },
       };
     }, traceOpts)

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -15,12 +15,12 @@ const STATE_FILENAME = 'workflow-state.toon';
 const SESSION_TOKEN_KEY = 'session_token';
 const SESSION_TOKEN_ENCRYPTED_KEY = '_session_token_encrypted';
 
-/** @internal Exported for testing. Validates that a path resolves within process.cwd(). */
-export function validateStatePath(inputPath: string): string {
-  const root = process.cwd();
+/** @internal Exported for testing. Validates that a path resolves within the workspace root. */
+export function validateStatePath(inputPath: string, workspaceRoot?: string): string {
+  const root = workspaceRoot ?? process.cwd();
   const resolved = resolve(inputPath);
   if (resolved !== root && !resolved.startsWith(root + sep)) {
-    throw new Error(`Path validation failed: "${inputPath}" resolves outside the workspace root`);
+    throw new Error(`Path validation failed: "${inputPath}" resolves outside the workspace root ("${root}")`);
   }
   return resolved;
 }
@@ -98,7 +98,7 @@ export function registerStateTools(server: McpServer, config: ServerConfig): voi
       );
 
       return {
-        content: [{ type: 'text' as const, text: JSON.stringify(summary, null, 2) }],
+        content: [{ type: 'text' as const, text: JSON.stringify(summary) }],
         _meta: { session_token: await advanceToken(session_token), validation },
       };
     }, traceOpts),
@@ -127,10 +127,12 @@ export function registerStateTools(server: McpServer, config: ServerConfig): voi
         try {
           const key = await getOrCreateServerKey();
           restored.state.variables[SESSION_TOKEN_KEY] = decryptToken(restored.state.variables[SESSION_TOKEN_KEY] as string, key);
-        } catch {
+        } catch (decryptErr) {
+          const cause = decryptErr instanceof Error ? decryptErr.message : String(decryptErr);
           throw new Error(
-            'Failed to decrypt session token from saved state. This typically occurs when the server key has been rotated ' +
-            '(~/.workflow-server/secret was regenerated). The saved state must be re-created with the current key.',
+            `Failed to decrypt session token from saved state (${cause}). ` +
+            'Possible causes: server key rotation (~/.workflow-server/secret was regenerated), ' +
+            'corrupted state file, or manually edited save. The saved state must be re-created with the current key.',
           );
         }
       }
@@ -140,7 +142,7 @@ export function registerStateTools(server: McpServer, config: ServerConfig): voi
       );
 
       return {
-        content: [{ type: 'text' as const, text: JSON.stringify(restored, null, 2) }],
+        content: [{ type: 'text' as const, text: JSON.stringify(restored) }],
         _meta: { session_token: await advanceToken(session_token), validation },
       };
     }, traceOpts),

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -5,7 +5,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ServerConfig } from '../config.js';
 import { NestedWorkflowStateSchema, StateSaveFileSchema } from '../schema/state.schema.js';
 import type { StateSaveFile } from '../schema/state.schema.js';
-import { decodeToon, encodeToon } from '../utils/toon.js';
+import { decodeToonRaw, encodeToon } from '../utils/toon.js';
 import { withAuditLog } from '../logging.js';
 import { decodeSessionToken, advanceToken, sessionTokenParam } from '../utils/session.js';
 import { buildValidation, validateWorkflowConsistency } from '../utils/validation.js';
@@ -116,7 +116,7 @@ export function registerStateTools(server: McpServer, config: ServerConfig): voi
 
       const validatedPath = validateStatePath(file_path);
       const content = await readFile(validatedPath, 'utf-8');
-      const decoded = decodeToon<Record<string, unknown>>(content);
+      const decoded = decodeToonRaw(content);
       const result = StateSaveFileSchema.safeParse(decoded);
       if (!result.success) {
         throw new Error(`State file validation failed: ${result.error.issues.map(i => `${i.path.join('.')}: ${i.message}`).join('; ')}`);

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -53,12 +53,12 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
         },
         available_workflows: workflows.map(w => ({ id: w.id, title: w.title, version: w.version })),
       };
-      return { content: [{ type: 'text' as const, text: JSON.stringify(guide, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify(guide) }] };
     }));
 
   server.tool('list_workflows', 'List all available workflow definitions. Call this after help to choose a workflow.', {},
     withAuditLog('list_workflows', async () => ({
-      content: [{ type: 'text' as const, text: JSON.stringify(await listWorkflows(config.workflowDir), null, 2) }],
+      content: [{ type: 'text' as const, text: JSON.stringify(await listWorkflows(config.workflowDir)) }],
     })));
 
   server.tool('get_workflow', 'Get a workflow definition. Use summary=true for lightweight metadata (rules, variables, activity stubs) to reduce context usage.',
@@ -94,9 +94,9 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
           initialActivity: wf.initialActivity,
           activities: wf.activities.map(a => ({ id: a.id, name: a.name, required: a.required })),
         };
-        content.push({ type: 'text', text: JSON.stringify(summaryData, null, 2) });
+        content.push({ type: 'text', text: JSON.stringify(summaryData) });
       } else {
-        content.push({ type: 'text', text: JSON.stringify(result.value, null, 2) });
+        content.push({ type: 'text', text: JSON.stringify(result.value) });
       }
 
       return { content, _meta: { session_token: await advanceToken(session_token, { wf: workflow_id }), validation } };
@@ -174,7 +174,7 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       }
 
       return {
-        content: [{ type: 'text' as const, text: JSON.stringify(activity, null, 2) }],
+        content: [{ type: 'text' as const, text: JSON.stringify(activity) }],
         _meta: meta,
       };
     }, traceOpts));
@@ -199,7 +199,7 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       );
 
       return {
-        content: [{ type: 'text' as const, text: JSON.stringify(checkpoint, null, 2) }],
+        content: [{ type: 'text' as const, text: JSON.stringify(checkpoint) }],
         _meta: { session_token: await advanceToken(session_token, { wf: workflow_id, act: activity_id }), validation },
       };
     }, traceOpts));
@@ -224,7 +224,7 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
         transitions,
       };
       return {
-        content: [{ type: 'text' as const, text: JSON.stringify(response, null, 2) }],
+        content: [{ type: 'text' as const, text: JSON.stringify(response) }],
         _meta: { session_token: await advanceToken(session_token, { wf: workflow_id }), validation },
       };
     }, traceOpts));
@@ -251,21 +251,21 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
         const result: Record<string, unknown> = { traceId: token.sid, source: 'tokens', event_count: allEvents.length, events: allEvents };
         if (errors.length > 0) result['token_errors'] = errors;
         return {
-          content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+          content: [{ type: 'text' as const, text: JSON.stringify(result) }],
           _meta: { session_token: await advanceToken(session_token), validation: buildValidation() },
         };
       }
 
       if (!config.traceStore) {
         return {
-          content: [{ type: 'text' as const, text: JSON.stringify({ traceId: token.sid, source: 'memory', tracing_enabled: false, event_count: 0, events: [] }, null, 2) }],
+          content: [{ type: 'text' as const, text: JSON.stringify({ traceId: token.sid, source: 'memory', tracing_enabled: false, event_count: 0, events: [] }) }],
           _meta: { session_token: await advanceToken(session_token), validation: buildValidation() },
         };
       }
 
       const events = config.traceStore.getEvents(token.sid);
       return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ traceId: token.sid, source: 'memory', tracing_enabled: true, event_count: events.length, events }, null, 2) }],
+        content: [{ type: 'text' as const, text: JSON.stringify({ traceId: token.sid, source: 'memory', tracing_enabled: true, event_count: events.length, events }) }],
         _meta: { session_token: await advanceToken(session_token), validation: buildValidation() },
       };
     }, traceOpts ? { ...traceOpts, excludeFromTrace: true } : undefined));
@@ -277,7 +277,7 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
         content: [{ type: 'text' as const, text: JSON.stringify({
           status: 'healthy', server: config.serverName, version: config.serverVersion,
           workflows_available: workflows.length, uptime_seconds: Math.floor(process.uptime()),
-        }, null, 2) }],
+        }) }],
       };
     }));
 }

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { getOrCreateServerKey, hmacSign, hmacVerify } from './utils/crypto.js';
+import { logWarn } from './logging.js';
 
 /** Mechanical trace event with compressed field names (opaque to agents). */
 export interface TraceEvent {
@@ -72,6 +73,7 @@ export class TraceStore {
       if (this.sessions.size >= this.maxSessions) {
         const oldest = this.sessions.keys().next().value;
         if (oldest !== undefined) {
+          logWarn('TraceStore evicting oldest session', { evictedSid: oldest, maxSessions: this.maxSessions });
           this.sessions.delete(oldest);
           this.cursors.delete(oldest);
         }
@@ -82,6 +84,9 @@ export class TraceStore {
   }
 
   append(sid: string, event: TraceEvent): void {
+    if (!this.sessions.has(sid)) {
+      this.initSession(sid);
+    }
     const events = this.sessions.get(sid);
     if (events) events.push(event);
   }

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -39,7 +39,11 @@ async function loadOrCreateKey(): Promise<Buffer> {
         await fh.close();
       } catch (writeErr: unknown) {
         if (writeErr instanceof Error && 'code' in writeErr && (writeErr as NodeJS.ErrnoException).code === 'EEXIST') {
-          return readFile(KEY_FILE);
+          const existingKey = await readFile(KEY_FILE);
+          if (existingKey.length !== KEY_LENGTH) {
+            throw new Error(`Server key must be exactly ${KEY_LENGTH} bytes, got ${existingKey.length} (concurrent write may have produced a truncated key)`);
+          }
+          return existingKey;
         }
         throw writeErr;
       }

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -87,11 +87,11 @@ export async function decodeSessionToken(token: string): Promise<SessionPayload>
   return decode(token);
 }
 
-export async function advanceToken(token: string, updates?: SessionAdvance): Promise<string> {
-  const decoded = await decode(token);
+export async function advanceToken(token: string, updates?: SessionAdvance, decoded?: SessionPayload): Promise<string> {
+  const payload = decoded ?? await decode(token);
   const advanced: SessionPayload = {
-    ...decoded,
-    seq: decoded.seq + 1,
+    ...payload,
+    seq: payload.seq + 1,
     ts: Math.floor(Date.now() / 1000),
     ...(updates?.wf !== undefined && { wf: updates.wf }),
     ...(updates?.act !== undefined && { act: updates.act }),

--- a/src/utils/toon.ts
+++ b/src/utils/toon.ts
@@ -1,12 +1,21 @@
+import { type ZodType } from 'zod';
 import { decode, encode } from '@toon-format/toon';
 
 /**
- * Decode a TOON string to a JavaScript object.
- * The caller is responsible for validating the returned structure
- * matches the expected type T (e.g., via Zod schema validation).
+ * Decode a TOON string and validate against a Zod schema.
+ * Returns the validated, typed result. Throws ZodError on validation failure.
  */
-export function decodeToon<T = unknown>(content: string): T {
-  return decode(content) as T;
+export function decodeToon<T>(content: string, schema: ZodType<T>): T {
+  return schema.parse(decode(content));
+}
+
+/**
+ * Decode a TOON string without schema validation.
+ * Returns an untyped value — callers must validate or narrow the result.
+ * Use decodeToon(content, schema) when a schema is available.
+ */
+export function decodeToonRaw(content: string): unknown {
+  return decode(content);
 }
 
 /**

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -21,7 +21,12 @@ export function validateWorkflowConsistency(token: SessionPayload, workflowId: s
 }
 
 export function validateActivityTransition(token: SessionPayload, workflow: Workflow, activityId: string): string | null {
-  if (!token.act) return null;
+  if (!token.act) {
+    if (workflow.initialActivity && activityId !== workflow.initialActivity) {
+      return `First activity must be '${workflow.initialActivity}' but '${activityId}' was requested. Start with the workflow's initialActivity.`;
+    }
+    return null;
+  }
   if (token.act === activityId) return null;
 
   const valid = getValidTransitions(workflow, token.act);
@@ -34,13 +39,13 @@ export function validateActivityTransition(token: SessionPayload, workflow: Work
 }
 
 export function validateSkillAssociation(workflow: Workflow, activityId: string, skillId: string): string | null {
-  if (!activityId) return null;
+  if (!activityId) return 'Skill association check skipped: no current activity in session';
 
   const activity = getActivity(workflow, activityId);
-  if (!activity) return null;
+  if (!activity) return `Skill association check skipped: activity '${activityId}' not found in workflow`;
 
   const { skills } = activity;
-  if (!skills) return null;
+  if (!skills) return `Activity '${activityId}' declares no skills`;
 
   const declared: string[] = [skills.primary];
   if (skills.supporting) declared.push(...skills.supporting);

--- a/tests/activity-loader.test.ts
+++ b/tests/activity-loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { listActivities, readActivity, readActivityIndex } from '../src/loaders/activity-loader.js';
+import { readActivity, listActivities, readActivityIndex } from '../src/loaders/activity-loader.js';
 import { resolve, join } from 'node:path';
 import { mkdir, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -7,50 +7,45 @@ import { tmpdir } from 'node:os';
 const WORKFLOW_DIR = resolve(import.meta.dirname, '../workflows');
 
 describe('activity-loader', () => {
-  describe('listActivities', () => {
-    it('should list available activities from meta workflow', async () => {
-      const activities = await listActivities(WORKFLOW_DIR);
-      expect(activities.length).toBeGreaterThanOrEqual(3);
-      
-      const ids = activities.map(i => i.id);
-      expect(ids).toContain('start-workflow');
-      expect(ids).toContain('resume-workflow');
-      expect(ids).toContain('end-workflow');
-    });
-
-    it('should not include index.toon in activity list', async () => {
-      const activities = await listActivities(WORKFLOW_DIR);
-      const ids = activities.map(i => i.id);
-      expect(ids).not.toContain('index');
-    });
-
-    it('should include index, name, and path in activity entries', async () => {
-      const activities = await listActivities(WORKFLOW_DIR);
-      const startWorkflow = activities.find(i => i.id === 'start-workflow');
-      
-      expect(startWorkflow).toBeDefined();
-      expect(startWorkflow?.index).toBe('01');
-      expect(startWorkflow?.name).toBe('Start Workflow');
-      expect(startWorkflow?.path).toBe('01-start-workflow.toon');
-    });
-  });
-
   describe('readActivity', () => {
-    it('should load a valid activity', async () => {
-      const result = await readActivity(WORKFLOW_DIR, 'start-workflow');
-      
+    it('should load a known activity from a specific workflow', async () => {
+      const result = await readActivity(WORKFLOW_DIR, 'start-workflow', 'meta');
+
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.value.id).toBe('start-workflow');
-        expect(result.value.version).toBe('4.0.0');
+        expect(result.value.version).toBeDefined();
         expect(result.value.name).toBeDefined();
-        expect(result.value.problem).toBeDefined();
+        expect(result.value.skills).toBeDefined();
+        expect(result.value.skills.primary).toBeDefined();
+        expect(result.value.workflowId).toBe('meta');
       }
     });
 
-    it('should return error for non-existent activity', async () => {
-      const result = await readActivity(WORKFLOW_DIR, 'non-existent-activity');
-      
+    it('should include next_action guidance pointing to the primary skill', async () => {
+      const result = await readActivity(WORKFLOW_DIR, 'start-workflow', 'meta');
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.value.next_action).toBeDefined();
+        expect(result.value.next_action.tool).toBe('get_skill');
+        expect(result.value.next_action.parameters.skill_id).toBe(result.value.skills.primary);
+        expect(result.value.next_action.parameters.workflow_id).toBe('meta');
+      }
+    });
+
+    it('should find an activity by searching all workflows when workflowId is omitted', async () => {
+      const result = await readActivity(WORKFLOW_DIR, 'start-workflow');
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.value.id).toBe('start-workflow');
+      }
+    });
+
+    it('should return ActivityNotFoundError for non-existent activity', async () => {
+      const result = await readActivity(WORKFLOW_DIR, 'this-activity-does-not-exist', 'meta');
+
       expect(result.success).toBe(false);
       if (!result.success) {
         expect(result.error.name).toBe('ActivityNotFoundError');
@@ -58,149 +53,192 @@ describe('activity-loader', () => {
       }
     });
 
-    it('should load activity with all required sections', async () => {
-      const result = await readActivity(WORKFLOW_DIR, 'start-workflow');
-      
-      expect(result.success).toBe(true);
-      if (result.success) {
-        const activity = result.value;
-        
-        // Check name (required in unified schema)
-        expect(activity.name).toBe('Start Workflow');
-        
-        // Check recognition patterns
-        expect(activity.recognition).toBeDefined();
-        expect(activity.recognition!.length).toBeGreaterThan(0);
-        
-        // Check skills
-        expect(activity.skills).toBeDefined();
-        expect(activity.skills.primary).toBe('workflow-execution');
-        expect(activity.skills.supporting).toBeDefined();
-        
-        // Check outcome
-        expect(activity.outcome).toBeDefined();
-        expect(activity.outcome!.length).toBeGreaterThan(0);
-        
-        // Check steps (unified schema uses steps, not flow)
-        expect(activity.steps).toBeDefined();
-        expect(activity.steps!.length).toBeGreaterThan(0);
-        
-        // Check context to preserve
-        expect(activity.context_to_preserve).toBeDefined();
-        expect(activity.context_to_preserve!.length).toBeGreaterThan(0);
+    it('should return ActivityNotFoundError for non-existent workflow', async () => {
+      const result = await readActivity(WORKFLOW_DIR, 'start-workflow', 'no-such-workflow');
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.name).toBe('ActivityNotFoundError');
       }
     });
 
-    it('should include next_action with primary skill guidance', async () => {
-      const result = await readActivity(WORKFLOW_DIR, 'start-workflow');
-      
+    it('should have all required fields on a successfully loaded activity', async () => {
+      const result = await readActivity(WORKFLOW_DIR, 'resume-workflow', 'meta');
+
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.value.next_action).toBeDefined();
-        expect(result.value.next_action.tool).toBe('get_skill');
-        expect(result.value.next_action.parameters).toBeDefined();
-        expect(result.value.next_action.parameters.skill_id).toBe(result.value.skills.primary);
+        const activity = result.value;
+        expect(typeof activity.id).toBe('string');
+        expect(typeof activity.version).toBe('string');
+        expect(typeof activity.name).toBe('string');
+        expect(activity.skills).toBeDefined();
+        expect(typeof activity.skills.primary).toBe('string');
+        expect(activity.next_action).toBeDefined();
+        expect(activity.next_action.tool).toBe('get_skill');
       }
     });
   });
 
-  describe('malformed TOON handling', () => {
+  describe('readActivity validation failures (BF-08)', () => {
     let tempDir: string;
 
     beforeEach(async () => {
       tempDir = await import('node:fs/promises').then(fs =>
         fs.mkdtemp(join(tmpdir(), 'activity-test-'))
       );
-      await mkdir(join(tempDir, 'meta', 'activities'), { recursive: true });
+      await mkdir(join(tempDir, 'test-wf', 'activities'), { recursive: true });
     });
 
     afterEach(async () => {
       await rm(tempDir, { recursive: true, force: true });
     });
 
-    it('should return error for malformed TOON content', async () => {
-      await writeFile(join(tempDir, 'meta', 'activities', '01-broken.toon'), 'this is not valid TOON {{{', 'utf-8');
-      const result = await readActivity(tempDir, 'broken');
+    it('should return ActivityNotFoundError on validation failure, not raw data', async () => {
+      await writeFile(
+        join(tempDir, 'test-wf', 'activities', '01-bad-activity.toon'),
+        'just plain text, not a valid activity',
+        'utf-8',
+      );
+      const result = await readActivity(tempDir, 'bad-activity', 'test-wf');
+
       expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.name).toBe('ActivityNotFoundError');
+        expect(result.error.code).toBe('ACTIVITY_NOT_FOUND');
+        expect(result.error.activityId).toBe('bad-activity');
+      }
     });
 
-    it('should return error for empty TOON file', async () => {
-      await writeFile(join(tempDir, 'meta', 'activities', '01-empty-activity.toon'), '', 'utf-8');
-      const result = await readActivity(tempDir, 'empty-activity');
+    it('should return ActivityNotFoundError for TOON missing required fields', async () => {
+      await writeFile(
+        join(tempDir, 'test-wf', 'activities', '01-missing-fields.toon'),
+        'id: missing-fields\nname: Missing Fields\n',
+        'utf-8',
+      );
+      const result = await readActivity(tempDir, 'missing-fields', 'test-wf');
+
       expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.name).toBe('ActivityNotFoundError');
+      }
     });
 
-    it('should return error for TOON with missing required fields', async () => {
-      await writeFile(join(tempDir, 'meta', 'activities', '01-incomplete.toon'), 'id: incomplete\n', 'utf-8');
-      const result = await readActivity(tempDir, 'incomplete');
+    it('should return ActivityNotFoundError for empty TOON file', async () => {
+      await writeFile(
+        join(tempDir, 'test-wf', 'activities', '01-empty.toon'),
+        '',
+        'utf-8',
+      );
+      const result = await readActivity(tempDir, 'empty', 'test-wf');
+
       expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.name).toBe('ActivityNotFoundError');
+      }
+    });
+  });
+
+  describe('listActivities', () => {
+    it('should list activities from a specific workflow', async () => {
+      const activities = await listActivities(WORKFLOW_DIR, 'meta');
+
+      expect(activities.length).toBeGreaterThanOrEqual(3);
+      const ids = activities.map(a => a.id);
+      expect(ids).toContain('start-workflow');
+      expect(ids).toContain('resume-workflow');
+      expect(ids).toContain('end-workflow');
+    });
+
+    it('should include index, id, name, path, and workflowId in each entry', async () => {
+      const activities = await listActivities(WORKFLOW_DIR, 'meta');
+      const startWf = activities.find(a => a.id === 'start-workflow');
+
+      expect(startWf).toBeDefined();
+      expect(startWf?.index).toBe('01');
+      expect(startWf?.name).toBe('Start Workflow');
+      expect(startWf?.path).toBe('01-start-workflow.toon');
+      expect(startWf?.workflowId).toBe('meta');
+    });
+
+    it('should list activities from all workflows when workflowId is omitted', async () => {
+      const activities = await listActivities(WORKFLOW_DIR);
+
+      expect(activities.length).toBeGreaterThan(3);
+      const workflowIds = [...new Set(activities.map(a => a.workflowId))];
+      expect(workflowIds.length).toBeGreaterThan(1);
+    });
+
+    it('should return empty array for non-existent workflow', async () => {
+      const activities = await listActivities(WORKFLOW_DIR, 'no-such-workflow');
+      expect(activities).toEqual([]);
+    });
+
+    it('should sort activities by index within a workflow', async () => {
+      const activities = await listActivities(WORKFLOW_DIR, 'meta');
+      const indices = activities.map(a => a.index);
+      const sorted = [...indices].sort();
+      expect(indices).toEqual(sorted);
     });
   });
 
   describe('readActivityIndex', () => {
-    it('should build activity index dynamically from activity files', async () => {
+    it('should build an index from all workflow activities', async () => {
       const result = await readActivityIndex(WORKFLOW_DIR);
-      
+
       expect(result.success).toBe(true);
       if (result.success) {
+        expect(result.value.activities.length).toBeGreaterThanOrEqual(3);
         expect(result.value.description).toBeDefined();
-        // 3 meta activities + 11 work-package activities = 14 total
-        expect(result.value.activities.length).toBeGreaterThanOrEqual(14);
+        expect(result.value.usage).toBeDefined();
+        expect(result.value.next_action).toBeDefined();
+        expect(result.value.next_action.tool).toBe('start_session');
       }
     });
 
-    it('should have quick_match patterns from activity recognition arrays', async () => {
+    it('should include id, workflowId, problem, and primary_skill for each entry', async () => {
       const result = await readActivityIndex(WORKFLOW_DIR);
-      
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.value.quick_match).toBeDefined();
-        // Recognition patterns are lowercased
-        expect(result.value.quick_match['start a workflow']).toBe('start-workflow');
-        expect(result.value.quick_match['resume workflow']).toBe('resume-workflow');
-        expect(result.value.quick_match['end workflow']).toBe('end-workflow');
-      }
-    });
 
-    it('should list all activities with problem and primary skill', async () => {
-      const result = await readActivityIndex(WORKFLOW_DIR);
-      
       expect(result.success).toBe(true);
       if (result.success) {
         for (const activity of result.value.activities) {
           expect(activity.id).toBeDefined();
+          expect(activity.workflowId).toBeDefined();
           expect(activity.problem).toBeDefined();
           expect(activity.primary_skill).toBeDefined();
-          expect(activity.workflowId).toBeDefined();
-        }
-        
-        // Meta activities should have workflow-execution or activity-resolution as primary skill
-        const metaActivities = result.value.activities.filter(a => a.workflowId === 'meta');
-        const validMetaSkills = ['workflow-execution', 'activity-resolution'];
-        for (const activity of metaActivities) {
-          expect(validMetaSkills).toContain(activity.primary_skill);
-        }
-      }
-    });
-
-    it('should include usage instructions and next_action for each activity', async () => {
-      const result = await readActivityIndex(WORKFLOW_DIR);
-      
-      expect(result.success).toBe(true);
-      if (result.success) {
-        // Check usage instructions exist
-        expect(result.value.usage).toBeDefined();
-        expect(result.value.usage).toContain('next_action');
-        
-        // Check each activity has next_action pointing to its primary skill
-        for (const activity of result.value.activities) {
           expect(activity.next_action).toBeDefined();
           expect(activity.next_action.tool).toBe('get_skill');
-          expect(activity.next_action.parameters).toBeDefined();
-          expect(activity.next_action.parameters.skill_id).toBe(activity.primary_skill);
         }
       }
     });
 
+    it('should populate quick_match from recognition patterns', async () => {
+      const result = await readActivityIndex(WORKFLOW_DIR);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const keys = Object.keys(result.value.quick_match);
+        expect(keys.length).toBeGreaterThan(0);
+
+        // start-workflow has recognition patterns like "Start a workflow"
+        const matchesStartWorkflow = Object.entries(result.value.quick_match)
+          .some(([, activityId]) => activityId === 'start-workflow');
+        expect(matchesStartWorkflow).toBe(true);
+      }
+    });
+
+    it('should return ActivityNotFoundError for empty workflow directory', async () => {
+      const tempDir = await import('node:fs/promises').then(fs =>
+        fs.mkdtemp(join(tmpdir(), 'empty-wf-'))
+      );
+      try {
+        const result = await readActivityIndex(tempDir);
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.error.name).toBe('ActivityNotFoundError');
+        }
+      } finally {
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    });
   });
 });

--- a/tests/rules-loader.test.ts
+++ b/tests/rules-loader.test.ts
@@ -1,77 +1,157 @@
-import { describe, it, expect, beforeAll } from 'vitest';
-import { resolve } from 'node:path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { readRules, readRulesRaw } from '../src/loaders/rules-loader.js';
+import { resolve, join } from 'node:path';
+import { mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 
 const WORKFLOW_DIR = resolve(import.meta.dirname, '../workflows');
 
 describe('rules-loader', () => {
-  describe('readRules', () => {
-    let rulesResult: Awaited<ReturnType<typeof readRules>>;
-
-    beforeAll(async () => {
-      rulesResult = await readRules(WORKFLOW_DIR);
-    });
-
-    it('should load global rules from meta/rules.toon', () => {
-      expect(rulesResult.success).toBe(true);
-      if (rulesResult.success) {
-        expect(rulesResult.value.id).toBe('agent-rules');
-        expect(rulesResult.value.version).toBeDefined();
-        expect(rulesResult.value.title).toBeDefined();
-        expect(rulesResult.value.description).toBeDefined();
+  describe('readRules with real workflow data', () => {
+    it('should load rules from meta/rules.toon successfully', async () => {
+      const result = await readRules(WORKFLOW_DIR);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const rules = result.value;
+        expect(rules.id).toBe('agent-rules');
+        expect(rules.version).toBe('1.0.0');
+        expect(rules.title).toBe('AI Agent Guidelines');
+        expect(rules.description).toBeDefined();
+        expect(rules.precedence).toBeDefined();
+        expect(rules.sections.length).toBeGreaterThan(0);
       }
     });
 
-    it('should have sections array with rule categories', () => {
-      expect(rulesResult.success).toBe(true);
-      if (rulesResult.success) {
-        expect(Array.isArray(rulesResult.value.sections)).toBe(true);
-        expect(rulesResult.value.sections.length).toBeGreaterThan(0);
+    it('should validate required schema fields (id, version, title, description, precedence, sections)', async () => {
+      const result = await readRules(WORKFLOW_DIR);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const rules = result.value;
+        expect(rules).toHaveProperty('id');
+        expect(rules).toHaveProperty('version');
+        expect(rules).toHaveProperty('title');
+        expect(rules).toHaveProperty('description');
+        expect(rules).toHaveProperty('precedence');
+        expect(rules).toHaveProperty('sections');
+        expect(Array.isArray(rules.sections)).toBe(true);
       }
     });
 
-    it('should include code-modification section', () => {
-      expect(rulesResult.success).toBe(true);
-      if (rulesResult.success) {
-        const codeModSection = rulesResult.value.sections.find(s => s.id === 'code-modification');
-        expect(codeModSection).toBeDefined();
-        expect(codeModSection?.title).toBe('Code Modification Boundaries');
-        expect(codeModSection?.priority).toBe('critical');
-      }
-    });
-
-    it('should include version-control section with GitHub CLI guidance', () => {
-      expect(rulesResult.success).toBe(true);
-      if (rulesResult.success) {
-        const githubSection = rulesResult.value.sections.find(s => s.id === 'github-cli');
-        expect(githubSection).toBeDefined();
-        expect(githubSection?.title).toBe('GitHub CLI Usage');
-      }
-    });
-
-    it('should include precedence statement', () => {
-      expect(rulesResult.success).toBe(true);
-      if (rulesResult.success) {
-        expect(rulesResult.value.precedence).toContain('Workflow-specific rules override');
-      }
-    });
-
-    it('should return error when rules file not found', async () => {
-      const result = await readRules('/non/existent/path');
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error.code).toBe('RULES_NOT_FOUND');
+    it('should have sections with id and title', async () => {
+      const result = await readRules(WORKFLOW_DIR);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        for (const section of result.value.sections) {
+          expect(section.id).toBeDefined();
+          expect(section.title).toBeDefined();
+        }
       }
     });
   });
 
-  describe('readRulesRaw', () => {
-    it('should return raw TOON content', async () => {
+  describe('readRulesRaw with real workflow data', () => {
+    it('should return raw TOON content as a string', async () => {
       const result = await readRulesRaw(WORKFLOW_DIR);
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.value).toContain('id: agent-rules');
-        expect(result.value).toContain('sections[');
+        expect(result.value).toBeTypeOf('string');
+        expect(result.value).toContain('agent-rules');
+      }
+    });
+  });
+
+  describe('BF-06: RulesSchema validation and error handling', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await import('node:fs/promises').then(fs =>
+        fs.mkdtemp(join(tmpdir(), 'rules-test-'))
+      );
+    });
+
+    afterEach(async () => {
+      await rm(tempDir, { recursive: true, force: true });
+    });
+
+    it('should return RulesNotFoundError when rules file is missing', async () => {
+      const result = await readRules(tempDir);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.name).toBe('RulesNotFoundError');
+        expect(result.error.code).toBe('RULES_NOT_FOUND');
+      }
+    });
+
+    it('should return RulesNotFoundError (not crash) for empty meta dir', async () => {
+      await mkdir(join(tempDir, 'meta'), { recursive: true });
+      const result = await readRules(tempDir);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.name).toBe('RulesNotFoundError');
+      }
+    });
+
+    it('should return parse error (not RulesNotFoundError without message) for malformed rules', async () => {
+      await mkdir(join(tempDir, 'meta'), { recursive: true });
+      await writeFile(join(tempDir, 'meta', 'rules.toon'), 'just a plain string with no structure', 'utf-8');
+      const result = await readRules(tempDir);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.name).toBe('RulesNotFoundError');
+        // The message should indicate a parse/validation problem, not just "not found"
+        expect(result.error.message).toContain('Rules file exists but');
+      }
+    });
+
+    it('should return validation error when required fields are missing', async () => {
+      await mkdir(join(tempDir, 'meta'), { recursive: true });
+      // TOON with some fields but missing required ones (no version, no precedence, no sections)
+      const incompleteToon = 'id: test-rules\ntitle: Incomplete Rules\n';
+      await writeFile(join(tempDir, 'meta', 'rules.toon'), incompleteToon, 'utf-8');
+      const result = await readRules(tempDir);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.message).toContain('failed validation');
+      }
+    });
+
+    it('should return validation error when sections is not an array', async () => {
+      await mkdir(join(tempDir, 'meta'), { recursive: true });
+      const badSections = [
+        'id: test-rules',
+        'version: 1.0.0',
+        'title: Bad Rules',
+        'description: Rules with wrong sections type',
+        'precedence: global',
+        'sections: not-an-array',
+      ].join('\n');
+      await writeFile(join(tempDir, 'meta', 'rules.toon'), badSections, 'utf-8');
+      const result = await readRules(tempDir);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.message).toContain('failed validation');
+      }
+    });
+
+    it('should succeed with valid minimal rules TOON', async () => {
+      await mkdir(join(tempDir, 'meta'), { recursive: true });
+      const validToon = [
+        'id: minimal-rules',
+        'version: 0.1.0',
+        'title: Minimal Rules',
+        'description: A minimal valid rules file',
+        'precedence: global',
+        'sections[1]:',
+        '  - id: basics',
+        '    title: Basic Rules',
+      ].join('\n');
+      await writeFile(join(tempDir, 'meta', 'rules.toon'), validToon, 'utf-8');
+      const result = await readRules(tempDir);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.value.id).toBe('minimal-rules');
+        expect(result.value.sections).toHaveLength(1);
+        expect(result.value.sections[0].id).toBe('basics');
       }
     });
   });

--- a/tests/skill-loader.test.ts
+++ b/tests/skill-loader.test.ts
@@ -79,10 +79,8 @@ describe('skill-loader', () => {
       if (result.success) {
         const skill = result.value;
         
-        // Check execution_pattern
-        expect(skill.execution_pattern).toBeDefined();
-        expect(skill.execution_pattern.start).toContain('list_workflows');
-        expect(skill.execution_pattern.start).toContain('get_workflow');
+        // Check protocol (refactored from execution_pattern)
+        expect(skill.protocol).toBeDefined();
         
         // Check tools
         expect(skill.tools).toBeDefined();

--- a/tests/skill-loader.test.ts
+++ b/tests/skill-loader.test.ts
@@ -145,20 +145,20 @@ describe('skill-loader', () => {
       await rm(tempDir, { recursive: true, force: true });
     });
 
-    it('should handle non-skill TOON content without crashing', async () => {
+    it('should reject non-skill TOON content as validation failure', async () => {
       await writeFile(join(tempDir, 'meta', 'skills', '01-not-a-skill.toon'), 'just a plain string', 'utf-8');
       const result = await readSkill('not-a-skill', tempDir);
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
     });
 
     it('should handle empty TOON file without crashing', async () => {
       await writeFile(join(tempDir, 'meta', 'skills', '01-empty-skill.toon'), '', 'utf-8');
       const result = await readSkill('empty-skill', tempDir);
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
     });
 
-    it('should handle TOON with minimal fields without crashing', async () => {
-      await writeFile(join(tempDir, 'meta', 'skills', '01-minimal.toon'), 'id: minimal\nversion: 1.0.0\n', 'utf-8');
+    it('should handle TOON with minimal valid fields', async () => {
+      await writeFile(join(tempDir, 'meta', 'skills', '01-minimal.toon'), 'id: minimal\nversion: 1.0.0\ncapability: test capability\n', 'utf-8');
       const result = await readSkill('minimal', tempDir);
       expect(result.success).toBe(true);
       if (result.success) {

--- a/tests/state-persistence.test.ts
+++ b/tests/state-persistence.test.ts
@@ -9,7 +9,7 @@ import {
   StateSaveFileSchema,
   createInitialState,
 } from '../src/schema/state.schema.js';
-import { encodeToon, decodeToon } from '../src/utils/toon.js';
+import { encodeToon, decodeToonRaw } from '../src/utils/toon.js';
 import { validateStatePath } from '../src/tools/state-tools.js';
 
 const TEST_DIR = join(tmpdir(), `state-persistence-test-${Date.now()}`);
@@ -188,7 +188,7 @@ describe('state-persistence', () => {
         state,
       };
       const encoded = encodeToon(saveFile);
-      const decoded = decodeToon<Record<string, unknown>>(encoded);
+      const decoded = decodeToonRaw(encoded);
       expect(decoded).toEqual(saveFile);
     });
 
@@ -246,7 +246,7 @@ describe('state-persistence', () => {
         },
       };
       const encoded = encodeToon(saveFile);
-      const decoded = decodeToon<Record<string, unknown>>(encoded);
+      const decoded = decodeToonRaw(encoded);
       expect(decoded).toEqual(saveFile);
     });
 
@@ -266,7 +266,7 @@ describe('state-persistence', () => {
       await writeFile(filePath, encoded, 'utf-8');
 
       const content = await readFile(filePath, 'utf-8');
-      const decoded = decodeToon<Record<string, unknown>>(content);
+      const decoded = decodeToonRaw(content);
       const result = StateSaveFileSchema.safeParse(decoded);
       expect(result.success).toBe(true);
       if (result.success) {

--- a/tests/trace.test.ts
+++ b/tests/trace.test.ts
@@ -55,10 +55,10 @@ describe('TraceStore', () => {
     expect(store.getEvents('s2').map(e => e.name)).toEqual(['only-in-s2']);
   });
 
-  it('append to uninitialized session is a no-op', () => {
+  it('append to uninitialized session auto-initializes and stores the event', () => {
     const store = new TraceStore();
-    store.append('unknown', makeEvent('ignored'));
-    expect(store.getEvents('unknown')).toEqual([]);
+    store.append('unknown', makeEvent('auto-init'));
+    expect(store.getEvents('unknown').map(e => e.name)).toEqual(['auto-init']);
   });
 
   describe('getSegmentAndAdvanceCursor', () => {

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateActivityTransition,
+  validateWorkflowConsistency,
+  validateWorkflowVersion,
+  validateSkillAssociation,
+  buildValidation,
+  buildErrorValidation,
+} from '../src/utils/validation.js';
+import { evaluateCondition } from '../src/schema/condition.schema.js';
+import type { Condition } from '../src/schema/condition.schema.js';
+import type { SessionPayload } from '../src/utils/session.js';
+import type { Workflow } from '../src/schema/workflow.schema.js';
+
+function makeToken(overrides: Partial<SessionPayload> = {}): SessionPayload {
+  return {
+    wf: 'test-wf',
+    act: '',
+    skill: '',
+    cond: '',
+    v: '1.0.0',
+    seq: 1,
+    ts: Date.now(),
+    sid: 'sess-1',
+    aid: 'agent-1',
+    ...overrides,
+  };
+}
+
+function makeWorkflow(overrides: Partial<Workflow> = {}): Workflow {
+  return {
+    id: 'test-wf',
+    version: '1.0.0',
+    title: 'Test Workflow',
+    activities: [
+      {
+        id: 'planning',
+        title: 'Planning',
+        steps: [{ id: 'plan-step', title: 'Plan', instructions: 'Plan it' }],
+        transitions: [{ to: 'implementation' }],
+      },
+      {
+        id: 'implementation',
+        title: 'Implementation',
+        steps: [{ id: 'impl-step', title: 'Implement', instructions: 'Do it' }],
+        transitions: [{ to: 'review' }],
+      },
+      {
+        id: 'review',
+        title: 'Review',
+        steps: [{ id: 'review-step', title: 'Review', instructions: 'Review it' }],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('validation', () => {
+  describe('BF-04: validateActivityTransition warning strings', () => {
+    it('returns null when transition is valid', () => {
+      const token = makeToken({ act: 'planning' });
+      const workflow = makeWorkflow();
+      const result = validateActivityTransition(token, workflow, 'implementation');
+      expect(result).toBeNull();
+    });
+
+    it('returns null when staying on the same activity', () => {
+      const token = makeToken({ act: 'planning' });
+      const workflow = makeWorkflow();
+      const result = validateActivityTransition(token, workflow, 'planning');
+      expect(result).toBeNull();
+    });
+
+    it('returns descriptive warning when transition is invalid', () => {
+      const token = makeToken({ act: 'planning' });
+      const workflow = makeWorkflow();
+      const result = validateActivityTransition(token, workflow, 'review');
+      expect(result).not.toBeNull();
+      expect(result).toBeTypeOf('string');
+      expect(result).toContain('review');
+      expect(result).toContain('planning');
+      expect(result).toContain('Valid transitions');
+    });
+
+    it('returns null when current activity has no transitions (terminal activity)', () => {
+      const token = makeToken({ act: 'review' });
+      const workflow = makeWorkflow();
+      const result = validateActivityTransition(token, workflow, 'planning');
+      expect(result).toBeNull();
+    });
+
+    it('returns null on first call (no current activity)', () => {
+      const token = makeToken({ act: '' });
+      const workflow = makeWorkflow();
+      const result = validateActivityTransition(token, workflow, 'planning');
+      expect(result).toBeNull();
+    });
+
+    it('lists valid transitions in the warning message', () => {
+      const workflow = makeWorkflow({
+        activities: [
+          {
+            id: 'hub',
+            title: 'Hub',
+            steps: [{ id: 's1', title: 'Step', instructions: 'Do' }],
+            transitions: [{ to: 'branch-a' }, { to: 'branch-b' }],
+          },
+          { id: 'branch-a', title: 'A', steps: [{ id: 'a1', title: 'A', instructions: 'A' }] },
+          { id: 'branch-b', title: 'B', steps: [{ id: 'b1', title: 'B', instructions: 'B' }] },
+          { id: 'branch-c', title: 'C', steps: [{ id: 'c1', title: 'C', instructions: 'C' }] },
+        ],
+      });
+      const token = makeToken({ act: 'hub' });
+      const result = validateActivityTransition(token, workflow, 'branch-c');
+      expect(result).not.toBeNull();
+      expect(result).toContain('branch-a');
+      expect(result).toContain('branch-b');
+    });
+  });
+
+  describe('BF-09: initialActivity enforcement', () => {
+    it('returns null on first call when no initialActivity is set', () => {
+      const token = makeToken({ act: '' });
+      const workflow = makeWorkflow();
+      const result = validateActivityTransition(token, workflow, 'review');
+      expect(result).toBeNull();
+    });
+
+    it('returns null when first call targets the initialActivity', () => {
+      const token = makeToken({ act: '' });
+      const workflow = makeWorkflow({ initialActivity: 'planning' });
+      const result = validateActivityTransition(token, workflow, 'planning');
+      expect(result).toBeNull();
+    });
+
+    it('returns warning when first call skips the initialActivity', () => {
+      const token = makeToken({ act: '' });
+      const workflow = makeWorkflow({ initialActivity: 'planning' });
+      const result = validateActivityTransition(token, workflow, 'implementation');
+      expect(result).not.toBeNull();
+      expect(result).toBeTypeOf('string');
+      expect(result).toContain('planning');
+      expect(result).toContain('implementation');
+      expect(result).toContain('initialActivity');
+    });
+
+    it('does not enforce initialActivity after the first call', () => {
+      const token = makeToken({ act: 'planning' });
+      const workflow = makeWorkflow({ initialActivity: 'planning' });
+      const result = validateActivityTransition(token, workflow, 'implementation');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('BF-13: toNumber coercion in condition evaluation', () => {
+    it('coerces string variable to number for > comparison', () => {
+      const condition: Condition = { type: 'simple', variable: 'count', operator: '>', value: 5 };
+      expect(evaluateCondition(condition, { count: '10' })).toBe(true);
+      expect(evaluateCondition(condition, { count: '3' })).toBe(false);
+    });
+
+    it('coerces string condition value to number for < comparison', () => {
+      const condition: Condition = { type: 'simple', variable: 'score', operator: '<', value: '100' };
+      expect(evaluateCondition(condition, { score: 50 })).toBe(true);
+      expect(evaluateCondition(condition, { score: 150 })).toBe(false);
+    });
+
+    it('handles >= and <= with string-to-number coercion', () => {
+      const gte: Condition = { type: 'simple', variable: 'x', operator: '>=', value: 10 };
+      expect(evaluateCondition(gte, { x: '10' })).toBe(true);
+      expect(evaluateCondition(gte, { x: '9' })).toBe(false);
+
+      const lte: Condition = { type: 'simple', variable: 'x', operator: '<=', value: '5' };
+      expect(evaluateCondition(lte, { x: 5 })).toBe(true);
+      expect(evaluateCondition(lte, { x: 6 })).toBe(false);
+    });
+
+    it('returns false for non-numeric strings in numeric comparisons', () => {
+      const condition: Condition = { type: 'simple', variable: 'val', operator: '>', value: 5 };
+      expect(evaluateCondition(condition, { val: 'not-a-number' })).toBe(false);
+    });
+
+    it('returns false when variable is undefined in numeric comparisons', () => {
+      const condition: Condition = { type: 'simple', variable: 'missing', operator: '>=', value: 0 };
+      expect(evaluateCondition(condition, {})).toBe(false);
+    });
+
+    it('handles both sides as strings that are numeric', () => {
+      const condition: Condition = { type: 'simple', variable: 'a', operator: '>', value: '5' };
+      expect(evaluateCondition(condition, { a: '10' })).toBe(true);
+      expect(evaluateCondition(condition, { a: '3' })).toBe(false);
+    });
+
+    it('uses strict equality for == (no coercion)', () => {
+      const condition: Condition = { type: 'simple', variable: 'x', operator: '==', value: 5 };
+      expect(evaluateCondition(condition, { x: 5 })).toBe(true);
+      expect(evaluateCondition(condition, { x: '5' })).toBe(false);
+    });
+
+    it('handles exists/notExists without coercion', () => {
+      const exists: Condition = { type: 'simple', variable: 'x', operator: 'exists' };
+      expect(evaluateCondition(exists, { x: '0' })).toBe(true);
+      expect(evaluateCondition(exists, {})).toBe(false);
+
+      const notExists: Condition = { type: 'simple', variable: 'x', operator: 'notExists' };
+      expect(evaluateCondition(notExists, {})).toBe(true);
+      expect(evaluateCondition(notExists, { x: 0 })).toBe(false);
+    });
+
+    it('resolves dot-delimited variable paths for numeric comparison', () => {
+      const condition: Condition = { type: 'simple', variable: 'metrics.score', operator: '>', value: 80 };
+      expect(evaluateCondition(condition, { metrics: { score: '95' } })).toBe(true);
+      expect(evaluateCondition(condition, { metrics: { score: '50' } })).toBe(false);
+    });
+
+    it('evaluates compound conditions with coerced numbers', () => {
+      const condition: Condition = {
+        type: 'and',
+        conditions: [
+          { type: 'simple', variable: 'min', operator: '>=', value: 1 },
+          { type: 'simple', variable: 'max', operator: '<=', value: 100 },
+        ],
+      };
+      expect(evaluateCondition(condition, { min: '5', max: '50' })).toBe(true);
+      expect(evaluateCondition(condition, { min: '0', max: '50' })).toBe(false);
+    });
+  });
+
+  describe('validateWorkflowConsistency', () => {
+    it('returns null when workflow matches session', () => {
+      const token = makeToken({ wf: 'my-wf' });
+      expect(validateWorkflowConsistency(token, 'my-wf')).toBeNull();
+    });
+
+    it('returns warning on workflow mismatch', () => {
+      const token = makeToken({ wf: 'wf-a' });
+      const result = validateWorkflowConsistency(token, 'wf-b');
+      expect(result).not.toBeNull();
+      expect(result).toContain('wf-a');
+      expect(result).toContain('wf-b');
+    });
+  });
+
+  describe('buildValidation / buildErrorValidation', () => {
+    it('builds valid result with no warnings', () => {
+      const result = buildValidation(null, null);
+      expect(result.status).toBe('valid');
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it('builds warning result from non-null strings', () => {
+      const result = buildValidation('problem 1', null, 'problem 2');
+      expect(result.status).toBe('warning');
+      expect(result.warnings).toEqual(['problem 1', 'problem 2']);
+    });
+
+    it('builds error result with errors array', () => {
+      const result = buildErrorValidation('fatal', 'also a warning');
+      expect(result.status).toBe('error');
+      expect(result.errors).toEqual(['fatal']);
+      expect(result.warnings).toContain('also a warning');
+    });
+  });
+});

--- a/tests/workflow-loader.test.ts
+++ b/tests/workflow-loader.test.ts
@@ -1,207 +1,265 @@
-import { describe, it, expect, beforeAll } from 'vitest';
-import { resolve } from 'node:path';
+import { describe, it, expect } from 'vitest';
 import {
   loadWorkflow,
   listWorkflows,
   getActivity,
   getCheckpoint,
   getValidTransitions,
+  getTransitionList,
   validateTransition,
 } from '../src/loaders/workflow-loader.js';
+import type { Workflow } from '../src/schema/workflow.schema.js';
+import { resolve } from 'node:path';
 
 const WORKFLOW_DIR = resolve(import.meta.dirname, '../workflows');
 
+async function loadMetaWorkflow(): Promise<Workflow> {
+  const result = await loadWorkflow(WORKFLOW_DIR, 'meta');
+  if (!result.success) throw new Error(`Failed to load meta workflow: ${result.error.message}`);
+  return result.value;
+}
+
 describe('workflow-loader', () => {
-  describe('listWorkflows', () => {
-    it('should list all available workflows', async () => {
-      const workflows = await listWorkflows(WORKFLOW_DIR);
-      expect(workflows.length).toBeGreaterThanOrEqual(2);
-      
-      const ids = workflows.map(w => w.id);
-      expect(ids).toContain('work-package');
-      expect(ids).toContain('meta');
-    });
-
-    it('should return empty array for non-existent directory', async () => {
-      const workflows = await listWorkflows('/non/existent/path');
-      expect(workflows).toEqual([]);
-    });
-
-    it('should include title and version in manifest entries', async () => {
-      const workflows = await listWorkflows(WORKFLOW_DIR);
-      const workPackage = workflows.find(w => w.id === 'work-package');
-      
-      expect(workPackage).toBeDefined();
-      expect(workPackage?.title).toBe('Work Package Implementation Workflow');
-      expect(workPackage?.version).toMatch(/^\d+\.\d+\.\d+$/);
-    });
-  });
-
   describe('loadWorkflow', () => {
-    it('should load a valid workflow', async () => {
-      const result = await loadWorkflow(WORKFLOW_DIR, 'work-package');
-      
+    it('should load the meta workflow successfully', async () => {
+      const result = await loadWorkflow(WORKFLOW_DIR, 'meta');
+
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.value.id).toBe('work-package');
-        expect(result.value.activities.length).toBeGreaterThanOrEqual(14);
-        expect(result.value.initialActivity).toBe('start-work-package');
+        expect(result.value.id).toBe('meta');
+        expect(result.value.version).toBeDefined();
+        expect(result.value.title).toBe('Meta Workflow');
+        expect(result.value.activities.length).toBeGreaterThanOrEqual(3);
       }
     });
 
-    it('should return error for non-existent workflow', async () => {
-      const result = await loadWorkflow(WORKFLOW_DIR, 'non-existent');
-      
+    it('should return WorkflowNotFoundError for non-existent workflow', async () => {
+      const result = await loadWorkflow(WORKFLOW_DIR, 'does-not-exist');
+
       expect(result.success).toBe(false);
       if (!result.success) {
         expect(result.error.name).toBe('WorkflowNotFoundError');
       }
     });
 
-    it('should load workflow with all activity types', async () => {
-      const result = await loadWorkflow(WORKFLOW_DIR, 'work-package');
-      
+    it('should load activities from the activities subdirectory', async () => {
+      const result = await loadWorkflow(WORKFLOW_DIR, 'meta');
+
       expect(result.success).toBe(true);
       if (result.success) {
-        // Check for activities with different features
-        const startWorkPackage = result.value.activities.find(a => a.id === 'start-work-package');
-        expect(startWorkPackage?.checkpoints?.length).toBeGreaterThan(0);
-        expect(startWorkPackage?.steps?.length).toBeGreaterThan(0);
-        expect(startWorkPackage?.transitions?.length).toBeGreaterThan(0);
-        
-        const implement = result.value.activities.find(a => a.id === 'implement');
-        expect(implement?.loops?.length).toBeGreaterThan(0);
-        
-        const strategicReview = result.value.activities.find(a => a.id === 'strategic-review');
-        expect(strategicReview?.decisions?.length).toBeGreaterThan(0);
+        const ids = result.value.activities.map(a => a.id);
+        expect(ids).toContain('start-workflow');
+        expect(ids).toContain('resume-workflow');
+        expect(ids).toContain('end-workflow');
       }
+    });
+  });
+
+  describe('listWorkflows', () => {
+    it('should list available workflows with manifest data', async () => {
+      const manifests = await listWorkflows(WORKFLOW_DIR);
+
+      expect(manifests.length).toBeGreaterThanOrEqual(2);
+      const ids = manifests.map(m => m.id);
+      expect(ids).toContain('meta');
+    });
+
+    it('should include id, title, and version in each manifest entry', async () => {
+      const manifests = await listWorkflows(WORKFLOW_DIR);
+      for (const m of manifests) {
+        expect(m.id).toBeDefined();
+        expect(m.title).toBeDefined();
+        expect(m.version).toBeDefined();
+      }
+    });
+
+    it('should return empty array for non-existent directory', async () => {
+      const result = await listWorkflows('/tmp/no-such-workflow-dir-xyz');
+      expect(result).toEqual([]);
     });
   });
 
   describe('getActivity', () => {
-    let workflow: Awaited<ReturnType<typeof loadWorkflow>>;
-    
-    beforeAll(async () => {
-      workflow = await loadWorkflow(WORKFLOW_DIR, 'work-package');
+    it('should find an activity by ID within a loaded workflow', async () => {
+      const workflow = await loadMetaWorkflow();
+      const activity = getActivity(workflow, 'resume-workflow');
+
+      expect(activity).toBeDefined();
+      expect(activity?.id).toBe('resume-workflow');
     });
 
-    it('should get existing activity', () => {
-      expect(workflow.success).toBe(true);
-      if (workflow.success) {
-        const activity = getActivity(workflow.value, 'start-work-package');
-        expect(activity).toBeDefined();
-        expect(activity?.name).toBe('Start Work Package');
-      }
-    });
-
-    it('should return undefined for non-existent activity', () => {
-      expect(workflow.success).toBe(true);
-      if (workflow.success) {
-        const activity = getActivity(workflow.value, 'non-existent-activity');
-        expect(activity).toBeUndefined();
-      }
+    it('should return undefined for a non-existent activity ID', async () => {
+      const workflow = await loadMetaWorkflow();
+      expect(getActivity(workflow, 'no-such-activity')).toBeUndefined();
     });
   });
 
   describe('getCheckpoint', () => {
-    let workflow: Awaited<ReturnType<typeof loadWorkflow>>;
-    
-    beforeAll(async () => {
-      workflow = await loadWorkflow(WORKFLOW_DIR, 'work-package');
+    it('should find a checkpoint within an activity', async () => {
+      const workflow = await loadMetaWorkflow();
+      const checkpoint = getCheckpoint(workflow, 'resume-workflow', 'state-verified');
+
+      expect(checkpoint).toBeDefined();
+      expect(checkpoint?.id).toBe('state-verified');
+      expect(checkpoint?.name).toBeDefined();
+      expect(checkpoint?.message).toBeDefined();
+      expect(checkpoint?.options.length).toBeGreaterThanOrEqual(2);
     });
 
-    it('should get existing checkpoint', () => {
-      expect(workflow.success).toBe(true);
-      if (workflow.success) {
-        const checkpoint = getCheckpoint(workflow.value, 'start-work-package', 'issue-verification');
-        expect(checkpoint).toBeDefined();
-        expect(checkpoint?.name).toBe('Issue Verification Checkpoint');
-        expect(checkpoint?.options.length).toBeGreaterThan(0);
-      }
-    });
-
-    it('should return undefined for non-existent checkpoint', () => {
-      expect(workflow.success).toBe(true);
-      if (workflow.success) {
-        const checkpoint = getCheckpoint(workflow.value, 'start-work-package', 'non-existent');
-        expect(checkpoint).toBeUndefined();
-      }
+    it('should return undefined for a non-existent checkpoint', async () => {
+      const workflow = await loadMetaWorkflow();
+      expect(getCheckpoint(workflow, 'resume-workflow', 'no-such-checkpoint')).toBeUndefined();
     });
   });
 
-  describe('getValidTransitions', () => {
-    let workflow: Awaited<ReturnType<typeof loadWorkflow>>;
-    
-    beforeAll(async () => {
-      workflow = await loadWorkflow(WORKFLOW_DIR, 'work-package');
+  describe('getTransitionList (BF-12)', () => {
+    it('should return transitions from the transitions array', async () => {
+      const workflow = await loadMetaWorkflow();
+      const transitions = getTransitionList(workflow, 'resume-workflow');
+
+      const targets = transitions.map(t => t.to);
+      // resume-workflow has transitions to target-activity and start-workflow
+      expect(targets).toContain('target-activity');
+      expect(targets).toContain('start-workflow');
     });
 
-    it('should get valid transitions from activity with single transition', () => {
-      expect(workflow.success).toBe(true);
-      if (workflow.success) {
-        const transitions = getValidTransitions(workflow.value, 'start-work-package');
-        expect(transitions).toContain('design-philosophy');
-      }
+    it('should include targets from decisions branches', async () => {
+      const workflow = await loadMetaWorkflow();
+      const transitions = getTransitionList(workflow, 'resume-workflow');
+
+      const targets = transitions.map(t => t.to);
+      // resume-workflow decisions branch to assess-state and determine-entry-point
+      expect(targets).toContain('assess-state');
+      expect(targets).toContain('determine-entry-point');
     });
 
-    it('should get transitions from decision branches', () => {
-      expect(workflow.success).toBe(true);
-      if (workflow.success) {
-        const transitions = getValidTransitions(workflow.value, 'strategic-review');
-        expect(transitions).toContain('submit-for-review');
-        expect(transitions).toContain('plan-prepare');
-      }
+    it('should deduplicate targets via the seen Set', async () => {
+      const workflow = await loadMetaWorkflow();
+      const transitions = getTransitionList(workflow, 'resume-workflow');
+
+      const targets = transitions.map(t => t.to);
+      const uniqueTargets = [...new Set(targets)];
+      // assess-state appears in multiple decision branches but should only appear once
+      expect(targets.length).toBe(uniqueTargets.length);
     });
 
-    it('should return empty array for non-existent activity', () => {
-      expect(workflow.success).toBe(true);
-      if (workflow.success) {
-        const transitions = getValidTransitions(workflow.value, 'non-existent');
+    it('should include condition strings for conditional transitions', async () => {
+      const workflow = await loadMetaWorkflow();
+      const transitions = getTransitionList(workflow, 'resume-workflow');
+
+      const conditionalTransition = transitions.find(t => t.to === 'target-activity');
+      expect(conditionalTransition).toBeDefined();
+      expect(conditionalTransition?.condition).toBeDefined();
+    });
+
+    it('should mark default transitions with isDefault', async () => {
+      const workflow = await loadMetaWorkflow();
+      const transitions = getTransitionList(workflow, 'resume-workflow');
+
+      const defaultTransition = transitions.find(t => t.isDefault);
+      expect(defaultTransition).toBeDefined();
+    });
+
+    it('should return empty array for activity with no transitions', async () => {
+      const workflow = await loadMetaWorkflow();
+      // start-workflow has no explicit transitions in the meta workflow
+      const activity = getActivity(workflow, 'start-workflow');
+      const hasTransitions = activity?.transitions && activity.transitions.length > 0;
+      const hasDecisions = activity?.decisions && activity.decisions.length > 0;
+      const hasCheckpoints = activity?.checkpoints && activity.checkpoints.length > 0;
+
+      if (!hasTransitions && !hasDecisions && !hasCheckpoints) {
+        const transitions = getTransitionList(workflow, 'start-workflow');
         expect(transitions).toEqual([]);
       }
     });
+
+    it('should return empty array for non-existent activity', async () => {
+      const workflow = await loadMetaWorkflow();
+      const transitions = getTransitionList(workflow, 'no-such-activity');
+      expect(transitions).toEqual([]);
+    });
+
+    it('should include checkpoint-sourced transitions with checkpoint: prefix', async () => {
+      const workflow = await loadMetaWorkflow();
+
+      // end-workflow has checkpoints with transitionTo effects
+      const endActivity = getActivity(workflow, 'end-workflow');
+      const hasCheckpointTransitions = endActivity?.checkpoints?.some(c =>
+        c.options.some(o => o.effect?.transitionTo),
+      );
+
+      if (hasCheckpointTransitions) {
+        const transitions = getTransitionList(workflow, 'end-workflow');
+        const checkpointEntry = transitions.find(t => t.condition?.startsWith('checkpoint:'));
+        expect(checkpointEntry).toBeDefined();
+      }
+    });
   });
 
-  describe('validateTransition', () => {
-    let workflow: Awaited<ReturnType<typeof loadWorkflow>>;
-    
-    beforeAll(async () => {
-      workflow = await loadWorkflow(WORKFLOW_DIR, 'work-package');
+  describe('getValidTransitions (BF-12)', () => {
+    it('should include targets from transitions, decisions, and checkpoints', async () => {
+      const workflow = await loadMetaWorkflow();
+      const valid = getValidTransitions(workflow, 'resume-workflow');
+
+      expect(valid).toContain('target-activity');
+      expect(valid).toContain('start-workflow');
+      expect(valid).toContain('assess-state');
+      expect(valid).toContain('determine-entry-point');
     });
 
-    it('should validate allowed transition', () => {
-      expect(workflow.success).toBe(true);
-      if (workflow.success) {
-        const result = validateTransition(workflow.value, 'start-work-package', 'design-philosophy');
-        expect(result.valid).toBe(true);
-        expect(result.reason).toBeUndefined();
-      }
+    it('should deduplicate targets', async () => {
+      const workflow = await loadMetaWorkflow();
+      const valid = getValidTransitions(workflow, 'resume-workflow');
+
+      const unique = [...new Set(valid)];
+      expect(valid.length).toBe(unique.length);
     });
 
-    it('should reject invalid transition', () => {
-      expect(workflow.success).toBe(true);
-      if (workflow.success) {
-        const result = validateTransition(workflow.value, 'start-work-package', 'complete');
-        expect(result.valid).toBe(false);
-        expect(result.reason).toContain('No valid transition');
-      }
+    it('should return empty array for non-existent activity', async () => {
+      const workflow = await loadMetaWorkflow();
+      expect(getValidTransitions(workflow, 'no-such-activity')).toEqual([]);
+    });
+  });
+
+  describe('validateTransition (BF-12)', () => {
+    it('should validate a real transition between activities', async () => {
+      const workflow = await loadMetaWorkflow();
+      // resume-workflow transitions to start-workflow, both are real activities
+      const result = validateTransition(workflow, 'resume-workflow', 'start-workflow');
+      expect(result.valid).toBe(true);
+      expect(result.reason).toBeUndefined();
     });
 
-    it('should reject transition from non-existent activity', () => {
-      expect(workflow.success).toBe(true);
-      if (workflow.success) {
-        const result = validateTransition(workflow.value, 'non-existent', 'requirements-elicitation');
-        expect(result.valid).toBe(false);
-        expect(result.reason).toContain('Source activity not found');
-      }
+    it('should reject transition to activity not in the valid transitions list', async () => {
+      const workflow = await loadMetaWorkflow();
+      // start-workflow -> end-workflow is not a defined transition
+      const result = validateTransition(workflow, 'start-workflow', 'end-workflow');
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBeDefined();
+      expect(result.reason).toContain('No valid transition');
     });
 
-    it('should reject transition to non-existent activity', () => {
-      expect(workflow.success).toBe(true);
-      if (workflow.success) {
-        const result = validateTransition(workflow.value, 'start-work-package', 'non-existent');
-        expect(result.valid).toBe(false);
-        expect(result.reason).toContain('Target activity not found');
+    it('should reject transition from non-existent source activity', async () => {
+      const workflow = await loadMetaWorkflow();
+      const result = validateTransition(workflow, 'no-such-activity', 'start-workflow');
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain('Source activity not found');
+    });
+
+    it('should reject transition to non-existent target activity', async () => {
+      const workflow = await loadMetaWorkflow();
+      const result = validateTransition(workflow, 'start-workflow', 'no-such-activity');
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain('Target activity not found');
+    });
+
+    it('should include valid targets in the rejection reason', async () => {
+      const workflow = await loadMetaWorkflow();
+      const result = validateTransition(workflow, 'resume-workflow', 'end-workflow');
+      expect(result.valid).toBe(false);
+      if (result.reason) {
+        expect(result.reason).toContain('Valid:');
       }
     });
   });


### PR DESCRIPTION
## Summary

Resolve 14 of 16 findings from the behavioral prism analysis. Fixes correctness issues in validation, type safety, error diagnostics, and crypto; removes response payload overhead.

📐 [Engineering](https://github.com/m2ux/workflow-server/blob/main/.engineering/artifacts/planning/2026-03-28-behavioral-prism-analysis/README.md)

---

## Motivation

A 4-lens behavioral prism analysis (error resilience, optimization, evolution, API surface + synthesis) identified 16 behavioral findings in the post-remediation codebase. The core insight: every abstraction boundary destroys information in exchange for interface simplicity, and this destruction propagates across error handling, performance, implicit contracts, and API promises simultaneously. This PR addresses the 14 findings that can be resolved without handler-pattern changes.

---

## Changes

**Type safety (BF-01, BF-16):** Add Zod validation to skill loading with `.passthrough()` to preserve domain-specific fields. Skills were the only content type with no validation checkpoint.

**Validation correctness (BF-04, BF-09):** Validation functions return warnings instead of silent `null` for missing data. First `next_activity` call enforces `initialActivity`.

**TraceStore (BF-05):** `append()` auto-initializes sessions instead of silently dropping events. Evictions are logged.

**Rules loading (BF-06):** Zod schema validation added; parse errors distinguished from not-found errors.

**Activity validation (BF-08):** `readActivityFromWorkflow` returns error on validation failure instead of silently returning unvalidated data.

**Crypto (BF-10):** Key length validated on EEXIST fallback in `loadOrCreateKey`.

**Path security (BF-11):** `validateStatePath` accepts optional `workspaceRoot` instead of hardcoding `process.cwd()`.

**Transition scope (BF-12):** `getTransitionList` now includes decisions and checkpoints, matching `getValidTransitions`.

**Condition evaluation (BF-13):** String-to-number coercion for comparison operators.

**Diagnostics (BF-02, BF-14):** 13 bare `catch {}` blocks replaced with diagnostic logging. `restore_state` preserves original decrypt error.

**Performance (BF-15):** Pretty-printing removed from 16 tool response serialization sites.

**API (BF-03 partial):** `advanceToken` accepts optional pre-decoded payload.

**Deferred:** BF-03 full fix (triple session decode) and BF-07 (workflow caching) require handler pattern changes — separate PR.

---

## ✅ Acceptance Criteria

Each finding maps to a verifiable behavioral change:

| Finding | Severity | Criterion | Verification |
|---------|----------|-----------|--------------|
| BF-01 | Critical | Skill loading validates decoded TOON against `SkillSchema` with `.passthrough()` | Non-skill TOON content returns `result.success === false` instead of passing silently |
| BF-02 | Critical | All 13 bare `catch {}` blocks in loaders emit diagnostic `console.error` with error details | Loader failures produce visible error output; callers still receive fallback values |
| BF-04 | High | `validateActivityTransition` and `validateSkillAssociation` return warning strings for missing-data cases | Empty `token.act` or missing activity produces a warning, not silent `null` |
| BF-05 | High | `TraceStore.append()` auto-initializes unknown sessions; evictions logged | Appending to unknown session creates it and stores the event; eviction emits `console.error` |
| BF-06 | High | `readRules()` validates against Zod schema; parse errors return distinct error type | TOON syntax error returns parse error, not `RulesNotFoundError` |
| BF-08 | Medium | `readActivityFromWorkflow` returns `err(...)` on validation failure | Validation failure no longer returns `ok(rawData)` |
| BF-09 | Medium | First `next_activity` call enforces `initialActivity` when `token.act === ''` | Attempting to skip to a non-initial activity is rejected or warned |
| BF-10 | Medium | EEXIST fallback in `loadOrCreateKey` validates key length | Truncated key file on race condition is detected and rejected |
| BF-11 | Medium | `validateStatePath` accepts optional `workspaceRoot` parameter | Security boundary is configurable, not derived from `process.cwd()` |
| BF-12 | Medium | `getTransitionList` includes transitions from decisions and checkpoints | Transition scope matches `getValidTransitions`; no spurious warnings on decision-branch transitions |
| BF-13 | Low | Comparison operators coerce string values to numbers before comparison | String `"5"` compared to number `3` evaluates correctly |
| BF-14 | Low | `restore_state` preserves original decrypt error in error message | Crypto error type (`ERR_OSSL_*`, auth tag mismatch, etc.) is visible in error output |
| BF-15 | Low | `JSON.stringify` calls in tool responses use compact format (no indentation) | Response payloads are ~25-35% smaller |
| BF-16 | Low | `readSkill` validates decoded TOON against `SkillSchema` (same fix as BF-01) | See BF-01 |

---

## 🧪 Test Plan

### Existing Test Coverage

| Test File | Finding | What It Verifies |
|-----------|---------|------------------|
| `tests/skill-loader.test.ts` | BF-01, BF-16 | Non-skill TOON → validation failure; empty TOON → validation failure; minimal valid fields accepted |
| `tests/trace.test.ts` | BF-05 | Append to uninitialized session auto-initializes and stores event |

### Findings Without Dedicated Tests

The following findings are verified through code review and behavioral inspection rather than automated tests:

- **BF-02** (diagnostic logging) — Verified by inspecting that all 13 catch blocks now call `console.error`
- **BF-04, BF-09** (validation correctness) — Verified by tracing code paths for missing-data conditions
- **BF-06** (rules validation) — Verified by inspecting Zod schema application and error type differentiation
- **BF-08** (activity validation) — Verified by inspecting `readActivityFromWorkflow` return path
- **BF-10** (crypto key length) — Verified by inspecting EEXIST fallback path
- **BF-11** (path security) — Verified by inspecting `validateStatePath` signature change
- **BF-12** (transition scope) — Verified by inspecting `getTransitionList` implementation
- **BF-13** (condition coercion) — Verified by inspecting `evaluateSimpleCondition`
- **BF-14** (decrypt error preservation) — Verified by inspecting `restore_state` error handling
- **BF-15** (pretty-print removal) — Verified by inspecting all `JSON.stringify` call sites

### Success Metrics

| Metric | Target |
|--------|--------|
| Findings resolved | 14 of 16 (BF-03 full and BF-07 deferred) |
| Tests passing | All existing + modified tests pass (`npm test`) |
| Type safety | No new TypeScript errors (`npm run typecheck`) |
| Backward compatibility | All changes are backward-compatible |
| Response payload reduction | ~25-35% smaller tool responses (BF-15) |

---

## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: patch-level fix
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [x] Update documentation (if relevant)

---

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other
- [x] N/A

---

## 🗹 TODO before merging

- [ ] Ready for review
- [ ] Address reviewer feedback