### PR TITLE
refactor: remove workflow_id and standalone session IDs from workflow TOON files

### DIFF
--- a/cicd-pipeline-security-audit/skills/04-dispatch-scanners.toon
+++ b/cicd-pipeline-security-audit/skills/04-dispatch-scanners.toon
@@ -12,7 +12,7 @@ inputs[2]:
 
 protocol:
   compose-scanner-prompts[1]:
-    - "For each agent in the roster, build a sub-agent prompt (spawn-agent operation, harness-compat skill) containing: (1) workflow-server bootstrap instructions — 'call start_session(workflow_id) then call next_activity({ workflow_id: cicd-pipeline-security-audit, activity_id: <assigned-activity-id> }), follow the activity steps sequentially'; (2) context variables — submodule path, workflow file list, scanner designator (S1-Sn), planning_folder_path, reconnaissance data for the assigned submodule; (3) output format requirement — 'write structured output to s{n}-{submodule}.json conforming to the output schema in resource 04'"
+    - "For each agent in the roster, build a sub-agent prompt (spawn-agent operation, harness-compat skill) containing: (1) workflow-server bootstrap instructions — 'call start_session(session_token, agent_id) to inherit the dispatched session, then call next_activity({ activity_id: <assigned-activity-id> }), follow the activity steps sequentially'; (2) context variables — submodule path, workflow file list, scanner designator (S1-Sn), planning_folder_path, reconnaissance data for the assigned submodule; (3) output format requirement — 'write structured output to s{n}-{submodule}.json conforming to the output schema in resource 04'"
   dispatch-scanners[2]:
     - "Dispatch all scanner agents in the roster using harness-compat::spawn-concurrent with the composed prompt from step 1."
     - "All scanner agents MUST be dispatched in a single batch"
@@ -22,9 +22,9 @@ protocol:
     - "Compare the scanner roster (input) against the dispatched scanner list. Every scanner in the roster must have been dispatched and returned a result. Produce a dispatch manifest table: scanner_id, assigned_submodule, dispatched (yes/no), returned (yes/no), status. If any scanner was NOT dispatched, flag as INCOMPLETE and return the manifest for re-dispatch. Set scanners_dispatched count."
     - "Verify scanners_dispatched equals scanners_assigned before proceeding"
   dispatch-verification[1]:
-    - "After all scanners return and dispatch completeness verified, compose V agent context with: all scanner output file paths, the workflow file inventory from scope-setup, and bootstrap instructions — 'call start_session(workflow_id) then call next_activity({ workflow_id: cicd-pipeline-security-audit, activity_id: sub-verification })'. Dispatch V agent using harness-compat::spawn-agent."
+    - "After all scanners return and dispatch completeness verified, compose V agent context with: all scanner output file paths, the workflow file inventory from scope-setup, and bootstrap instructions — 'call start_session(session_token, agent_id) to inherit the dispatched session, then call next_activity({ activity_id: sub-verification })'. Dispatch V agent using harness-compat::spawn-agent."
   dispatch-merge[1]:
-    - "After V returns, compose M agent context with: all scanner output file paths, the verification report, severity rubric (resource 02), and bootstrap instructions — 'call start_session(workflow_id) then call next_activity({ workflow_id: cicd-pipeline-security-audit, activity_id: sub-merge })'. Dispatch M agent using harness-compat::spawn-agent."
+    - "After V returns, compose M agent context with: all scanner output file paths, the verification report, severity rubric (resource 02), and bootstrap instructions — 'call start_session(session_token, agent_id) to inherit the dispatched session, then call next_activity({ activity_id: sub-merge })'. Dispatch M agent using harness-compat::spawn-agent."
 
 output[1]:
   - id: dispatch-status

--- a/cicd-pipeline-security-audit/skills/08-execute-sub-agent.toon
+++ b/cicd-pipeline-security-audit/skills/08-execute-sub-agent.toon
@@ -9,9 +9,9 @@ resources[1]:
 
 protocol:
   bootstrap-get-rules[1]:
-    - Call start_session(workflow_id) to load agent rules and obtain a session token
+    - Call start_session(session_token, agent_id) to inherit the dispatched session and obtain a session token. The workflow is derived from the token.
   bootstrap-get-activity[1]:
-    - "Call next_activity({ workflow_id: 'cicd-pipeline-security-audit', activity_id: '<assigned-activity-id>' }) to load the activity definition with its steps"
+    - "Call next_activity({ activity_id: '<assigned-activity-id>' }) to load the activity definition with its steps"
   exec-read-steps[1]:
     - Read the activity's steps array in order
   exec-per-step-description[1]:

