### PR TITLE
feat: add requirements-refinement workflow

### DIFF
--- a/requirements-refinement/README.md
+++ b/requirements-refinement/README.md
@@ -1,0 +1,68 @@
+# Requirements Refinement Workflow
+
+> v1.0.0 — Refine a canonical requirements specification from a source document (a meeting transcript or an unstructured document): classify, analyze, apply, validate, correct within a bounded loop, and stage the result for human promotion. Operates on local files; performs no version-control operations.
+
+---
+
+## Overview
+
+This workflow turns a source document — a meeting transcript or an unstructured document (a proposal,
+brief, email, or similar) — into reviewed changes against a canonical requirements specification (an
+SRS-style document). It classifies the source, analyzes it for requirement changes, applies them while
+preserving the [specification protocol](resources/specification-protocol.md) verbatim, validates the
+result, iteratively corrects within a bounded loop, and stages a finalized specification plus a change
+summary in the planning folder for a human to review and promote.
+
+Each source is traced: a meeting transcript is recorded as an `SRC-MTG###` reference, an unstructured
+document as an `SRC-DOC###` reference credited to its author.
+
+It is parameterized: the source document and the target specification are supplied as inputs, so the
+workflow both **augments** an existing specification and **creates** one from scratch. Every
+intermediate and final artifact lives in the run's planning folder; the workflow makes no commits and
+never edits the canonical document in place.
+
+**Use this workflow when you want to:**
+
+- Fold the requirement changes from a meeting or a document into a specification, with traceability.
+- Keep a specification conformant to a fixed protocol (entry format, identifier schemes, status rules).
+- Review proposed specification changes — analysis, working drafts, validation verdict, and a change
+  summary — as artifacts before anything is promoted.
+
+## Inputs
+
+| Variable | Description |
+|----------|-------------|
+| `source_path` | Filesystem path to the source document to process (a meeting transcript or an unstructured document) |
+| `target_doc_path` | Filesystem path to the canonical specification to augment or create |
+
+## Activities
+
+| # | Activity | Purpose |
+|---|----------|---------|
+| 01 | [Intake Sources](activities/01-intake-sources.toon) | Capture and validate the source paths; classify source type; detect augment-vs-create; load sources |
+| 02 | [Analyze Source](activities/02-analyze-source.toon) | Produce a structured requirements analysis report; confirm before applying |
+| 03 | [Update Specification](activities/03-update-specification.toon) | Apply the analysis (or corrections) to a versioned working specification |
+| 04 | [Validate Specification](activities/04-validate-specification.toon) | Validate, categorize issues, and route |
+| 05 | [Finalize Specification](activities/05-finalize-specification.toon) | Stage the final specification and change summary for promotion |
+| 06 | [Report Failure](activities/06-report-failure.toon) | Compile a failure report when critical issues or the correction budget stop refinement |
+
+## Flow
+
+```
+intake-sources → analyze-source → update-specification → validate-specification
+                                              ▲                      │
+              (correctable & under the cap)   └──────────────────────┤
+                                                                     ├─ validation passed → finalize-specification
+                                                                     └─ critical / cap reached → report-failure
+```
+
+The correction loop is bounded by `max_correction_iterations` (default 3). When validation passes the
+workflow finalizes; when critical issues appear or the budget is exhausted it reports failure. No
+specification is promoted automatically.
+
+## Structure
+
+- [`workflow.toon`](workflow.toon) — metadata, variables, rules, and artifact location.
+- [`activities/`](activities/) — the six pipeline activities.
+- [`techniques/`](techniques/) — the procedures the activities apply.
+- [`resources/`](resources/) — the specification protocol and the report/rubric/summary templates.

--- a/requirements-refinement/README.md
+++ b/requirements-refinement/README.md
@@ -1,6 +1,6 @@
 # Requirements Refinement Workflow
 
-> v1.0.0 — Refine a canonical requirements specification from a source document (a meeting transcript or an unstructured document): classify, analyze, apply, validate, correct within a bounded loop, and stage the result for human promotion. Operates on local files; performs no version-control operations.
+> v1.1.0 — Refine a canonical requirements specification from a source document (a meeting transcript or an unstructured document): classify, analyze, apply, validate, correct within a bounded loop, and stage the result for human promotion. Operates on local files; performs no version-control operations.
 
 ---
 
@@ -42,7 +42,7 @@ never edits the canonical document in place.
 | 01 | [Intake Sources](activities/01-intake-sources.toon) | Capture and validate the source paths; classify source type; detect augment-vs-create; load sources |
 | 02 | [Analyze Source](activities/02-analyze-source.toon) | Produce a structured requirements analysis report; confirm before applying |
 | 03 | [Update Specification](activities/03-update-specification.toon) | Apply the analysis (or corrections) to a versioned working specification |
-| 04 | [Validate Specification](activities/04-validate-specification.toon) | Validate, categorize issues, and route |
+| 04 | [Validate Specification](activities/04-validate-specification.toon) | Validate (conformance + source coverage), categorize issues, and route |
 | 05 | [Finalize Specification](activities/05-finalize-specification.toon) | Stage the final specification and change summary for promotion |
 | 06 | [Report Failure](activities/06-report-failure.toon) | Compile a failure report when critical issues or the correction budget stop refinement |
 

--- a/requirements-refinement/activities/01-intake-sources.toon
+++ b/requirements-refinement/activities/01-intake-sources.toon
@@ -1,0 +1,94 @@
+id: intake-sources
+version: 1.1.0
+name: Intake Sources
+description: "Capture and validate the source-document and target-specification paths, classify the source as a meeting transcript or an unstructured document, determine whether the specification is being augmented or created, and load both sources."
+problem: The workflow needs validated input paths, a classified source type, and loaded source content before analysis can begin
+recognition[5]:
+  - refine requirements from transcript
+  - update requirements specification
+  - process meeting transcript
+  - parse document into requirements
+  - augment requirements document
+required: true
+estimatedTime: 5-10m
+rules[1]:
+  - "Capture, classify, and load sources only; do not analyze or modify the specification during intake"
+steps[6]:
+  - id: capture-paths
+    name: Capture Source Paths
+    description: "Capture source_path and target_doc_path from the user request, and record spec_basename from the target path."
+    actions[1]:
+      - action: set
+        target: spec_basename
+        description: "Basename of target_doc_path (filename without directory)."
+  - id: validate-source
+    name: Validate Source Readable
+    description: "Confirm the source document at source_path exists and is non-empty before proceeding."
+    actions[1]:
+      - action: validate
+        target: "source_path readable and non-empty"
+        message: "Source document not found or empty at the supplied source_path"
+  - id: classify-source-type
+    name: Classify Source Type
+    description: "Infer from the document's content whether the source is a meeting transcript or an unstructured document, and set source_type — meeting sources are referenced as SRC-MTG###, document sources as SRC-DOC### credited to the author."
+    actions[1]:
+      - action: set
+        target: source_type
+        description: "meeting when the document is a meeting transcript; document when it is an unstructured document."
+  - id: detect-target-existence
+    name: Detect Target Existence
+    description: "Set target_doc_exists according to whether a file exists at target_doc_path — true selects augment behaviour, false selects create-from-scratch."
+    actions[1]:
+      - action: set
+        target: target_doc_exists
+        description: "True when a file exists at target_doc_path; false otherwise."
+  - id: load-sources
+    name: Load Sources
+    description: "Read the source document and, when target_doc_exists, the current specification, so downstream activities can reference their content."
+  - id: record-intake
+    name: Record Intake
+    description: "Record the captured sources, classified source type, detected mode, and spec_basename in the intake artifact."
+    actions[1]:
+      - action: message
+        message: "Created: intake.md"
+checkpoints[1]:
+  - id: sources-confirmed
+    name: Sources Confirmation
+    message: "Source ({source_type}): {source_path}. Target specification: {target_doc_path} ({target_doc_exists}). Proceed with these sources?"
+    blocking: true
+    options[2]:
+      - id: confirmed
+        label: "Yes, proceed"
+        description: "Sources, classified type, and mode are correct; continue to analysis."
+        effect:
+          setVariable:
+            sources_confirmed: true
+      - id: revise
+        label: "Correct the sources"
+        description: "A source path, the classified source type, or the augment/create mode is wrong and must be corrected before proceeding."
+artifacts[1]:
+  - id: intake-doc
+    name: intake.md
+    location: planning
+    description: "Captured source-document and target-specification paths, classified source type, detected augment/create mode, and spec_basename"
+transitions[1]:
+  - to: analyze-source
+    condition:
+      type: simple
+      variable: sources_confirmed
+      operator: ==
+      value: true
+    isDefault: true
+exitActions[1]{action,message}:
+  message,README PROGRESS: Update planning folder README.md — mark intake sources as ✅ Complete.
+outcome[4]:
+  - Source-document and target-specification paths captured and validated
+  - Source classified as meeting transcript or unstructured document
+  - Augment-versus-create mode determined
+  - Sources loaded for downstream activities
+context_to_preserve[5]:
+  - source_path - Path to the source document
+  - source_type - Meeting transcript or unstructured document
+  - target_doc_path - Path to the canonical specification
+  - target_doc_exists - Whether the specification is being augmented or created
+  - spec_basename - Basename of the target specification

