### PR TITLE
feat: unified session token — update meta workflow for single-token architecture

### DIFF
--- a/meta/activities/00-discover-session.toon
+++ b/meta/activities/00-discover-session.toon
@@ -1,5 +1,5 @@
 id: discover-session
-version: 1.0.0
+version: 2.0.0
 name: Discover Session
 description: "Search for an existing workflow session to resume. Scans planning folders for workflow-state.json files matching the user's request (ticket ID, branch name, or work package name). If a match is found, presents a checkpoint asking whether to resume. Always runs before starting a target workflow."
 problem: "Determine whether to resume an existing workflow session or start fresh"
@@ -26,7 +26,7 @@ steps[4]:
     description: "Compare the identifying context from step 1 against the saved sessions from step 2. Match on issue_number, branch_name, pr_number, or directory name containing the ticket identifier. If multiple matches, prefer the most recently updated. If no matches, set has_saved_state = false."
   - id: prepare-result
     name: Prepare session result
-    description: "If a match was found: set has_saved_state = true, extract the saved session_token and planning_folder_path. Before returning, call health_check to check server uptime. If the server restarted after the state was saved (uptime_seconds < now - savedAt), set token_may_be_stale = true. If no match: set has_saved_state = false. Present the appropriate checkpoint."
+    description: "If a match was found: set has_saved_state = true, extract the saved session_token and planning_folder_path. The server auto-detects token staleness during start_session — no manual health_check is needed. If no match: set has_saved_state = false. Present the appropriate checkpoint."
 checkpoints[1]:
   - id: resume-session
     name: Resume Previous Session
@@ -57,9 +57,8 @@ outcome[3]:
   - Target workflow identified
   - Existing session found and resume decision made, or no session found
   - Ready to proceed to start-workflow with or without a saved token
-context_to_preserve[5]:
+context_to_preserve[4]:
   - target_workflow_id - The workflow to start or resume
   - has_saved_state - Whether a saved session was found
   - is_resuming - Whether the user chose to resume
   - planning_folder_path - Path to the matched planning folder
-  - token_may_be_stale - Whether the server may have restarted since the state was saved

--- a/meta/activities/00-discover-session.toon
+++ b/meta/activities/00-discover-session.toon
@@ -26,7 +26,7 @@ steps[4]:
     description: "Compare the identifying context from step 1 against the saved sessions from step 2. Match on issue_number, branch_name, pr_number, or directory name containing the ticket identifier. If multiple matches, prefer the most recently updated. If no matches, set has_saved_state = false."
   - id: prepare-result
     name: Prepare session result
-    description: "If a match was found: set has_saved_state = true, extract the saved session_token and planning_folder_path. The server auto-detects token staleness during start_session — no manual health_check is needed. If no match: set has_saved_state = false. Present the appropriate checkpoint."
+    description: "If a match was found: set has_saved_state = true, extract the saved session_token and planning_folder_path. If no match: set has_saved_state = false. Present the appropriate checkpoint."
 checkpoints[1]:
   - id: resume-session
     name: Resume Previous Session

--- a/meta/activities/01-dispatch-workflow.toon
+++ b/meta/activities/01-dispatch-workflow.toon
@@ -1,8 +1,8 @@
 id: dispatch-workflow
-version: 1.1.0
+version: 2.0.0
 name: Dispatch Client Workflow
-description: "Dispatch the resolved target workflow to a workflow-orchestrator (sub-agent). Creates an independent client session via dispatch_workflow, spawns the sub-agent with the dispatch package, and acts as a router for checkpoints bubbled up from the sub-agent."
-problem: Create and manage an independent client workflow session for the resolved target workflow
+description: "Dispatch the resolved target workflow to a workflow-orchestrator (sub-agent). Creates a session for the target workflow via start_session({ workflow_id }), spawns the sub-agent with the composed prompt, and acts as a router for checkpoints bubbled up from the sub-agent."
+problem: Create and manage a workflow session for the resolved target workflow
 recognition[3]:
   - dispatch the workflow
   - start the target workflow
