### PR TITLE
test(e2e): retarget walks and baselines at work-package 3.15.0 checkpoint set

### DIFF
--- a/tests/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/tests/e2e/__snapshots__/snapshot.test.ts.snap
@@ -82,12 +82,7 @@ exports[`work-package walk snapshots (baseline) > [default] matches committed ba
       ],
       "checkpoints": [
         {
-          "id": "classification-confirmed",
-          "option": "confirmed",
-          "setVariable": undefined,
-        },
-        {
-          "id": "workflow-path-selected",
+          "id": "classification-and-path-confirmed",
           "option": "skip-optional",
           "setVariable": {
             "needs_elicitation": false,
@@ -299,13 +294,6 @@ exports[`work-package walk snapshots (baseline) > [default] matches committed ba
         {
           "id": "file-index-table",
           "option": "rationale-confirmed",
-          "setVariable": {
-            "rationale_confirmed": true,
-          },
-        },
-        {
-          "id": "rationale-amendment",
-          "option": "all-accurate",
           "setVariable": undefined,
         },
       ],
@@ -432,12 +420,10 @@ exports[`work-package walk snapshots (baseline) > [default] matches committed ba
       "artifacts": [
         "NNNN-{decision_title}.md",
         "COMPLETE.md",
-        "workflow-retrospective.md",
       ],
       "artifactsWritten": [
         "14-NNNN-decision_title.md",
         "14-COMPLETE.md",
-        "14-workflow-retrospective.md",
       ],
       "checkpoints": [],
       "manifestStatus": "warning",
@@ -542,12 +528,7 @@ exports[`work-package walk snapshots (baseline) > [elicitation-only] matches com
       ],
       "checkpoints": [
         {
-          "id": "classification-confirmed",
-          "option": "confirmed",
-          "setVariable": undefined,
-        },
-        {
-          "id": "workflow-path-selected",
+          "id": "classification-and-path-confirmed",
           "option": "elicitation-only",
           "setVariable": {
             "needs_elicitation": true,
@@ -832,13 +813,6 @@ exports[`work-package walk snapshots (baseline) > [elicitation-only] matches com
         {
           "id": "file-index-table",
           "option": "rationale-confirmed",
-          "setVariable": {
-            "rationale_confirmed": true,
-          },
-        },
-        {
-          "id": "rationale-amendment",
-          "option": "all-accurate",
           "setVariable": undefined,
         },
       ],
@@ -965,12 +939,10 @@ exports[`work-package walk snapshots (baseline) > [elicitation-only] matches com
       "artifacts": [
         "NNNN-{decision_title}.md",
         "COMPLETE.md",
-        "workflow-retrospective.md",
       ],
       "artifactsWritten": [
         "14-NNNN-decision_title.md",
         "14-COMPLETE.md",
-        "14-workflow-retrospective.md",
       ],
       "checkpoints": [],
       "manifestStatus": "warning",
@@ -1078,12 +1050,7 @@ exports[`work-package walk snapshots (baseline) > [full-workflow] matches commit
       ],
       "checkpoints": [
         {
-          "id": "classification-confirmed",
-          "option": "confirmed",
-          "setVariable": undefined,
-        },
-        {
-          "id": "workflow-path-selected",
+          "id": "classification-and-path-confirmed",
           "option": "full-workflow",
           "setVariable": {
             "needs_elicitation": true,
@@ -1410,13 +1377,6 @@ exports[`work-package walk snapshots (baseline) > [full-workflow] matches commit
         {
           "id": "file-index-table",
           "option": "rationale-confirmed",
-          "setVariable": {
-            "rationale_confirmed": true,
-          },
-        },
-        {
-          "id": "rationale-amendment",
-          "option": "all-accurate",
           "setVariable": undefined,
         },
       ],
@@ -1543,12 +1503,10 @@ exports[`work-package walk snapshots (baseline) > [full-workflow] matches commit
       "artifacts": [
         "NNNN-{decision_title}.md",
         "COMPLETE.md",
-        "workflow-retrospective.md",
       ],
       "artifactsWritten": [
         "14-NNNN-decision_title.md",
         "14-COMPLETE.md",
-        "14-workflow-retrospective.md",
       ],
       "checkpoints": [],
       "manifestStatus": "warning",
@@ -1655,12 +1613,7 @@ exports[`work-package walk snapshots (baseline) > [research-only] matches commit
       ],
       "checkpoints": [
         {
-          "id": "classification-confirmed",
-          "option": "confirmed",
-          "setVariable": undefined,
-        },
-        {
-          "id": "workflow-path-selected",
+          "id": "classification-and-path-confirmed",
           "option": "research-only",
           "setVariable": {
             "needs_elicitation": false,
@@ -1947,13 +1900,6 @@ exports[`work-package walk snapshots (baseline) > [research-only] matches commit
         {
           "id": "file-index-table",
           "option": "rationale-confirmed",
-          "setVariable": {
-            "rationale_confirmed": true,
-          },
-        },
-        {
-          "id": "rationale-amendment",
-          "option": "all-accurate",
           "setVariable": undefined,
         },
       ],
@@ -2080,12 +2026,10 @@ exports[`work-package walk snapshots (baseline) > [research-only] matches commit
       "artifacts": [
         "NNNN-{decision_title}.md",
         "COMPLETE.md",
-        "workflow-retrospective.md",
       ],
       "artifactsWritten": [
         "14-NNNN-decision_title.md",
         "14-COMPLETE.md",
-        "14-workflow-retrospective.md",
       ],
       "checkpoints": [],
       "manifestStatus": "warning",
@@ -2204,12 +2148,7 @@ exports[`work-package walk snapshots (baseline) > [review-mode] matches committe
       ],
       "checkpoints": [
         {
-          "id": "classification-confirmed",
-          "option": "confirmed",
-          "setVariable": undefined,
-        },
-        {
-          "id": "workflow-path-selected",
+          "id": "classification-and-path-confirmed",
           "option": "skip-optional",
           "setVariable": {
             "needs_elicitation": false,
@@ -2414,13 +2353,6 @@ exports[`work-package walk snapshots (baseline) > [review-mode] matches committe
         {
           "id": "file-index-table",
           "option": "rationale-confirmed",
-          "setVariable": {
-            "rationale_confirmed": true,
-          },
-        },
-        {
-          "id": "rationale-amendment",
-          "option": "all-accurate",
           "setVariable": undefined,
         },
       ],
@@ -2557,12 +2489,10 @@ exports[`work-package walk snapshots (baseline) > [review-mode] matches committe
       "artifacts": [
         "NNNN-{decision_title}.md",
         "COMPLETE.md",
-        "workflow-retrospective.md",
       ],
       "artifactsWritten": [
         "14-NNNN-decision_title.md",
         "14-COMPLETE.md",
-        "14-workflow-retrospective.md",
       ],
       "checkpoints": [],
       "manifestStatus": "warning",
@@ -2662,12 +2592,7 @@ exports[`work-package walk snapshots (baseline) > [skip-optional] matches commit
       ],
       "checkpoints": [
         {
-          "id": "classification-confirmed",
-          "option": "confirmed",
-          "setVariable": undefined,
-        },
-        {
-          "id": "workflow-path-selected",
+          "id": "classification-and-path-confirmed",
           "option": "skip-optional",
           "setVariable": {
             "needs_elicitation": false,
@@ -2879,13 +2804,6 @@ exports[`work-package walk snapshots (baseline) > [skip-optional] matches commit
         {
           "id": "file-index-table",
           "option": "rationale-confirmed",
-          "setVariable": {
-            "rationale_confirmed": true,
-          },
-        },
-        {
-          "id": "rationale-amendment",
-          "option": "all-accurate",
           "setVariable": undefined,
         },
       ],
@@ -3012,12 +2930,10 @@ exports[`work-package walk snapshots (baseline) > [skip-optional] matches commit
       "artifacts": [
         "NNNN-{decision_title}.md",
         "COMPLETE.md",
-        "workflow-retrospective.md",
       ],
       "artifactsWritten": [
         "14-NNNN-decision_title.md",
         "14-COMPLETE.md",
-        "14-workflow-retrospective.md",
       ],
       "checkpoints": [],
       "manifestStatus": "warning",

--- a/tests/e2e/policies.ts
+++ b/tests/e2e/policies.ts
@@ -61,30 +61,30 @@ export const defaultPolicy: Policy = makePolicy({ name: 'default' });
 /** Direct path: skip optional discovery activities (elicitation, research, analysis). */
 export const skipOptionalPolicy: Policy = makePolicy({
   name: 'skip-optional',
-  choices: { 'workflow-path-selected': 'skip-optional' },
+  choices: { 'classification-and-path-confirmed': 'skip-optional' },
 });
 
 /** Full path: requirements elicitation + research + implementation analysis. */
 export const fullWorkflowPolicy: Policy = makePolicy({
   name: 'full-workflow',
-  choices: { 'workflow-path-selected': 'full-workflow' },
+  choices: { 'classification-and-path-confirmed': 'full-workflow' },
 });
 
 /** Research-only path: skip elicitation, keep research. */
 export const researchOnlyPolicy: Policy = makePolicy({
   name: 'research-only',
-  choices: { 'workflow-path-selected': 'research-only' },
+  choices: { 'classification-and-path-confirmed': 'research-only' },
 });
 
 /** Elicitation-only path: keep elicitation, skip research. */
 export const elicitationOnlyPolicy: Policy = makePolicy({
   name: 'elicitation-only',
-  choices: { 'workflow-path-selected': 'elicitation-only' },
+  choices: { 'classification-and-path-confirmed': 'elicitation-only' },
 });
 
 /** Review mode: review an existing PR rather than implement. */
 export const reviewModePolicy: Policy = makePolicy({
   name: 'review-mode',
   initialVariables: { is_review_mode: true },
-  choices: { 'workflow-path-selected': 'skip-optional' },
+  choices: { 'classification-and-path-confirmed': 'skip-optional' },
 });

--- a/tests/e2e/robot-execution.test.ts
+++ b/tests/e2e/robot-execution.test.ts
@@ -111,7 +111,8 @@ describe('work-package robot execution (Layer 3c)', () => {
   // position, so there are NO orphan/unbound checkpoints — the deterministic robot reaches them all.
   // (Previously six situational checkpoints — block-interview, rationale-amendment, the three
   // start-work-package selection gates, body-non-conformant — were defined out-of-line and
-  // unreachable by the robot; the migration positioned them in the sequence.)
+  // unreachable by the robot; the migration positioned them in the sequence. rationale-amendment
+  // has since been removed entirely by the work-package 3.15.0 checkpoint consolidation.)
   const BASELINE_UNBOUND_CHECKPOINTS: string[] = [];
 
   it('surfaces no unbound checkpoints (all are inline kind:checkpoint steps)', () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1169,7 +1169,7 @@ describe('mcp-server integration', () => {
       });
       const actMeta = act._meta as Record<string, unknown>;
       const tokenWithAct = actMeta['session_index'] as string;
-      const firstCpId = 'classification-confirmed'; // Known from the workflow
+      const firstCpId = 'classification-and-path-confirmed'; // Known from the workflow
 
       const yieldResult = await client.callTool({
         name: 'yield_checkpoint',
@@ -1179,7 +1179,7 @@ describe('mcp-server integration', () => {
 
       const cpResult = await client.callTool({
         name: 'respond_checkpoint',
-        arguments: { session_index: cpHandle, option_id: 'confirmed' }, // Assumes 'confirmed' is a valid option
+        arguments: { session_index: cpHandle, option_id: 'revise-classification' }, // Assumes 'revise-classification' is a valid option
       });
       expect(cpResult.isError).toBeFalsy();
       const response = parseToolResponse(cpResult);
@@ -1193,7 +1193,7 @@ describe('mcp-server integration', () => {
       });
       const actMeta = act._meta as Record<string, unknown>;
       const tokenWithAct = actMeta['session_index'] as string;
-      const firstCpId = 'classification-confirmed';
+      const firstCpId = 'classification-and-path-confirmed';
 
       const yieldResult = await client.callTool({
         name: 'yield_checkpoint',
@@ -1258,7 +1258,7 @@ describe('mcp-server integration', () => {
       });
       const actMeta = act._meta as Record<string, unknown>;
       const tokenWithAct = actMeta['session_index'] as string;
-      const unconditionalCpId = 'workflow-path-selected';
+      const unconditionalCpId = 'classification-and-path-confirmed';
 
       const yieldResult = await client.callTool({
         name: 'yield_checkpoint',
@@ -1370,13 +1370,13 @@ describe('mcp-server integration', () => {
 
       const yieldResult = await client.callTool({
         name: 'yield_checkpoint',
-        arguments: { session_index: tokenWithAct, checkpoint_id: 'classification-confirmed' },
+        arguments: { session_index: tokenWithAct, checkpoint_id: 'classification-and-path-confirmed' },
       });
       const cpHandle = (yieldResult._meta as Record<string, unknown>)['session_index'] as string;
 
       const result = await client.callTool({
         name: 'respond_checkpoint',
-        arguments: { session_index: cpHandle, option_id: 'confirmed', auto_advance: true },
+        arguments: { session_index: cpHandle, option_id: 'revise-classification', auto_advance: true },
       });
       expect(result.isError).toBe(true);
       const errorText = (result.content[0] as { type: string; text: string }).text;
@@ -1390,7 +1390,7 @@ describe('mcp-server integration', () => {
       });
       const actMeta = act._meta as Record<string, unknown>;
       const tokenWithAct = actMeta['session_index'] as string;
-      const firstCpId = 'classification-confirmed';
+      const firstCpId = 'classification-and-path-confirmed';
 
       await client.callTool({
         name: 'yield_checkpoint',
@@ -1414,7 +1414,7 @@ describe('mcp-server integration', () => {
       });
       const actMeta = act._meta as Record<string, unknown>;
       const tokenWithAct = actMeta['session_index'] as string;
-      const firstCpId = 'classification-confirmed';
+      const firstCpId = 'classification-and-path-confirmed';
 
       await client.callTool({
         name: 'yield_checkpoint',
@@ -1423,7 +1423,7 @@ describe('mcp-server integration', () => {
 
       const result = await client.callTool({
         name: 'respond_checkpoint',
-        arguments: { session_index: tokenWithAct, option_id: 'confirmed' },
+        arguments: { session_index: tokenWithAct, option_id: 'revise-classification' },
       });
       expect(result.isError).toBeFalsy();
       const response = parseToolResponse(result);
@@ -1443,7 +1443,7 @@ describe('mcp-server integration', () => {
     it('respond_checkpoint errors when no active checkpoint is set', async () => {
       const result = await client.callTool({
         name: 'respond_checkpoint',
-        arguments: { session_index: sessionToken, option_id: 'confirmed' },
+        arguments: { session_index: sessionToken, option_id: 'revise-classification' },
       });
       expect(result.isError).toBe(true);
       const errorText = (result.content[0] as { type: string; text: string }).text;


### PR DESCRIPTION
## Summary

Server-side follow-up to #154: retarget the e2e walks and baselines at the work-package 3.15.0 checkpoint set (−3/+1: `classification-confirmed` + `workflow-path-selected` → `classification-and-path-confirmed`; `rationale-amendment` and `merge-strategy-reminder` removed).

- **`policies.ts`** — walk-steering choice key renamed; the four path option IDs are unchanged in the merged checkpoint, so the five policies steer identically.
- **`mcp-server.test.ts`** — checkpoint IDs retargeted; the removed `confirmed` option becomes `revise-classification` (the merged checkpoint's only effect-free option).
- **Walk snapshots** — regenerated for all six policies. The diff is exactly the expected delta per walk: one merged checkpoint replaces two, `rationale-amendment` and its `rationale_confirmed` effect disappear, and `workflow-retrospective.md` drops from the `complete` activity's artifact contract (terminal-document collapse).
- **`robot-execution.test.ts`** — `BASELINE_UNBOUND_CHECKPOINTS` stays empty; comment updated.
- **Submodule** — pointed at `603447a7` (tip of `workflow/artifact-efficiency`). Merge #154 first; the SHA stays reachable under a merge commit, or re-point at the merge commit if preferred.

## Validation

`npm run typecheck` clean. Suite fully green: **364 passed / 14 skipped / 0 failed**.

The `binding-fidelity` and `identifier-qualification` drift guards were failing before this PR — pre-existing `codebase-wiki` violations that fail identically against the submodule pointer previously recorded on main (`0128e1fd`, verified directly), so main's CI was already red on them. Rather than absorbing them into the baselines, they are fixed at the source in `603447a7` on the #154 branch (`{$page_slug}` dollar-local in `ingest.md`; `question`/`answer` → `wiki_question`/`wiki_answer` per AP-60), which this PR's submodule bump picks up.

## Notes

- The legacy-session migration fixture retains a `classification-confirmed` checkpoint response by design (frozen historical data); migration tests pass unchanged — stale responses are never consulted against the live definition.
- Edge case worth knowing (no code change): a session suspended exactly at a since-removed checkpoint would resume against 3.15.0 with an unknown `activeCheckpoint`. No such session exists in fixtures; flagging for awareness.

Merge order: #154 (content → `workflows`) first, then this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