--- a/requirements-refinement/activities/02-analyze-source.toon
+++ b/requirements-refinement/activities/02-analyze-source.toon
@@ -1,5 +1,5 @@
 id: analyze-source
-version: 1.0.0
+version: 1.1.0
 name: Analyze Source
 description: "Parse the source document against the current specification and produce a structured requirements analysis report, then confirm it with the user before any changes are applied."
 problem: Requirement changes expressed in the source document must be identified and mapped before the specification can be updated
@@ -10,7 +10,7 @@ techniques:
 steps[2]:
   - id: analyze
     name: Analyze Source
-    description: "Apply analyze-source to parse the source document and current specification into the requirements analysis report (source reference, new/updated/deprecated requirements, document updates required, quality issues, implementation notes)."
+    description: "Apply analyze-source to parse the source document and current specification into the requirements analysis report, including a completeness sweep that traces every normative source statement into the source-coverage matrix (source reference, new/updated/deprecated requirements, coverage matrix, document updates required, quality issues, implementation notes)."
   - id: record-analysis
     name: Record Analysis
     description: "Record the completed analysis report in the planning folder."
@@ -36,7 +36,7 @@ artifacts[1]:
   - id: requirements-analysis-doc
     name: requirements-analysis.md
     location: planning
-    description: "Structured requirements analysis report: source reference, new/updated/deprecated requirements, document updates required, quality issues, implementation notes"
+    description: "Structured requirements analysis report: source reference, new/updated/deprecated requirements, source-coverage matrix, document updates required, quality issues, implementation notes"
 transitions[1]:
   - to: update-specification
     condition:

--- a/requirements-refinement/activities/02-analyze-source.toon
+++ b/requirements-refinement/activities/02-analyze-source.toon
@@ -1,0 +1,55 @@
+id: analyze-source
+version: 1.0.0
+name: Analyze Source
+description: "Parse the source document against the current specification and produce a structured requirements analysis report, then confirm it with the user before any changes are applied."
+problem: Requirement changes expressed in the source document must be identified and mapped before the specification can be updated
+required: true
+estimatedTime: 10-20m
+techniques:
+  primary: analyze-source
+steps[2]:
+  - id: analyze
+    name: Analyze Source
+    description: "Apply analyze-source to parse the source document and current specification into the requirements analysis report (source reference, new/updated/deprecated requirements, document updates required, quality issues, implementation notes)."
+  - id: record-analysis
+    name: Record Analysis
+    description: "Record the completed analysis report in the planning folder."
+    actions[1]:
+      - action: message
+        message: "Created: requirements-analysis.md"
+checkpoints[1]:
+  - id: analysis-confirmed
+    name: Analysis Confirmation
+    message: "Here is the requirements analysis derived from the source. Approve it for application to the specification?"
+    blocking: true
+    options[2]:
+      - id: confirmed
+        label: "Yes, apply this analysis"
+        description: "Analysis is accurate; proceed to update the specification."
+        effect:
+          setVariable:
+            analysis_confirmed: true
+      - id: revise
+        label: "Revise the analysis"
+        description: "Analysis misreads the source or misses changes and must be revised before proceeding."
+artifacts[1]:
+  - id: requirements-analysis-doc
+    name: requirements-analysis.md
+    location: planning
+    description: "Structured requirements analysis report: source reference, new/updated/deprecated requirements, document updates required, quality issues, implementation notes"
+transitions[1]:
+  - to: update-specification
+    condition:
+      type: simple
+      variable: analysis_confirmed
+      operator: ==
+      value: true
+    isDefault: true
+exitActions[1]{action,message}:
+  message,README PROGRESS: Update planning folder README.md — mark source analysis as ✅ Complete.
+outcome[2]:
+  - Requirement changes identified and mapped to identifiers
+  - Analysis report approved for application
+context_to_preserve[2]:
+  - analysis_confirmed - Whether the analysis was approved
+  - requirements_analysis - Path to the analysis artifact

--- a/requirements-refinement/activities/03-update-specification.toon
+++ b/requirements-refinement/activities/03-update-specification.toon
@@ -1,0 +1,47 @@
+id: update-specification
+version: 1.0.0
+name: Update Specification
+description: "Apply the requirements analysis (initial pass) or the validation findings (correction pass) to produce the complete updated specification, preserving the specification protocol verbatim, and write it as a versioned working specification."
+problem: The confirmed requirement changes — or outstanding correction findings — must be applied to produce an updated specification
+required: true
+estimatedTime: 15-30m
+techniques:
+  primary: update-specification
+steps[3]:
+  - id: register-correction-pass
+    name: Register Correction Pass
+    description: "On a correction re-entry, increment correction_iteration so the working specification is versioned per pass."
+    condition:
+      type: simple
+      variable: has_correctable_issues
+      operator: ==
+      value: true
+    actions[1]:
+      - action: set
+        target: correction_iteration
+        description: "Previous correction_iteration value plus one; runs only on correction re-entry."
+  - id: apply-changes
+    name: Apply Changes
+    description: "Apply update-specification: in the initial pass apply the confirmed analysis; in a correction pass address the correctable validation findings. Produce the complete updated specification with the protocol preserved and new requirements set to pending."
+  - id: record-working-spec
+    name: Record Working Specification
+    description: "Record the updated specification as the versioned working specification for this pass."
+    actions[1]:
+      - action: message
+        message: "Created: working-spec-{correction_iteration}.md"
+artifacts[1]:
+  - id: working-specification
+    name: working-spec-{correction_iteration}.md
+    location: planning
+    description: "Complete updated specification for this pass (pass 0 is the initial update; later numbers are correction passes)"
+transitions[1]:
+  - to: validate-specification
+    isDefault: true
+exitActions[1]{action,message}:
+  message,README PROGRESS: Update planning folder README.md — record the working specification for this pass.
+outcome[2]:
+  - Complete updated specification produced with the protocol preserved
+  - Versioned working specification recorded for validation
+context_to_preserve[2]:
+  - correction_iteration - Current correction pass number
+  - working_specification - Path to the working specification for this pass