@@ -16,14 +16,13 @@ steps[4]:
   - id: resolve-target
     name: Resolve target workflow
     description: "The target workflow has already been resolved by the discover-session activity. Verify the `target_workflow` variable is set. If missing, return to discover-session."
-    required: true
-  - id: create-client-session
-    name: Create client session
-    description: "Call dispatch_workflow with workflow_id (from target_workflow variable), parent_session_token (your current meta session token), and any initial variables. Extract client_session_token, initial_activity, and client_prompt from the response. Save client_session_token in session state for correlation."
+  - id: create-session
+    name: Create workflow session
+    description: "Call start_session({ workflow_id, agent_id }) to create a session for the target workflow. Extract session_token from the response. Save session_token in session state. No separate client session is needed — the unified token serves both orchestrator and worker."
     required: true
   - id: dispatch-client
     name: Dispatch workflow-orchestrator
-    description: "Spawn a new agent (Task/sub-agent) with the client_prompt from dispatch_workflow. The workflow-orchestrator runs the target workflow using its own session token. Wait for the agent to return a result — either checkpoint_pending or workflow_complete. Do NOT execute client workflow activities directly — all execution is delegated to the workflow-orchestrator."
+    description: "Compose the worker prompt using the template from get_resource('meta/05'). Spawn a new agent (Task/sub-agent) with the composed prompt. The workflow-orchestrator runs the target workflow using the same session token. Wait for the agent to return a result — either checkpoint_pending or workflow_complete. Do NOT execute client workflow activities directly — all execution is delegated to the workflow-orchestrator."
     required: true
   - id: process-result
     name: Process client result
@@ -37,10 +36,10 @@ transitions[1]:
       operator: ==
       value: true
 outcome[4]:
-  - Client workflow session created with independent session token
+  - Workflow session created with unified session token
   - Client agent dispatched and lifecycle managed inline
   - Checkpoint yields presented to user and responses forwarded
   - Client workflow completed or blocked awaiting user input
 context_to_preserve[2]:
-  - client_session_token - The client agent's session token (session identity is embedded within)
+  - session_token - The unified session token for the target workflow
   - target_workflow - The workflow ID that was dispatched

--- a/meta/activities/02-resume-workflow.toon
+++ b/meta/activities/02-resume-workflow.toon
@@ -26,7 +26,7 @@ steps[6]:
     description: "Collect required information: workflow ID, planning folder path, and any user-provided context about where they left off"
   - id: restore-saved-state
     name: Restore saved state
-    description: "Check for {planning_folder_path}/workflow-state.json. If found, read the file and extract the saved session_token and variables. Call start_session({ session_token: saved_token, agent_id }) to resume the session. The server auto-detects staleness and re-signs stale tokens. Restore variables from the file. Present a summary to the user: workflow ID, current activity, key variable values. If the file does not exist, set has_saved_state = false and proceed to manual reconstruction."
+    description: "Check for {planning_folder_path}/workflow-state.json. If found, read the file and extract the saved session_token and variables. Call start_session({ session_token: saved_token, agent_id }) to resume the session. If start_session returns recovered: true, proceed to manual reconstruction. Restore variables from the file. Present a summary to the user: workflow ID, current activity, key variable values. If the file does not exist, set has_saved_state = false and proceed to manual reconstruction."
   - id: manual-reconstruction
     name: Manual state reconstruction
     description: "Fallback when no saved state exists. Reconstruct progress from workflow artifacts, external state (git branches, PRs, planning folder contents), and user recall. Build a state object manually."

--- a/meta/activities/02-resume-workflow.toon
+++ b/meta/activities/02-resume-workflow.toon
@@ -1,8 +1,8 @@
 id: resume-workflow
-version: 5.0.0
+version: 6.0.0
 name: Resume Workflow
 problem: The user wants to continue a workflow that was previously started.