--- a/cicd-pipeline-security-audit/workflow.toon
+++ b/cicd-pipeline-security-audit/workflow.toon
@@ -30,7 +30,7 @@ rules[19]:
   - "REMEDIATION GUIDANCE: Every finding in the final report MUST include a specific remediation recommendation referencing the playbook in resource 03."
   - "AI CONFIG FILES: Detection pattern P6 covers CLAUDE.md, AGENTS.md, .cursorrules, .cursor/rules/, and similar AI agent configuration files. These are high-value prompt injection targets when not protected by CODEOWNERS."
   - "AGENT OUTPUT PERSISTENCE: Every sub-agent MUST write its own structured output as a JSON file to the planning folder. The orchestrator verifies all expected files exist BEFORE dispatching V or M. If any file is missing, the orchestrator re-dispatches the agent. File naming: s{n}-{submodule}.json for scanners, verification-report.json for V, merged-findings.json and reconciliation-table.json for M."
-  - "SUB-AGENT BOOTSTRAP: Every sub-agent receives workflow-server bootstrap instructions in its spawn-agent prompt (harness-compat): call start_session(workflow_id), then next_activity({ workflow_id: cicd-pipeline-security-audit, activity_id: <assigned> }), then follow activity steps sequentially. Sub-agents self-load their activity definition — the orchestrator does NOT inline the activity content."
+  - "SUB-AGENT BOOTSTRAP: Every sub-agent receives workflow-server bootstrap instructions in its spawn-agent prompt (harness-compat): call start_session(session_token, agent_id) to inherit the dispatched session, then next_activity({ activity_id: <assigned> }), then follow activity steps sequentially. Sub-agents self-load their activity definition — the orchestrator does NOT inline the activity content."
 skills:
   primary: meta/workflow-orchestrator
 variables[14]:

--- a/meta/activities/00-discover-session.toon
+++ b/meta/activities/00-discover-session.toon
@@ -20,13 +20,13 @@ steps[4]:
     description: "Extract from the user request: the target workflow ID (e.g., 'work-package'), and any identifying context — ticket number (GitHub #N, Jira PROJ-123), branch name, PR number, or work package description. These are used to match against saved state files."
   - id: scan-planning-folders
     name: Scan planning folders for saved sessions
-    description: "List directories under .engineering/artifacts/planning/. For each directory that contains a workflow-state.json, read the file and extract: the saved session_token, sessionId, workflow_id, current activity, and key variables (issue_number, branch_name, pr_number). Collect all matches."
+    description: "List directories under .engineering/artifacts/planning/. For each directory that contains a workflow-state.json, read the file and extract: the saved session_token, workflow_id, current activity, and key variables (issue_number, branch_name, pr_number). Collect all matches."
   - id: match-session
     name: Match saved session to user request
     description: "Compare the identifying context from step 1 against the saved sessions from step 2. Match on issue_number, branch_name, pr_number, or directory name containing the ticket identifier. If multiple matches, prefer the most recently updated. If no matches, set has_saved_state = false."
   - id: prepare-result
     name: Prepare session result
-    description: "If a match was found: set has_saved_state = true, extract the saved session_token, sessionId, and planning_folder_path. Before returning, call health_check to check server uptime. If the server restarted after the state was saved (uptime_seconds < now - savedAt), set token_may_be_stale = true. If no match: set has_saved_state = false. Present the appropriate checkpoint."
+    description: "If a match was found: set has_saved_state = true, extract the saved session_token and planning_folder_path. Before returning, call health_check to check server uptime. If the server restarted after the state was saved (uptime_seconds < now - savedAt), set token_may_be_stale = true. If no match: set has_saved_state = false. Present the appropriate checkpoint."
 checkpoints[1]:
   - id: resume-session
     name: Resume Previous Session
@@ -57,10 +57,9 @@ outcome[3]:
   - Target workflow identified
   - Existing session found and resume decision made, or no session found
   - Ready to proceed to start-workflow with or without a saved token
-context_to_preserve[6]:
+context_to_preserve[5]:
   - target_workflow_id - The workflow to start or resume
   - has_saved_state - Whether a saved session was found
   - is_resuming - Whether the user chose to resume
   - planning_folder_path - Path to the matched planning folder
-  - sessionId - Server session ID from the state file (for stale-session detection)
   - token_may_be_stale - Whether the server may have restarted since the state was saved

--- a/meta/activities/01-dispatch-workflow.toon
+++ b/meta/activities/01-dispatch-workflow.toon
@@ -19,7 +19,7 @@ steps[4]:
     required: true
   - id: create-client-session
     name: Create client session