--- a/requirements-refinement/activities/04-validate-specification.toon
+++ b/requirements-refinement/activities/04-validate-specification.toon
@@ -1,0 +1,66 @@
+id: validate-specification
+version: 1.0.0
+name: Validate Specification
+description: "Validate the updated specification against structural, identifier-uniqueness, consistency, and protocol-conformance checks, categorize each issue as critical or correctable, and route to finalization, another correction pass, or failure reporting."
+problem: The updated specification must be checked for quality and conformance before it can be finalized
+required: true
+estimatedTime: 10-20m
+techniques:
+  primary: validate-specification
+steps[2]:
+  - id: validate
+    name: Validate Specification
+    description: "Apply validate-specification to check the working specification against the validation rubric and produce a categorized verdict in the validation report."
+  - id: evaluate-verdict
+    name: Evaluate Verdict
+    description: "Read the verdict and set the routing variables that the transitions evaluate."
+    actions[3]:
+      - action: set
+        target: validation_passed
+        description: "True when the verdict is passed with no critical or correctable issues."
+      - action: set
+        target: has_critical_issues
+        description: "True when any issue is critical or irreconcilable."
+      - action: set
+        target: has_correctable_issues
+        description: "True when correctable issues remain and no critical issue is present."
+artifacts[1]:
+  - id: validation-report
+    name: validation-report-{correction_iteration}.md
+    location: planning
+    description: "Validation verdict and categorized issues (critical/irreconcilable versus correctable) for this pass"
+transitions[3]:
+  - to: finalize-specification
+    condition:
+      type: simple
+      variable: validation_passed
+      operator: ==
+      value: true
+  - to: update-specification
+    condition:
+      type: and
+      conditions[3]:
+        - type: simple
+          variable: has_correctable_issues
+          operator: ==
+          value: true
+        - type: simple
+          variable: has_critical_issues
+          operator: ==
+          value: false
+        - type: simple
+          variable: correction_iteration
+          operator: "<"
+          value: 3
+  - to: report-failure
+    isDefault: true
+exitActions[1]{action,message}:
+  message,README PROGRESS: Update planning folder README.md — record the validation verdict for this pass.
+outcome[2]:
+  - Updated specification validated and issues categorized
+  - Routing decision made toward finalization, correction, or failure
+context_to_preserve[4]:
+  - validation_passed - Whether validation passed cleanly
+  - has_correctable_issues - Whether a correction pass is warranted
+  - has_critical_issues - Whether manual intervention is required
+  - validation_report - Path to the validation report for this pass

--- a/requirements-refinement/activities/04-validate-specification.toon
+++ b/requirements-refinement/activities/04-validate-specification.toon
@@ -1,5 +1,5 @@
 id: validate-specification
-version: 1.0.0
+version: 1.1.0
 name: Validate Specification
 description: "Validate the updated specification against structural, identifier-uniqueness, consistency, and protocol-conformance checks, categorize each issue as critical or correctable, and route to finalization, another correction pass, or failure reporting."
 problem: The updated specification must be checked for quality and conformance before it can be finalized
@@ -7,23 +7,30 @@ required: true
 estimatedTime: 10-20m
 techniques:
   primary: validate-specification
-steps[2]:
+steps[3]:
   - id: validate
     name: Validate Specification
-    description: "Apply validate-specification to check the working specification against the validation rubric and produce a categorized verdict in the validation report."
+    description: "Apply validate-specification to check the working specification against the validation rubric (conformance and source coverage) and produce a categorized verdict in the validation report."
+  - id: check-source-coverage
+    name: Check Source Coverage
+    description: "Confirm every normative source statement maps to a requirement via the source-coverage matrix, and set source_coverage_complete."
+    actions[1]:
+      - action: set
+        target: source_coverage_complete
+        description: "True when every normative source statement maps to at least one requirement."
   - id: evaluate-verdict
     name: Evaluate Verdict
     description: "Read the verdict and set the routing variables that the transitions evaluate."
     actions[3]:
       - action: set
         target: validation_passed
-        description: "True when the verdict is passed with no critical or correctable issues."
+        description: "True when no critical or correctable issues remain and source_coverage_complete is true."
       - action: set
         target: has_critical_issues
         description: "True when any issue is critical or irreconcilable."
       - action: set
         target: has_correctable_issues
-        description: "True when correctable issues remain and no critical issue is present."
+        description: "True when correctable issues remain — including source-coverage gaps — and no critical issue is present."
 artifacts[1]:
   - id: validation-report
     name: validation-report-{correction_iteration}.md
@@ -59,8 +66,9 @@ exitActions[1]{action,message}:
 outcome[2]:
   - Updated specification validated and issues categorized
   - Routing decision made toward finalization, correction, or failure
-context_to_preserve[4]:
+context_to_preserve[5]:
   - validation_passed - Whether validation passed cleanly
   - has_correctable_issues - Whether a correction pass is warranted
   - has_critical_issues - Whether manual intervention is required
+  - source_coverage_complete - Whether every normative source statement maps to a requirement
   - validation_report - Path to the validation report for this pass

--- a/requirements-refinement/activities/05-finalize-specification.toon
+++ b/requirements-refinement/activities/05-finalize-specification.toon
@@ -1,0 +1,53 @@
+id: finalize-specification
+version: 1.0.0
+name: Finalize Specification
+description: "Assemble the validation-passed specification and a human-readable change summary as planning-folder artifacts, and confirm the user accepts them for promotion to the canonical location."
+problem: A validated specification must be staged with a change summary for the user to review and promote
+required: true
+estimatedTime: 5-10m
+techniques:
+  primary: finalize-specification
+steps[3]:
+  - id: assemble-final-spec
+    name: Assemble Final Specification
+    description: "Apply finalize-specification to copy the validation-passed working specification into the final specification artifact."
+  - id: write-change-summary
+    name: Write Change Summary
+    description: "Summarize the applied changes (new/updated/deprecated requirements, added sources, validation status) into the change summary artifact."
+    actions[1]:
+      - action: message
+        message: "Created: final-spec.md and change-summary.md"
+  - id: present-for-promotion
+    name: Present for Promotion
+    description: "Present the final specification and change summary for the user to review and promote to {target_doc_path}."
+checkpoints[1]:
+  - id: finalization-confirmed
+    name: Finalization Confirmation
+    message: "The final specification ({spec_basename}) and change summary are staged in the planning folder. Accept them for promotion?"
+    blocking: true
+    options[2]:
+      - id: accepted
+        label: "Accept — staged for promotion"
+        description: "Final specification and change summary are accepted; the user will promote them to the canonical location."
+        effect:
+          setVariable:
+            finalization_confirmed: true
+      - id: revise
+        label: "Revise before finalizing"
+        description: "The final specification or change summary needs revision before acceptance."
+artifacts[2]:
+  - id: final-specification
+    name: final-spec.md
+    location: planning
+    description: "The validation-passed specification, staged for promotion to the canonical location"
+  - id: change-summary
+    name: change-summary.md
+    location: planning
+    description: "Human-readable summary of all applied changes and the validation status"
+outcome[2]:
+  - Final specification and change summary staged in the planning folder
+  - User acceptance for promotion recorded
+context_to_preserve[3]:
+  - finalization_confirmed - Whether the final specification was accepted
+  - final_specification - Path to the final specification artifact
+  - change_summary - Path to the change summary artifact