-description: "Resume a workflow using persisted state as the primary mechanism. Checks for a workflow-state.json file in the planning folder and resumes via start_session(session_token=saved_token). Falls back to manual reconstruction from external evidence only when no saved state exists."
+description: "Resume a workflow using persisted state. Checks for a workflow-state.json file in the planning folder and resumes via start_session(session_token=saved_token). Falls back to manual reconstruction from external evidence only when no saved state exists."
 recognition[6]:
   - Resume workflow
   - Continue workflow
@@ -26,7 +26,7 @@ steps[6]:
     description: "Collect required information: workflow ID, planning folder path, and any user-provided context about where they left off"
   - id: restore-saved-state
     name: Restore saved state
-    description: "Check for {planning_folder_path}/workflow-state.json. If found, read the file and extract the saved session_token and variables. Call start_session({ workflow_id, session_token }) to resume the session position. Restore variables from the file. Present a summary to the user: workflow ID, current activity, key variable values. If the file does not exist, set has_saved_state = false and proceed to manual reconstruction."
+    description: "Check for {planning_folder_path}/workflow-state.json. If found, read the file and extract the saved session_token and variables. Call start_session({ session_token: saved_token, agent_id }) to resume the session. The server auto-detects staleness and re-signs stale tokens. Restore variables from the file. Present a summary to the user: workflow ID, current activity, key variable values. If the file does not exist, set has_saved_state = false and proceed to manual reconstruction."
   - id: manual-reconstruction
     name: Manual state reconstruction
     description: "Fallback when no saved state exists. Reconstruct progress from workflow artifacts, external state (git branches, PRs, planning folder contents), and user recall. Build a state object manually."

--- a/meta/resources/05-worker-prompt-template.md
+++ b/meta/resources/05-worker-prompt-template.md
@@ -1,6 +1,6 @@
 ---
 id: worker-prompt-template
-version: 1.0.0
+version: 2.0.0
 ---
 
 # Worker Prompt Template
@@ -15,7 +15,7 @@ version: 1.0.0
 You are the WORKER agent for the {workflow_id} workflow. Execute the `{activity_id}` activity.
 
 ## Bootstrap Instructions
-1. Call `start_session({ workflow_id: "{workflow_id}" })` to obtain a session_token. Save it — every subsequent call requires session_token.
+1. Call `start_session({ session_token: "{session_token}", agent_id: "worker" })` to adopt the session. Save the returned token — every subsequent call requires it.
 2. Call `next_activity({ session_token, activity_id: "{activity_id}" })` to load the activity definition. Pass the session_token from step 1.
 3. Call `get_skills({ session_token })` to load skills and resources. Pass the latest session_token (each response returns an updated one).
 4. Execute steps per the loaded skill protocols
