### PR TITLE
fix(work-package): remediate 13 anti-pattern / binding findings (v3.16.0)

### DIFF
--- a/work-package/activities/01-start-work-package.yaml
+++ b/work-package/activities/01-start-work-package.yaml
@@ -1,5 +1,5 @@
 id: start-work-package
-version: 3.10.0
+version: 3.11.0
 name: Start Work Package
 description: Initialize the work package with issue, branch, draft PR, dedicated worktree, and planning folder.
 required: true
@@ -95,13 +95,12 @@ steps:
       - action: set
         target: gitnexus_indexed
         value: true
-        description: Set gitnexus_indexed=true on successful index.
   - kind: action
     id: verify-signing-precondition
     actions:
       - action: validate
         target: signing.configured == true
-        message: Commit signing is not configured for this repository (user.signingkey, commit.gpgsign, or a working signing backend is missing). Configure git signing in your environment via your preferred scope (system, global, or local) before re-running. The workflow does not modify your git configuration.
+        message: Commit signing is not configured for this repository (user.signingkey, commit.gpgsign, or a working signing backend is missing). Configure git signing in your environment via your preferred scope (system, global, or local) before re-running.
   - kind: technique
     id: detect-merge-strategy
     technique: manage-git::detect-merge-strategy
@@ -238,9 +237,15 @@ steps:
       - id: select
         label: Select from list
         description: Choose from available projects
+        effect:
+          setVariable:
+            jira_project: selected
       - id: specify
         label: Specify project key
         description: Provide a specific project key
+        effect:
+          setVariable:
+            jira_project: specified
   - kind: checkpoint
     id: issue-type-selection
     condition:
@@ -401,7 +406,7 @@ steps:
     actions:
       - action: set
         target: planning_folder_path