--- a/requirements-refinement/activities/06-report-failure.toon
+++ b/requirements-refinement/activities/06-report-failure.toon
@@ -1,0 +1,38 @@
+id: report-failure
+version: 1.0.0
+name: Report Failure
+description: "Compile a failure report describing the unresolved critical issues, the correction history, and the manual resolution required when refinement cannot complete automatically; no specification is promoted."
+problem: When critical issues remain or the correction budget is exhausted, the user needs a clear account of what requires manual intervention
+required: true
+estimatedTime: 5-10m
+techniques:
+  primary: report-failure
+steps[2]:
+  - id: compile-failure-report
+    name: Compile Failure Report
+    description: "Apply report-failure to record the verdict, the correction history (correction_iteration of max_correction_iterations), the critical or irreconcilable issues, and the manual resolution required."
+    actions[1]:
+      - action: message
+        message: "Created: failure-report.md"
+  - id: present-failure
+    name: Present Failure
+    description: "Present the failure report and the required manual intervention to the user."
+checkpoints[1]:
+  - id: failure-acknowledged
+    name: Failure Acknowledgement
+    message: "Refinement could not complete automatically. The failure report lists the critical issues and the manual resolution required. Acknowledge?"
+    blocking: true
+    options[1]:
+      - id: acknowledged
+        label: "Acknowledged"
+        description: "The failure report has been reviewed; manual intervention will follow outside the workflow."
+artifacts[1]:
+  - id: failure-report
+    name: failure-report.md
+    location: planning
+    description: "Critical/irreconcilable issues, correction history, and manual-resolution guidance"
+outcome[2]:
+  - Failure report compiled with critical issues and resolution guidance
+  - No specification promoted
+context_to_preserve[1]:
+  - failure_report - Path to the failure report artifact

--- a/requirements-refinement/activities/README.md
+++ b/requirements-refinement/activities/README.md
@@ -1,0 +1,18 @@
+# Requirements Refinement Activities
+
+> Part of the [Requirements Refinement Workflow](../README.md)
+
+The six sequential activities of the pipeline. The numeric prefix is the execution order and supplies
+each activity's artifact prefix.
+
+| # | Activity | Produces | Transitions to |
+|---|----------|----------|----------------|
+| 01 | [intake-sources](01-intake-sources.toon) | `intake.md` | analyze-source |
+| 02 | [analyze-source](02-analyze-source.toon) | `requirements-analysis.md` | update-specification |
+| 03 | [update-specification](03-update-specification.toon) | `working-spec-{n}.md` | validate-specification |
+| 04 | [validate-specification](04-validate-specification.toon) | `validation-report-{n}.md` | finalize-specification · update-specification · report-failure |
+| 05 | [finalize-specification](05-finalize-specification.toon) | `final-spec.md`, `change-summary.md` | — (complete) |
+| 06 | [report-failure](06-report-failure.toon) | `failure-report.md` | — (complete) |
+
+The correction loop is the conditional edge from `validate-specification` back to `update-specification`,
+guarded by the correctable-issue flags and the `correction_iteration` counter.

--- a/requirements-refinement/resources/README.md
+++ b/requirements-refinement/resources/README.md
@@ -1,0 +1,13 @@
+# Requirements Refinement Resources
+
+> Part of the [Requirements Refinement Workflow](../README.md)
+
+Reference material the techniques draw on: the canonical specification protocol and the templates for
+the analysis report, validation, and change summary.
+
+| Resource | Contents |
+|----------|----------|
+| [specification-protocol](specification-protocol.md) | The canonical specification layout, preserved verbatim: section structure, identifier schemes, requirement-entry format, status conventions, and source-reference format |
+| [requirements-analysis-report](requirements-analysis-report.md) | Structure for the analysis of requirement changes derived from a source document |
+| [validation-rubric](validation-rubric.md) | Validation checks and the severity/type categorization that drives routing |
+| [change-summary](change-summary.md) | Structure for the change summary that accompanies a finalized specification |

--- a/requirements-refinement/resources/change-summary.md
+++ b/requirements-refinement/resources/change-summary.md
@@ -1,0 +1,35 @@
+# Change Summary
+
+The structure for the human-readable summary that accompanies a finalized specification, so a reviewer
+can see what changed before promoting it to the canonical location.
+
+## Template
+
+```markdown
+# Change Summary — [specification name]
+
+**Source**: SRC-MTG### — [meeting title / date]  ·  or  SRC-DOC### — [document title] (Author Name)
+**Validation**: [passed | passed after N correction passes]
+
+## New Requirements
+- [REQ-ID]: [one-line title]
+
+## Updated Requirements
+- [REQ-ID]: [what changed]
+
+## Deprecated Requirements
+- [REQ-ID]: [reason]
+
+## Sources Added
+- SRC-MTG###: [meeting title]  ·  or  SRC-DOC###: [document title] — Author Name
+
+## Promotion
+Final specification staged at: [path]
+Promote to: [canonical target path]
+```
+
+## Conventions
+
+- List every new, updated, and deprecated requirement by identifier.
+- State the validation outcome, including the number of correction passes when more than zero.
+- Name the staged path and the canonical target path so promotion is unambiguous.

--- a/requirements-refinement/resources/requirements-analysis-report.md
+++ b/requirements-refinement/resources/requirements-analysis-report.md
@@ -28,6 +28,11 @@ with the heading — no preamble.
 ### Deprecated Requirements
 [Each requirement to deprecate: REQ-ID, rationale.]
 
+## Source Coverage Matrix
+| Source section | Normative? | Covered by |
+|----------------|-----------|------------|
+| [§n — title] | yes / no | REQ-ID(s), or "out of scope" |
+
 ## Document Updates Required
 [Sections that need updating, including new source references for 2.2 Meeting Transcripts.]
 
@@ -37,6 +42,14 @@ with the heading — no preamble.
 ## Implementation Notes
 [Additional context for applying the changes to the specification.]
 ```
+
+## Source Coverage Matrix
+
+The coverage matrix traces every source section to the requirement(s) it is covered by, so completeness
+is verifiable. Each row records a source section, whether it carries a normative obligation
+(`SHALL`/`MUST`/`SHOULD`/`MAY`, a constraint, or a rule), and the requirement identifier(s) covering it.
+A normative section with no covering requirement is a coverage gap; a section with no obligation is
+marked out of scope.
 
 ## Conventions
 

--- a/requirements-refinement/resources/requirements-analysis-report.md
+++ b/requirements-refinement/resources/requirements-analysis-report.md
@@ -1,0 +1,48 @@
+# Requirements Analysis Report
+
+The structure for the analysis of requirement changes derived from a source document — a meeting
+transcript or an unstructured document. The report is a structured markdown document beginning directly
+with the heading — no preamble.
+
+## Template
+
+```markdown
+# Requirements Analysis Report
+
+## Source
+- **Source ID**: SRC-MTG### (meeting) or SRC-DOC### (document)
+- **Source Type**: meeting | document
+- **Title**: [meeting title or document title]
+- **Attribution**: [participant initials for a meeting; author name for a document]
+- **Source Path**: [path to the source document]
+- **Analysis Date**: [date]
+
+## Requirements Changes
+
+### New Requirements
+[Each new requirement to create: proposed REQ-ID, title, rationale, target section.]
+
+### Updated Requirements
+[Each existing requirement to modify: REQ-ID, change needed, rationale.]
+
+### Deprecated Requirements
+[Each requirement to deprecate: REQ-ID, rationale.]
+
+## Document Updates Required
+[Sections that need updating, including new source references for 2.2 Meeting Transcripts.]
+
+## Quality Issues Identified
+[Ambiguities, duplications, conflicts, or inconsistencies found.]
+
+## Implementation Notes
+[Additional context for applying the changes to the specification.]
+```
+
+## Conventions
+
+- Map each change to an existing requirement identifier where one applies; otherwise propose a new
+  identifier within the correct category.
+- Assign a source reference for the document and list it under Document Updates Required so it is added
+  to the correct section — a meeting transcript (`SRC-MTG###`) to section 2.2, an unstructured document
+  (`SRC-DOC###`, credited to its author) to section 2.5.
+- State each change precisely enough to be applied without re-reading the source document.