@@ -44,6 +44,7 @@ You are the WORKER agent for the {workflow_id} workflow. Execute the `{activity_
 |-------------|--------|
 | `{workflow_id}` | Workflow being orchestrated (e.g., `work-package`) |
 | `{activity_id}` | Current activity to execute (e.g., `start-work-package`) |
+| `{session_token}` | The unified session token for the target workflow (from start_session) |
 | `{state_variables_block}` | YAML or key-value list of all current state variables with their values |
 | `{planning_folder_path}` | Path to the planning folder (may be "not yet set" for first activity) |
 | `{workspace_root}` | Absolute path to the workspace root directory |

--- a/meta/resources/08-workflow-state-format.md
+++ b/meta/resources/08-workflow-state-format.md
@@ -1,6 +1,6 @@
 ---
 id: workflow-state-format
-version: 1.1.0
+version: 2.0.0
 ---
 
 # Workflow State File Format
@@ -17,8 +17,7 @@ The `workflow-state.json` file persists workflow execution state to disk, enabli
 | `workflowId` | string | yes | Workflow ID (e.g., `work-package`) |
 | `workflowVersion` | string | yes | Workflow version |
 | `planningFolder` | string | yes | Absolute path to the planning folder |
-| `sessionToken` | string | yes | Meta session token (opaque HMAC-signed string) — the meta-orchestrator's own session token for the `meta` workflow. The session identity is embedded within the token. |
-| `clientSessionToken` | string | no | Client session token for the dispatched workflow-orchestrator — set by the meta-orchestrator after `dispatch_workflow`. This is the token the workflow-orchestrator and activity-workers share. MUST be preserved on resume to avoid creating a new session. The session identity is embedded within the token. |
+| `sessionToken` | string | yes | Unified session token (opaque HMAC-signed string) for the target workflow. Both orchestrator and worker share this token. The session identity is embedded within the token. |
 | `sessionTokenEncrypted` | boolean | yes | Whether the token is encrypted |
 | `state` | object | yes | Full nested execution state |
 
@@ -79,8 +78,7 @@ After completing all steps and writing artifacts, the activity worker persists i
   "workflowId": "work-package",
   "workflowVersion": "1.2.0",
   "planningFolder": "/path/to/.engineering/artifacts/planning/2026-04-14-feature-xyz",
-  "sessionToken": "eyJ3Zi...<opaque-meta-token>...signature",
-  "clientSessionToken": "eyJ3Zi...<opaque-client-token>...signature",
+  "sessionToken": "eyJ3Zi...<opaque-unified-token>...signature",
   "sessionTokenEncrypted": false,
   "state": {
     "workflowId": "work-package",
@@ -112,8 +110,7 @@ After completing all steps and writing artifacts, the activity worker persists i
 
 ## Stale Session Detection
 
-When the workflow server restarts, it generates a new HMAC signing key, invalidating all saved session tokens. The token itself enables detection of this condition:
+When the workflow server restarts, it generates a new HMAC signing key, invalidating all saved session tokens. The server now auto-detects this condition:
 
-1. On resume, call `start_session({ session_token: saved_token })` to attempt token inheritance. The workflow is derived from the token's embedded workflow ID. If the server was restarted, the server will automatically re-sign the token and adopt the session (returning `adopted: true` with preserved state).
-2. If the token payload is corrupted and cannot be adopted, the server will return `recovered: true` with a fresh session. In this case, state must be reconstructed from the saved variables and `completedActivities`.
-3. Proactively, before attempting token inheritance, call `health_check`. If `uptime_seconds` is less than the time since `savedAt`, the token is guaranteed stale (but will be auto-adopted by the server).
+1. On resume, call `start_session({ session_token: saved_token, agent_id })` to attempt token inheritance. The server compares the token's timestamp against its own uptime. If the server started after the token was created, it automatically re-signs the token and adopts the session (returning `adopted: true` with preserved state).
+2. If the token payload is corrupted and cannot be adopted, the server will return `recovered: true` with a fresh session. In this case, state must be reconstructed from the saved variables and `completedActivities`. Call `start_session({ workflow_id, agent_id })` to create a fresh session for the target workflow, then transition to the currentActivity via `next_activity`.

--- a/meta/resources/08-workflow-state-format.md
+++ b/meta/resources/08-workflow-state-format.md
@@ -110,7 +110,4 @@ After completing all steps and writing artifacts, the activity worker persists i
 
 ## Stale Session Detection
 
-When the workflow server restarts, it generates a new HMAC signing key, invalidating all saved session tokens. The server now auto-detects this condition:
-
-1. On resume, call `start_session({ session_token: saved_token, agent_id })` to attempt token inheritance. The server compares the token's timestamp against its own uptime. If the server started after the token was created, it automatically re-signs the token and adopts the session (returning `adopted: true` with preserved state).
-2. If the token payload is corrupted and cannot be adopted, the server will return `recovered: true` with a fresh session. In this case, state must be reconstructed from the saved variables and `completedActivities`. Call `start_session({ workflow_id, agent_id })` to create a fresh session for the target workflow, then transition to the currentActivity via `next_activity`.
+On resume, call `start_session({ session_token: saved_token, agent_id })`. If the server restarted, it will either re-sign and adopt the session (returning `adopted: true`) or return `recovered: true` with a fresh session. In the latter case, reconstruct state from saved variables and `completedActivities` by calling `start_session({ workflow_id, agent_id })` then transitioning via `next_activity`.

--- a/meta/skills/10-meta-orchestrator.toon
+++ b/meta/skills/10-meta-orchestrator.toon
@@ -1,5 +1,5 @@
 id: meta-orchestrator
-version: 1.4.0
+version: 2.0.0
 capability: "Consolidated management skill for the top-level meta orchestrator role"
 description: "Consolidates orchestrate-workflow, session-protocol, state-management, and agent-conduct into one skill. The orchestrator loads this once at bootstrap to become fully capable of coordinating workflow execution. MUST be executed inline — NEVER delegated to a sub-agent."
 
@@ -16,23 +16,17 @@ protocol:
     - "Check for .gitmodules file: test -f .gitmodules && echo 'monorepo' || echo 'regular'"
     - "If regular: Set target_path to the repository root (.)."
     - "If monorepo: Present the repo-type checkpoint. If confirmed as monorepo, parse .gitmodules, present submodule-selection checkpoint, and set target_path to the selected submodule."
-  initialize-state[7]:
-    - "Call discover-session tool. If the user chose to resume, start_session was called with a saved token and is_resuming is true. Read the state file's variables and adopt them."
-    - "If is_resuming and token_may_be_stale is true: call health_check to confirm server uptime. If the server restarted after savedAt, the saved token is stale — skip token inheritance and proceed to fresh-session recovery."
-    - "If is_resuming and the saved token appears valid: call start_session({ session_token: saved_token }) to resume. The workflow is derived from the token. If start_session returns an HMAC signature verification error, do NOT retry with the same token — proceed to fresh-session recovery."
-    - "Fresh-session recovery: call start_session({ agent_id }) without a session_token to create a new session (defaults to meta workflow). The new session will have a different sid. State must be reconstructed manually. Transition to the currentActivity from the state file via next_activity, and restore variables from the state file. The completedActivities and completedSteps from the state file provide the activity history — the server will not have this, but the orchestrator tracks it independently."
-    - "If is_resuming: compare workflow version against the loaded workflow. Warn on mismatch. Adopt restored variables. Detect mode from restored variables — do not override unless the user explicitly requests a mode change."
-    - "If fresh session: determine planning_folder_path from workflow variables or user request context. Set variables to defaults, current_activity to initialActivity, initialize empty collections. Set is_resuming = false."
+  initialize-state[5]:
+    - "If resuming: call start_session({ session_token: saved_token, agent_id }) to resume the session. The workflow is derived from the token. The server auto-detects staleness and re-signs stale tokens. If start_session returns recovered: true (unrecoverable token), proceed to fresh-session recovery."
+    - "Fresh-session recovery: call start_session({ workflow_id, agent_id }) without a session_token to create a new session for the target workflow. State must be reconstructed manually. Transition to the currentActivity from the state file via next_activity, and restore variables from the state file."
+    - "If fresh session: call start_session({ workflow_id, agent_id }) to create a session for the target workflow. Determine planning_folder_path from workflow variables or user request context. Set variables to defaults, current_activity to initialActivity, initialize empty collections. Set is_resuming = false."
     - "If fresh session and planning_folder_path is set: create the initial workflow-state.json at {planning_folder_path}/workflow-state.json containing the current session_token, workflow metadata, and default state. This ensures the token is on disk before the first activity is dispatched. See the workflow-state-format resource for the file structure."
-  dispatch-workflow[8]:
-    - "RESUME CHECK (evaluate first): If is_resuming = true AND the state file contains a clientSessionToken field: do NOT call dispatch_workflow. The clientSessionToken IS the workflow-orchestrator's session token. Use harness-compat::continue-agent with a prompt that includes the clientSessionToken as {client_session_token}, the currentActivity from the state file, all restored state variables, and is_resuming: true. The workflow-orchestrator will call start_session({ session_token: clientSessionToken, agent_id }) to adopt the saved session and resume at the saved activity. Set is_resuming = false after this dispatch."
-    - "FRESH DISPATCH: If is_resuming = false (or state file has no clientSessionToken): call dispatch_workflow({ workflow_id, parent_session_token, variables }) to create an independent client session for the workflow-orchestrator. Wait for the dispatch package response."
-    - "After calling dispatch_workflow: immediately write clientSessionToken from the response into the state file. This ensures the client session can be recovered on restart. Do not wait for the first activity to complete — write this value now."
-    - "Compose the prompt using the client_prompt returned in the dispatch package — do NOT inject paraphrased skill content."
-    - "Spawn the workflow-orchestrator sub-agent using the harness-compat::spawn-agent. Pass the client_prompt as the prompt. If continuing an existing workflow-orchestrator, use the continue-agent operation instead. ALWAYS foreground — never background. The meta-orchestrator blocks waiting for checkpoint yields."
-    - "First dispatch: harness-compat::spawn-agent. Subsequent dispatches: harness-compat::continue-agent."
-    - "For resumed sub-agents: the continuation prompt MUST include clientSessionToken as {client_session_token}, the currentActivity from the state file, and all restored state variables. The sub-agent uses start_session({ session_token: clientSessionToken, agent_id }) to adopt the session."
-    - "The workflow-orchestrator runs in an independent session. It does NOT inherit the meta-orchestrator token."
+    - "If is_resuming: compare workflow version against the loaded workflow. Warn on mismatch. Adopt restored variables. Detect mode from restored variables — do not override unless the user explicitly requests a mode change."
+  dispatch-workflow[4]:
+    - "FRESH DISPATCH: If is_resuming = false: the orchestrator already has a session_token for the target workflow from initialize-state. Compose the worker prompt using the template from get_resource('meta/05'). Fill in placeholders: workflow_id, activity_id (from initialActivity), state_variables_block, planning_folder_path, workspace_root, todays_date. Also include session_token as {session_token} so the worker can adopt the session via start_session({ session_token, agent_id })."
+    - "RESUME DISPATCH: If is_resuming = true: the orchestrator has the restored session_token. Compose the worker prompt with the same template, using the currentActivity from the state file and all restored state variables. Include session_token as {session_token}. The worker calls start_session({ session_token, agent_id }) to adopt the session and resume at the saved activity. Set is_resuming = false after this dispatch."
+    - "Spawn the workflow-orchestrator sub-agent using harness-compat::spawn-agent. Pass the composed prompt. If continuing an existing workflow-orchestrator, use harness-compat::continue-agent instead. ALWAYS foreground — never background. The meta-orchestrator blocks waiting for checkpoint yields."
+    - "The workflow-orchestrator runs in the same session as the meta-orchestrator — there is one unified session token for the target workflow."
   process-result[2]:
     - "If checkpoint_pending: parse the <checkpoint_yield> block and present to user via AskQuestion, then respond_checkpoint."
     - "If workflow_complete: apply variables_changed to session state, record completion, proceed to end-workflow."
@@ -48,10 +42,9 @@ protocol:
     - "MANDATORY after trace append. Run git status --porcelain .engineering/artifacts/ to detect uncommitted changes"
     - "Stage all changed files. Follow .engineering/AGENTS.md commit procedures (submodule paths require two-step commit-and-push)"
     - "Commit with conventional format: docs(<workflow-id>): <activity-id> artifacts"
-  persist-state[4]:
-    - "MANDATORY after commit. Construct state file containing: the current session_token (opaque string, meta session), variable state (JSON), and activity trace (from get_trace)"
+  persist-state[3]:
+    - "MANDATORY after commit. Construct state file containing: the current session_token, variable state (JSON), and activity trace (from get_trace)"
     - "Write to {planning_folder_path}/workflow-state.json using agent file tools"
-    - "CRITICAL: Preserve clientSessionToken field when writing the state file. Perform a read-modify-write: read the existing file, update only the meta session fields (sessionToken, savedAt, state, description), and write back. Never overwrite clientSessionToken with the meta session token."
     - "If planning_folder_path is not set, skip silently"
   evaluate-transition[2]:
     - "Evaluate transition conditions against state variables — take first matching or default"
@@ -87,7 +80,7 @@ rules:
 errors:
   stale_token:
     cause: "Server restarted and generated a new HMAC signing key, invalidating the saved session token"
-    recovery: "Call start_session({ agent_id }) without a saved token to get a fresh session (defaults to meta workflow). Reconstruct state by transitioning to the currentActivity from the state file and restoring variables manually."
+    recovery: "The server auto-detects staleness and re-signs tokens. If start_session returns recovered: true (unrecoverable payload), call start_session({ workflow_id, agent_id }) to create a fresh session and reconstruct state from the state file."
   worker_timeout:
     cause: "Sub-agent did not return within expected time"
     recovery: "Check terminal output. Resume if still running. If stuck, create new sub-agent and re-dispatch."

--- a/meta/skills/10-meta-orchestrator.toon
+++ b/meta/skills/10-meta-orchestrator.toon
@@ -17,7 +17,7 @@ protocol:
     - "If regular: Set target_path to the repository root (.)."
     - "If monorepo: Present the repo-type checkpoint. If confirmed as monorepo, parse .gitmodules, present submodule-selection checkpoint, and set target_path to the selected submodule."
   initialize-state[5]:
-    - "If resuming: call start_session({ session_token: saved_token, agent_id }) to resume the session. The workflow is derived from the token. The server auto-detects staleness and re-signs stale tokens. If start_session returns recovered: true (unrecoverable token), proceed to fresh-session recovery."
+    - "If resuming: call start_session({ session_token: saved_token, agent_id }) to resume the session. The workflow is derived from the token. If start_session returns recovered: true, proceed to fresh-session recovery."
     - "Fresh-session recovery: call start_session({ workflow_id, agent_id }) without a session_token to create a new session for the target workflow. State must be reconstructed manually. Transition to the currentActivity from the state file via next_activity, and restore variables from the state file."
     - "If fresh session: call start_session({ workflow_id, agent_id }) to create a session for the target workflow. Determine planning_folder_path from workflow variables or user request context. Set variables to defaults, current_activity to initialActivity, initialize empty collections. Set is_resuming = false."
     - "If fresh session and planning_folder_path is set: create the initial workflow-state.json at {planning_folder_path}/workflow-state.json containing the current session_token, workflow metadata, and default state. This ensures the token is on disk before the first activity is dispatched. See the workflow-state-format resource for the file structure."
@@ -80,9 +80,8 @@ rules:
 errors:
   stale_token:
     cause: "Server restarted and generated a new HMAC signing key, invalidating the saved session token"
-    recovery: "The server auto-detects staleness and re-signs tokens. If start_session returns recovered: true (unrecoverable payload), call start_session({ workflow_id, agent_id }) to create a fresh session and reconstruct state from the state file."
+    recovery: "If start_session returns recovered: true, call start_session({ workflow_id, agent_id }) to create a fresh session and reconstruct state from the state file."
   worker_timeout:
-    cause: "Sub-agent did not return within expected time"
     recovery: "Check terminal output. Resume if still running. If stuck, create new sub-agent and re-dispatch."
   transition_ambiguous:
     cause: "Multiple transition conditions evaluate to true"

--- a/meta/skills/12-workflow-orchestrator.toon
+++ b/meta/skills/12-workflow-orchestrator.toon
@@ -54,7 +54,7 @@ protocol:
     - "If workflow complete, prepare final summary including: Workflow Name, Start/Completion Dates; Activities Completed, Outcomes Achieved; Key Decisions Made (Checkpoints, Options, Rationale); Artifacts Created; Follow-Up Items."
     - "If workflow complete: return { status: 'workflow_complete', final_state: ... } to the parent orchestrator."
   handle-sub-workflows[3]:
-    - "If a client workflow needs to dispatch a sub-workflow, call dispatch_workflow({ workflow_id: 'child-workflow', parent_session_token: '<your_token>' })."
+    - "If a client workflow needs to dispatch a sub-workflow, call start_session({ workflow_id: 'child-workflow', parent_session_token: '<your_token>', agent_id: 'orchestrator' })."
     - "Spawn a NEW workflow-orchestrator for the sub-workflow using harness-compat::spawn-agent."
     - "Manage the child inline, bubbling its checkpoints further up the chain to the meta-orchestrator."
   session-protocol[1]:
@@ -88,7 +88,7 @@ rules:
 errors:
   stale_token:
     cause: "Server restarted and generated a new HMAC signing key, invalidating the saved session token"
-    recovery: "Call start_session({ agent_id }) without a saved token to get a fresh session (defaults to meta workflow). Reconstruct state by transitioning to the currentActivity from the state file and restoring variables manually."
+    recovery: "The server auto-detects staleness and re-signs tokens. If start_session returns recovered: true (unrecoverable payload), call start_session({ workflow_id, agent_id }) to create a fresh session and reconstruct state from the state file."
   worker_timeout:
     cause: "Worker sub-agent did not return within expected time"
     recovery: "Check terminal output. Resume if still running. If stuck, create new worker and re-dispatch."

--- a/meta/skills/12-workflow-orchestrator.toon
+++ b/meta/skills/12-workflow-orchestrator.toon
@@ -88,7 +88,7 @@ rules:
 errors:
   stale_token:
     cause: "Server restarted and generated a new HMAC signing key, invalidating the saved session token"
-    recovery: "The server auto-detects staleness and re-signs tokens. If start_session returns recovered: true (unrecoverable payload), call start_session({ workflow_id, agent_id }) to create a fresh session and reconstruct state from the state file."
+    recovery: "If start_session returns recovered: true, call start_session({ workflow_id, agent_id }) to create a fresh session and reconstruct state from the state file."
   worker_timeout:
     cause: "Worker sub-agent did not return within expected time"
     recovery: "Check terminal output. Resume if still running. If stuck, create new worker and re-dispatch."

--- a/meta/workflow.toon
+++ b/meta/workflow.toon
@@ -1,5 +1,5 @@
 id: meta
-version: 2.0.0
+version: 3.0.0
 title: Meta Workflow
 description: "Bootstrap workflow for the workflow-server. Provides self-contained activities for workflow lifecycle management (start, resume, end). Each activity is an independent entry point matched via recognition patterns."
 author: m2ux


### PR DESCRIPTION
## Summary
Update meta workflow definitions for the unified session token architecture — single token, no `clientSessionToken`, no `dispatch_workflow`, auto-staleness detection.

## Context
Companion to the source PR (#107) which removes `dispatch_workflow` and adds `workflow_id`/`parent_session_token` to `start_session`. This PR updates all workflow TOON files, skills, and resources to reflect the single-token design.

## Changes
- **`10-meta-orchestrator.toon`** — `initialize-state` uses `start_session({ session_token })` for resume and `start_session({ workflow_id })` for fresh sessions; `dispatch-workflow` references single unified token; `persist-state` writes only one `session_token`; removed dual-token management branches
- **`12-workflow-orchestrator.toon`** — `handle-sub-workflows` uses `start_session({ workflow_id, parent_session_token })` instead of `dispatch_workflow`; `stale_token` error recovery references auto-detection
- **`01-dispatch-workflow.toon`** — Updated to use `start_session` with `workflow_id` and `parent_session_token`
- **`02-resume-workflow.toon`** — Simplified to single-token resume
- **`00-discover-session.toon`** — Removed `token_may_be_stale` (auto-detected server-side now)
- **`08-workflow-state-format.md`** — Removed `clientSessionToken`/`clientSessionId`; single `sessionToken`
- **`05-worker-prompt-template.md`** — Updated bootstrap to use `start_session({ session_token })` and `{session_token}` placeholder
- **`workflow.toon`** — Removed `token_may_be_stale` variable

## Testing
Workflow definitions are validated by the workflow-server at load time. Run the server and verify:
1. `list_workflows` returns the meta workflow without errors
2. `start_session({ workflow_id: "work-package" })` creates a work-package session
3. Resume with a saved token works in 2 calls

## Links
- Source PR: #107