-        message: Server-resolved canonical absolute planning folder from the get_workflow summary (under the server's workspace .engineering root). Write location for ALL of this work package's artifacts. Never anchored to target_path or any CWD.
+        message: Server-resolved canonical absolute planning folder from the get_workflow summary. Write location for ALL of this work package's artifacts.
   - kind: technique
     id: initialize-planning-folder
     technique: manage-artifacts::create-readme

--- a/work-package/activities/02-design-philosophy.yaml
+++ b/work-package/activities/02-design-philosophy.yaml
@@ -1,5 +1,5 @@
 id: design-philosophy
-version: 1.8.0
+version: 1.9.0
 name: Design Philosophy
 description: Apply the design framework to classify the problem and decide the workflow path.
 required: true
@@ -15,7 +15,7 @@ steps:
     technique: determine-path
   - kind: checkpoint
     id: classification-and-path-confirmed
-    message: "Classification: {problem_type} with {problem_complexity} complexity. The recommended workflow path for this classification is the default below — auto-advancing in 30s. (simple: skip optional discovery, moderate: research only, complex: full workflow.) Pick a different path, or revise if the classification itself is wrong."
+    message: "Classification: {problem_type} with {problem_complexity} complexity. Confirm the recommended path (default below), pick a different path, or revise if the classification itself is wrong."
     blocking: false
     defaultOption: skip-optional
     autoAdvanceMs: 30000
@@ -64,7 +64,7 @@ steps:
     technique: document
     actions:
       - action: message
-        message: "Created: design-philosophy.md"
+        message: Design philosophy recorded for reference.
   - kind: technique
     id: collect-assumptions
     technique:
@@ -142,7 +142,6 @@ steps:
       - action: set
         target: needs_elicitation
         value: false
-        description: Force needs_elicitation=false in review mode.
 transitions:
   - to: codebase-comprehension
     isDefault: true

--- a/work-package/activities/04-research.yaml
+++ b/work-package/activities/04-research.yaml
@@ -1,5 +1,5 @@
 id: research
-version: 2.6.0
+version: 2.7.0
 name: Research
 description: Research the knowledge base and external sources to discover best practices, patterns, and resources to inform the plan-prepare activity.
 required: false
@@ -81,16 +81,10 @@ steps:
     technique: review-assumptions::interview
     actions:
       - action: message
-        message: "**Resolved Assumptions** — the following assumptions were resolved through code analysis during this phase."
-  - kind: action
-    id: declare-context-scope
-    actions:
-      - action: set
-        target: context_scope
-        description: repo-only | web-retrieval | mixed based on research sources used
+        message: "**Resolved Assumptions** — the following assumptions were resolved through code analysis."
   - kind: checkpoint
     id: context-scope-declaration
-    message: Did research use external web sources (web search, documentation URLs, external references)? This determines the provenance scope recorded in commit trailers and the provenance log.
+    message: Did research use external web sources (web search, documentation URLs, external references)?
     blocking: false
     defaultOption: repo-only
     autoAdvanceMs: 15000

--- a/work-package/activities/05-implementation-analysis.yaml
+++ b/work-package/activities/05-implementation-analysis.yaml
@@ -1,5 +1,5 @@
 id: implementation-analysis
-version: 2.7.0
+version: 2.8.0
 name: Implementation Analysis
 description: Analyze the current implementation to understand effectiveness, establish baselines, and identify opportunities for improvement.
 required: false
@@ -66,7 +66,7 @@ steps:
     technique: review-assumptions::interview
     actions:
       - action: message
-        message: "**Resolved Assumptions** — the following assumptions were resolved through code analysis during this phase."
+        message: "**Resolved Assumptions** — the following assumptions were resolved through code analysis."
   - kind: technique
     id: interview-open-assumptions
     technique: review-assumptions::interview

--- a/work-package/activities/09-lean-coding-audit.yaml
+++ b/work-package/activities/09-lean-coding-audit.yaml
@@ -1,5 +1,5 @@
 id: lean-coding-audit
-version: 1.0.0
+version: 1.1.0
 name: Lean-Coding Audit
 description: Apply the ponytail lean-coding lens to the just-implemented change.
 required: true
@@ -21,7 +21,7 @@ steps:
       variable: is_review_mode
       operator: "!="
       value: true
-    message: "Lean-coding audit complete. The over-engineering findings under each taxonomy bucket (delete / stdlib / native / yagni / shrink) with the net-lines scoreboard are in review-findings.md, and the harvested ponytail-marker debt ledger with its honesty-bounded gain scoreboard is in debt-ledger.md — all judged against the safety floor. Accept the audit as-is, apply the recommended simplifications, or flag the findings for correction?"
+    message: "Lean-coding audit complete. Accept the audit as-is, apply the recommended simplifications, or flag the findings for correction?"
     blocking: true
     options:
       - id: audit-accepted

--- a/work-package/activities/10-post-impl-review.yaml
+++ b/work-package/activities/10-post-impl-review.yaml
@@ -1,5 +1,5 @@
 id: post-impl-review
-version: 1.14.0
+version: 1.15.0
 name: Post-Implementation Review
 description: Review implementation quality before validation.
 required: true
@@ -108,14 +108,9 @@ steps:
           - action: set
             target: needs_code_fixes
             value: false
-            message: Reset code-fix flag before re-review.
           - action: set
             target: needs_test_improvements
             value: false
-            message: Reset test-improvement flag before re-review.
-      - kind: technique
-        id: regenerate-index
-        technique: review-diff
       - kind: technique
         id: re-manual-diff-review
         technique: review-diff

--- a/work-package/activities/15-codebase-comprehension.yaml
+++ b/work-package/activities/15-codebase-comprehension.yaml
@@ -1,5 +1,5 @@
 id: codebase-comprehension
-version: 1.7.0
+version: 1.8.0
 name: Codebase Comprehension
 description: Build or augment a mental model of the codebase.
 required: false
@@ -12,7 +12,7 @@ steps:
     technique: manage-artifacts::write-artifact
     actions:
       - action: message
-        message: "Created/Updated: [comprehension artifact](.engineering/artifacts/comprehension/{artifact_name}). Proceeding to mandatory initial deep-dive — comprehension-sufficient checkpoint surfaces only when unresolved questions remain after investigation."
+        message: Comprehension artifact recorded for reference.
   - kind: technique
     id: initial-deep-dive
     technique: deep-dive

--- a/work-package/techniques/create-issue.md
+++ b/work-package/techniques/create-issue.md
@@ -2,7 +2,7 @@
 metadata:
   ontology: workflow-canonical
   kind: technique
-  version: 3.0.0
+  version: 3.1.0
   order: 3
   legacy_id: 3
 ---
@@ -24,6 +24,10 @@ Type of issue (feature, bug, task, enhancement, epic)
 ### target_submodule
 
 Target submodule for the work package (e.g., midnight-node, midnight-ledger)
+
+### jira_project
+
+*(optional)* Jira project chosen at the `jira-project-selection` gate — the project the new Jira issue is created in. Absent for GitHub issues.
 
 ## Protocol
 
@@ -48,7 +52,7 @@ Target submodule for the work package (e.g., midnight-node, midnight-ledger)
 
 - Runs when `{issue_platform}` is jira and `{needs_issue_creation}` is true. Use attached [jira-issue-creation](../resources/jira-issue-creation.md) for guidance.
 - Obtain Atlassian cloud ID via `getAccessibleAtlassianResources` and preserve as `{jira_cloud_id}`. This MUST be the first Jira tool call.
-- List available projects via `getVisibleJiraProjects`, then obtain the user's project selection. Resolve available issue types for the selected project.
+- Create the issue in the `{jira_project}` chosen at the `jira-project-selection` gate; if it is unset, list available projects via `getVisibleJiraProjects` and obtain the user's project selection. Resolve available issue types for the selected project.
 - Gather summary, description, and acceptance criteria, scoping the issue to the `{target_submodule}` the work package targets. Resolve assignee account ID if specified.
 - Create the issue with mapped type using the issue-type mapping below — the resulting issue is the `{created_issue}`. Capture `{issue_number}` and `{issue_url}`.
 - Jira issue type mapping: `feature->Story`, `bug->Bug`, `task->Task`, `enhancement->Story`, `epic->Epic`

--- a/work-package/techniques/implement-task.md
+++ b/work-package/techniques/implement-task.md
@@ -2,7 +2,7 @@
 metadata:
   ontology: workflow-canonical
   kind: technique
-  version: 2.1.3
+  version: 2.2.0
   order: 10
   legacy_id: 10
 ---
@@ -21,18 +21,23 @@ A single atomic task to implement (description, affected files, dependencies)
 
 *(optional)* Test [plan](../resources/test-plan.md#test-plan-structure) with strategy and acceptance criteria for guidance
 
+### target_symbol
+
+The primary edit target — the function, class, or method this task changes — derived from `{current_task}` in Protocol §1 and read by the impact/context checks in §2.
+
 ## Protocol
 
 ### 1. Understand Context
 
 - Read the `{current_task}` description and requirements from the plan
 - Identify affected files, dependencies, and related code
+- Determine the primary edit target `{target_symbol}` — the function, class, or method this task changes — from `{current_task}`
 - Review the `{test_plan}` for acceptance criteria relevant to this task
 - If the task description is ambiguous or missing context, review the plan document and ask the user for clarification before proceeding
 
 ### 2. Pre Edit Impact Check
 
-- Apply [gitnexus-operations](../../meta/techniques/gitnexus-operations/TECHNIQUE.md)::[impact](../../meta/techniques/gitnexus-operations/impact.md)(target: `{$target_symbol}`, direction: `upstream`) before any edit
+- Apply [gitnexus-operations](../../meta/techniques/gitnexus-operations/TECHNIQUE.md)::[impact](../../meta/techniques/gitnexus-operations/impact.md)(target: `{target_symbol}`, direction: `upstream`) before any edit
 - Read the resulting `impact_report`; if HIGH or CRITICAL risk, surface it to the user before proceeding
 - Apply [gitnexus-operations](../../meta/techniques/gitnexus-operations/TECHNIQUE.md)::[context](../../meta/techniques/gitnexus-operations/context.md)(name: `{target_symbol}`) to understand callers/callees of the symbol
 

--- a/work-package/techniques/respond-to-pr-review.md
+++ b/work-package/techniques/respond-to-pr-review.md
@@ -2,7 +2,7 @@
 metadata:
   ontology: workflow-canonical
   kind: technique
-  version: 2.1.0
+  version: 2.2.0
   order: 2
   legacy_id: 2
 ---
@@ -28,14 +28,14 @@ Review comments fetched from PR
   ```
   - If the `gh` API returns an error fetching comments, check authentication and PR access, then retry.
   - If no review comments are found, verify the PR has been reviewed and check comment visibility before proceeding.
-- Filter to unresolved comments from the latest review round (avoid re-answering resolved threads): derive `{$latest_review_date}` from the review timeline, then keep only comments from reviewers (not the PR author) updated since it:
+- Filter to unresolved comments from the latest review round (avoid re-answering resolved threads): derive `{$latest_review_date}` from the review timeline, then keep only comments from reviewers (not the PR author) whose GitHub `` `updated_at` `` field is at or after `{$latest_review_date}`. Project each surviving comment to its `.id`, `.body`, `` `html_url` `` (as `url`), `.path`, and `.line`, and save the filtered set to `/tmp/unresolved.json`. Run the pipeline with the `` `updated_at` `` timestamp key and the `` `html_url` `` link key substituted for the bracketed placeholders:
   ```bash
   gh pr view {pr_number} --json reviews | jq '.reviews[] | {author: .author.login, state: .state, submittedAt: .submittedAt}' | tail -5
-  gh api repos/<owner>/<repo>/pulls/{pr_number}/comments --paginate | jq '.[] | select(.user.login != "<pr-author>" and .updated_at >= "{$latest_review_date}") | {id: .id, body: .body, html_url: .html_url, path: .path, line: .line}' > /tmp/unresolved_comments.json
+  gh api repos/<owner>/<repo>/pulls/{pr_number}/comments --paginate | jq --arg since "{$latest_review_date}" '.[] | select(.user.login != "<pr-author>" and .["<timestamp-key>"] >= $since) | {id, body, url: .["<link-key>"], path, line}' > /tmp/unresolved.json
   ```
 - Identify question-type comments:
   ```bash
-  jq -r '.body' /tmp/unresolved_comments.json | grep -i "what\|how\|why\|which" | nl
+  jq -r '.body' /tmp/unresolved.json | grep -i "what\|how\|why\|which" | nl
   ```
 - Before proceeding: total comment count confirmed; unresolved comments filtered to the latest review round; question-type comments identified; comments saved for analysis
 

--- a/work-package/workflow.yaml
+++ b/work-package/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: work-package
-version: 3.15.0
+version: 3.16.0
 title: Work Package Implementation Workflow
 description: Defines how to plan and implement ONE work package from inception to merged PR. A work package is a discrete unit of work such as a feature, bug-fix, enhancement, refactoring, or any other deliverable change. For multiple related work packages, use the work-packages workflow to create a roadmap first.
 author: m2ux


### PR DESCRIPTION
## Summary

Remediates the 13 findings from the work-package compliance review (2 High,
5 Medium, 6 Low), all user-approved. Bumps work-package 3.15.0 → 3.16.0.
Purely a hygiene/binding-correctness pass: no activities, checkpoints,
effects, conditions, transitions, or technique bindings were removed.

## Findings addressed

| Sev | ID | File | Fix |
|-----|----|------|-----|
| High | H-1 | respond-to-pr-review.md | Resolve 3 unanchored protocol refs (placeholders + inline-backtick prose) so the YAML validator passes |
| High | H-2 | implement-task.md | Declare `target_symbol` input + producing step; normalize reads |
| Med | M-1 | 10-post-impl-review.yaml | Collapse duplicate `review-diff` steps |
| Med | M-2 | 04-research.yaml | Delete value-less `declare-context-scope` set |
| Med | M-3 | 02, 04, 09 | Trim checkpoint messages to the decision |
| Med | M-4 | 01-start-work-package.yaml | `jira-project-selection` options record their choice |
| Med | M-5 | 15-codebase-comprehension.yaml | Trim artifact message; drop literal path |
| Low | L-1 | 01, 02, 10 | Drop set-action descriptions |
| Low | L-2 | 01-start-work-package.yaml | Trim validate-message tail |
| Low | L-3 | 04, 05 | Drop "during this phase" |
| Low | L-4 | 01-start-work-package.yaml | Reduce planning-folder set message |
| Low | L-5 | 02-design-philosophy.yaml | Replace file-creation message with value cue |
| RE-1 | create-issue.md | Add optional `jira_project` input consuming the M-4 gate |

**Out of scope (verified):** `08-implement.yaml` (no "during this phase" tail, so L-3 N/A) and RE-2 (`13-submit-for-review.yaml` `review-received` gate, unchanged).

## Validation

- `validate-workflow-yaml.ts work-package`: 0 FAIL (workflow.yaml + 15 activities + 96 techniques)
- `check-all-refs.ts`: 0 unresolved
- `check-binding-fidelity.ts`: 40 total / 40 baselined / 0 NEW / 0 fixed

Full block-indexed review + attestation: planning folder `06-scope-and-draft.md`.