--- a/requirements-refinement/resources/specification-protocol.md
+++ b/requirements-refinement/resources/specification-protocol.md
@@ -1,0 +1,102 @@
+# Specification Protocol
+
+The canonical layout and conventions a requirements specification follows. This protocol is preserved
+verbatim when augmenting an existing specification, and instantiated in full when creating one from
+scratch.
+
+## Section Structure
+
+A specification is organized into these top-level sections, in order:
+
+1. **Executive Summary** — purpose and scope of the system.
+2. **Requirements Sources** — the documents and discussions requirements derive from:
+   - 2.1 Product and Solution Documents
+   - 2.2 Meeting Transcripts
+   - 2.3 Vendor Documents
+   - 2.4 Source Reference Format
+   - 2.5 Reference Documents
+3. **Use Case Definition** — primary use case, personas, user journey, key success criteria.
+4. **Functional Requirements** — capabilities the system provides, grouped into domain subsections with priority tags (`P0`, `P1`, …).
+5. **Non-Functional Requirements** — architectural, operational, security, and governance constraints, grouped into subsections.
+6. **Performance Requirements** — throughput, latency, and capacity targets.
+7. **Project and Process Requirements** — delivery, process, and project-level requirements.
+
+When augmenting, the existing section set and ordering are retained; new material is added under the
+matching section.
+
+## Identifier Schemes
+
+| Entity | Identifier | Example |
+|--------|-----------|---------|
+| Product/solution source | `SRC-PRD###` | `SRC-PRD001` |
+| Meeting transcript source | `SRC-MTG###` | `SRC-MTG004` |
+| Vendor document source | `SRC-VDR###` | `SRC-VDR001` |
+| Reference (unstructured) document source | `SRC-DOC###` | `SRC-DOC001` |
+| Functional requirement | `REQ-F###` | `REQ-F012` |
+| Non-functional requirement | `REQ-NF###` | `REQ-NF007` |
+| Success criterion | `SUCCESS-###` | `SUCCESS-005` |
+
+Identifiers are unique and never reused. Numbering need not be contiguous — a gap is not a defect.
+Each new requirement takes the next available number within its category.
+
+## Requirement Entry Format
+
+Each requirement is a four-part entry, with a blank line between the title and each field and between
+fields:
+
+```markdown
+**REQ-ID: The system SHALL/SHOULD/MAY [atomic, testable requirement statement]**
+
+*Status*: *status value*
+
+*Rationale*: explanation of why the requirement exists and any relevant design context
+
+*Source*: source reference
+```
+
+The statement uses the keyword `SHALL` (mandatory), `SHOULD` (recommended), or `MAY` (optional), and
+is atomic, testable, and unambiguous.
+
+## Status Conventions
+
+Permitted status values: `pending`, `under review`, `accepted`, `deprecated`.
+
+- A newly added requirement takes status `pending`. The value `new` is not used.
+- A status change away from `pending` follows explicit confirmation during requirements review.
+- A retired requirement takes status `deprecated` rather than being deleted.
+
+## Source Reference Format
+
+Requirements, constraints, and success criteria cite their sources as:
+
+```
+*Source: [Source ID] - [specific section or requirement]*
+```
+
+When a requirement originates from a specific discussion within a meeting, participant initials MAY be
+included for attribution; when it originates from a reference document, the document's author is
+included for attribution:
+
+```
+*Source: [Source ID] (Initials)*
+*Source: [Source ID] (Author Name)*
+```
+
+Examples:
+
+- `*Source*: SRC-PRD001 - Core Features (P0) functional requirements`
+- `*Source*: SRC-MTG006 (PW, MC)`
+- `*Source*: SRC-DOC001 (Jane Doe)`
+
+A requirement may cite multiple comma-separated sources: `*Source*: SRC-PRD001, SRC-MTG005, SRC-DOC001`.
+
+## Reference Documents
+
+An unstructured reference document (a proposal, brief, email, or similar) is recorded under section 2.5
+with an `SRC-DOC###` reference and credited to its author, mirroring the meeting-transcript listing:
+
+```
+**SRC-DOC###**: [Document Title](path/to/document) — Author Name
+```
+
+Example: `**SRC-DOC001**: [Cross-chain settlement brief](sources/documents/settlement-brief.md) — Jane Doe`

--- a/requirements-refinement/resources/validation-rubric.md
+++ b/requirements-refinement/resources/validation-rubric.md
@@ -25,6 +25,11 @@ critical issues stop refinement.
 - Source references resolve to entries listed in section 2 (Requirements Sources).
 - No two requirements contradict one another; duplicates are flagged.
 
+### Source Coverage
+- Every normative statement in the source — a `SHALL`/`MUST`/`SHOULD`/`MAY` obligation, constraint, or rule — maps to at least one requirement in the specification.
+- The source-coverage matrix from the analysis is the reference; a matrix row marked normative with no covering requirement is a coverage gap.
+- A coverage gap is a **correctable** issue (type `content`): the verdict is `passed` only when conformance holds **and** source coverage is complete.
+
 ## Issue Categorization
 
 Each issue is tagged with a severity and a type:

--- a/requirements-refinement/resources/validation-rubric.md
+++ b/requirements-refinement/resources/validation-rubric.md
@@ -1,0 +1,53 @@
+# Validation Rubric
+
+The checks applied to an updated specification and the scheme for categorizing each issue. The verdict
+drives routing: a clean result finalizes, correctable issues trigger another correction pass, and
+critical issues stop refinement.
+
+## Checks
+
+### Structure
+- All canonical sections are present and correctly ordered.
+- Requirement entries use the four-part format (title, status, rationale, source) with correct spacing.
+- Markdown syntax is well-formed.
+
+### Identifiers
+- Every requirement and source identifier is unique.
+- New identifiers fall in the correct category (`REQ-F###`, `REQ-NF###`, `SRC-MTG###`, …).
+- Non-sequential identifiers are expected and are **not** a failure.
+
+### Content
+- Requirement statements are atomic, testable, and use `SHALL` / `SHOULD` / `MAY` appropriately.
+- Every requirement carries a complete rationale and at least one source reference.
+- Status values are drawn from the permitted set; newly added requirements are `pending`.
+
+### Consistency
+- Source references resolve to entries listed in section 2 (Requirements Sources).
+- No two requirements contradict one another; duplicates are flagged.
+
+## Issue Categorization
+
+Each issue is tagged with a severity and a type:
+
+| Field | Values |
+|-------|--------|
+| severity | `critical`, `high`, `medium`, `low` |
+| type | `irreconcilable`, `structure`, `content`, `syntax` |
+
+**Critical / irreconcilable** issues require manual intervention and stop refinement:
+- Fundamental requirement conflicts or contradictions.
+- Essential requirement information that cannot be inferred.
+- Structural damage that breaks document integrity.
+- Source-traceability problems that cannot be resolved automatically.
+
+**Correctable** issues can be addressed by another correction pass:
+- Markdown and formatting errors.
+- Minor wording improvements.
+- Requirement-identifier collisions.
+- Incomplete rationales that can be completed from available context.
+
+## Verdict
+
+- **passed** — no critical and no correctable issues.
+- **correctable** — one or more correctable issues, no critical issues.
+- **critical** — one or more critical or irreconcilable issues.

--- a/requirements-refinement/techniques/README.md
+++ b/requirements-refinement/techniques/README.md
@@ -1,0 +1,15 @@
+# Requirements Refinement Techniques
+
+> Part of the [Requirements Refinement Workflow](../README.md)
+
+The procedures the activities apply. [`TECHNIQUE.md`](TECHNIQUE.md) is the workflow-root base contract:
+it declares the inputs shared across techniques (`planning_folder_path`, `source_path`,
+`target_doc_path`) and the specification-fidelity rules every technique inherits.
+
+| Technique | Capability |
+|-----------|-----------|
+| [analyze-source](analyze-source.md) | Parse the source document against the current specification into a structured analysis report |
+| [update-specification](update-specification.md) | Apply the analysis or correction findings to a complete updated specification |
+| [validate-specification](validate-specification.md) | Validate the updated specification and categorize each issue |
+| [finalize-specification](finalize-specification.md) | Assemble the final specification and change summary for promotion |
+| [report-failure](report-failure.md) | Compile a failure report when refinement cannot complete automatically |