-    description: "Call dispatch_workflow with workflow_id (from target_workflow variable), parent_session_token (your current meta session token), and any initial variables. Extract client_session_token, client_session_id, initial_activity, and client_prompt from the response. Save client_session_token and client_session_id in session state for correlation."
+    description: "Call dispatch_workflow with workflow_id (from target_workflow variable), parent_session_token (your current meta session token), and any initial variables. Extract client_session_token, initial_activity, and client_prompt from the response. Save client_session_token in session state for correlation."
     required: true
   - id: dispatch-client
     name: Dispatch workflow-orchestrator
@@ -41,7 +41,6 @@ outcome[4]:
   - Client agent dispatched and lifecycle managed inline
   - Checkpoint yields presented to user and responses forwarded
   - Client workflow completed or blocked awaiting user input
-context_to_preserve[3]:
-  - client_session_token - The client agent's session token
-  - client_session_id - The client session SID for trace correlation
+context_to_preserve[2]:
+  - client_session_token - The client agent's session token (session identity is embedded within)
   - target_workflow - The workflow ID that was dispatched

--- a/meta/resources/00-bootstrap-protocol.md
+++ b/meta/resources/00-bootstrap-protocol.md
@@ -7,7 +7,7 @@ version: 1.1.0
 2. **Compare** the user's stated goal to workflow descriptions. If multiple workflows could match:
    * Present workflows with title, description, and tags and let the user select one.
    * IMPORTANT! Never skip workflow matching. If no workflow matches, **inform the user** — this is a design gap.
-3. Start a new session by calling: `start_session(workflow_id: "meta","agent_id: "meta")`.  
+3. Start a new session by calling: `start_session(agent_id: "meta")`.  The workflow defaults to "meta" (the bootstrap orchestration workflow).
 4. Save the returned `session_token` — it is required for all subsequent calls.
 5. Call `get_skill(session_token: <session_token>,"agent_id: "meta")` to load the meta workflow's primary skill
 6. Follow the skill protocol to continue the bootstrap process

