### PR TITLE
chore(prism): pipeline-internal definitive-findings-template + bump workflows to prism-consumer-reuse

### DIFF
--- a/scripts/check-prism-lens-reachability.ts
+++ b/scripts/check-prism-lens-reachability.ts
@@ -46,6 +46,7 @@ const PIPELINE_INTERNAL = new Set([
   'writer-critique', // writer pipeline pass 2 (cross-workflow-only chain)
   'writer-synthesis', // writer pipeline pass 3 (cross-workflow-only chain)
   'final-output-template', // REPORT.md skeleton — a template, not a lens
+  'definitive-findings-template', // DEFINITIVE-FINDINGS.md skeleton — a template, not a lens
 ]);
 
 export interface LensReachabilityViolation {


### PR DESCRIPTION
## What & why

Server-side half of the prism-contract-reuse change. Ships one guard update and bumps the `workflows` submodule to the content commit.

## Changes

- **`scripts/check-prism-lens-reachability.ts`** — add `definitive-findings-template` to the `PIPELINE_INTERNAL` set. The content PR introduces `prism/resources/definitive-findings-template.md`, a document skeleton (like `final-output-template`), not a goal-routable lens; without this the lens-reachability guard flags it as an orphan.
- **`workflows` submodule** — bump to the `prism-consumer-reuse` content (see the content PR).

## Verification

`npm run typecheck`, all guard scripts, and the full test suite were run against this branch (with the submodule at the new content): **362 passing**, all e2e walks/definition-lint/snapshots green, **zero new** binding-fidelity/identifier/bound-step/artifact violations from the change. No baseline or snapshot files needed updating. (The 2 remaining suite failures are pre-existing `codebase-wiki` drift, unrelated to this change.)

## Coordinated PR

Pairs with the **content** PR #152 (workflow definitions). **Merge #152 first**; after it lands on the `workflows` branch, the submodule pointer here can be fast-forwarded to the merge commit if it differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