--- a/requirements-refinement/techniques/TECHNIQUE.md
+++ b/requirements-refinement/techniques/TECHNIQUE.md
@@ -1,0 +1,32 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Base contract for the requirements-refinement techniques: the inputs every technique reads, and the specification-fidelity invariants they all uphold.
+
+## Inputs
+
+### planning_folder_path
+
+Absolute path to this run's planning folder; each technique reads prior artifacts from, and writes its own artifact into, this folder.
+
+### source_path
+
+Filesystem path to the source document being processed — a meeting transcript or an unstructured document.
+
+### target_doc_path
+
+Filesystem path to the canonical requirements specification being augmented or created.
+
+## Rules
+
+### specification-protocol-preserved
+
+The section structure, requirement-entry format, identifier schemes, and status conventions defined in [specification-protocol](../resources/specification-protocol.md) are preserved verbatim.
+
+### artifacts-confined-to-planning-folder
+
+Each technique writes its artifact under `{planning_folder_path}`, performs no version-control operations, and never edits the canonical document in place.

--- a/requirements-refinement/techniques/analyze-source.md
+++ b/requirements-refinement/techniques/analyze-source.md
@@ -1,11 +1,11 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
 
-Parse a source document — a meeting transcript or an unstructured document — against the current specification and produce a structured requirements analysis report identifying new, updated, and deprecated requirements.
+Parse a source document — a meeting transcript or an unstructured document — against the current specification and produce a structured requirements analysis report identifying new, updated, and deprecated requirements, with a source-coverage matrix tracing every normative statement to a requirement.
 
 ## Protocol
 