--- a/meta/resources/05-workflow-orchestrator-prompt.md
+++ b/meta/resources/05-workflow-orchestrator-prompt.md
@@ -13,7 +13,7 @@ You are an autonomous workflow orchestrator managing the execution of the `{work
 
 ## Bootstrap Instructions
 
-1. Call `start_session( workflow_id: {workflow_id}, session_token: {client_session_token}, agent_id: {agent_id} )` to activate the session.
+1. Call `start_session( session_token: {client_session_token}, agent_id: {agent_id} )` to activate the session. The workflow is derived from the token's embedded workflow ID — no workflow_id parameter is needed.
 2. Call `get_workflow( session_token: <token from step 1>, summary: false )` to load the workflow structure and primary skill.
 3. Examine the returned skill definition. If it contains a `_resources` array, call `get_resource({ session_token, resource_index })` to fetch the full text content for EACH required resource.
 4. **Resume detection:** If `start_session` returned `inherited: true` or `adopted: true`, you are resuming a previous session. Call `get_activity({ session_token })` to confirm the current activity (the session already encodes the activity position — do NOT start from `initialActivity`). Dispatch the activity-worker for the returned activity with the restored state variables provided in this prompt.

--- a/meta/resources/08-workflow-state-format.md
+++ b/meta/resources/08-workflow-state-format.md
@@ -17,10 +17,8 @@ The `workflow-state.json` file persists workflow execution state to disk, enabli
 | `workflowId` | string | yes | Workflow ID (e.g., `work-package`) |
 | `workflowVersion` | string | yes | Workflow version |
 | `planningFolder` | string | yes | Absolute path to the planning folder |
-| `sessionToken` | string | yes | Meta session token (opaque HMAC-signed string) — the meta-orchestrator's own session token for the `meta` workflow. |
-| `sessionId` | string | yes | Meta session ID (from the `session_id` field returned by start_session). Enables stale-session detection on resume. |
-| `clientSessionToken` | string | no | Client session token for the dispatched workflow-orchestrator — set by the meta-orchestrator after `dispatch_workflow`. This is the token the workflow-orchestrator and activity-workers share. MUST be preserved on resume to avoid creating a new session. |
-| `clientSessionId` | string | no | Client session ID corresponding to `clientSessionToken`. |
+| `sessionToken` | string | yes | Meta session token (opaque HMAC-signed string) — the meta-orchestrator's own session token for the `meta` workflow. The session identity is embedded within the token. |
+| `clientSessionToken` | string | no | Client session token for the dispatched workflow-orchestrator — set by the meta-orchestrator after `dispatch_workflow`. This is the token the workflow-orchestrator and activity-workers share. MUST be preserved on resume to avoid creating a new session. The session identity is embedded within the token. |
 | `sessionTokenEncrypted` | boolean | yes | Whether the token is encrypted |
 | `state` | object | yes | Full nested execution state |
 
@@ -57,7 +55,6 @@ After completing all steps and writing artifacts, the activity worker persists i
 2. **If the file does not exist**, skip silently. The orchestrator creates the file on first persist.
 3. **Update** these fields on the parsed object:
    - `sessionToken` — set to the worker's current `session_token`
-   - `sessionId` — set from the `session_id` field returned by start_session or dispatch_workflow. NEVER decode the session_token payload to obtain this value.
    - `savedAt` — set to the current ISO 8601 timestamp
    - `description` — set to `"State after {activity_id}"`
    - `state.updatedAt` — set to the current ISO 8601 timestamp
@@ -68,7 +65,7 @@ After completing all steps and writing artifacts, the activity worker persists i
 ### Constraints
 
 - **Read before write.** Never overwrite with a partial state — always merge into the existing file.
-- **Token is opaque.** NEVER parse, decode, or modify the session token string. Obtain sessionId from the `session_id` field returned by start_session or dispatch_workflow — do NOT extract it by decoding the token.
+- **Token is opaque.** NEVER parse, decode, or modify the session token string. The session identity is embedded within the token — there is no separate `session_id` field.
 - **Preserve unmodified fields.** Only touch the fields listed above; leave everything else unchanged.
 - **No file creation.** Workers do not create the state file — they only update an existing one.
 
@@ -83,9 +80,7 @@ After completing all steps and writing artifacts, the activity worker persists i
   "workflowVersion": "1.2.0",
   "planningFolder": "/path/to/.engineering/artifacts/planning/2026-04-14-feature-xyz",
   "sessionToken": "eyJ3Zi...<opaque-meta-token>...signature",
-  "sessionId": "9ef82af4-7752-4c0a-9c60-ab8d5c03dcdf",
   "clientSessionToken": "eyJ3Zi...<opaque-client-token>...signature",
-  "clientSessionId": "3ba91c7d-2e44-4b8a-a1f2-cd9e04b12345",
   "sessionTokenEncrypted": false,
   "state": {
     "workflowId": "work-package",
@@ -117,8 +112,8 @@ After completing all steps and writing artifacts, the activity worker persists i
 
 ## Stale Session Detection
 
-When the workflow server restarts, it generates a new HMAC signing key, invalidating all saved session tokens. The `sessionId` field enables detection of this condition:
+When the workflow server restarts, it generates a new HMAC signing key, invalidating all saved session tokens. The token itself enables detection of this condition:
 
-1. On resume, call `start_session({ workflow_id, session_token: saved_token })` to attempt token inheritance. If the server was restarted, the server will automatically re-sign the token and adopt the session (returning `adopted: true` with preserved state).
-2. If the token payload is corrupted and cannot be adopted, the server will return `recovered: true` with a fresh session. In this case, compare the new session's `sid` with the saved `sessionId`. If they differ, state must be reconstructed from the saved variables and `completedActivities`.
+1. On resume, call `start_session({ session_token: saved_token })` to attempt token inheritance. The workflow is derived from the token's embedded workflow ID. If the server was restarted, the server will automatically re-sign the token and adopt the session (returning `adopted: true` with preserved state).
+2. If the token payload is corrupted and cannot be adopted, the server will return `recovered: true` with a fresh session. In this case, state must be reconstructed from the saved variables and `completedActivities`.
 3. Proactively, before attempting token inheritance, call `health_check`. If `uptime_seconds` is less than the time since `savedAt`, the token is guaranteed stale (but will be auto-adopted by the server).

--- a/meta/skills/00-session-protocol.toon
+++ b/meta/skills/00-session-protocol.toon
@@ -6,10 +6,10 @@ description: "Cross-cutting skill defining the protocol for workflow sessions. C
 
 protocol:
   token-management[5]:
-    - "CRITICAL: EVERY tool call requires a session_token parameter. There is NO workflow_id parameter on any tool except start_session — the workflow identity is encoded inside the token."
+    - "CRITICAL: EVERY tool call requires a session_token parameter. There is NO workflow_id parameter on start_session — the workflow is derived from the token's embedded wf field, or defaults to 'meta' for fresh sessions."
     - "Use the updated session_token from each response for the next call. Tokens are returned both in the response body and in _meta.session_token. ALWAYS prefer the token from the most recent response — do not reuse a token from an earlier call in the same session."
     - "TOKEN SUCCESSION: Each tool call that accepts a session_token returns a NEW token in its response. The old token is consumed and MUST NOT be reused. If you call two tools sequentially, the second call MUST use the token returned by the first call — not the token you passed to the first call. Failure to follow token succession causes HMAC signature verification failures."
-    - "STALE TOKEN RECOVERY: If any tool call returns 'HMAC signature verification failed', the server has restarted and generated a new signing key. Do NOT retry with the same token. Instead: call start_session({ workflow_id }) to get a fresh token, then reconstruct state by transitioning to the correct activity. See meta-orchestrator initialize-state protocol for the full recovery procedure."
+    - "STALE TOKEN RECOVERY: If any tool call returns 'HMAC signature verification failed', the server has restarted and generated a new signing key. Do NOT retry with the same token. Instead: call start_session({ agent_id }) to get a fresh token (defaults to meta workflow), then reconstruct state by transitioning to the correct activity. See meta-orchestrator initialize-state protocol for the full recovery procedure."
     - "Token-exempt tools: discover, list_workflows, start_session, and health_check do not require a session token."
   checkpoint-token-discipline[4]:
     - "CHECKPOINT TOKENS ARE DISTINCT FROM SESSION TOKENS. yield_checkpoint returns a checkpoint_handle — an HMAC-signed token string (contains a '.' separator) that encodes the checkpoint state. This is NOT the same as the checkpoint_id (a short name like 'classification-confirmed')."

--- a/meta/skills/03-state-management.toon
+++ b/meta/skills/03-state-management.toon
@@ -11,7 +11,7 @@ protocol:
     - "After each step, checkpoint response, or activity transition, the orchestrator updates the corresponding state fields in the session"
     - "Record every state change in the history array with timestamp and event type"
   persist[4]:
-    - "After each completed activity, the meta-orchestrator writes a state file containing: the current session_token, sessionId (the 'sid' field from the token payload), variable state, and activity trace"
+    - "After each completed activity, the meta-orchestrator writes a state file containing: the current session_token, variable state, and activity trace"
     - "Write to {planning_folder_path}/workflow-state.json using agent file tools"
     - "To resume, the meta-orchestrator passes the saved session_token to start_session. The workflow-orchestrator then inherits this session via dispatch_workflow."
-    - "STALE SESSION DETECTION: When resuming, compare the saved sessionId against the session returned by start_session. If the sessionIds differ, the session was not inherited — state must be reconstructed manually from the saved variables and completedActivities. This happens when the workflow server was restarted (new HMAC signing key) and start_session fell back to creating a fresh session."
+    - "STALE SESSION DETECTION: When resuming, call start_session with the saved session_token. If the server was restarted (new HMAC signing key), start_session will return adopted: true (re-signed with preserved state) or recovered: true (fresh session, state must be reconstructed from saved variables and completedActivities). The session identity is embedded in the token — there is no separate sessionId field."

--- a/meta/skills/05-workflow-state-file.toon
+++ b/meta/skills/05-workflow-state-file.toon
@@ -13,9 +13,8 @@ protocol:
   read-state[2]:
     - "Read {planning_folder_path}/workflow-state.json using agent file tools"
     - "If the file does not exist, return null — the orchestrator creates it on first persist"
-  update-token[5]:
+  update-token[4]:
     - "Parse the existing JSON and update sessionToken to the current session_token"
-    - "Set sessionId from the session_id field returned by start_session or dispatch_workflow. NEVER decode the session_token payload — obtain session_id from the API response instead."
     - "Set savedAt to the current ISO 8601 timestamp"
     - "Increment state.stateVersion by 1"
     - "Set state.updatedAt to the current ISO 8601 timestamp"
@@ -30,7 +29,7 @@ protocol:
 rules:
   read-before-write: "Always read the existing file before writing. Never overwrite with a partial state — merge into the existing file."
   skip-if-missing: "If the state file does not exist and this is a worker update, skip silently. The orchestrator creates the file on first persist."
-  token-is-opaque: "Treat the session token as an opaque string. NEVER parse, decode, or modify its contents. Obtain session_id from the start_session or dispatch_workflow API response — do NOT extract it by decoding the token."
+  token-is-opaque: "Treat the session token as an opaque string. NEVER parse, decode, or modify its contents. The session identity is embedded within the token — there is no separate session_id field."
   preserve-unmodified: "When updating specific fields, preserve all other fields unchanged."
 
 resources[1]:

--- a/meta/skills/10-meta-orchestrator.toon
+++ b/meta/skills/10-meta-orchestrator.toon
@@ -19,19 +19,19 @@ protocol:
   initialize-state[7]:
     - "Call discover-session tool. If the user chose to resume, start_session was called with a saved token and is_resuming is true. Read the state file's variables and adopt them."
     - "If is_resuming and token_may_be_stale is true: call health_check to confirm server uptime. If the server restarted after savedAt, the saved token is stale — skip token inheritance and proceed to fresh-session recovery."
-    - "If is_resuming and the saved token appears valid: call start_session({ workflow_id, session_token: saved_token }) to resume. If start_session returns an HMAC signature verification error, do NOT retry with the same token — proceed to fresh-session recovery."
-    - "Fresh-session recovery: call start_session({ workflow_id }) without a session_token to create a new session. Compare the new session's sid with the saved sessionId — if they differ, state must be reconstructed manually. Transition to the currentActivity from the state file via next_activity, and restore variables from the state file. The completedActivities and completedSteps from the state file provide the activity history — the server will not have this, but the orchestrator tracks it independently."
+    - "If is_resuming and the saved token appears valid: call start_session({ session_token: saved_token }) to resume. The workflow is derived from the token. If start_session returns an HMAC signature verification error, do NOT retry with the same token — proceed to fresh-session recovery."
+    - "Fresh-session recovery: call start_session({ agent_id }) without a session_token to create a new session (defaults to meta workflow). The new session will have a different sid. State must be reconstructed manually. Transition to the currentActivity from the state file via next_activity, and restore variables from the state file. The completedActivities and completedSteps from the state file provide the activity history — the server will not have this, but the orchestrator tracks it independently."
     - "If is_resuming: compare workflow version against the loaded workflow. Warn on mismatch. Adopt restored variables. Detect mode from restored variables — do not override unless the user explicitly requests a mode change."
     - "If fresh session: determine planning_folder_path from workflow variables or user request context. Set variables to defaults, current_activity to initialActivity, initialize empty collections. Set is_resuming = false."
-    - "If fresh session and planning_folder_path is set: create the initial workflow-state.json at {planning_folder_path}/workflow-state.json containing the current session_token, sessionId, workflow metadata, and default state. This ensures the token is on disk before the first activity is dispatched. See the workflow-state-format resource for the file structure."
+    - "If fresh session and planning_folder_path is set: create the initial workflow-state.json at {planning_folder_path}/workflow-state.json containing the current session_token, workflow metadata, and default state. This ensures the token is on disk before the first activity is dispatched. See the workflow-state-format resource for the file structure."
   dispatch-workflow[8]:
-    - "RESUME CHECK (evaluate first): If is_resuming = true AND the state file contains a clientSessionToken field: do NOT call dispatch_workflow. The clientSessionToken IS the workflow-orchestrator's session token. Use harness-compat::continue-agent with a prompt that includes the clientSessionToken as {client_session_token}, the currentActivity from the state file, all restored state variables, and is_resuming: true. The workflow-orchestrator will call start_session({ workflow_id, session_token: clientSessionToken }) to adopt the saved session and resume at the saved activity. Set is_resuming = false after this dispatch."
+    - "RESUME CHECK (evaluate first): If is_resuming = true AND the state file contains a clientSessionToken field: do NOT call dispatch_workflow. The clientSessionToken IS the workflow-orchestrator's session token. Use harness-compat::continue-agent with a prompt that includes the clientSessionToken as {client_session_token}, the currentActivity from the state file, all restored state variables, and is_resuming: true. The workflow-orchestrator will call start_session({ session_token: clientSessionToken, agent_id }) to adopt the saved session and resume at the saved activity. Set is_resuming = false after this dispatch."
     - "FRESH DISPATCH: If is_resuming = false (or state file has no clientSessionToken): call dispatch_workflow({ workflow_id, parent_session_token, variables }) to create an independent client session for the workflow-orchestrator. Wait for the dispatch package response."
-    - "After calling dispatch_workflow: immediately write clientSessionToken and clientSessionId from the response into the state file. This ensures the client session can be recovered on restart. Do not wait for the first activity to complete — write these values now."
+    - "After calling dispatch_workflow: immediately write clientSessionToken from the response into the state file. This ensures the client session can be recovered on restart. Do not wait for the first activity to complete — write this value now."
     - "Compose the prompt using the client_prompt returned in the dispatch package — do NOT inject paraphrased skill content."
     - "Spawn the workflow-orchestrator sub-agent using the harness-compat::spawn-agent. Pass the client_prompt as the prompt. If continuing an existing workflow-orchestrator, use the continue-agent operation instead. ALWAYS foreground — never background. The meta-orchestrator blocks waiting for checkpoint yields."
     - "First dispatch: harness-compat::spawn-agent. Subsequent dispatches: harness-compat::continue-agent."
-    - "For resumed sub-agents: the continuation prompt MUST include clientSessionToken as {client_session_token}, the currentActivity from the state file, and all restored state variables. The sub-agent uses start_session({ workflow_id, session_token: clientSessionToken }) to adopt the session."
+    - "For resumed sub-agents: the continuation prompt MUST include clientSessionToken as {client_session_token}, the currentActivity from the state file, and all restored state variables. The sub-agent uses start_session({ session_token: clientSessionToken, agent_id }) to adopt the session."
     - "The workflow-orchestrator runs in an independent session. It does NOT inherit the meta-orchestrator token."
   process-result[2]:
     - "If checkpoint_pending: parse the <checkpoint_yield> block and present to user via AskQuestion, then respond_checkpoint."
@@ -48,12 +48,11 @@ protocol:
     - "MANDATORY after trace append. Run git status --porcelain .engineering/artifacts/ to detect uncommitted changes"
     - "Stage all changed files. Follow .engineering/AGENTS.md commit procedures (submodule paths require two-step commit-and-push)"
     - "Commit with conventional format: docs(<workflow-id>): <activity-id> artifacts"
-  persist-state[5]:
-    - "MANDATORY after commit. Construct state file containing: the current session_token (opaque string, meta session), sessionId (from the session_id field returned by start_session — NEVER decode the token payload), variable state (JSON), and activity trace (from get_trace)"
+  persist-state[4]:
+    - "MANDATORY after commit. Construct state file containing: the current session_token (opaque string, meta session), variable state (JSON), and activity trace (from get_trace)"
     - "Write to {planning_folder_path}/workflow-state.json using agent file tools"
-    - "CRITICAL: Preserve clientSessionToken and clientSessionId fields when writing the state file. Perform a read-modify-write: read the existing file, update only the meta session fields (sessionToken, sessionId, savedAt, state, description), and write back. Never overwrite clientSessionToken with the meta session token."
+    - "CRITICAL: Preserve clientSessionToken field when writing the state file. Perform a read-modify-write: read the existing file, update only the meta session fields (sessionToken, savedAt, state, description), and write back. Never overwrite clientSessionToken with the meta session token."
     - "If planning_folder_path is not set, skip silently"
-    - "sessionId enables stale-session detection on resume: if the server restarted, start_session will return a different sid, signaling that state must be reconstructed from the saved variables rather than inherited via token"
   evaluate-transition[2]:
     - "Evaluate transition conditions against state variables — take first matching or default"
     - "If no transitions exist, the workflow is complete"
@@ -88,7 +87,7 @@ rules:
 errors:
   stale_token:
     cause: "Server restarted and generated a new HMAC signing key, invalidating the saved session token"
-    recovery: "Call start_session({ workflow_id }) without a saved token to get a fresh session. Reconstruct state by transitioning to the currentActivity from the state file and restoring variables manually."
+    recovery: "Call start_session({ agent_id }) without a saved token to get a fresh session (defaults to meta workflow). Reconstruct state by transitioning to the currentActivity from the state file and restoring variables manually."
   worker_timeout:
     cause: "Sub-agent did not return within expected time"
     recovery: "Check terminal output. Resume if still running. If stuck, create new sub-agent and re-dispatch."

--- a/meta/skills/12-workflow-orchestrator.toon
+++ b/meta/skills/12-workflow-orchestrator.toon
@@ -39,13 +39,12 @@ protocol:
     - "MANDATORY after trace append. Run git status --porcelain .engineering/artifacts/ to detect uncommitted changes"
     - "Stage all changed files. Follow .engineering/AGENTS.md commit procedures (submodule paths require two-step commit-and-push)"
     - "Commit with conventional format: docs(<workflow-id>): <activity-id> artifacts"
-  persist-state[6]:
+  persist-state[5]:
     - "Track state changes triggered by activities: activity_transition logs activity_entered, step_completion increments currentStep and logs step_completed, decision_outcome records branch taken in decisionOutcomes."
-    - "MANDATORY after commit. Construct state file containing: the current session_token (opaque string), sessionId (from the session_id field returned by start_session or dispatch_workflow — NEVER decode the token payload), variable state (JSON), and activity trace (from get_trace)"
-    - "Update state sessionToken with the current session_token, set sessionId from the session_id field returned by start_session or dispatch_workflow (NEVER decode the token payload), set savedAt and state.updatedAt to the current ISO 8601 timestamp, increment state.stateVersion by 1, set state.completedSteps[activity_id] to the completed step indices, and set description to 'State after {activity_id}'."
+    - "MANDATORY after commit. Construct state file containing: the current session_token (opaque string), variable state (JSON), and activity trace (from get_trace)"
+    - "Update state sessionToken with the current session_token, set savedAt and state.updatedAt to the current ISO 8601 timestamp, increment state.stateVersion by 1, set state.completedSteps[activity_id] to the completed step indices, and set description to 'State after {activity_id}'."
     - "Write to {planning_folder_path}/workflow-state.json using agent file tools"
     - "If planning_folder_path is not set, skip silently"
-    - "sessionId enables stale-session detection on resume: if the server restarted, start_session will return a different sid, signaling that state must be reconstructed from the saved variables rather than inherited via token"
   evaluate-transition[2]:
     - "Evaluate transition conditions against state variables — take first matching or default"
     - "If no transitions exist, the workflow is complete"
@@ -89,7 +88,7 @@ rules:
 errors:
   stale_token:
     cause: "Server restarted and generated a new HMAC signing key, invalidating the saved session token"
-    recovery: "Call start_session({ workflow_id }) without a saved token to get a fresh session. Reconstruct state by transitioning to the currentActivity from the state file and restoring variables manually."
+    recovery: "Call start_session({ agent_id }) without a saved token to get a fresh session (defaults to meta workflow). Reconstruct state by transitioning to the currentActivity from the state file and restoring variables manually."
   worker_timeout:
     cause: "Worker sub-agent did not return within expected time"
     recovery: "Check terminal output. Resume if still running. If stuck, create new worker and re-dispatch."

--- a/substrate-node-security-audit/skills/02-execute-sub-agent.toon
+++ b/substrate-node-security-audit/skills/02-execute-sub-agent.toon
@@ -9,9 +9,9 @@ resources[1]:
 
 protocol:
   bootstrap-get-rules[1]:
-    - Call start_session(workflow_id) to load agent rules and obtain a session token
+    - Call start_session(session_token, agent_id) to inherit the dispatched session and obtain a session token. The workflow is derived from the token.
   bootstrap-get-activity[1]:
-    - "Call next_activity({ workflow_id: 'substrate-node-security-audit', activity_id: '<assigned-activity-id>' }) to load the activity definition with its steps"
+    - "Call next_activity({ activity_id: '<assigned-activity-id>' }) to load the activity definition with its steps"
   exec-read-steps[1]:
     - Read the activity's steps array in order
   exec-per-step-description[1]:

--- a/substrate-node-security-audit/skills/04-dispatch-sub-agents.toon
+++ b/substrate-node-security-audit/skills/04-dispatch-sub-agents.toon
@@ -10,7 +10,7 @@ inputs[1]:
 
 protocol:
   compose-prompts[1]:
-    - "For each agent in the roster, build a sub-agent prompt (spawn-agent operation, harness-compat skill) containing: (1) workflow-server bootstrap instructions — 'call start_session(workflow_id) then call next_activity with the assigned activity_id, follow the activity steps sequentially'; (2) context variables — crate path, in_scope/out_of_scope, function registry entries; (3) supplementary cross-scope files — file paths from other crates needed for cross-boundary checks; (4) output format requirement — 'return structured output conforming to the output schema resource.'"
+    - "For each agent in the roster, build a sub-agent prompt (spawn-agent operation, harness-compat skill) containing: (1) workflow-server bootstrap instructions — 'call start_session(session_token, agent_id) to inherit the dispatched session, then call next_activity with the assigned activity_id, follow the activity steps sequentially'; (2) context variables — crate path, in_scope/out_of_scope, function registry entries; (3) supplementary cross-scope files — file paths from other crates needed for cross-boundary checks; (4) output format requirement — 'return structured output conforming to the output schema resource.'"
   dispatch-all[1]:
     - "Dispatch all agents in the roster using harness-compat::spawn-concurrent. Each agent uses the composed prompt from step 1."
   collect-all[1]:

--- a/work-package/activities/13-complete.toon
+++ b/work-package/activities/13-complete.toon
@@ -29,7 +29,7 @@ artifacts[4]:
     description: "PR review analysis document"
 skills:
   primary: meta/activity-worker
-steps[9]:
+steps[10]:
   - id: create-adr
     name: Create Architecture Decision Record
     description: "Create ADR at .engineering/artifacts/adr/ documenting the architectural decision, rationale, and alternatives."


### PR DESCRIPTION
## Summary

Update all workflow TOON files to align with the session token API simplification in the server codebase (PR #104).

### Changes
- Remove `workflow_id` parameter from all `start_session` calls (fresh sessions default to `meta`, inherited sessions derive workflow from token)
- Remove `sessionId`/`clientSessionId` references from state format, skills, and activity definitions
- Update sub-agent bootstrap instructions to use `start_session(session_token, agent_id)` without `workflow_id`
- Fix `13-complete.toon` steps count (9 -> 10)
- Update stale-session detection to use `adopted`/`recovered` flags instead of `sessionId` comparison

### Affected workflows
- meta (resources, skills, activities)
- work-package (activities)
- cicd-pipeline-security-audit (skills)
- substrate-node-security-audit (skills)