### PR TITLE
review-mode: harden against interaction/config-change defects misclassified as low-severity (#145)

### DIFF
--- a/prism/techniques/structural-analysis.md
+++ b/prism/techniques/structural-analysis.md
@@ -47,6 +47,15 @@ Apply L12 structural analysis lens to code for deep structural findings, conserv
 - Conclude with the concrete bug table — every bug, edge case, and silent failure discovered at any stage
 - If the analysis stays at the surface without reaching the conservation law, re-execute from the structural invariant step — the depth comes from the inversion chain, not the initial claim
 
+#### Producer/clearer ledger
+
+The conservation law names a resource the code must conserve (a storage record, a queue entry, an allocation, a lock, a handle). Make the conservation concrete with a written ledger that enumerates, set-wide, every site that **produces** the resource against every site that **clears** it — not only the sites on the diff's path. For each resource the conservation law identifies:
+
+- List every producer (each site that creates an instance of the resource) and every clearer (each site that ends an instance's lifecycle), across the whole reachable code set, using the structural context gathered in step 3 to find producers and clearers in unchanged upstream code.
+- Match each producer to the clearer(s) that release what it creates, and trace **every** termination path — normal completion, early return, error, panic, and governance/teardown — to confirm a matching clear exists on each.
+- A producer with no matching clearer on some reachable termination path is an **unmatched producer**: the resource accumulates without bound on that path. Record it as a Bug-Table entry (see step 6) so it reaches classification.
+- The conservation law holds — "no new bug" — only when the invariant is satisfied on **every** producing path. A single unmatched path falsifies it.
+
 ### 5. Write Artifact
 
 - Write the complete analysis as `{structural_analysis}` into `{output_path}`. If the write fails, verify `{output_path}` exists and is writable.
@@ -55,7 +64,8 @@ Apply L12 structural analysis lens to code for deep structural findings, conserv
 ### 6. Format Output
 
 - Structure `{structural_analysis}` with clear section headers: Claim, Dialectic, Concealment Mechanism, Improvements, Structural Invariant, Conservation Law, Meta-Law, Bug Table
-- In the Bug Table, classify each finding as fixable or structural based on whether the conservation law predicts it can be resolved
+- Render the producer/clearer ledger as a table within the Conservation Law section — one row per resource with its producers, clearers, and the matched/unmatched verdict per termination path
+- In the Bug Table, classify each finding as fixable or structural based on whether the conservation law predicts it can be resolved; every unmatched producer from the ledger appears as a Bug-Table entry
 - Include file paths, line numbers, and specific function names for every finding
 
 ## Outputs
@@ -70,7 +80,7 @@ L12 structural analysis with conservation law, meta-law, and classified bug tabl
 
 #### conservation_law
 
-The named conservation law between original and inverted impossibilities
+The named conservation law between original and inverted impossibilities, carrying the producer/clearer ledger — the set-wide enumeration of every producer of each conserved resource against its clearers, with the matched/unmatched verdict per termination path
 
 #### meta_law
 
@@ -78,7 +88,7 @@ What the conservation law itself conceals — the deeper finding
 
 #### bug_table
 
-Every concrete bug with location, severity, and fixable/structural classification
+Every concrete bug with location, severity, and fixable/structural classification — including each unmatched producer surfaced by the producer/clearer ledger
 
 #### concealment_mechanism
 

--- a/work-package/activities/01-start-work-package.yaml
+++ b/work-package/activities/01-start-work-package.yaml
@@ -68,6 +68,14 @@ steps:
           setVariable:
             is_review_mode: false
   - kind: technique
+    id: ingest-prior-feedback
+    technique: review-existing-feedback
+    condition:
+      type: simple
+      variable: is_review_mode
+      operator: ==
+      value: true
+  - kind: technique
     id: resolve-reference
     technique: reference-resolution
   - kind: technique

--- a/work-package/activities/11-validate.yaml
+++ b/work-package/activities/11-validate.yaml
@@ -35,6 +35,14 @@ steps:
       variable: is_review_mode
       operator: ==
       value: true
+  - kind: technique
+    id: triage-reported-failures
+    technique: review-test-suite
+    condition:
+      type: simple
+      variable: is_review_mode
+      operator: ==
+      value: true
   - kind: action
     id: fix-failures
     condition:

--- a/work-package/resources/review-mode.md
+++ b/work-package/resources/review-mode.md
@@ -165,6 +165,7 @@ https://github.com/{ENG_REPO_OWNER}/{ENG_REPO_NAME}/blob/main/.engineering/artif
 
 | Report Name | Artifact |
 |-------------|----------|
+| Prior Feedback Triage | `prior-feedback-triage.md` |
 | Code Review | `code-review.md` |
 | Test Suite Review | `test-suite-review.md` |
 
@@ -191,6 +192,7 @@ Resolve `{WORKFLOW_REPO_OWNER}`, `{WORKFLOW_REPO_NAME}`, and `{WORKFLOW_BRANCH}`
 
 | Section | Prefix |
 |---------|--------|
+| Prior Feedback Triage | PF |
 | Code Review Findings | CR |
 | Test Review Findings | TR |
 | Documentation Review | DR |
@@ -212,6 +214,26 @@ Example: `(CR-1)` refers to Code Review finding 1, `(TR-3)` refers to Test Revie
 [1-2 sentence overall assessment]
 
 **Overall Rating**: [Approve / Request Changes / Comment Only]
+
+---
+
+### Prior Feedback Triage
+
+Disposition of every prior comment and review on the PR (human and bot), determined before independent analysis.
+
+| # | Prior Comment | Author | Disposition | Reasoning |
+|---|---------------|--------|-------------|-----------|
+| [1](pr-comment-url) | Storage record never cleared on close | reviewer | Confirmed | Unaddressed — clear missing on the governance-close path |
+| [2](pr-comment-url) | Naming nit on handler | bot | Refuted | Name follows the crate convention |
+
+<details>
+<summary>Finding Details</summary>
+
+#### PF-1. Storage record never cleared on close (Confirmed — blocker)
+[Why the concern holds and remains unaddressed]
+**Disposition**: Confirmed — caps the Overall Rating
+
+</details>
 
 ---
 
@@ -338,6 +360,18 @@ Example: `(CR-1)` refers to Code Review finding 1, `(TR-3)` refers to Test Revie
 | Medium | No | Can be follow-up PR |
 | Low | No | Nice to have |
 
+Findings are classified on the classification scale (Critical / Major / Minor / Nit / Informational) and rendered on the summary scale above. The render map preserves the classified severity end to end — a finding classified above "safe" renders above "safe":
+
+| Classified severity | Renders as |
+|---------------------|------------|
+| Critical | Critical |
+| Major | High |
+| Minor | Medium |
+| Nit | Low |
+| Informational | (omitted from the tables — recorded in the report only) |
+
+A correct-but-harmful finding (one classified Major or Critical on an impact axis such as unbounded state growth, economic/spam, liveness/halt, or migration/upgrade) therefore renders at High or Critical and reaches the Action Items as a blocking item — it is not downgraded to "safe" at the render boundary.
+
 ---
 
 ## Posting Reviews
@@ -362,6 +396,8 @@ gh pr review {pr_number} --approve --body-file review.md
 | Critical/High severity blockers | `--request-changes` |
 | Medium/Low findings only | `--comment` |
 | No significant issues | `--approve` with summary |
+
+The Prior Feedback Triage caps the Overall Rating: when any prior blocker-class comment is dispositioned Confirmed (valid and unaddressed), the rating cannot exceed Request Changes — it cannot be Approve or Comment Only — regardless of how light the review's own findings are. An unaddressed external blocker is never rated away.
 
 ---
 

--- a/work-package/techniques/findings-classification.md
+++ b/work-package/techniques/findings-classification.md
@@ -33,6 +33,10 @@ True when any code-review finding has severity >= Minor (Critical, Major, or Min
 
 True when any test-suite finding has severity >= Minor (Critical, Major, or Minor); false when all test-suite findings are Nit/Informational or there are no findings.
 
+### classified_findings
+
+The input findings, each carrying its assigned severity and — where one applies — its `impact_axis` (the dimension on which a behaviourally correct change is nonetheless harmful: unbounded-state-growth, economic-spam, liveness-halt, or migration-upgrade). Downstream rendering reads the severity to place each finding on the render scale and reads the impact axis to justify a correct-but-harmful classification.
+
 ## Protocol
 
 ### 1. Classify Findings
@@ -40,6 +44,17 @@ True when any test-suite finding has severity >= Minor (Critical, Major, or Mino
 - Assign every finding in `{findings_to_classify}` a severity on the single scale: Critical, Major, Minor, Nit, or Informational.
 - Judge severity by impact, not surface: Critical for security or data-loss risks and failing tests; Major for correctness defects and build failures; Minor for maintainability and lint issues; Nit for style; Informational for observations carrying no required action.
 - When the findings are validation diagnostics (test/build/lint failures), map them onto the same scale — test failures are Critical, build failures are Major — and do NOT attempt to fix them here; classification only.
+
+#### Impact-based severity axes
+
+Code-correctness is one axis of severity; system impact is another, orthogonal to it. A change can be locally correct — the new lines do exactly what they read as doing — and still be harmful through its effect on the system as a whole. Judge each finding against these impact axes in addition to correctness, and record the axis that applies on the classified finding (`impact_axis`):
+
+- **unbounded-state-growth** — a code path creates persistent state (a storage record, a queue entry, an allocation) on a recurring or attacker-driven action without a matching reclaim on every path that ends that state's lifecycle, so the footprint grows without bound.
+- **economic-spam** — a path lets an actor impose cost (storage, compute, fees borne by others, griefing) disproportionate to the cost or authority required to trigger it.
+- **liveness-halt** — a path can stall, deadlock, or halt progress for the system or a class of participants (a panic on a reachable input, an unbounded loop, a lock never released).
+- **migration-upgrade** — a change to persisted shape, encoding, or governance binding leaves existing on-chain or on-disk state unreadable, mis-governed, or un-upgradeable without an accompanying migration.
+
+A finding that is correct on the code-correctness axis but lands on any impact axis is **correct-but-harmful**. Classify a correct-but-harmful finding at **Major** at minimum, and at **Critical** when the impact is unrecoverable without intervention (state already corrupted, funds already lost, chain already halted). Because correct-but-harmful classifies Major or above, it is ≥ Minor and therefore sets `{needs_code_fixes}` through the existing routing rule — the impact axes add severity without changing the routing threshold.
 
 ### 2. Route Code Findings
 

--- a/work-package/techniques/review-code.md
+++ b/work-package/techniques/review-code.md
@@ -40,6 +40,15 @@ Folder where the code review report is written
 - For each changed symbol of interest, apply [gitnexus-operations](../../meta/techniques/gitnexus-operations/TECHNIQUE.md)::[impact](../../meta/techniques/gitnexus-operations/impact.md) `{target, direction: 'upstream'}` to surface upstream callers and bound the review's blast radius
 - Use the resulting blast radius to inform severity judgements — high-fanout callers and process-critical paths raise the severity ceiling for findings in those symbols.
 
+#### Associated-type / trait-impl swap
+
+When the diff changes a `Config` impl, an associated type, or any trait-implementation binding, the blast radius extends beyond the changed line to every site that reads or writes through that binding — including unchanged upstream code that now resolves to the swapped type. A change that reads as locally correct can silently re-govern that unchanged code. For each such change:
+
+- Enumerate every upstream read site and write site keyed on the changed type or binding (use the `impact upstream` result as the starting set; follow each caller to the operations it performs on the type).
+- Verify the full state lifecycle stays balanced across that set: every site that **creates** state through the binding has a matching **clearer** on every path that ends the state's lifecycle, and every invariant the prior binding upheld still holds under the new one.
+- Treat the unchanged upstream code as in-scope evidence — the imbalance often lives in code the diff never touched.
+- A detected imbalance is a finding that classifies ≥ Minor (so it sets `needs_code_fixes`); when the imbalance causes unbounded state growth or other system harm, classify it on the matching impact axis (Major or above), so a correct-but-harmful config swap is rated above "safe".
+
 ### 3. Review Files
 
 - Review each changed file against architecture and design patterns

--- a/work-package/techniques/review-code.md
+++ b/work-package/techniques/review-code.md
@@ -42,11 +42,9 @@ Folder where the code review report is written
 
 #### Associated-type / trait-impl swap
 
-When the diff changes a `Config` impl, an associated type, or any trait-implementation binding, the blast radius extends beyond the changed line to every site that reads or writes through that binding — including unchanged upstream code that now resolves to the swapped type. A change that reads as locally correct can silently re-govern that unchanged code. For each such change:
+When the diff changes a `Config` impl, an associated type, or any trait-implementation binding, the blast radius extends beyond the changed line to every site that reads or writes through that binding — including unchanged upstream code that now resolves to the swapped type. A change that reads as locally correct can silently re-govern that unchanged code, so the swapped binding is in scope for the state-lifecycle conservation walk over that upstream set.
 
-- Enumerate every upstream read site and write site keyed on the changed type or binding (use the `impact upstream` result as the starting set; follow each caller to the operations it performs on the type).
-- Verify the full state lifecycle stays balanced across that set: every site that **creates** state through the binding has a matching **clearer** on every path that ends the state's lifecycle, and every invariant the prior binding upheld still holds under the new one.
-- Treat the unchanged upstream code as in-scope evidence — the imbalance often lives in code the diff never touched.
+- Run the set-wide producer/clearer conservation walk over the upstream read and write sites keyed on the changed binding — the [prism](../../prism/techniques/structural-analysis.md)::[structural-analysis](../../prism/techniques/structural-analysis.md#producerclearer-ledger) producer/clearer ledger owns the method (enumerate every producer against every clearer across the unchanged upstream set; confirm a matching clear on every termination path). Seed it from the `impact upstream` result.
 - A detected imbalance is a finding that classifies ≥ Minor (so it sets `needs_code_fixes`); when the imbalance causes unbounded state growth or other system harm, classify it on the matching impact axis (Major or above), so a correct-but-harmful config swap is rated above "safe".
 
 ### 3. Review Files

--- a/work-package/techniques/review-existing-feedback.md
+++ b/work-package/techniques/review-existing-feedback.md
@@ -1,0 +1,72 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Ingest and triage every prior comment and review on the PR under review — human and bot, top-level and inline — before any independent analysis begins, so the verdict accounts for signal others have already raised. Each prior finding is dispositioned Confirmed, Refuted, or Superseded with reasoning, and an unaddressed external blocker-class comment caps the Overall Rating so the review cannot conclude "Comment Only / no blocker" while a blocker stands.
+
+## Inputs
+
+### review_pr_url
+
+The URL of the PR under review, captured during PR-reference detection. Identifies the PR whose existing comments and reviews are ingested.
+
+## Outputs
+
+### prior_feedback_triage
+
+The triage table: one row per prior comment or review thread, each marked Confirmed, Refuted, or Superseded with the reasoning for that disposition and the author and class (human or bot, blocker or non-blocker) of the original. A reported runtime error in a thread is captured here once, tagged as a reported failure, so downstream reported-failure triage consumes it rather than re-reading the thread.
+
+#### artifact
+
+`prior-feedback-triage.md`
+
+### rating_cap
+
+The ceiling the Overall Rating may not exceed, derived from the triage. When any prior comment is a blocker-class concern left unaddressed by the PR, the cap is the request-changes tier; otherwise the cap is unset and the rating is governed solely by the review's own findings. The summary applies this cap so an unaddressed external blocker cannot be rated away.
+
+## Protocol
+
+### 1. Ingest All Prior Feedback
+
+- Read every top-level comment and review on `{review_pr_url}` with `gh pr view {pr_number} --json comments,reviews`.
+- Read every inline review thread with `gh api repos/{owner}/{repo}/pulls/{pr_number}/comments`, resolving `{owner}` and `{repo}` from `{review_pr_url}`.
+- Include both human and bot authors — a bot finding is signal, not noise. Do this before any independent code, structural, or test analysis, so the existing signal frames the review rather than being reconciled after a verdict is formed.
+
+### 2. Triage Each Prior Finding
+
+- For each prior comment or thread, assign a disposition with reasoning:
+  - **Confirmed** — the concern is valid and unaddressed by the PR as it stands.
+  - **Refuted** — the concern does not hold; record why (the code does not do what the comment claims, the case is handled elsewhere, the premise is mistaken).
+  - **Superseded** — the concern was valid but a later commit or a subsequent comment resolves it; record the resolving change.
+- Tag each row with the author class (human / bot) and whether the original concern is blocker-class (it asserts a correctness, safety, data-loss, or runtime-failure defect) or non-blocker (style, preference, question).
+- Tag any reported runtime error so it is traceable as a reported failure downstream — captured once here.
+
+### 3. Derive the Rating Cap
+
+- Set `{rating_cap}` to the request-changes tier when any blocker-class concern is dispositioned Confirmed (valid and unaddressed); leave it unset when every blocker-class concern is Refuted or Superseded.
+- An unaddressed external blocker therefore prevents an "approve" or "comment only" verdict regardless of the review's own findings.
+
+### 4. Write the Triage
+
+- Write `{prior_feedback_triage}` to `{planning_folder_path}` so the consolidated summary renders the triage section and applies the cap.
+
+## Rules
+
+### ingest-before-analysis
+
+Prior feedback is ingested and triaged before any independent analysis activity runs, so existing signal informs the review rather than being reconciled against a verdict already formed.
+
+### every-prior-finding-dispositioned
+
+Every prior comment and review thread receives an explicit Confirmed / Refuted / Superseded disposition with reasoning — none is silently dropped.
+
+### unaddressed-blocker-caps-rating
+
+An unaddressed blocker-class concern sets the rating cap; the Overall Rating may not exceed it. A blocker is never rated away by the review's own findings being light.
+
+### single-ingest-of-reported-failures
+
+A runtime error reported in a thread is captured here exactly once and tagged as a reported failure; downstream reported-failure triage consumes the tagged entry rather than re-reading the thread, so it is ingested once and traced once.

--- a/work-package/techniques/review-summary.md
+++ b/work-package/techniques/review-summary.md
@@ -17,6 +17,14 @@ The findings gathered and classified across code review, test review, validation
 
 The attached [review-mode](../resources/review-mode.md) resource, whose [Consolidated Review Format](../resources/review-mode.md#consolidated-review-format) defines the summary structure.
 
+### prior_feedback_triage
+
+The triage of prior PR feedback — each prior comment dispositioned Confirmed / Refuted / Superseded — rendered as the summary's Prior Feedback Triage section.
+
+### rating_cap
+
+The ceiling the Overall Rating may not exceed, derived from the prior-feedback triage. When set to the request-changes tier (an unaddressed external blocker), the rendered Overall Rating is held at or below Request Changes.
+
 ## Outputs
 
 ### review_summary
@@ -32,5 +40,7 @@ The structured consolidated review summary text, organized per the Consolidated 
 ### 2. Render the Summary
 
 - Populate the template from `{consolidated_findings}`: executive summary, per-category findings (code, test, documentation, validation, branch hygiene), action items, and severity definitions.
+- Render the Prior Feedback Triage section from `{prior_feedback_triage}`: one row per prior comment with its Confirmed / Refuted / Superseded disposition, and carry each Confirmed blocker-class entry into the Action Items as a blocking item.
+- Apply `{rating_cap}` to the Overall Rating: when the cap is the request-changes tier, the Overall Rating is held at or below Request Changes — never Approve or Comment Only — even if the review's own findings are light.
 - Produce `{review_summary}` as the rendered text.
 - Follow the loaded format exactly — do not invent a parallel structure; the review-mode resource is the authoritative owner of the format.

--- a/work-package/techniques/review-test-suite.md
+++ b/work-package/techniques/review-test-suite.md
@@ -21,6 +21,10 @@ List of files changed in the work package (from `git diff`)
 
 Folder where the test suite review report is written
 
+### prior_feedback_triage
+
+*(optional)* The triage of prior PR feedback, when present. Its entries tagged as reported runtime failures are the input to reported-failure triage — each is traced to a code path and state precondition here rather than re-read from the PR thread.
+
 ## Protocol
 
 ### 1. Load Guidance
@@ -47,6 +51,21 @@ Folder where the test suite review report is written
 - Verify test isolation and independence
 - Review assertion quality and error message clarity
 - For Rust projects, reference TDD best practices from [tdd-concepts-rust](../resources/tdd-concepts-rust.md)
+
+#### Multi-instance coverage gate
+
+Generic and multi-instance code — a generic function, a trait implemented for several types, a handler parameterised over a runtime-configured instance set — is covered only when each instance it can take is exercised. Coverage of one instance is not coverage of the type:
+
+- Enumerate the instances the changed generic / multi-instance code can take in the running system, and flag any instance with no exercising test as a coverage gap (≥ Minor, so it routes).
+- When a branch is unreachable under the current test mock — the mock pins a single instance, so a path that only the other instances reach can never execute — escalate the **test harness itself** as a finding: the mock conceals the branch from coverage. This is a harness defect, classified ≥ Minor, not a default-Medium nit on the untested branch.
+
+#### Reported-failure triage
+
+When `{prior_feedback_triage}` is present, every entry tagged as a reported runtime failure is traced to its origin — captured once during feedback ingest, traced once here, never re-read from the thread:
+
+- Trace each reported failure to the specific code path that raises it and the state precondition under which that path is reached.
+- Reproduce the failure where the harness allows; otherwise trace it statically and name the triggering conditions.
+- Record each traced failure as a finding (≥ Minor, so it routes); a failure with no test exercising its triggering path is also a coverage gap per the multi-instance gate above.
 
 ### 5. Document Findings
 


### PR DESCRIPTION
## Summary

Harden the `work-package` review-mode path so interaction-driven and configuration-change defects can no longer pass as low-severity, closing the gap surfaced by the midnight-node PR #1428 retrospective via five coordinated augmentations (9 files, +188/−3) that give the motivating defect class two independent detection paths.


🐛 [Issue](https://github.com/m2ux/workflow-server/issues/145)  📐 [Engineering](https://github.com/m2ux/workflow-server/blob/engineering/artifacts/planning/2026-06-30-review-mode-harden-config-defects/README.md)

---

## Motivation

Review-mode judged a PR by reading the proposed change in isolation, which let a locally-correct but globally-harmful single-line `Config` swap through — it silently re-governed untouched code and leaked storage on every routine governance close. Five gaps combined: prior reviewer feedback was never ingested, config blast-radius was never traced, no conservation ledger proved every created record is cleared, the severity model had no "correct-but-harmful" axis, and reported runtime failures were silently downgraded. This change hardens the path against all five so that defect class cannot pass un-flagged again.

---

## Changes

- **Prior-feedback ingestion** — New `review-existing-feedback` technique ingests every existing PR comment and review (human and bot, top-level and inline) before independent analysis, triages each as Confirmed / Refuted / Superseded, and caps the Overall Rating when an external blocker is unaddressed. Bound after PR capture in start-work-package, gated on review-mode.
- **Config blast-radius** — `review-code` gains an associated-type / trait-impl swap sub-check that extends the review scope to every read/write site keyed on the swapped binding, including unchanged upstream callers, and delegates the lifecycle walk to the structural ledger.
- **Conservation ledger** — The shared structural-analysis lens now writes a set-wide producer/clearer ledger across every termination path (normal, early-return, error, panic, teardown); an unmatched producer surfaces as a classifiable finding. Purely additive to the lens contract, so cross-workflow bindings are unaffected.
- **Correct-but-harmful severity** — `findings-classification` adds impact axes (unbounded-state-growth, economic/spam, liveness/halt, migration/upgrade) so a correct-but-harmful change classifies Major or higher and sets the code-fix routing flag; the review-mode resource adds a documented Major→High / Minor→Medium / Nit→Low render map so the severity is preserved end-to-end rather than downgraded at the render boundary.
- **Reported-failure triage and coverage gate** — `review-test-suite` traces each reported runtime failure to a code path and state precondition, auto-flags untested multi-instance variants, and escalates a mock-masked branch as a harness finding rather than a default nit; bound as a review-mode step in validate.
- **Review-summary rendering** — The consolidated review resource and `review-summary` render the Prior Feedback Triage section and apply the rating cap to the Overall Rating.
- **Tests** — Definition-lint stays green (`BASELINE_UNRESOLVED = []`, every new reference resolves) and all 6 workflow-e2e policies reach `complete`; standard-mode walks are unperturbed as every new step is gated on review-mode.

---

## 🤖 AI Assistance

- **Assistant / Model:** Claude Code / claude-opus-4-8[1m]
- **Context scope:** repo-only
- **Prompt classes:** workflow-definition authoring, technique/resource editing, review-mode analysis, docs
- **Provenance log:** [engineering planning folder](https://github.com/m2ux/workflow-server/blob/engineering/artifacts/planning/2026-06-30-review-mode-harden-config-defects/README.md)

---

## ⚠️ Required follow-up (cross-repo, deferred)

The workflow-definition changes in this PR live on the `workflows` orphan branch. The e2e baseline (`tests/e2e/__snapshots__/snapshot.test.ts.snap` and the robot-execution manifest) lives in the **server repo**, not here, so it is intentionally **not** part of this PR. After this PR merges into `workflows`, a coordinated server-repo follow-up must, together:

1. Bump the `workflows` submodule pointer to the merged commit, and
2. Regenerate the `[review-mode]` e2e baseline (the new gated steps and artifacts).

The baseline is deferred because the harness resolves definitions from the main-checkout working tree — regenerating it requires the merged definitions in place. In-branch validation already confirms the meaningful gates: definition-lint clean and 6/6 workflow-e2e policies `complete` against the feature definitions.

---

## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: definition-layer workflow change; no server change file applies
- [x] If the changes introduce a new feature, I have bumped the node minor version
- [x] Update documentation (if relevant)
- [x] No new todos introduced

---

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other
- [x] N/A

---

## 🗹 TODO before merging

- [x] Ready for review