@@ -25,22 +25,36 @@ Parse a source document — a meeting transcript or an unstructured document —
 - When `{source_type}` is `document`, assign a document source reference (`SRC-DOC###`) credited to the document's author.
 - Follow [specification-protocol](../resources/specification-protocol.md#source-reference-format) for both forms.
 
-### 4. Compile Analysis Report
+### 4. Completeness Sweep
 
-- Write `{requirements_analysis}` to `{planning_folder_path}` using the [requirements-analysis-report](../resources/requirements-analysis-report.md) structure: source reference, new / updated / deprecated requirements, document updates required, quality issues, and implementation notes.
+- Re-walk the source document section by section as a completeness critic: for every normative statement (a `SHALL`/`MUST`/`SHOULD`/`MAY` obligation, constraint, or rule), confirm it maps to an identified requirement.
+- Add any normative statement that has no mapped requirement as a new requirement.
+- Record each source section against the requirement(s) it maps to as the source-coverage matrix, marking any section with no obligation as out of scope.
+
+### 5. Compile Analysis Report
+
+- Write `{requirements_analysis}` to `{planning_folder_path}` using the [requirements-analysis-report](../resources/requirements-analysis-report.md) structure: source reference, new / updated / deprecated requirements, the [source coverage matrix](../resources/requirements-analysis-report.md#source-coverage-matrix), document updates required, quality issues, and implementation notes.
 
 ## Output
 
 ### requirements_analysis
 
-Structured analysis of the requirement changes derived from the source document.
+Structured analysis of the requirement changes derived from the source document, including the source-coverage matrix.
 
 #### artifact
 
 `requirements-analysis.md`
+
+#### source_coverage_matrix
+
+Mapping of each source section to the requirement identifier(s) it is covered by, with out-of-scope sections marked.
 
 ## Rules
 
 ### analysis-records-intended-changes-only
 
 The analysis records intended changes; it does not modify the specification.
+
+### every-normative-statement-is-mapped
+
+Every normative statement in the source document maps to at least one requirement in the source-coverage matrix.

--- a/requirements-refinement/techniques/analyze-source.md
+++ b/requirements-refinement/techniques/analyze-source.md
@@ -1,0 +1,46 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Parse a source document — a meeting transcript or an unstructured document — against the current specification and produce a structured requirements analysis report identifying new, updated, and deprecated requirements.
+
+## Protocol
+
+### 1. Read Sources
+
+- Read the source document at `{source_path}`; when `{target_doc_exists}`, also read the current specification at `{target_doc_path}`.
+
+### 2. Identify Requirement Changes
+
+- Extract explicit requirement statements, modifications, additions, and deprecations from the source document, and derive reasonably-implied requirements.
+- Map each change to an existing requirement identifier (`REQ-F###` or `REQ-NF###`) where one applies; otherwise mark it as a new requirement.
+- Note ambiguities and conflicts for the quality-issues section.
+
+### 3. Create Source Reference
+
+- When `{source_type}` is `meeting`, assign a meeting source reference (`SRC-MTG###`) with participant initials for attribution.
+- When `{source_type}` is `document`, assign a document source reference (`SRC-DOC###`) credited to the document's author.
+- Follow [specification-protocol](../resources/specification-protocol.md#source-reference-format) for both forms.
+
+### 4. Compile Analysis Report
+
+- Write `{requirements_analysis}` to `{planning_folder_path}` using the [requirements-analysis-report](../resources/requirements-analysis-report.md) structure: source reference, new / updated / deprecated requirements, document updates required, quality issues, and implementation notes.
+
+## Output
+
+### requirements_analysis
+
+Structured analysis of the requirement changes derived from the source document.
+
+#### artifact
+
+`requirements-analysis.md`
+
+## Rules
+
+### analysis-records-intended-changes-only
+
+The analysis records intended changes; it does not modify the specification.

--- a/requirements-refinement/techniques/finalize-specification.md
+++ b/requirements-refinement/techniques/finalize-specification.md
@@ -1,0 +1,56 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Assemble the validation-passed specification and a human-readable change summary as planning-folder artifacts for human promotion.
+
+## Inputs
+
+### working_specification
+
+The validation-passed specification document.
+
+### requirements_analysis
+
+The structured analysis of requirement changes, used to compose the change summary.
+
+## Protocol
+
+### 1. Assemble Final Specification
+
+- Copy the validation-passed `{working_specification}` into `{final_specification}` in `{planning_folder_path}`.
+
+### 2. Write Change Summary
+
+- Summarize the applied changes — new, updated, and deprecated requirements and added sources — from `{requirements_analysis}` into `{change_summary}` using the [change-summary](../resources/change-summary.md) structure.
+
+### 3. Present for Promotion
+
+- Present `{final_specification}` and `{change_summary}` for the user to review and promote to `{target_doc_path}`.
+
+## Output
+
+### final_specification
+
+The finalized specification staged for promotion.
+
+#### artifact
+
+`final-spec.md`
+
+### change_summary
+
+Human-readable summary of all applied changes and the validation status.
+
+#### artifact
+
+`change-summary.md`
+
+## Rules
+
+### promotion-is-the-users-action
+
+The finalized specification is staged in `{planning_folder_path}`; promotion to the canonical location is performed by the user.

--- a/requirements-refinement/techniques/report-failure.md
+++ b/requirements-refinement/techniques/report-failure.md
@@ -1,0 +1,44 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Compile a failure report describing the unresolved critical issues, the correction history, and the manual resolution required when refinement cannot complete automatically.
+
+## Inputs
+
+### validation_report
+
+Categorized validation findings whose critical or unresolved issues stopped refinement.
+
+## Protocol
+
+### 1. Summarize Failure
+
+- Record the verdict, the number of correction passes attempted (`{correction_iteration}` of `{max_correction_iterations}`), and every critical or irreconcilable issue drawn from `{validation_report}`.
+
+### 2. Provide Resolution Guidance
+
+- State, for each critical issue, the manual resolution a requirements engineer should perform.
+
+### 3. Write Failure Report
+
+- Write `{failure_report}` to `{planning_folder_path}`.
+
+## Output
+
+### failure_report
+
+Failure report carrying the critical issues, correction history, and manual-resolution guidance.
+
+#### artifact
+
+`failure-report.md`
+
+## Rules
+
+### promotion-withheld-on-failure
+
+A specification is promoted only after passing validation; a failed run stages no specification for promotion.

--- a/requirements-refinement/techniques/update-specification.md
+++ b/requirements-refinement/techniques/update-specification.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -31,7 +31,7 @@ Structured analysis of the requirement changes to apply on the initial pass.
 
 ### 3. Apply Corrections — Correction Mode
 
-- Address each correctable finding in `{validation_report}` without changing requirement meaning and without introducing new requirements.
+- Address each correctable finding in `{validation_report}`: resolve a source-coverage finding by adding the missing requirement(s); otherwise change no requirement's meaning and introduce no new requirement.
 
 ### 4. Write Working Specification
 
@@ -55,4 +55,4 @@ A newly added requirement takes status `pending`; a status change away from `pen
 
 ### corrections-preserve-meaning
 
-On a correction pass, only the reported findings are addressed — no new requirements are introduced and no requirement's meaning is changed.
+On a correction pass, only the reported findings are addressed: a source-coverage finding is resolved by adding the missing requirement, and otherwise no requirement is added and no requirement's meaning is changed.

--- a/requirements-refinement/techniques/update-specification.md
+++ b/requirements-refinement/techniques/update-specification.md
@@ -1,0 +1,58 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Apply the requirements analysis (initial pass) or the validation findings (correction pass) to produce the complete updated specification, preserving the specification protocol verbatim.
+
+## Inputs
+
+### requirements_analysis
+
+Structured analysis of the requirement changes to apply on the initial pass.
+
+### validation_report
+
+*(optional)* Categorized validation findings to address on a correction pass.
+
+## Protocol
+
+### 1. Determine Mode
+
+- Operate in correction mode when `{validation_report}` carries correctable findings; otherwise operate in initial mode.
+
+### 2. Apply Changes — Initial Mode
+
+- Apply each change in `{requirements_analysis}`: add `SRC-MTG###` source references, create new requirements with sequential identifiers, update existing requirements, and deprecate as directed.
+- Set every newly added requirement's status to `pending`.
+- Preserve the existing section structure when `{target_doc_exists}`; instantiate the full [specification-protocol](../resources/specification-protocol.md#section-structure) structure when creating from scratch.
+
+### 3. Apply Corrections — Correction Mode
+
+- Address each correctable finding in `{validation_report}` without changing requirement meaning and without introducing new requirements.
+
+### 4. Write Working Specification
+
+- Write the complete `{working_specification}` to `{planning_folder_path}`.
+
+## Output
+
+### working_specification
+
+The complete updated specification document for this pass.
+
+#### artifact
+
+`working-spec-{correction_iteration}.md`
+
+## Rules
+
+### new-requirements-are-pending
+
+A newly added requirement takes status `pending`; a status change away from `pending` follows explicit user confirmation.
+
+### corrections-preserve-meaning
+
+On a correction pass, only the reported findings are addressed — no new requirements are introduced and no requirement's meaning is changed.

--- a/requirements-refinement/techniques/validate-specification.md
+++ b/requirements-refinement/techniques/validate-specification.md
@@ -1,0 +1,44 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Validate the updated specification against structural, identifier-uniqueness, consistency, and protocol-conformance checks, and categorize each issue as critical or correctable.
+
+## Inputs
+
+### working_specification
+
+The updated specification document to validate.
+
+## Protocol
+
+### 1. Run Checks
+
+- Validate `{working_specification}` against the checks in [validation-rubric](../resources/validation-rubric.md): section structure, requirement-identifier uniqueness, source-reference accuracy, markdown syntax, and cross-section consistency.
+
+### 2. Categorize Issues
+
+- Assign each issue a severity and type per [validation-rubric](../resources/validation-rubric.md#issue-categorization), and treat critical or irreconcilable issues as blocking and the remainder as correctable.
+
+### 3. Compile Verdict
+
+- Write `{validation_report}` to `{planning_folder_path}`, recording the overall verdict (passed, correctable, or critical), the categorized issues, and the correction-pass number.
+
+## Output
+
+### validation_report
+
+Categorized validation findings with an overall verdict.
+
+#### artifact
+
+`validation-report-{correction_iteration}.md`
+
+## Rules
+
+### non-sequential-identifiers-accepted
+
+Non-sequential requirement identifiers are expected and do not constitute a validation failure.

--- a/requirements-refinement/techniques/validate-specification.md
+++ b/requirements-refinement/techniques/validate-specification.md
@@ -1,11 +1,11 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
 
-Validate the updated specification against structural, identifier-uniqueness, consistency, and protocol-conformance checks, and categorize each issue as critical or correctable.
+Validate the updated specification against structural, identifier-uniqueness, consistency, source-coverage, and protocol-conformance checks, and categorize each issue as critical or correctable.
 
 ## Inputs
 
@@ -13,25 +13,33 @@ Validate the updated specification against structural, identifier-uniqueness, co
 
 The updated specification document to validate.
 
+### requirements_analysis
+
+The structured analysis whose source-coverage matrix is the completeness reference for validation.
+
 ## Protocol
 
-### 1. Run Checks
+### 1. Run Conformance Checks
 
 - Validate `{working_specification}` against the checks in [validation-rubric](../resources/validation-rubric.md): section structure, requirement-identifier uniqueness, source-reference accuracy, markdown syntax, and cross-section consistency.
 
-### 2. Categorize Issues
+### 2. Check Source Coverage
 
-- Assign each issue a severity and type per [validation-rubric](../resources/validation-rubric.md#issue-categorization), and treat critical or irreconcilable issues as blocking and the remainder as correctable.
+- Using the source-coverage matrix in `{requirements_analysis}`, confirm every normative source statement maps to a requirement present in `{working_specification}`, and record any uncovered statement per [validation-rubric](../resources/validation-rubric.md#source-coverage).
 
-### 3. Compile Verdict
+### 3. Categorize Issues
 
-- Write `{validation_report}` to `{planning_folder_path}`, recording the overall verdict (passed, correctable, or critical), the categorized issues, and the correction-pass number.
+- Assign each issue a severity and type per [validation-rubric](../resources/validation-rubric.md#issue-categorization), treating critical or irreconcilable issues as blocking and the remainder — including coverage gaps — as correctable.
+
+### 4. Compile Verdict
+
+- Write `{validation_report}` to `{planning_folder_path}`, recording the overall verdict (passed, correctable, or critical), the categorized issues, the source-coverage result, and the correction-pass number.
 
 ## Output
 
 ### validation_report
 
-Categorized validation findings with an overall verdict.
+Categorized validation findings with an overall verdict and the source-coverage result.
 
 #### artifact
 
@@ -42,3 +50,7 @@ Categorized validation findings with an overall verdict.
 ### non-sequential-identifiers-accepted
 
 Non-sequential requirement identifiers are expected and do not constitute a validation failure.
+
+### coverage-gaps-are-correctable
+
+An uncovered normative source statement is a correctable finding, not a clean pass; the verdict is passed only when conformance holds and source coverage is complete.

--- a/requirements-refinement/workflow.toon
+++ b/requirements-refinement/workflow.toon
@@ -1,6 +1,6 @@
 "$schema": ../../schemas/workflow.schema.json
 id: requirements-refinement
-version: 1.0.0
+version: 1.1.0
 title: Requirements Refinement Workflow
 description: "Refine a canonical requirements specification from a source document — a meeting transcript or an unstructured document — preserving the specification protocol verbatim and staging the finalized specification and a change summary in the planning folder for human promotion. Operates on local files and performs no version-control operations."
 author: m2ux
@@ -11,7 +11,7 @@ tags[6]:
   - document-automation
   - validation
   - iterative-refinement
-rules[7]:
+rules[8]:
   - "The target specification's protocol — section structure, requirement-entry format, identifier schemes (SRC-MTG###, SRC-DOC###, REQ-F###, REQ-NF###), and status conventions defined in resources/specification-protocol.md — is preserved verbatim across every activity."
   - "The source document is classified as a meeting transcript or an unstructured document; a meeting source takes an SRC-MTG### reference, and a document source takes an SRC-DOC### reference credited to the document's author."
   - "All artifacts — analysis report, working specifications, validation reports, final specification, and failure report — are written to the planning folder; the workflow performs no git operations and never edits the canonical document in place."
@@ -19,11 +19,12 @@ rules[7]:
   - "Validation routing is deterministic: evaluate validate-specification's transitions in order — finalize-specification when validation_passed, update-specification while correctable issues remain and correction_iteration is below max_correction_iterations, otherwise report-failure."
   - "Confirm the requirements analysis with the user before applying any changes to the specification."
   - "When the target document exists, preserve its existing section structure; when it does not, instantiate the full specification protocol structure."
+  - "Validation includes a source-coverage check: every normative statement in the source document maps to at least one requirement; an uncovered statement is a correctable finding routed through the correction loop."
 techniques:
 artifactLocations:
   planning:
     path: "{planning_folder_path}"
-variables[13]:
+variables[14]:
   - name: source_path
     type: string
     description: "Filesystem path to the local source document being processed (a meeting transcript or an unstructured document)"
@@ -75,5 +76,9 @@ variables[13]:
   - name: finalization_confirmed
     type: boolean
     description: "True once the user has accepted the finalized specification for promotion"
+    defaultValue: false
+  - name: source_coverage_complete
+    type: boolean
+    description: "True once every normative statement in the source document maps to at least one requirement"
     defaultValue: false
 initialActivity: intake-sources

--- a/requirements-refinement/workflow.toon
+++ b/requirements-refinement/workflow.toon
@@ -1,0 +1,79 @@
+"$schema": ../../schemas/workflow.schema.json
+id: requirements-refinement
+version: 1.0.0
+title: Requirements Refinement Workflow
+description: "Refine a canonical requirements specification from a source document — a meeting transcript or an unstructured document — preserving the specification protocol verbatim and staging the finalized specification and a change summary in the planning folder for human promotion. Operates on local files and performs no version-control operations."
+author: m2ux
+tags[6]:
+  - requirements
+  - specification
+  - source-document
+  - document-automation
+  - validation
+  - iterative-refinement
+rules[7]:
+  - "The target specification's protocol — section structure, requirement-entry format, identifier schemes (SRC-MTG###, SRC-DOC###, REQ-F###, REQ-NF###), and status conventions defined in resources/specification-protocol.md — is preserved verbatim across every activity."
+  - "The source document is classified as a meeting transcript or an unstructured document; a meeting source takes an SRC-MTG### reference, and a document source takes an SRC-DOC### reference credited to the document's author."
+  - "All artifacts — analysis report, working specifications, validation reports, final specification, and failure report — are written to the planning folder; the workflow performs no git operations and never edits the canonical document in place."
+  - "Newly added requirements are created with status pending; changing a requirement's status requires explicit user confirmation."
+  - "Validation routing is deterministic: evaluate validate-specification's transitions in order — finalize-specification when validation_passed, update-specification while correctable issues remain and correction_iteration is below max_correction_iterations, otherwise report-failure."
+  - "Confirm the requirements analysis with the user before applying any changes to the specification."
+  - "When the target document exists, preserve its existing section structure; when it does not, instantiate the full specification protocol structure."
+techniques:
+artifactLocations:
+  planning:
+    path: "{planning_folder_path}"
+variables[13]:
+  - name: source_path
+    type: string
+    description: "Filesystem path to the local source document being processed (a meeting transcript or an unstructured document)"
+    required: true
+  - name: source_type
+    type: string
+    description: "Classification of the source document: meeting (a meeting transcript) or document (an unstructured document)"
+    defaultValue: ""
+  - name: target_doc_path
+    type: string
+    description: "Filesystem path to the canonical requirements specification being augmented or created"
+    required: true
+  - name: target_doc_exists
+    type: boolean
+    description: "True when the target specification already exists and is being augmented; false when it is created from scratch"
+    defaultValue: false
+  - name: spec_basename
+    type: string
+    description: "Basename of the target specification"
+    defaultValue: ""
+  - name: sources_confirmed
+    type: boolean
+    description: "True once the source-document and target-specification sources are captured and confirmed"
+    defaultValue: false
+  - name: analysis_confirmed
+    type: boolean
+    description: "True once the requirements analysis is approved for application to the specification"
+    defaultValue: false
+  - name: validation_passed
+    type: boolean
+    description: "True when the updated specification passed validation with no critical or correctable issues"
+    defaultValue: false
+  - name: has_correctable_issues
+    type: boolean
+    description: "True when validation found issues that can be addressed by another correction pass"
+    defaultValue: false
+  - name: has_critical_issues
+    type: boolean
+    description: "True when validation found critical or irreconcilable issues that require manual intervention"
+    defaultValue: false
+  - name: correction_iteration
+    type: number
+    description: "Count of correction passes performed so far; 0 on the initial update"
+    defaultValue: 0
+  - name: max_correction_iterations
+    type: number
+    description: "Maximum number of correction passes before routing to report-failure"
+    defaultValue: 3
+  - name: finalization_confirmed
+    type: boolean
+    description: "True once the user has accepted the finalized specification for promotion"
+    defaultValue: false
+initialActivity: intake-sources


### PR DESCRIPTION
## Summary

Adds a new sequential workflow, **`requirements-refinement`** (v1.1.0), that refines a canonical requirements specification (SRS-style document) from a **source document** — a meeting transcript or an unstructured document — and stages the result for human promotion. Port of an n8n multi-agent automation (`req_update_agent`) into the Goal → Activity → Technique → Tools model; operates on local files with **no version-control operations**.

## Pipeline

`intake-sources` → `analyze-source` → `update-specification` → `validate-specification` → `finalize-specification`, with a bounded correction loop (correctable issues route back to `update-specification` under `max_correction_iterations` = 3) and a `report-failure` terminal.

## Highlights

- **Source discrimination** — meetings referenced as `SRC-MTG###` (initials), unstructured documents as `SRC-DOC###` credited to the author.
- **Source-coverage gate (v1.1)** — `analyze-source` runs a completeness sweep + emits a source-coverage matrix; `validate-specification` treats any uncovered normative statement as a correctable finding (`source_coverage_complete`) routed back through the correction loop.
- **Specification protocol preserved verbatim** — encoded in `resources/specification-protocol.md`, enforced by `validate-specification` + the rubric.
- **Work-package artifact style** — all artifacts in the planning folder; canonical document never edited in place.
- **Reusable** — `source_path` and `target_doc_path` are inputs; augments or creates from scratch.

## Contents (21 files)

`workflow.toon`, 6 activities, root `TECHNIQUE.md` + 5 techniques, 4 resources, 4 READMEs.

## Validation

7 TOON files pass their schemas (WorkflowSchema / ActivitySchema); the workflow loads through the server loader with all technique references resolved. Audited against the 14 design principles and the 60-entry anti-pattern catalog. The v1.1 coverage gate was added after dogfooding on `docs/technique-protocol-specification.md` surfaced 9 extraction omissions that conformance-only validation had passed.

> Note: the parent repo's submodule pointer is intentionally left unchanged until this PR merges to `workflows`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
