### PR TITLE
feat(codebase-wiki): add codebase-wiki workflow

### DIFF
--- a/codebase-wiki/README.md
+++ b/codebase-wiki/README.md
@@ -1,0 +1,76 @@
+# Codebase Wiki Workflow
+
+> v1.0.0 — Build and maintain a durable, citation-backed, navigable LLM knowledge base over a codebase, in the Karpathy LLM-wiki format adapted for code. Its operations are reusable techniques other workflows bind to create, augment, query, and update the wiki.
+
+---
+
+## Overview
+
+A codebase wiki is a tree of typed Markdown pages — concepts, entities, source-summaries, and comparisons — navigated hierarchically from an index, where every claim cites a raw source path and carries a confidence score. It adapts the [Karpathy LLM-wiki knowledge-base format](https://blog.starmorph.com/blog/karpathy-llm-wiki-knowledge-base-guide) for code: knowledge that compounds across operations instead of being rebuilt each time, and that an agent reads by following `[[wikilinks]]` from the index rather than loading the whole codebase into context.
+
+**Why build a wiki instead of re-reading the code each time?**
+
+- **Knowledge compounds.** Each ingest augments the existing wiki rather than starting over, so understanding accumulates across sessions and across workflows.
+- **Every claim is traceable.** A claim cites the raw source path it rests on, pinned to an immutable baseline commit, and carries a confidence score — so a reader knows both where a fact came from and how sure the wiki is of it.
+- **Navigation over brute force.** Reading `index.md` and following `[[wikilinks]]` to the relevant pages costs a fraction of the context of loading the codebase, and scales as the codebase grows.
+- **Reusable by other workflows.** The wiki operations are techniques other workflows bind directly — a comprehension or review workflow can ingest into, or query, the shared wiki without re-implementing any of it.
+
+**Use this workflow when you want to:**
+- Build a persistent, cited knowledge base over a codebase or subsystem.
+- Augment an existing wiki with a new area, or with task-derived findings from another workflow.
+- Answer questions about the codebase from cited, confidence-scored pages instead of ad-hoc re-reading.
+- Check a wiki's integrity — citation coverage, contradictions, orphan pages, stale claims.
+
+## Concepts
+
+- **Typed page** — every page is one of four types: `concept` (an architectural idea), `entity` (a concrete code unit), `source-summary` (a per-file/area digest), or `comparison` (a cross-cutting comparison). See [wiki-format](./resources/wiki-format.md).
+- **Raw baseline** — the source tree at the pinned `raw_baseline_commit`, referenced in place; there is no physical copy. Citations are repo-relative paths at that commit.
+- **Citation + confidence** — every claim cites a raw source and carries a `high`/`medium`/`low` confidence. See [citation-conventions](./resources/citation-conventions.md).
+- **Index and log** — `index.md` is the navigable catalog; `log.md` is the append-only operation ledger. Both are maintained on every mutation.
+
+---
+
+## Activities
+
+The spine is linear with a single rework back-edge. Definitions live in [`activities/`](./activities/README.md) and are served by `get_activity`.
+
+| # | Activity | Purpose |
+|---|----------|---------|
+| 01 | [Confirm Scope](./activities/01-confirm-scope.yaml) | Resolve `wiki_path`, pin `raw_baseline_commit`, and confirm the ordered `ingest_plan`. |
+| 02 | [Build Wiki](./activities/02-build-wiki.yaml) | For each area in the plan: ingest source and/or task knowledge into typed, cited pages; maintain index and log. |
+| 03 | [Lint Wiki](./activities/03-lint-wiki.yaml) | Run the integrity checks; on findings, decide whether to re-ingest (back to Build Wiki) or accept and publish. |
+| 04 | [Publish](./activities/04-publish.yaml) | Finalize index, log, and overview; record the wiki as published. Local-only — no branch, commit, or PR. |
+
+## Techniques
+
+Five standalone operations plus the shared workflow-root base contract. Definitions live in [`techniques/`](./techniques/README.md).
+
+| Technique | Capability |
+|-----------|------------|
+| [`ingest`](./techniques/ingest.md) | Source area at the pinned commit and/or task knowledge → typed, cited, confidence-scored pages; cascade related-page links. |
+| [`query`](./techniques/query.md) | Search the index, follow `[[wikilinks]]`, synthesize a cited answer; optionally persist it. |
+| [`lint`](./techniques/lint.md) | Single-shot integrity checks over the whole wiki → findings count and report. |
+| [`maintain-index-log`](./techniques/maintain-index-log.md) | Update `index.md` and append `log.md` on every mutation. |
+| [`cross-link`](./techniques/cross-link.md) | Maintain bidirectional `[[wikilink]]` relationships and `related[]` frontmatter. |
+
+The shared contract — the common inputs `wiki_path` and `raw_baseline_commit`, the citation and confidence rules, and the workflow's invariants — lives in [`techniques/TECHNIQUE.md`](./techniques/TECHNIQUE.md) and is inherited by every technique.
+
+## Reuse by other workflows
+
+The five operations are standalone, so another workflow binds them at a step with the slash form `codebase-wiki/<op>` — exactly as any standalone technique in another workflow is referenced:
+
+```yaml
+- kind: technique
+  id: ingest-area
+  technique:
+    name: codebase-wiki/ingest
+    inputs:
+      target_area: "{current_subsystem}"
+      task_knowledge: "{review_findings}"
+```
+
+`codebase-wiki/ingest` builds or augments the wiki, `codebase-wiki/query` reads it, and `codebase-wiki/lint` checks it. Internally these techniques delegate file IO to [`work-package::manage-artifacts::write-artifact`](../work-package/techniques/manage-artifacts/write-artifact.md) with `target_dir` bound to `{wiki_path}`, so the wiki tree is the single place pages, index, log, and overview land.
+
+## The wiki standard
+
+What "well-formed" means for a wiki page is defined in [`resources/`](./resources/README.md): the [page format](./resources/wiki-format.md) and [templates](./resources/page-templates.md), the [citation conventions](./resources/citation-conventions.md), and the [lint checklist](./resources/lint-checklist.md) that verifies conformance. The techniques compose content; these resources define what content has to be.

--- a/codebase-wiki/activities/01-confirm-scope.yaml
+++ b/codebase-wiki/activities/01-confirm-scope.yaml
@@ -4,15 +4,9 @@ name: Confirm Scope
 description: "Resolve the wiki target and pin the citation baseline, then capture and confirm what this build pass will ingest."
 required: true
 steps:
-  - kind: action
-    id: resolve-wiki-target
-    actions:
-      - action: set
-        target: wiki_path
-        message: Resolve the wiki tree root from the user request — an existing wiki to augment or a new directory to create. Holds index.md, log.md, overview.md, and the typed-page subfolders.
-      - action: set
-        target: raw_baseline_commit
-        message: Pin the source commit every citation will be relative to — the current HEAD of the target source tree unless the user names a specific commit. The raw baseline is the source at this commit, referenced in place; there is no physical copy.
+  - kind: technique
+    id: collect-scope
+    technique: collect-scope
   - kind: checkpoint
     id: wiki-target-confirmed
     message: "Wiki tree root and citation baseline: wiki_path '{wiki_path}', raw_baseline_commit '{raw_baseline_commit}'. Confirm these before ingest begins."
@@ -28,15 +22,6 @@ steps:
       - id: revise
         label: Change target or baseline
         description: The wiki root or the pinned commit needs adjustment before ingest begins.
-  - kind: action
-    id: capture-ingest-plan
-    actions:
-      - action: set
-        target: ingest_scope
-        message: Capture the free-form description of what this build pass should cover — the source areas, and any task-derived knowledge, to ingest into the wiki.
-      - action: set
-        target: ingest_plan
-        message: Derive the ordered list of areas to ingest from ingest_scope — one entry per module, package, subsystem, or file set named in the scope. This is the collection the build-wiki loop iterates.
   - kind: checkpoint
     id: ingest-scope-confirmed
     message: "Here is the ingest plan derived from the scope — the ordered list of areas to ingest. Confirm before the build pass runs."

--- a/codebase-wiki/activities/01-confirm-scope.yaml
+++ b/codebase-wiki/activities/01-confirm-scope.yaml
@@ -1,0 +1,61 @@
+id: confirm-scope
+version: 1.0.0
+name: Confirm Scope
+description: "Resolve the wiki target and pin the citation baseline, then capture and confirm what this build pass will ingest."
+required: true
+steps:
+  - kind: action
+    id: resolve-wiki-target
+    actions:
+      - action: set
+        target: wiki_path
+        message: Resolve the wiki tree root from the user request — an existing wiki to augment or a new directory to create. Holds index.md, log.md, overview.md, and the typed-page subfolders.
+      - action: set
+        target: raw_baseline_commit
+        message: Pin the source commit every citation will be relative to — the current HEAD of the target source tree unless the user names a specific commit. The raw baseline is the source at this commit, referenced in place; there is no physical copy.
+  - kind: checkpoint
+    id: wiki-target-confirmed
+    message: "Wiki tree root and citation baseline: wiki_path '{wiki_path}', raw_baseline_commit '{raw_baseline_commit}'. Confirm these before ingest begins."
+    blocking: true
+    options:
+      - id: confirmed
+        label: Yes, target and baseline are correct
+        description: The wiki tree root and the pinned source commit are correct; citations will be relative to this commit.
+        effect:
+          setVariable:
+            wiki_path: "{wiki_path}"
+            raw_baseline_commit: "{raw_baseline_commit}"
+      - id: revise
+        label: Change target or baseline
+        description: The wiki root or the pinned commit needs adjustment before ingest begins.
+  - kind: action
+    id: capture-ingest-plan
+    actions:
+      - action: set
+        target: ingest_scope
+        message: Capture the free-form description of what this build pass should cover — the source areas, and any task-derived knowledge, to ingest into the wiki.
+      - action: set
+        target: ingest_plan
+        message: Derive the ordered list of areas to ingest from ingest_scope — one entry per module, package, subsystem, or file set named in the scope. This is the collection the build-wiki loop iterates.
+  - kind: checkpoint
+    id: ingest-scope-confirmed
+    message: "Here is the ingest plan derived from the scope — the ordered list of areas to ingest. Confirm before the build pass runs."
+    blocking: true
+    options:
+      - id: confirmed
+        label: Yes, the ingest plan is correct
+        description: The ordered list of source areas and any task-derived knowledge to ingest is accurate.
+        effect:
+          setVariable:
+            ingest_plan: "{ingest_plan}"
+            ingest_scope_confirmed: true
+      - id: revise
+        label: Revise the ingest plan
+        description: The set or order of areas to ingest needs adjustment.
+transitions:
+  - to: build-wiki
+    isDefault: true
+outcome:
+  - The wiki tree root is fixed, so every page and the index/log ledger land in one known location
+  - The citation baseline is pinned to a single source commit, so every claim is anchored to an immutable, reproducible reference
+  - The build pass has a confirmed, ordered ingest plan, so the loop covers exactly the agreed areas with no implicit scope

--- a/codebase-wiki/activities/02-build-wiki.yaml
+++ b/codebase-wiki/activities/02-build-wiki.yaml
@@ -12,7 +12,7 @@ steps:
         message: Cannot build the wiki without a confirmed ingest plan
       - action: validate
         target: raw_baseline_commit
-        message: Cannot ingest without a pinned raw_baseline_commit — every area is read from the immutable source tree at this commit, so the baseline pointer must be set before the build loop reads any raw source
+        message: Cannot ingest without a pinned raw_baseline_commit
   - kind: loop
     id: area-ingest-cycle
     name: Area Ingest Cycle

--- a/codebase-wiki/activities/02-build-wiki.yaml
+++ b/codebase-wiki/activities/02-build-wiki.yaml
@@ -1,0 +1,40 @@
+id: build-wiki
+version: 1.0.0
+name: Build Wiki
+description: Ingest each area in the confirmed plan into typed, cited wiki pages, maintaining the index and log on every mutation.
+required: true
+steps:
+  - kind: action
+    id: verify-preconditions
+    actions:
+      - action: validate
+        target: ingest_scope_confirmed
+        message: Cannot build the wiki without a confirmed ingest plan
+      - action: validate
+        target: raw_baseline_commit
+        message: Cannot ingest without a pinned raw_baseline_commit — every area is read from the immutable source tree at this commit, so the baseline pointer must be set before the build loop reads any raw source
+  - kind: loop
+    id: area-ingest-cycle
+    name: Area Ingest Cycle
+    loopType: forEach
+    variable: target_area
+    over: ingest_plan
+    maxIterations: 50
+    steps:
+      - kind: technique
+        id: ingest-area
+        technique: ingest
+      - kind: technique
+        id: maintain-index-log
+        technique:
+          name: maintain-index-log
+          inputs:
+            mutated_pages: wiki_pages.page_slugs
+            operation_summary: ingest_summary
+transitions:
+  - to: lint-wiki
+    isDefault: true
+outcome:
+  - Every area in the ingest plan is captured as typed wiki pages whose claims cite a raw source path and carry a confidence score
+  - The index catalog and the append-only log ledger are kept current with each ingest, so navigation and provenance never fall behind the pages
+  - Knowledge compounds — each area augments the existing wiki rather than rebuilding it, including any task-derived knowledge folded into the same pages

--- a/codebase-wiki/activities/03-lint-wiki.yaml
+++ b/codebase-wiki/activities/03-lint-wiki.yaml
@@ -1,0 +1,53 @@
+id: lint-wiki
+version: 1.0.0
+name: Lint Wiki
+description: Run the wiki integrity checks over the built pages and decide whether findings warrant a re-ingest pass.
+required: true
+steps:
+  - kind: technique
+    id: lint
+    technique: lint
+  - kind: checkpoint
+    id: lint-findings-confirmed
+    condition:
+      type: simple
+      variable: lint_findings_count
+      operator: ">"
+      value: 0
+    message: "Lint surfaced {lint_findings_count} finding(s) — see the report above. Re-ingest to fix them, or accept and publish as-is?"
+    blocking: true
+    options:
+      - id: reingest
+        label: Re-ingest to fix findings
+        description: Return to the build pass to address the lint findings before publishing.
+        effect:
+          setVariable:
+            needs_reingest: true
+      - id: accept
+        label: Accept findings and publish
+        description: The findings are acceptable as recorded; proceed to publish without a further build pass.
+        effect:
+          setVariable:
+            needs_reingest: false
+decisions:
+  - id: reingest-gate
+    name: Re-Ingest Gate
+    branches:
+      - id: needs-reingest
+        label: Findings to fix — return to build
+        condition:
+          type: simple
+          variable: needs_reingest
+          operator: ==
+          value: true
+        transitionTo: build-wiki
+      - id: clean
+        label: No re-ingest needed — proceed to publish
+        isDefault: true
+transitions:
+  - to: publish
+    isDefault: true
+outcome:
+  - The wiki has been checked for citation coverage, confidence presence, contradictions, orphan pages, missing referenced concepts, and stale claims
+  - Contradictions and gaps are surfaced explicitly rather than silently reconciled, so the user decides whether to fix or accept them
+  - When findings warrant it, the flow returns to the build pass to re-ingest, closing the one rework loop before publish

--- a/codebase-wiki/activities/04-publish.yaml
+++ b/codebase-wiki/activities/04-publish.yaml
@@ -18,12 +18,9 @@ steps:
       inputs:
         mutated_pages: published_pages
         operation_summary: publish finalization — index, log, and overview refreshed at publish
-  - kind: action
+  - kind: technique
     id: compose-overview
-    actions:
-      - action: set
-        target: wiki_overview
-        message: Compose the overview.md completion summary from the log ledger and index — what areas the build covered, the page counts by type, the citation baseline commit, and any accepted lint findings. Follows the overview section of the wiki-format resource.
+    technique: compose-overview
   - kind: technique
     id: write-overview
     technique:

--- a/codebase-wiki/activities/04-publish.yaml
+++ b/codebase-wiki/activities/04-publish.yaml
@@ -1,0 +1,46 @@
+id: publish
+version: 1.0.0
+name: Publish
+description: Finalize the index, log, and overview, then record the wiki as published. Local-only — no branch, commit, or pull-request operations.
+required: true
+steps:
+  - kind: action
+    id: set-published-pages
+    actions:
+      - action: set
+        target: published_pages
+        value:
+          - overview.md
+  - kind: technique
+    id: finalize-index-log
+    technique:
+      name: maintain-index-log
+      inputs:
+        mutated_pages: published_pages
+        operation_summary: publish finalization — index, log, and overview refreshed at publish
+  - kind: action
+    id: compose-overview
+    actions:
+      - action: set
+        target: wiki_overview
+        message: Compose the overview.md completion summary from the log ledger and index — what areas the build covered, the page counts by type, the citation baseline commit, and any accepted lint findings. Follows the overview section of the wiki-format resource.
+  - kind: technique
+    id: write-overview
+    technique:
+      name: work-package::manage-artifacts::write-artifact
+      inputs:
+        bare_filename: overview.md
+        artifact_content: wiki_overview
+        target_dir: "{wiki_path}"
+  - kind: action
+    id: record-published
+    actions:
+      - action: set
+        target: wiki_published
+        value: true
+      - action: message
+        message: "Wiki published locally at {wiki_path} — index.md, log.md, and overview.md are finalized. No branch, commit, or PR was created."
+outcome:
+  - The index catalog, the append-only log, and the overview are finalized, so the wiki reads as a complete, navigable knowledge base
+  - A completion summary in overview.md records what the build covered, leaving a durable entry point for future readers and augment passes
+  - The wiki is published in place under wiki_path with no version-control side effects — delivery is local-only by design

--- a/codebase-wiki/activities/README.md
+++ b/codebase-wiki/activities/README.md
@@ -1,0 +1,52 @@
+# Codebase Wiki Activities
+
+> Part of the [Codebase Wiki Workflow](../README.md)
+
+Four activities that take a codebase from a confirmed ingest scope to a finalized, citation-backed wiki. The spine is linear — `confirm-scope` → `build-wiki` → `lint-wiki` → `publish` — with a single rework back-edge from `lint-wiki` to `build-wiki` when the user opts to fix lint findings by re-ingesting. There is no mode split and no review-only path; every run follows the same four steps.
+
+This file is an orientation map. The authoritative definition of each activity — its steps, checkpoints, decisions, loops, and transitions — lives in the per-activity YAML linked from each section below and is served by `get_activity`.
+
+---
+
+### 01. Confirm Scope
+
+Resolve the wiki tree root, pin the citation baseline, and capture the ingest plan. Two blocking checkpoints set the run's foundation: `wiki-target-confirmed` fixes `wiki_path` and `raw_baseline_commit` (the immutable source commit every citation is relative to), and `ingest-scope-confirmed` fixes the ordered `ingest_plan` the build loop iterates. Nothing is written until both are confirmed, so the build pass operates on an agreed target and an explicit scope.
+
+Definition: [`01-confirm-scope.yaml`](./01-confirm-scope.yaml). Leads to [Build Wiki](#02-build-wiki).
+
+---
+
+### 02. Build Wiki
+
+For each area in the confirmed `ingest_plan`, ingest the raw source at the pinned commit — and any task-derived knowledge — into typed wiki pages whose claims cite a source path and carry a confidence score, then update the index and append the log. The activity is a `forEach` loop over `ingest_plan` (bound to `target_area`) whose body runs `ingest` then `maintain-index-log` per area, so the catalog and ledger never fall behind the pages. Knowledge compounds: each area augments the existing wiki rather than rebuilding it.
+
+Definition: [`02-build-wiki.yaml`](./02-build-wiki.yaml). Leads to [Lint Wiki](#03-lint-wiki).
+
+---
+
+### 03. Lint Wiki
+
+Run the wiki integrity checks over the built pages and decide whether the findings warrant another build pass. The `lint` technique emits `lint_findings_count`; the `lint-findings-confirmed` checkpoint surfaces only when that count is greater than zero and sets `needs_reingest`. A `decisions` gate routes on that flag — `needs_reingest == true` returns to [Build Wiki](#02-build-wiki) (the one rework edge), otherwise the flow proceeds to publish. Contradictions and gaps are surfaced for a decision, never silently reconciled.
+
+Definition: [`03-lint-wiki.yaml`](./03-lint-wiki.yaml). Leads to [Publish](#04-publish), or back to [Build Wiki](#02-build-wiki) when re-ingest is chosen.
+
+---
+
+### 04. Publish
+
+Finalize the index, log, and overview, and record the wiki as published. A closing `maintain-index-log` refresh and an `overview.md` completion summary (written via `work-package::manage-artifacts::write-artifact` into `wiki_path`) leave a durable entry point, then `wiki_published` is set. Publish is local-only by design — no branch, commit, or pull-request operations — so the wiki is delivered in place under `wiki_path`.
+
+Definition: [`04-publish.yaml`](./04-publish.yaml). Terminal.
+
+---
+
+## Transition map
+
+```
+confirm-scope → build-wiki → lint-wiki → publish
+                    ^             |
+                    └─────────────┘
+                    needs_reingest == true
+```
+
+A linear spine with exactly one rework edge: `lint-wiki` returns to `build-wiki` only when the user chooses to re-ingest in response to lint findings; otherwise every activity advances to the next.

--- a/codebase-wiki/activities/README.md
+++ b/codebase-wiki/activities/README.md
@@ -10,7 +10,7 @@ This file is an orientation map. The authoritative definition of each activity �
 
 ### 01. Confirm Scope
 
-Resolve the wiki tree root, pin the citation baseline, and capture the ingest plan. Two blocking checkpoints set the run's foundation: `wiki-target-confirmed` fixes `wiki_path` and `raw_baseline_commit` (the immutable source commit every citation is relative to), and `ingest-scope-confirmed` fixes the ordered `ingest_plan` the build loop iterates. Nothing is written until both are confirmed, so the build pass operates on an agreed target and an explicit scope.
+Resolve the wiki tree root, pin the citation baseline, and capture and confirm what this build pass will ingest. Nothing is written until the target and scope are agreed, so the build pass operates on a known target and an explicit scope.
 
 Definition: [`01-confirm-scope.yaml`](./01-confirm-scope.yaml). Leads to [Build Wiki](#02-build-wiki).
 
@@ -18,7 +18,7 @@ Definition: [`01-confirm-scope.yaml`](./01-confirm-scope.yaml). Leads to [Build 
 
 ### 02. Build Wiki
 
-For each area in the confirmed `ingest_plan`, ingest the raw source at the pinned commit — and any task-derived knowledge — into typed wiki pages whose claims cite a source path and carry a confidence score, then update the index and append the log. The activity is a `forEach` loop over `ingest_plan` (bound to `target_area`) whose body runs `ingest` then `maintain-index-log` per area, so the catalog and ledger never fall behind the pages. Knowledge compounds: each area augments the existing wiki rather than rebuilding it.
+Ingest each area in the confirmed plan — the raw source at the pinned commit and any task-derived knowledge — into typed wiki pages whose claims cite a source path and carry a confidence score, maintaining the index and log on every mutation. Knowledge compounds: each area augments the existing wiki rather than rebuilding it.
 
 Definition: [`02-build-wiki.yaml`](./02-build-wiki.yaml). Leads to [Lint Wiki](#03-lint-wiki).
 
@@ -26,7 +26,7 @@ Definition: [`02-build-wiki.yaml`](./02-build-wiki.yaml). Leads to [Lint Wiki](#
 
 ### 03. Lint Wiki
 
-Run the wiki integrity checks over the built pages and decide whether the findings warrant another build pass. The `lint` technique emits `lint_findings_count`; the `lint-findings-confirmed` checkpoint surfaces only when that count is greater than zero and sets `needs_reingest`. A `decisions` gate routes on that flag — `needs_reingest == true` returns to [Build Wiki](#02-build-wiki) (the one rework edge), otherwise the flow proceeds to publish. Contradictions and gaps are surfaced for a decision, never silently reconciled.
+Run the wiki integrity checks over the built pages and decide whether the findings warrant another build pass. Contradictions and gaps are surfaced for a decision, never silently reconciled.
 
 Definition: [`03-lint-wiki.yaml`](./03-lint-wiki.yaml). Leads to [Publish](#04-publish), or back to [Build Wiki](#02-build-wiki) when re-ingest is chosen.
 
@@ -34,7 +34,7 @@ Definition: [`03-lint-wiki.yaml`](./03-lint-wiki.yaml). Leads to [Publish](#04-p
 
 ### 04. Publish
 
-Finalize the index, log, and overview, and record the wiki as published. A closing `maintain-index-log` refresh and an `overview.md` completion summary (written via `work-package::manage-artifacts::write-artifact` into `wiki_path`) leave a durable entry point, then `wiki_published` is set. Publish is local-only by design — no branch, commit, or pull-request operations — so the wiki is delivered in place under `wiki_path`.
+Finalize the index, log, and overview, leaving an `overview.md` completion summary as a durable entry point, and record the wiki as published. Publish is local-only by design — no branch, commit, or pull-request operations — so the wiki is delivered in place under the wiki tree root.
 
 Definition: [`04-publish.yaml`](./04-publish.yaml). Terminal.
 

--- a/codebase-wiki/resources/README.md
+++ b/codebase-wiki/resources/README.md
@@ -8,12 +8,12 @@ Four Markdown resources that concretize the wiki standard the techniques work to
 
 ## Resource index
 
-| Order | Resource | Purpose | Loaded by |
-|-------|----------|---------|-----------|
-| `00` | [Wiki Format](./wiki-format.md) | The Karpathy LLM-wiki format adapted for code — page frontmatter schema, the four page types, the wiki tree layout, and the in-place commit-pinned raw baseline. | `ingest` (page classification), `maintain-index-log`, `publish` (overview). |
-| `01` | [Page Templates](./page-templates.md) | One body skeleton per page type (concept, entity, source-summary, comparison) — the frontmatter block and the cited-claim, confidence-scored layout each page follows. | `ingest` (drafting pages). |
-| `02` | [Lint Checklist](./lint-checklist.md) | The integrity checks `lint` runs over the whole wiki, each with its pass/fail criterion. | `lint`. |
-| `03` | [Citation Conventions](./citation-conventions.md) | The raw-baseline citation form, the confidence vocabulary, and the `[[wikilink]]` cross-reference convention. | `ingest`, `query`, `lint`, `cross-link`. |
+| Order | Resource | Purpose |
+|-------|----------|---------|
+| `00` | [Wiki Format](./wiki-format.md) | The Karpathy LLM-wiki format adapted for code — page frontmatter schema, the four page types, the wiki tree layout, and the in-place commit-pinned raw baseline. |
+| `01` | [Page Templates](./page-templates.md) | One body skeleton per page type (concept, entity, source-summary, comparison) — the frontmatter block and the cited-claim, confidence-scored layout each page follows. |
+| `02` | [Lint Checklist](./lint-checklist.md) | The integrity checks the wiki is verified against, each with its pass/fail criterion. |
+| `03` | [Citation Conventions](./citation-conventions.md) | The raw-baseline citation form, the confidence vocabulary, and the `[[wikilink]]` cross-reference convention. |
 
 ---
 

--- a/codebase-wiki/resources/README.md
+++ b/codebase-wiki/resources/README.md
@@ -1,0 +1,22 @@
+# Codebase Wiki Resources
+
+> Part of the [Codebase Wiki Workflow](../README.md)
+
+Four Markdown resources that concretize the wiki standard the techniques work to: the Karpathy-adapted page format, the per-type page templates, the lint checklist, and the citation conventions. Each is loaded via `get_resource` by the technique that references it — this file orients, it does not restate the resource content.
+
+---
+
+## Resource index
+
+| Order | Resource | Purpose | Loaded by |
+|-------|----------|---------|-----------|
+| `00` | [Wiki Format](./wiki-format.md) | The Karpathy LLM-wiki format adapted for code — page frontmatter schema, the four page types, the wiki tree layout, and the in-place commit-pinned raw baseline. | `ingest` (page classification), `maintain-index-log`, `publish` (overview). |
+| `01` | [Page Templates](./page-templates.md) | One body skeleton per page type (concept, entity, source-summary, comparison) — the frontmatter block and the cited-claim, confidence-scored layout each page follows. | `ingest` (drafting pages). |
+| `02` | [Lint Checklist](./lint-checklist.md) | The integrity checks `lint` runs over the whole wiki, each with its pass/fail criterion. | `lint`. |
+| `03` | [Citation Conventions](./citation-conventions.md) | The raw-baseline citation form, the confidence vocabulary, and the `[[wikilink]]` cross-reference convention. | `ingest`, `query`, `lint`, `cross-link`. |
+
+---
+
+## How the resources relate
+
+[Wiki Format](./wiki-format.md) is the schema; [Page Templates](./page-templates.md) is that schema rendered as fill-in skeletons; [Citation Conventions](./citation-conventions.md) defines the claim-level citation and confidence rules the schema requires; [Lint Checklist](./lint-checklist.md) is the verification that pages actually conform to all three. Together they are the wiki standard — the techniques compose content, these resources define what well-formed content is.

--- a/codebase-wiki/resources/citation-conventions.md
+++ b/codebase-wiki/resources/citation-conventions.md
@@ -8,7 +8,7 @@ metadata:
 
 # Citation Conventions
 
-The wiki's two non-negotiable invariants — every claim cites a raw source, and every claim carries a confidence — are encoded by the conventions below. They are referenced by [ingest](../techniques/ingest.md), [query](../techniques/query.md), [lint](../techniques/lint.md), and [cross-link](../techniques/cross-link.md).
+The wiki's two non-negotiable invariants — every claim cites a raw source, and every claim carries a confidence — are encoded by the conventions below.
 
 ## Raw-baseline citations
 
@@ -47,7 +47,7 @@ Cross-references between pages use double-bracket wikilinks naming the target pa
 ```
 
 - A wikilink names the **slug** (the filename without `.md` or subfolder), not a path — the index and the page type locate it.
-- Relationships are **bidirectional**: a `[[wikilink]]` from page A to page B is matched by one from B to A (maintained by [cross-link](../techniques/cross-link.md)).
+- Relationships are **bidirectional**: a `[[wikilink]]` from page A to page B is matched by one from B to A.
 - The body links are the source of truth; each page's `related[]` frontmatter mirrors them.
 - A wikilink is inserted only to an **existing** page — a dangling link is a missing-referenced-concept lint finding, so an intended link to a not-yet-created page waits for the ingest that creates it.
 - In a synthesized `query` answer, each part of the answer carries the `[[wikilink]]` of the page it rests on, so the answer is traceable back to its evidence.

--- a/codebase-wiki/resources/citation-conventions.md
+++ b/codebase-wiki/resources/citation-conventions.md
@@ -1,0 +1,53 @@
+---
+name: citation-conventions
+description: How wiki claims cite raw source, the confidence vocabulary, and the [[wikilink]] cross-reference convention.
+metadata:
+  version: 1.0.0
+  order: 3
+---
+
+# Citation Conventions
+
+The wiki's two non-negotiable invariants — every claim cites a raw source, and every claim carries a confidence — are encoded by the conventions below. They are referenced by [ingest](../techniques/ingest.md), [query](../techniques/query.md), [lint](../techniques/lint.md), and [cross-link](../techniques/cross-link.md).
+
+## Raw-baseline citations
+
+The raw baseline is the source tree at `raw_baseline_commit`, referenced in place — there is no physical copy under the wiki. A citation is therefore a repo-relative source path interpreted against the pinned commit:
+
+```
+(cite: pallets/midnight/src/lib.rs, confidence: high)
+(cite: pallets/midnight/src/lib.rs:120-148, confidence: medium)
+```
+
+- The path is **repo-relative**, not absolute and not wiki-relative — it names a file in the source tree, read at `raw_baseline_commit`.
+- A line range may be appended (`:120-148`) to pin a claim to a specific span.
+- The frontmatter `sources[]` list collects the distinct paths a page's claims cite; the inline `(cite: …)` markers attribute each individual claim.
+- Because the commit is pinned, a citation is reproducible and the stale-claim lint check can verify the path still exists and still matches.
+
+## Confidence vocabulary
+
+Every claim carries exactly one of three confidence values:
+
+| Value | Use when |
+|-------|----------|
+| `high` | The claim is directly evidenced by the cited source — the code says so plainly. |
+| `medium` | The claim is a reasonable reading of the source but rests on some inference. |
+| `low` | The claim is inferred, incomplete, or rests on a source that only partly supports it — a candidate for a deeper ingest. |
+
+- A page's frontmatter `confidence` is the floor of its claims' confidences — a page with any `low` claim is at best `low` overall until that claim is resolved.
+- A claim derived from task knowledge cites both the raw source and the task; its confidence reflects the weaker of the two supports.
+
+## `[[wikilink]]` conventions
+
+Cross-references between pages use double-bracket wikilinks naming the target page's kebab-case slug:
+
+```
+[[epoch-validator-selection]]
+[[babe-consensus]]
+```
+
+- A wikilink names the **slug** (the filename without `.md` or subfolder), not a path — the index and the page type locate it.
+- Relationships are **bidirectional**: a `[[wikilink]]` from page A to page B is matched by one from B to A (maintained by [cross-link](../techniques/cross-link.md)).
+- The body links are the source of truth; each page's `related[]` frontmatter mirrors them.
+- A wikilink is inserted only to an **existing** page — a dangling link is a missing-referenced-concept lint finding, so an intended link to a not-yet-created page waits for the ingest that creates it.
+- In a synthesized `query` answer, each part of the answer carries the `[[wikilink]]` of the page it rests on, so the answer is traceable back to its evidence.

--- a/codebase-wiki/resources/lint-checklist.md
+++ b/codebase-wiki/resources/lint-checklist.md
@@ -1,0 +1,27 @@
+---
+name: lint-checklist
+description: The integrity checks the lint technique runs over the whole wiki, each with its pass/fail criterion.
+metadata:
+  version: 1.0.0
+  order: 2
+---
+
+# Lint Checklist
+
+The [lint](../techniques/lint.md) technique runs every check below in one pass over the whole wiki and counts the violations as `lint_findings_count`. Each finding names the offending page(s) and the check it failed. Lint reports; it never fixes — fixing is a re-ingest decision.
+
+| # | Check | Passes when | Fails when |
+|---|-------|-------------|------------|
+| 1 | **Citation coverage** | Every claim on every page cites at least one raw source path. | A claim has no citation. |
+| 2 | **Confidence presence** | Every claim carries a `high`/`medium`/`low` confidence, and every page has a frontmatter `confidence`. | A claim or page is missing a confidence score, or uses a value outside the vocabulary. |
+| 3 | **Contradictions** | No two pages or claims assert conflicting facts without both being recorded as a conflict. | Two pages state incompatible facts and neither flags the conflict. |
+| 4 | **Orphan pages** | Every page is reachable from `index.md` by following `[[wikilinks]]`. | A page exists in the tree but nothing links to it and the index omits it. |
+| 5 | **Missing referenced concepts** | Every `[[wikilink]]` resolves to an existing page. | A `[[wikilink]]` points at a page that does not exist. |
+| 6 | **Stale claims** | Every cited source path still exists at `raw_baseline_commit` and the claim still matches the source. | A cited path is gone at the baseline commit, or the claim no longer matches the cited source. |
+| 7 | **Index/log integrity** | `index.md` lists every page and `log.md` has an entry for every mutation. | A page is missing from the index, or a mutation is missing from the log. |
+
+## Notes
+
+- **Contradictions are findings, not reconciliations.** Check 3 records the conflict for the user to resolve at the `lint-findings-confirmed` checkpoint; lint never picks a side.
+- **The baseline is the reference for staleness.** Check 6 evaluates cited paths against `raw_baseline_commit` — the immutable, in-place baseline — so a path that moved after the baseline is not flagged, but one absent at the baseline is.
+- **Index and log are not optional.** Check 7 enforces the index-and-log-on-every-mutation invariant — if `maintain-index-log` was skipped for a mutation, this check catches it.

--- a/codebase-wiki/resources/lint-checklist.md
+++ b/codebase-wiki/resources/lint-checklist.md
@@ -8,7 +8,7 @@ metadata:
 
 # Lint Checklist
 
-The [lint](../techniques/lint.md) technique runs every check below in one pass over the whole wiki and counts the violations as `lint_findings_count`. Each finding names the offending page(s) and the check it failed. Lint reports; it never fixes — fixing is a re-ingest decision.
+Every check below is run in one pass over the whole wiki and the violations are counted as `lint_findings_count`. Each finding names the offending page(s) and the check it failed. The checklist reports; it never fixes — fixing is a re-ingest decision.
 
 | # | Check | Passes when | Fails when |
 |---|-------|-------------|------------|

--- a/codebase-wiki/resources/page-templates.md
+++ b/codebase-wiki/resources/page-templates.md
@@ -1,0 +1,129 @@
+---
+name: page-templates
+description: One body skeleton per wiki page type — the frontmatter block and the cited-claim, confidence-scored layout each ingest page follows.
+metadata:
+  version: 1.0.0
+  order: 1
+---
+
+# Page Templates
+
+One template per page type. Each `ingest` page is drafted from the matching template: the frontmatter follows the [wiki-format](./wiki-format.md) schema, and every claim cites a source and carries a confidence per [citation-conventions](./citation-conventions.md). Replace bracketed placeholders; keep the section headings.
+
+## Concept
+
+```markdown
+---
+title: [Concept name]
+type: concept
+sources:
+  - [repo-relative/path.rs]
+related:
+  - "[[related-entity]]"
+created: [YYYY-MM-DD]
+updated: [YYYY-MM-DD]
+confidence: [high|medium|low]
+---
+
+# [Concept name]
+
+## Summary
+[One-paragraph statement of the concept — what it is and why it exists.] (cite: [path], confidence: [high|medium|low])
+
+## How it works
+- [Claim about the mechanism.] (cite: [path], confidence: [...])
+
+## Realized by
+- [[entity]] — [how this entity implements the concept.]
+
+## Open questions
+- [Anything the source did not settle.]
+```
+
+## Entity
+
+```markdown
+---
+title: [Entity name]
+type: entity
+sources:
+  - [repo-relative/path.rs]
+related:
+  - "[[concept]]"
+created: [YYYY-MM-DD]
+updated: [YYYY-MM-DD]
+confidence: [high|medium|low]
+---
+
+# [Entity name]
+
+## Responsibility
+[What this code unit is responsible for.] (cite: [path], confidence: [...])
+
+## Interface
+- [Key symbol / method / endpoint and its contract.] (cite: [path], confidence: [...])
+
+## Relationships
+- Callers: [[entity]]
+- Callees: [[entity]]
+- Realizes: [[concept]]
+```
+
+## Source summary
+
+```markdown
+---
+title: [path or area name]
+type: source-summary
+sources:
+  - [repo-relative/path.rs]
+related:
+  - "[[entity]]"
+created: [YYYY-MM-DD]
+updated: [YYYY-MM-DD]
+confidence: [high|medium|low]
+---
+
+# [path or area name]
+
+## Contents
+[What this file or area contains.] (cite: [path], confidence: [...])
+
+## Key symbols
+- `[symbol]` — [role.] (cite: [path], confidence: [...])
+
+## Summarized by
+- [[concept]] / [[entity]] this source backs.
+```
+
+## Comparison
+
+```markdown
+---
+title: [A vs B]
+type: comparison
+sources:
+  - [repo-relative/path-a.rs]
+  - [repo-relative/path-b.rs]
+related:
+  - "[[entity-a]]"
+  - "[[entity-b]]"
+created: [YYYY-MM-DD]
+updated: [YYYY-MM-DD]
+confidence: [high|medium|low]
+---
+
+# [A vs B]
+
+## Subjects
+- [[entity-a]]
+- [[entity-b]]
+
+## Comparison
+| Dimension | [A] | [B] |
+|-----------|-----|-----|
+| [aspect]  | [...] (cite: [path-a], confidence: [...]) | [...] (cite: [path-b], confidence: [...]) |
+
+## Trade-offs
+- [Where A wins / where B wins, and why.] (cite: [...], confidence: [...])
+```

--- a/codebase-wiki/resources/wiki-format.md
+++ b/codebase-wiki/resources/wiki-format.md
@@ -1,0 +1,58 @@
+---
+name: wiki-format
+description: The Karpathy LLM-wiki format adapted for code — page schema, the four page types, the wiki tree layout, and the in-place commit-pinned raw baseline.
+metadata:
+  version: 1.0.0
+  order: 0
+---
+
+# Wiki Format
+
+The codebase-wiki adapts the [Karpathy LLM-wiki knowledge-base format](https://blog.starmorph.com/blog/karpathy-llm-wiki-knowledge-base-guide) for code. A wiki is a tree of typed Markdown pages with YAML frontmatter, navigated hierarchically from an index, every claim cited to raw source and scored for confidence. This resource defines the page schema, the page-type taxonomy, the tree layout, and the raw-baseline model. The per-type body skeletons are in [page-templates](./page-templates.md); the citation and confidence vocabulary is in [citation-conventions](./citation-conventions.md).
+
+## Page frontmatter schema
+
+Every page begins with a YAML frontmatter block:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `title` | string | Human-readable page title. |
+| `type` | enum | One of `concept`, `entity`, `source-summary`, `comparison`. |
+| `sources` | list | Repo-relative source paths the page's claims rest on, interpreted at `raw_baseline_commit`. |
+| `related` | list | `[[wikilinks]]` to related pages — kept in sync with the body links by `cross-link`. |
+| `created` | date | When the page was first written. |
+| `updated` | date | When the page was last augmented. |
+| `confidence` | enum | The page's overall confidence — `high`, `medium`, or `low` — the floor of its claims' confidences. |
+
+A page body records claims; each claim cites at least one source path and carries its own confidence, per [citation-conventions](./citation-conventions.md).
+
+## Page-type taxonomy
+
+The four types map the Karpathy schema onto code:
+
+- **`concept`** — an architectural concept, subsystem, or pattern (e.g. a consensus mechanism, an error-handling strategy). Explains an idea the code realizes.
+- **`entity`** — a concrete code unit: a module, package, class, service, or endpoint. Documents what the unit is, what it does, and how it relates to others.
+- **`source-summary`** — a per-file or per-area digest of the raw source: what the file contains, its key symbols, and its responsibilities.
+- **`comparison`** — a cross-cutting comparison of two or more units or approaches (e.g. two implementations of the same interface), surfacing differences and trade-offs.
+
+## Wiki tree layout
+
+```
+{wiki_path}/
+├── index.md          # catalog — every page, organized by type, linked by [[wikilink]]
+├── log.md            # append-only ledger — one entry per mutation
+├── overview.md       # wiki overview / completion summary
+├── concepts/         # type: concept
+├── entities/         # type: entity
+├── sources/          # type: source-summary
+└── comparisons/      # type: comparison
+```
+
+- `index.md` is the navigation entry point — read it and follow `[[wikilinks]]` rather than loading the whole tree.
+- `log.md` is append-only; `maintain-index-log` adds an entry on every mutation and never rewrites prior ones.
+- `overview.md` is written at publish as the completion summary.
+- Page filenames are kebab-case (`epoch-validator-selection.md`), under the subfolder for their type.
+
+## Raw baseline — in place, commit-pinned
+
+There is no physical `raw/` copy of the source under the wiki. The raw baseline is the source tree as it stands at `raw_baseline_commit`, referenced in place. Citations are repo-relative source paths interpreted against that commit; immutability and change-tracking come from git, not from a snapshot. Pinning the baseline to a single commit makes every citation reproducible and lets the stale-claim lint check verify that a cited path still exists and still matches.

--- a/codebase-wiki/techniques/README.md
+++ b/codebase-wiki/techniques/README.md
@@ -1,0 +1,37 @@
+# Codebase Wiki Techniques
+
+> Part of the [Codebase Wiki Workflow](../README.md)
+
+The technique library for the codebase-wiki workflow. Each technique is one capability an activity step binds via `step.technique`; the authoritative protocol, inputs, outputs, and rules live in the per-technique `.md` file and are served by `get_technique`. This file orients — it does not restate protocols.
+
+[`TECHNIQUE.md`](./TECHNIQUE.md) is the workflow-root base contract inherited by every technique here. Its shared inputs (`wiki_path`, `raw_baseline_commit`), its citation and confidence requirements, and the workflow's invariants merge into each technique, and its `Initial`/`Final` protocol blocks wrap each technique's protocol. Because the wiki has a single operation cluster, the shared contract lives in this workflow-root base rather than a group `TECHNIQUE.md` — the five operations are standalone, not a group.
+
+The cross-cutting meta strategy technique [`variable-binding`](../../meta/techniques/variable-binding.md) is declared at the workflow/activity level and inherited, not bound per step.
+
+---
+
+## Workflow-local techniques
+
+| Technique | Capability |
+|-----------|------------|
+| [`ingest`](./ingest.md) | Read a scoped source area at the pinned commit — and optional task knowledge — into typed, cited, confidence-scored pages; cascade related-page links. The augment/update path is folded in here. |
+| [`query`](./query.md) | Search the index, follow `[[wikilinks]]` to the relevant pages, and synthesize a cited answer; optionally persist it as a page. |
+| [`lint`](./lint.md) | Run the single-shot integrity checks over the whole wiki and emit a findings count and report. |
+| [`maintain-index-log`](./maintain-index-log.md) | Update `index.md` and append `log.md` on every mutation. |
+| [`cross-link`](./cross-link.md) | Maintain bidirectional `[[wikilink]]` relationships and `related[]` frontmatter between pages. |
+
+## Cross-workflow consumption and delegation
+
+These operations are standalone, so other workflows bind them with the slash form:
+
+| Reference | Used for |
+|-----------|----------|
+| `codebase-wiki/ingest` | Build or augment the wiki from source and/or task knowledge. |
+| `codebase-wiki/query` | Read the wiki to answer a question with cited claims. |
+| `codebase-wiki/lint` | Check wiki integrity. |
+
+Internally, the techniques delegate raw file IO to work-package's `manage-artifacts` group with the triple-`::` form:
+
+| Reference | Used for |
+|-----------|----------|
+| [`work-package::manage-artifacts`](../../work-package/techniques/manage-artifacts/TECHNIQUE.md) | `write-artifact` — page, index, log, and overview writes, with `target_dir` bound to `{wiki_path}`. |

--- a/codebase-wiki/techniques/README.md
+++ b/codebase-wiki/techniques/README.md
@@ -4,7 +4,7 @@
 
 The technique library for the codebase-wiki workflow. Each technique is one capability an activity step binds via `step.technique`; the authoritative protocol, inputs, outputs, and rules live in the per-technique `.md` file and are served by `get_technique`. This file orients — it does not restate protocols.
 
-[`TECHNIQUE.md`](./TECHNIQUE.md) is the workflow-root base contract inherited by every technique here. Its shared inputs (`wiki_path`, `raw_baseline_commit`), its citation and confidence requirements, and the workflow's invariants merge into each technique, and its `Initial`/`Final` protocol blocks wrap each technique's protocol. Because the wiki has a single operation cluster, the shared contract lives in this workflow-root base rather than a group `TECHNIQUE.md` — the five operations are standalone, not a group.
+[`TECHNIQUE.md`](./TECHNIQUE.md) is the workflow-root base contract inherited by every technique here. Its shared inputs (`wiki_path`, `raw_baseline_commit`), its citation and confidence requirements, and the workflow's invariants merge into each technique, and its `Initial`/`Final` protocol blocks wrap each technique's protocol. Because the wiki has a single operation cluster, the shared contract lives in this workflow-root base rather than a group `TECHNIQUE.md` — the techniques are standalone, not a group. The set is 5 reuse operations (`ingest`, `query`, `lint`, `maintain-index-log`, `cross-link`) plus 2 internal techniques (`collect-scope`, `compose-overview`) bound within `confirm-scope` and `publish`.
 
 The cross-cutting meta strategy technique [`variable-binding`](../../meta/techniques/variable-binding.md) is declared at the workflow/activity level and inherited, not bound per step.
 
@@ -19,6 +19,8 @@ The cross-cutting meta strategy technique [`variable-binding`](../../meta/techni
 | [`lint`](./lint.md) | Run the single-shot integrity checks over the whole wiki and emit a findings count and report. |
 | [`maintain-index-log`](./maintain-index-log.md) | Update `index.md` and append `log.md` on every mutation. |
 | [`cross-link`](./cross-link.md) | Maintain bidirectional `[[wikilink]]` relationships and `related[]` frontmatter between pages. |
+| [`collect-scope`](./collect-scope.md) | Resolve the wiki tree root, pin the citation baseline, capture the ingest scope, and derive the ordered ingest plan. Internal to `confirm-scope`. |
+| [`compose-overview`](./compose-overview.md) | Compose the `overview.md` completion summary from the index and log. Internal to `publish`. |
 
 ## Cross-workflow consumption and delegation
 

--- a/codebase-wiki/techniques/TECHNIQUE.md
+++ b/codebase-wiki/techniques/TECHNIQUE.md
@@ -1,0 +1,52 @@
+---
+metadata:
+  ontology: workflow-canonical
+  kind: technique
+  version: 1.0.0
+---
+
+## Capability
+
+Shared base contract for the codebase-wiki techniques. Any Inputs, Outputs, or Rules defined here are inherited by every technique in this workflow. A Protocol here WRAPS each descendant's own protocol: blocks titled `Initial` are placed before, blocks titled `Final` after, and the server renumbers the combined sequence; any other protocol block here is delivered only when this contract is referenced directly. The wrap is recursive — every ancestor container contributes its `Initial`/`Final`.
+
+The wiki operations are STANDALONE top-level techniques, not a group — there is one operation cluster, so the workflow-root base carries the shared contract directly rather than a group `TECHNIQUE.md`. The technique set is implied by the folder contents; do not list techniques here. Other workflows bind these operations cross-workflow with the slash form `codebase-wiki/<op>` (for example `codebase-wiki/ingest`, `codebase-wiki/query`), exactly as a standalone technique in any other workflow is referenced. Keep this contract minimal: only genuinely cross-technique material belongs here.
+
+## Inputs
+
+### wiki_path
+
+Root of the wiki tree — the directory holding `index.md`, `log.md`, `overview.md`, and the typed-page subfolders (`concepts/`, `entities/`, `sources/`, `comparisons/`). Bound as `target_dir` whenever a technique delegates a page write to `work-package::manage-artifacts::write-artifact`.
+
+### raw_baseline_commit
+
+The pinned source commit every citation is relative to. The raw baseline is the source tree at this commit, referenced in place — there is no physical copy. Citations are repo-relative source paths interpreted against this commit.
+
+## Rules
+
+### immutable-raw-baseline
+
+The raw baseline is immutable — it is the source tree at the pinned `raw_baseline_commit` and is never edited or copied. Citations reference repo-relative source paths at that commit; reproducibility and change-tracking come from git, not from a snapshot under the wiki.
+
+### every-claim-cites-a-source
+
+Every wiki claim cites a raw source path. No claim is recorded without a citation to the source it rests on, in the form defined by the [citation conventions](../resources/citation-conventions.md).
+
+### every-claim-carries-confidence
+
+Every wiki claim carries a confidence score of `high`, `medium`, or `low`, per the confidence vocabulary in the [citation conventions](../resources/citation-conventions.md). A claim without a confidence score is not recorded.
+
+### index-and-log-on-every-mutation
+
+`index.md` and `log.md` are maintained on every mutation — the catalog and the append-only operation ledger never fall behind the pages. Any operation that creates or updates a page also updates the index and appends the log in the same pass.
+
+### contradictions-surfaced-at-lint
+
+Contradictions between pages or claims are surfaced at lint, not silently reconciled. An ingest that encounters a conflicting prior claim records both and leaves reconciliation to the lint pass and the user.
+
+### knowledge-compounds
+
+Knowledge compounds across operations — each ingest augments the existing wiki rather than rebuilding it. Existing pages are updated in place with new sections and deeper detail; prior content is preserved unless a cited source contradicts it.
+
+### hierarchical-navigation
+
+Read `index.md` and follow `[[wikilinks]]` to the relevant pages rather than loading the whole wiki. Hierarchical navigation, not brute-force context loading, is how every operation locates the pages it needs.

--- a/codebase-wiki/techniques/collect-scope.md
+++ b/codebase-wiki/techniques/collect-scope.md
@@ -1,0 +1,56 @@
+---
+metadata:
+  ontology: workflow-canonical
+  kind: technique
+  version: 1.0.0
+---
+
+## Capability
+
+Establish the run's foundation from the user's request: resolve the wiki tree root, pin the citation baseline commit, capture what this build pass should cover, and derive the ordered ingest plan from that scope. This is the producer for the rest of the run — it lands `wiki_path` and `raw_baseline_commit` (inherited as inputs across the other techniques) along with `ingest_scope` and `ingest_plan`.
+
+## Outputs
+
+### wiki_path
+
+Root of the wiki tree — the directory holding `index.md`, `log.md`, `overview.md`, and the typed-page subfolders. Resolved from the user request as an existing wiki to augment or a new directory to create.
+
+### raw_baseline_commit
+
+The pinned source commit every citation is relative to — the current HEAD of the target source tree unless the user names a specific commit. The raw baseline is the source at this commit, referenced in place; there is no physical copy.
+
+### ingest_scope
+
+The free-form description of what this build pass should cover — the source areas, and any task-derived knowledge, to ingest into the wiki.
+
+### ingest_plan
+
+The ordered list of areas to ingest, derived from `{ingest_scope}` — one entry per module, package, subsystem, or file set named in the scope. This is the collection the build-wiki loop iterates.
+
+## Protocol
+
+### 1. Resolve The Wiki Target
+
+- Resolve `{wiki_path}` from the user request — an existing wiki to augment or a new directory to create. It holds `index.md`, `log.md`, `overview.md`, and the typed-page subfolders.
+
+### 2. Pin The Citation Baseline
+
+- Pin `{raw_baseline_commit}` to the source commit every citation will be relative to — the current HEAD of the target source tree unless the user names a specific commit. The raw baseline is the source at this commit, referenced in place; there is no physical copy.
+
+### 3. Capture The Ingest Scope
+
+- Capture `{ingest_scope}` as the free-form description of what this build pass should cover — the source areas, and any task-derived knowledge, to ingest into the wiki.
+
+### 4. Derive The Ingest Plan
+
+- Derive `{ingest_plan}` from `{ingest_scope}` as an ordered list, one entry per module, package, subsystem, or file set named in the scope. This is the collection the build-wiki loop iterates.
+
+## Rules
+
+### baseline-pinned-before-ingest
+
+The baseline is pinned here, before any ingest reads raw source, so every citation resolves against one immutable commit for the whole run.
+
+### plan-derives-from-scope
+
+The ingest plan is derived from the captured scope, not invented — every planned area traces back to a source area or task-derived knowledge named in the scope.

--- a/codebase-wiki/techniques/compose-overview.md
+++ b/codebase-wiki/techniques/compose-overview.md
@@ -1,0 +1,33 @@
+---
+metadata:
+  ontology: workflow-canonical
+  kind: technique
+  version: 1.0.0
+---
+
+## Capability
+
+Compose the `overview.md` completion summary from the finalized wiki state — the log ledger and the index — so the published wiki has a durable entry point. The summary records what the build covered, the page counts by type, the citation baseline commit, and any accepted lint findings.
+
+## Outputs
+
+### wiki_overview
+
+The composed `overview.md` completion summary — areas covered, page counts by type, the citation baseline commit, and any accepted lint findings. Written to `{wiki_path}` as `overview.md`.
+
+## Protocol
+
+### 1. Read The Wiki State
+
+- Read `index.md` for the catalog of pages and their types, and `log.md` for the ledger of what the build covered across its operations.
+
+### 2. Compose The Summary
+
+- Compose `{wiki_overview}` covering: the areas the build covered, the page counts by type (`concept`, `entity`, `source-summary`, `comparison`), the `{raw_baseline_commit}` every citation is relative to, and any lint findings the user accepted at the lint pass.
+- Follow the overview section of the [wiki-format](../resources/wiki-format.md) resource for structure.
+
+## Rules
+
+### summary-from-recorded-state
+
+The overview is composed from the recorded wiki state — the index and the append-only log — not from memory of the run, so it reflects exactly what was written.

--- a/codebase-wiki/techniques/cross-link.md
+++ b/codebase-wiki/techniques/cross-link.md
@@ -1,0 +1,56 @@
+---
+metadata:
+  ontology: workflow-canonical
+  kind: technique
+  version: 1.0.0
+---
+
+## Capability
+
+Maintain the `[[wikilink]]` relationships that make the wiki navigable: insert links between related pages, keep each page's `related[]` frontmatter in sync with the links in its body, and ensure relationships are bidirectional so navigation works in both directions. Invoked by `ingest` to cascade a change across the pages it relates to.
+
+## Inputs
+
+### subject_pages
+
+The pages whose relationships are being maintained — the pages an ingest created or updated, for which links to and from related pages must be established or refreshed.
+
+### related_pages
+
+The pages the subject pages relate to — callers, callees, sibling concepts, source-summaries of the same area, and comparisons that reference them. The other end of each relationship.
+
+## Protocol
+
+### 1. Identify Relationships
+
+- For each subject page, determine which `{related_pages}` it should link to: the concept a code entity realizes, the entities a comparison spans, the source-summary a concept rests on, and the callers/callees of an entity.
+
+### 2. Insert Links
+
+- Add a `[[wikilink]]` in the subject page body wherever it references a related page, using the slug form defined in the [citation conventions](../resources/citation-conventions.md).
+- Add the reciprocal `[[wikilink]]` in the related page so the relationship is bidirectional — a link from A to B implies a link from B to A.
+
+### 3. Sync Frontmatter
+
+- Update the `related[]` frontmatter on both ends to list the linked pages, so the frontmatter is a faithful summary of the body links and `query`/`lint` can rely on it.
+- Remove a `related[]` entry only when the corresponding body link is gone — frontmatter follows the body, never the reverse.
+
+## Outputs
+
+### linked_pages
+
+The pages whose `[[wikilink]]` body links and `related[]` frontmatter were inserted or refreshed, in sync on both ends of each relationship.
+
+## Rules
+
+### bidirectional-links
+
+Every relationship is recorded on both ends — a `[[wikilink]]` from A to B is matched by one from B to A — so navigation and the orphan-page lint check both hold.
+
+### frontmatter-follows-body
+
+`related[]` frontmatter mirrors the `[[wikilinks]]` in the page body; the body is the source of truth and the frontmatter is kept consistent with it, never the other way around.
+
+### resolve-or-omit
+
+A `[[wikilink]]` is inserted only to an existing page; an intended link to a page that does not yet exist is left for the ingest that creates it, so no dangling links are introduced (the missing-referenced-concept lint check stays clean).

--- a/codebase-wiki/techniques/ingest.md
+++ b/codebase-wiki/techniques/ingest.md
@@ -1,0 +1,98 @@
+---
+metadata:
+  ontology: workflow-canonical
+  kind: technique
+  version: 1.0.0
+---
+
+## Capability
+
+Ingest a scoped source area at the pinned baseline commit — and, optionally, task-derived knowledge — into typed wiki pages whose every claim cites a raw source path and carries a confidence score. Creates new pages or augments existing ones in place, then cascades the change to related pages so cross-references stay consistent. Augment and update are folded into ingest: task knowledge is an additional input source alongside the raw code, not a separate operation. This is the operation other workflows bind as `codebase-wiki/ingest` to build or grow the wiki.
+
+## Inputs
+
+### target_area
+
+The single source area to ingest — a module, package, subsystem, or file set named in the ingest plan (the entry the build loop is iterating, bound to `target_area` each pass). Defines which raw sources this pass reads.
+
+### task_knowledge
+
+*(optional)* Task-derived knowledge to fold into the pages alongside the raw code — findings, decisions, or context produced by a calling workflow. When present, the resulting claims cite both the raw source and the task; when absent, ingest covers raw source only.
+
+#### default
+
+`""`
+
+## Protocol
+
+### 1. Locate Existing Pages
+
+- Read `index.md` and follow `[[wikilinks]]` to find any pages that already cover `{target_area}` or concepts it touches — ingest augments rather than rebuilds, so existing coverage is the starting point.
+- Note the related pages that may need a cascade update once this area changes (callers, callees, sibling concepts, comparisons that reference this area).
+
+### 2. Read Raw Source
+
+- Read the raw source for `{target_area}` in place at `{raw_baseline_commit}` — the immutable baseline. Do not copy source into the wiki.
+- Where a graph index is available, use it to resolve the area's entry points, exported symbols, and caller/callee relationships so claims about structure and impact rest on evidence rather than inference.
+- If `{task_knowledge}` was supplied, read it as a second source of claims for the same pages.
+
+### 3. Classify Into Typed Pages
+
+- Map what the area contains onto the four page types per the [wiki-format](../resources/wiki-format.md) taxonomy: `concept` (architectural concept, subsystem, or pattern), `entity` (a concrete code unit — module, package, class, service, endpoint), `source-summary` (a per-file or per-area digest of the raw source), `comparison` (a cross-cutting comparison of two or more units).
+- Choose a kebab-case page slug per page; place each page under the subfolder for its type.
+
+### 4. Draft Cited, Confidence-Scored Claims
+
+- Write each page from the matching template in [page-templates](../resources/page-templates.md), filling the frontmatter (`title`, `type`, `sources[]` at `{raw_baseline_commit}`, `related[]`, `created`, `updated`, `confidence`).
+- For every claim, attach a citation to the raw source path it rests on (and to the task when the claim derives from `{task_knowledge}`) per the [citation conventions](../resources/citation-conventions.md), and a confidence of `high`, `medium`, or `low`.
+- When a claim contradicts an existing page, record both and leave the conflict for the lint pass — do not silently reconcile.
+- When augmenting an existing page, add or deepen sections and refresh `updated`; preserve prior content unless a cited source contradicts it.
+
+### 5. Cascade Related Pages
+
+- Apply [cross-link](./cross-link.md) to insert `[[wikilink]]` relationships between the new or changed pages and their related pages, and to update the `related[]` frontmatter on both ends.
+- Update any related page whose claims are affected by this area's change (for example a caller's source-summary or a comparison that references the changed entity).
+
+### 6. Write Pages
+
+- Write each page by delegating to [`work-package::manage-artifacts::write-artifact`](../../work-package/techniques/manage-artifacts/write-artifact.md), binding `bare_filename` to the page's `{page_slug}.md`, `artifact_content` to the page body, and `target_dir` to `{wiki_path}` (or the typed subfolder beneath it). The find-or-create behavior of `write-artifact` augments an existing page in place and creates a new one otherwise.
+
+## Outputs
+
+### wiki_pages
+
+The typed wiki pages created or updated for `{target_area}` — each with cited, confidence-scored claims and maintained `[[wikilink]]` relationships.
+
+#### artifact
+
+`{page_slug}.md`
+
+#### page_slugs
+
+The kebab-case slugs of every page this ingest created or updated, used by `maintain-index-log` to update the catalog and append the ledger.
+
+#### cascaded_pages
+
+The related pages whose `[[wikilinks]]` or claims were updated as a consequence of this ingest.
+
+### ingest_summary
+
+A one-line description of this ingest for the log ledger — the area covered (`{target_area}`), whether the pass was code-driven or task-driven, and the page count. Consumed by `maintain-index-log` as its `operation_summary`.
+
+## Rules
+
+### typed-pages-only
+
+Every page is one of the four types — `concept`, `entity`, `source-summary`, `comparison` — and lives under the subfolder for its type. No untyped pages.
+
+### augment-not-rebuild
+
+When a page already covers the area, augment it with new sections and deeper detail and refresh `updated`; never discard prior content except where a cited source contradicts it.
+
+### delegate-file-writes
+
+Page file IO is delegated to `work-package::manage-artifacts::write-artifact` — ingest composes page content and citations, it does not re-implement file writing.
+
+### cite-the-task-too
+
+When a claim derives from `{task_knowledge}`, its citation names both the raw source it rests on and the task, so task-driven claims are as traceable as code-derived ones.

--- a/codebase-wiki/techniques/lint.md
+++ b/codebase-wiki/techniques/lint.md
@@ -1,0 +1,60 @@
+---
+metadata:
+  ontology: workflow-canonical
+  kind: technique
+  version: 1.0.0
+---
+
+## Capability
+
+Run a single-shot integrity pass over the whole wiki, applying each check in the [lint-checklist](../resources/lint-checklist.md) — citation coverage, confidence presence, contradictions, orphan pages, missing referenced concepts, stale claims, and index/log integrity — and emit a count of findings plus a per-finding report. Lint surfaces problems; it does not fix them. The count drives the workflow's re-ingest decision.
+
+## Inputs
+
+This technique consumes the workflow-root contract inputs (`wiki_path`, `raw_baseline_commit`) and reads the wiki tree at `{wiki_path}`; it takes no additional inputs.
+
+## Protocol
+
+### 1. Load The Wiki
+
+- Read `index.md` to enumerate every page, then read the pages and `log.md` — lint operates over the whole wiki, not a single area.
+
+### 2. Run Each Check
+
+- Apply every check in the [lint-checklist](../resources/lint-checklist.md) in turn, recording each violation as a finding with the page (or pages) it concerns and the check it failed:
+  - Citation coverage — every claim cites a raw source path.
+  - Confidence presence — every claim carries a `high`/`medium`/`low` score.
+  - Contradictions — no two pages or claims assert conflicting facts without both being recorded as a conflict.
+  - Orphan pages — every page is reachable from `index.md` via `[[wikilinks]]`.
+  - Missing referenced concepts — every `[[wikilink]]` resolves to an existing page.
+  - Stale claims — every cited source path still exists at `{raw_baseline_commit}` and the claim still matches it.
+  - Index/log integrity — `index.md` lists every page and `log.md` records every mutation.
+
+### 3. Report Findings
+
+- Compile the findings into a report grouped by check, each finding naming the offending page(s) and the specific failure, and count them.
+- Contradictions are reported as findings for the user to resolve at re-ingest; lint never reconciles them itself.
+
+## Outputs
+
+### lint_findings_count
+
+The number of findings from the pass — `0` means the wiki passed every check. Drives the `lint-findings-confirmed` checkpoint and the re-ingest decision.
+
+### lint_findings
+
+The per-finding report grouped by check, each entry naming the page(s) and the specific failure.
+
+## Rules
+
+### single-shot-pass
+
+Lint runs every check in one pass over the whole wiki; it is not a per-check loop. Adding a check means adding an entry to the checklist, not a new iteration construct.
+
+### report-do-not-fix
+
+Lint records findings and counts them; it never edits pages. Fixing is a re-ingest decision the user makes at the `lint-findings-confirmed` checkpoint.
+
+### contradictions-are-findings
+
+A contradiction between pages or claims is a finding, never a silent reconciliation — this is where the workflow's contradiction-surfacing invariant is enforced.

--- a/codebase-wiki/techniques/maintain-index-log.md
+++ b/codebase-wiki/techniques/maintain-index-log.md
@@ -1,0 +1,59 @@
+---
+metadata:
+  ontology: workflow-canonical
+  kind: technique
+  version: 1.0.0
+---
+
+## Capability
+
+Keep the wiki's catalog and ledger current with every mutation: update `index.md` to list and route to each page, and append `log.md` with an entry for each create/update operation. This is how the index-and-log-on-every-mutation invariant is enforced — every ingest and every publish refresh runs this technique so navigation and provenance never fall behind the pages. File IO is delegated to `work-package::manage-artifacts::write-artifact`.
+
+## Inputs
+
+### mutated_pages
+
+The pages created or updated in the mutation being recorded — the `page_slugs` an ingest produced, or the set of pages a publish refresh touched. Drives which index entries and log lines to write.
+
+### operation_summary
+
+A one-line description of the mutation for the log entry — the area ingested, the trigger (build pass or task-driven update), and the page count.
+
+## Protocol
+
+### 1. Update The Index
+
+- For each page in `{mutated_pages}`, ensure `index.md` has an entry under its type section linking to the page by `[[wikilink]]`, with its title and one-line summary; add a new entry for a new page, refresh the summary for an updated one.
+- Keep the index organized by page type (`concepts`, `entities`, `sources`, `comparisons`) so it stays navigable as it grows.
+
+### 2. Append The Log
+
+- Append one entry to `log.md` recording the operation: a timestamp, the `{operation_summary}`, the pages touched, the `{raw_baseline_commit}` the claims cite, and whether the mutation was code-driven or task-driven. The log is append-only — never rewrite prior entries.
+
+### 3. Write Both Files
+
+- Write `index.md` and `log.md` by delegating to [`work-package::manage-artifacts::write-artifact`](../../work-package/techniques/manage-artifacts/write-artifact.md), binding `bare_filename` to `index.md` / `log.md`, `artifact_content` to the composed content, and `target_dir` to `{wiki_path}`.
+
+## Outputs
+
+### index_log
+
+The refreshed catalog and the appended ledger for the wiki.
+
+#### artifact
+
+`index.md` and `log.md`
+
+## Rules
+
+### every-mutation
+
+This technique runs on every mutation — paired with each ingest in the build loop and again at publish. The catalog and ledger are never updated lazily or in a batch after the fact.
+
+### log-is-append-only
+
+`log.md` is an append-only ledger — new entries are added; prior entries are never edited or removed, so the log is a faithful operation history.
+
+### delegate-file-writes
+
+Both files are written through `work-package::manage-artifacts::write-artifact`; this technique composes their content, it does not re-implement file writing.

--- a/codebase-wiki/techniques/query.md
+++ b/codebase-wiki/techniques/query.md
@@ -1,0 +1,74 @@
+---
+metadata:
+  ontology: workflow-canonical
+  kind: technique
+  version: 1.0.0
+---
+
+## Capability
+
+Answer a question against the wiki by navigating hierarchically — search `index.md`, follow `[[wikilinks]]` to the relevant pages, and synthesize an answer whose claims carry `[[wikilink]]` citations back to the pages they rest on and the confidence of those pages. Optionally persist the synthesized answer as a page so the knowledge compounds. This is the operation other workflows bind as `codebase-wiki/query` to read the wiki without loading it whole.
+
+## Inputs
+
+### question
+
+The question to answer against the wiki — a natural-language query about the codebase the wiki covers.
+
+### persist_answer
+
+*(optional)* Whether to persist the synthesized answer as a wiki page (a `comparison` or `concept` page, as appropriate) so future queries can reuse it. When false, the answer is returned without writing a page.
+
+#### default
+
+`false`
+
+## Protocol
+
+### 1. Search The Index
+
+- Read `index.md` to locate the pages whose titles, types, or covered areas match `{question}` — the catalog is the entry point, not a full-wiki scan.
+- Pick the smallest set of pages that could answer the question; prefer following `[[wikilinks]]` from a matched page over re-scanning the catalog.
+
+### 2. Read Relevant Pages
+
+- Read the selected pages and follow their `[[wikilinks]]` and `related[]` frontmatter to any adjacent pages the answer depends on.
+- Note each page's claims, their citations, and their confidence — these become the evidence the answer is built from.
+
+### 3. Synthesize The Answer
+
+- Compose an answer to `{question}` from the pages' claims, attributing each part of the answer to the page it came from with a `[[wikilink]]` citation per the [citation conventions](../resources/citation-conventions.md).
+- Carry the confidence of the underlying claims into the answer — flag where the answer rests on `low`-confidence pages or where the wiki has no coverage.
+- Where pages disagree, surface the disagreement rather than picking a side silently — a contradiction is a lint finding, not a query decision.
+
+### 4. Persist If Requested
+
+- When `{persist_answer}` is true, write the answer as a typed page (`comparison` for a cross-cutting synthesis, `concept` for a single subject) via [`work-package::manage-artifacts::write-artifact`](../../work-package/techniques/manage-artifacts/write-artifact.md) into `{wiki_path}`, then apply [maintain-index-log](./maintain-index-log.md) so the new page enters the catalog and ledger.
+
+## Outputs
+
+### answer
+
+The synthesized answer to `{question}`, with `[[wikilink]]` citations to the pages it rests on and the confidence carried from those pages.
+
+#### coverage_gaps
+
+Parts of the question the wiki does not cover, surfaced so the caller can decide whether to ingest the missing area.
+
+#### answer_page
+
+*(present only when `persist_answer` is true)* The slug of the page the answer was persisted to.
+
+## Rules
+
+### navigate-do-not-scan
+
+Locate pages through `index.md` and `[[wikilinks]]`, never by loading the whole wiki — hierarchical navigation is the contract.
+
+### cite-every-claim
+
+Every part of the answer cites the page it rests on with a `[[wikilink]]`; an uncited assertion is not part of the answer.
+
+### surface-do-not-reconcile
+
+When pages disagree, report the disagreement and its citations rather than choosing one — reconciliation is the user's call at lint, not the query's.

--- a/codebase-wiki/workflow.yaml
+++ b/codebase-wiki/workflow.yaml
@@ -12,66 +12,48 @@ tags:
   - karpathy-wiki
   - code-comprehension
 rules:
-  workflow:
-    - The raw baseline is immutable — it is the source tree at the pinned raw_baseline_commit and is never edited or copied; citations reference repo-relative source paths at that commit
-    - Every wiki claim cites a raw source path — no claim is recorded without a citation to the source it rests on
-    - Every wiki claim carries a confidence score of high, medium, or low
-    - index.md and log.md are maintained on every mutation — the catalog and the append-only operation ledger never fall behind the pages
-    - Contradictions between pages or claims are surfaced at lint, not silently reconciled
-    - Knowledge compounds across operations — each ingest augments the existing wiki rather than rebuilding it
-    - Hierarchical navigation over brute-force context loading — read index.md and follow [[wikilinks]] to the relevant pages instead of loading the whole wiki
-  activity:
-    - Never use prose where a formal schema construct exists — steps, checkpoints, decisions, loops, transitions, conditions, triggers, actions, artifacts, and variables must use their dedicated schema fields
-    - Never modify schemas during workflow creation — the schema is a fixed constraint; all content must conform as-is
-    - Convention over invention — search for existing naming conventions before introducing new patterns
-    - Modular over inline — workflow.yaml defines metadata and references; activities, techniques, and resources live in their own files
-    - Encode critical constraints as structure, not just text — back rules with checkpoints, conditions, and validate actions
-    - Every workflow must include a README.md at the root and in each subfolder (activities/, techniques/, resources/) following the style established by the prism workflow
-    - "Ordered-procedure prose is forbidden in any `description` field (activity or step) — a step's procedure lives in its bound technique's `protocol[]`, reached via the structured `step.technique` — either a bare string (`group::operation` or a bare single-file id, no deviations) or an object `{ name, inputs, outputs }` whose `inputs` map carries input deviations and `outputs` map carries output remaps. A BOUND step has NO `description` at all (omit it entirely): the step's `name` is the one-line WHAT label, and the bound technique's `capability` / `protocol` / `rules` carry ALL of the step's semantics. There is NO `step.note` field: any agent-relevant action or constraint that might read as a step caveat is, by nature, technique content — encode it IN the bound technique (as a `## Rules` entry, a protocol step, or an input), never on the step. A caveat that adds no agent value is omitted. Caveat prose never lives in a step `description` or any note."
-    - Every step must bind an operation via `step.technique`, EXCEPT a pure action/control step — one whose only effects are `set`/`log`/`emit`/`message` actions and/or a `when` gate and/or a `checkpoint`/`triggers` — which is exempt. A bound step names exactly ONE operation; compound multi-operation steps are split, one operation per step.
-    - "`techniques[]` is reserved for activity-wide STRATEGY/capability techniques (e.g. `variable-binding`, `scatter-gather`) — protocols that apply across the activity's steps. It MUST NOT list per-step operations; an operation a step invokes is bound at that step via `step.technique`."
-    - On completing each activity, update the planning-folder `README.md` progress tracker — mark this activity's row ✅ Complete in the Activity Progress table and set the session Status to the current milestone. (No session README exists in review mode, where the seed step is skipped.)
+  activity: []
 techniques:
   activity:
     - variable-binding
 variables:
   - name: wiki_path
     type: string
-    description: Root of the wiki tree (holds index.md, log.md, overview.md, and the typed-page subfolders). Resolved and confirmed at wiki-target-confirmed; bound as target_dir when delegating page writes to manage-artifacts.
+    description: Root of the wiki tree — holds index.md, log.md, overview.md, and the typed-page subfolders.
   - name: raw_baseline_commit
     type: string
-    description: The pinned source commit every citation is relative to. The raw baseline is the source tree at this commit, referenced in place — there is no physical copy. Set at wiki-target-confirmed.
+    description: The pinned source commit every citation is relative to. The raw baseline is the source tree at this commit, referenced in place — there is no physical copy.
   - name: ingest_scope
     type: string
     description: Free-form description of what this build pass should cover — the source areas, and any task-derived knowledge, to ingest into the wiki.
     defaultValue: ""
   - name: target_area
     type: string
-    description: A single source area (module, package, subsystem, or file set) named within the ingest scope — the unit an ingest pass operates over. Bound by the build-wiki loop to the current entry of ingest_plan each iteration, and consumed by ingest as its target_area input.
+    description: A single source area — module, package, subsystem, or file set — named within the ingest scope, the unit an ingest pass operates over.
     defaultValue: ""
   - name: ingest_plan
     type: array
-    description: Ordered list of areas to ingest, derived from ingest_scope and confirmed at ingest-scope-confirmed. Iterated by the build-wiki loop.
+    description: Ordered list of areas to ingest, derived from ingest_scope.
   - name: ingest_scope_confirmed
     type: boolean
-    description: Whether the user confirmed the ingest scope and plan — gates the transition into build-wiki. Set at ingest-scope-confirmed.
+    description: Whether the user confirmed the ingest scope and plan.
     defaultValue: false
   - name: lint_findings_count
     type: number
-    description: Number of lint findings from the lint pass. Drives the lint-findings-confirmed gate.
+    description: Number of lint findings from the lint pass.
     defaultValue: 0
   - name: needs_reingest
     type: boolean
-    description: Whether the user opted to fix lint findings by re-ingesting. Drives the rework back-edge from lint-wiki to build-wiki.
+    description: Whether the user opted to fix lint findings by re-ingesting.
     defaultValue: false
   - name: published_pages
     type: array
-    description: The pages the publish refresh touches — the overview.md finalized at publish. Set at publish (set-published-pages) and bound as mutated_pages when maintain-index-log records the publish finalization, mirroring how the build loop binds wiki_pages.page_slugs.
+    description: The pages the publish refresh touches — the overview.md finalized at publish.
   - name: wiki_overview
     type: string
-    description: The composed overview.md completion summary — areas covered, page counts by type, the citation baseline commit, and any accepted lint findings. Set at publish (compose-overview) and written to wiki_path as overview.md.
+    description: The composed overview.md completion summary — areas covered, page counts by type, the citation baseline commit, and any accepted lint findings.
   - name: wiki_published
     type: boolean
-    description: Whether the wiki has been finalized — index/log/overview refreshed and the completion summary written. Set at publish.
+    description: Whether the wiki has been finalized — index, log, and overview refreshed and the completion summary written.
     defaultValue: false
 initialActivity: confirm-scope

--- a/codebase-wiki/workflow.yaml
+++ b/codebase-wiki/workflow.yaml
@@ -1,0 +1,77 @@
+$schema: ../../schemas/workflow.schema.json
+id: codebase-wiki
+version: 1.0.0
+title: Codebase Wiki Workflow
+description: Build and maintain a durable, citation-backed, navigable LLM knowledge base over a codebase, in the Karpathy LLM-wiki format adapted for code. Its operations are reusable techniques other workflows bind via codebase-wiki/<op> to create, augment, query, or update the wiki.
+author: m2ux
+tags:
+  - codebase-wiki
+  - knowledge-base
+  - documentation
+  - citations
+  - karpathy-wiki
+  - code-comprehension
+rules:
+  workflow:
+    - The raw baseline is immutable — it is the source tree at the pinned raw_baseline_commit and is never edited or copied; citations reference repo-relative source paths at that commit
+    - Every wiki claim cites a raw source path — no claim is recorded without a citation to the source it rests on
+    - Every wiki claim carries a confidence score of high, medium, or low
+    - index.md and log.md are maintained on every mutation — the catalog and the append-only operation ledger never fall behind the pages
+    - Contradictions between pages or claims are surfaced at lint, not silently reconciled
+    - Knowledge compounds across operations — each ingest augments the existing wiki rather than rebuilding it
+    - Hierarchical navigation over brute-force context loading — read index.md and follow [[wikilinks]] to the relevant pages instead of loading the whole wiki
+  activity:
+    - Never use prose where a formal schema construct exists — steps, checkpoints, decisions, loops, transitions, conditions, triggers, actions, artifacts, and variables must use their dedicated schema fields
+    - Never modify schemas during workflow creation — the schema is a fixed constraint; all content must conform as-is
+    - Convention over invention — search for existing naming conventions before introducing new patterns
+    - Modular over inline — workflow.yaml defines metadata and references; activities, techniques, and resources live in their own files
+    - Encode critical constraints as structure, not just text — back rules with checkpoints, conditions, and validate actions
+    - Every workflow must include a README.md at the root and in each subfolder (activities/, techniques/, resources/) following the style established by the prism workflow
+    - "Ordered-procedure prose is forbidden in any `description` field (activity or step) — a step's procedure lives in its bound technique's `protocol[]`, reached via the structured `step.technique` — either a bare string (`group::operation` or a bare single-file id, no deviations) or an object `{ name, inputs, outputs }` whose `inputs` map carries input deviations and `outputs` map carries output remaps. A BOUND step has NO `description` at all (omit it entirely): the step's `name` is the one-line WHAT label, and the bound technique's `capability` / `protocol` / `rules` carry ALL of the step's semantics. There is NO `step.note` field: any agent-relevant action or constraint that might read as a step caveat is, by nature, technique content — encode it IN the bound technique (as a `## Rules` entry, a protocol step, or an input), never on the step. A caveat that adds no agent value is omitted. Caveat prose never lives in a step `description` or any note."
+    - Every step must bind an operation via `step.technique`, EXCEPT a pure action/control step — one whose only effects are `set`/`log`/`emit`/`message` actions and/or a `when` gate and/or a `checkpoint`/`triggers` — which is exempt. A bound step names exactly ONE operation; compound multi-operation steps are split, one operation per step.
+    - "`techniques[]` is reserved for activity-wide STRATEGY/capability techniques (e.g. `variable-binding`, `scatter-gather`) — protocols that apply across the activity's steps. It MUST NOT list per-step operations; an operation a step invokes is bound at that step via `step.technique`."
+    - On completing each activity, update the planning-folder `README.md` progress tracker — mark this activity's row ✅ Complete in the Activity Progress table and set the session Status to the current milestone. (No session README exists in review mode, where the seed step is skipped.)
+techniques:
+  activity:
+    - variable-binding
+variables:
+  - name: wiki_path
+    type: string
+    description: Root of the wiki tree (holds index.md, log.md, overview.md, and the typed-page subfolders). Resolved and confirmed at wiki-target-confirmed; bound as target_dir when delegating page writes to manage-artifacts.
+  - name: raw_baseline_commit
+    type: string
+    description: The pinned source commit every citation is relative to. The raw baseline is the source tree at this commit, referenced in place — there is no physical copy. Set at wiki-target-confirmed.
+  - name: ingest_scope
+    type: string
+    description: Free-form description of what this build pass should cover — the source areas, and any task-derived knowledge, to ingest into the wiki.
+    defaultValue: ""
+  - name: target_area
+    type: string
+    description: A single source area (module, package, subsystem, or file set) named within the ingest scope — the unit an ingest pass operates over. Bound by the build-wiki loop to the current entry of ingest_plan each iteration, and consumed by ingest as its target_area input.
+    defaultValue: ""
+  - name: ingest_plan
+    type: array
+    description: Ordered list of areas to ingest, derived from ingest_scope and confirmed at ingest-scope-confirmed. Iterated by the build-wiki loop.
+  - name: ingest_scope_confirmed
+    type: boolean
+    description: Whether the user confirmed the ingest scope and plan — gates the transition into build-wiki. Set at ingest-scope-confirmed.
+    defaultValue: false
+  - name: lint_findings_count
+    type: number
+    description: Number of lint findings from the lint pass. Drives the lint-findings-confirmed gate.
+    defaultValue: 0
+  - name: needs_reingest
+    type: boolean
+    description: Whether the user opted to fix lint findings by re-ingesting. Drives the rework back-edge from lint-wiki to build-wiki.
+    defaultValue: false
+  - name: published_pages
+    type: array
+    description: The pages the publish refresh touches — the overview.md finalized at publish. Set at publish (set-published-pages) and bound as mutated_pages when maintain-index-log records the publish finalization, mirroring how the build loop binds wiki_pages.page_slugs.
+  - name: wiki_overview
+    type: string
+    description: The composed overview.md completion summary — areas covered, page counts by type, the citation baseline commit, and any accepted lint findings. Set at publish (compose-overview) and written to wiki_path as overview.md.
+  - name: wiki_published
+    type: boolean
+    description: Whether the wiki has been finalized — index/log/overview refreshed and the completion summary written. Set at publish.
+    defaultValue: false
+initialActivity: confirm-scope


### PR DESCRIPTION
## Purpose

Adds a standalone **codebase-wiki** workflow that builds an LLM-oriented wiki from a codebase. It adapts the Karpathy LLM-wiki knowledge-base standard to source code: each page is structured for machine and human readers, grounded in the actual repository at a pinned commit rather than in model recollection.

## Activity spine

```
confirm-scope -> build-wiki -> lint-wiki -> publish
```

- **confirm-scope** — agree the target codebase, the wiki's coverage boundary, and the commit to pin against.
- **build-wiki** — ingest the codebase and author the wiki pages.
- **lint-wiki** — enforce the wiki invariants across every page.
- **publish** — emit the finished wiki.

## Reusable techniques

Five standalone techniques ship with the workflow and are designed to be bound cross-workflow as `codebase-wiki/<op>`:

- **ingest** — read the codebase and capture a commit-pinned raw baseline in place.
- **query** — answer questions against the ingested baseline.
- **lint** — check pages against the wiki invariants.
- **maintain-index-log** — keep the wiki index and change log current.
- **cross-link** — wire pages together with consistent internal references.

## Wiki invariants

- **Commit-pinned baseline** — the raw baseline is captured in place against a specific commit, so every claim is anchored to a concrete revision.
- **Citation invariant** — every claim on a page cites its source in the codebase.
- **Confidence invariant** — each page carries an explicit confidence signal, distinguishing verified facts from inferences.

These invariants are encoded structurally (lint checks), not just described in prose.

## Compliance review fixes

A compliance review of the workflow was resolved in commit `1c245b43`:

- **M1** — dropped transplanted authoring rules from the activity contract that did not belong there.
- **M2** — removed the no-op workflow-rules duplication, keeping the invariants in `TECHNIQUE.md` as the single source of truth.
- **M3** — replaced three procedural `set` steps with bound techniques `collect-scope` and `compose-overview` (two new technique files).
- Removed AP-44 resource backlinks; trimmed the `activities/README` transcription; de-narrated variable descriptions; trimmed a validate-message tail.
- Clarified `techniques/README` — five cross-workflow reuse ops plus two internal techniques.
