### PR TITLE
feat(workflow-design): verify High findings before remediation (v1.5.0)

### DIFF
--- a/workflow-design/README.md
+++ b/workflow-design/README.md
@@ -233,6 +233,7 @@ workflows/workflow-design/
 │   ├── audit-conformance.md
 │   ├── audit-rule-hygiene.md
 │   ├── audit-rule-enforcement.md
+│   ├── verify-high-findings.md
 │   ├── review-draft-yaml.md
 │   ├── apply-audit-fixes.md
 │   ├── scope-audit.md

--- a/workflow-design/README.md
+++ b/workflow-design/README.md
@@ -136,6 +136,7 @@ The `techniques/` directory is a flat library of workflow-local standalone techn
 | [`audit-conformance`](./techniques/audit-conformance.md) | Check convention conformance against reference workflows | Quality Review |
 | [`audit-rule-hygiene`](./techniques/audit-rule-hygiene.md) | Detect rule restatements, contradictions, duplications, prefix patterns | Quality Review |
 | [`audit-rule-enforcement`](./techniques/audit-rule-enforcement.md) | Flag critical rules lacking structural enforcement | Quality Review |
+| [`verify-high-findings`](./techniques/verify-high-findings.md) | Adversarially verify High findings and recalibrate severity before remediation | Quality Review |
 | [`audit-principles`](./techniques/audit-principles.md) | Audit against the design principles (review mode) | Quality Review |
 | [`audit-anti-patterns`](./techniques/audit-anti-patterns.md) | Scan for all prohibited patterns (review mode) | Quality Review |
 | [`audit-schema-validation`](./techniques/audit-schema-validation.md) | Validate every YAML file against its schema | Quality Review, Validate and Commit |

--- a/workflow-design/activities/08-quality-review.yaml
+++ b/workflow-design/activities/08-quality-review.yaml
@@ -1,5 +1,5 @@
 id: quality-review
-version: 1.4.0
+version: 1.5.0
 name: Quality Review
 description: Quality review of drafted workflow content.
 required: true
@@ -7,6 +7,7 @@ rules:
   - Each review pass is independent — complete one pass fully before starting the next
   - Flag every instance of prose that maps to a formal schema construct
   - Flag every rule that can be violated by ignoring it and lacks structural enforcement
+  - High findings must be independently verified before they drive remediation
 steps:
   - kind: technique
     id: load-all-workflow-files
@@ -193,17 +194,28 @@ steps:
       variable: is_review_mode
       operator: "!="
       value: true
-    message: Rule-to-structure audit complete. {enforcement_finding_count} text-only rules found. Accepting in 30s unless you intervene.
+    message: Rule-to-structure audit complete. {enforcement_finding_count} text-only rules found. Adding structural enforcement in 30s unless you elect to keep them as text-only guidance.
     blocking: false
-    defaultOption: accept-text-only
+    defaultOption: add-enforcement
     autoAdvanceMs: 30000
     options:
       - id: add-enforcement
         label: Add structural enforcement
-        description: Add checkpoints, conditions, or validate actions for flagged rules
+        description: Ship checkpoints, conditions, or validate actions for the flagged rules — the fix cycle applies the structural change and records enforcement as added (default — auto-accepts after 30s)
+        effect:
+          setVariable:
+            needs_audit_fixes: true
       - id: accept-text-only
-        label: Accept text-only rules
-        description: These rules are acceptable as text-only guidance (default — auto-accepts after 30s)
+        label: Accept text-only rules — no structural change
+        description: Ship no structural change; the flagged rules stay as text-only guidance and are recorded as accepted text-only
+  - kind: technique
+    id: verify-high-findings
+    technique: verify-high-findings
+    condition:
+      type: simple
+      variable: is_review_mode
+      operator: "!="
+      value: true
   - kind: action
     id: classify-audit-findings
     condition:
@@ -214,10 +226,10 @@ steps:
     actions:
       - action: set
         target: needs_audit_fixes
-        message: Set true iff any of the four audit passes surfaced findings the user elected to fix (fix-all / selective / add-enforcement / revise); false when every pass was accepted as-is.
+        message: Set true iff the verified findings (verified_findings, recalibrated by verify-high-findings) include findings the user elected to fix (fix-all / selective / revise); the enforcement-confirmed checkpoint's add-enforcement option sets this separately via its own effect. False when every pass was accepted as-is.
       - action: set
         target: has_critical_finding
-        message: Set true iff any audit finding is Critical severity — a schema-invalid or structurally broken construct that must not be committed.
+        message: Set true iff any verified finding (verified_findings) is Critical severity — a schema-invalid or structurally broken construct that must not be committed.
   - kind: loop
     id: audit-fix-cycle
     name: Audit Fix Cycle

--- a/workflow-design/techniques/README.md
+++ b/workflow-design/techniques/README.md
@@ -20,7 +20,7 @@ For the full technique-to-activity table with capability summaries, see the [wor
 | **Elicitation** | `elicitation`, `reconcile-design-assumptions` |
 | **Analysis** | `pattern-analysis`, `impact-analysis` |
 | **Scope & draft** | `scope-definition`, `content-drafting`, `yaml-authoring`, `review-draft-yaml` |
-| **Quality audits** | `audit-expressiveness`, `audit-conformance`, `audit-rule-hygiene`, `audit-rule-enforcement`, `audit-principles`, `audit-anti-patterns`, `audit-schema-validation`, `audit-consistency`, `apply-audit-fixes`, `scope-audit` |
+| **Quality audits** | `audit-expressiveness`, `audit-conformance`, `audit-rule-hygiene`, `audit-rule-enforcement`, `verify-high-findings`, `audit-principles`, `audit-anti-patterns`, `audit-schema-validation`, `audit-consistency`, `apply-audit-fixes`, `scope-audit` |
 | **Reporting** | `compile-report`, `summarize-findings`, `persist-report`, `run-audit-passes` |
 | **Validate, commit & PR** | `scope-verification`, `readme-authoring`, `commit-verification`, `prepare-workflow-branch`, `publish-workflow-pr` |
 | **Completion** | `create-completion-doc`, `conduct-retrospective` |

--- a/workflow-design/techniques/verify-high-findings.md
+++ b/workflow-design/techniques/verify-high-findings.md
@@ -1,0 +1,45 @@
+---
+metadata:
+  ontology: workflow-canonical
+  kind: technique
+  version: 1.0.0
+---
+
+## Capability
+
+Independently verify each High-tier audit finding before it drives remediation: re-derive the finding from the cited construct without relying on the originating pass's reasoning, refute by default, recalibrate severity, and confirm which Highs are real. Run a lighter confirmation pass over surviving Medium findings.
+
+## Outputs
+
+### verified_findings
+
+The recalibrated finding set after verification — each High finding marked confirmed, downgraded, or withdrawn with its re-derivation evidence, and each surviving Medium finding spot-confirmed. This is the finding set that drives classification and remediation.
+
+## Protocol
+
+### 1. Re-Derive High Findings Adversarially
+
+- For each High-tier finding, re-derive it from the cited file and construct alone, without reading the originating pass's reasoning — refute by default. A finding survives only when the adversarial re-derivation independently reproduces it against the construct it names.
+- Record the re-derivation evidence for each High: the construct inspected and whether the finding was independently reproduced.
+
+### 2. Recalibrate Severity
+
+- Withdraw any High finding the re-derivation failed to reproduce; downgrade a High whose evidence supports only a lesser issue; raise severity only where the re-derivation surfaces a graver problem than originally rated.
+
+### 3. Confirm Medium Findings
+
+- Run a lighter confirmation pass over surviving Medium findings: spot-confirm that the cited construct exists and the finding class is right. No full adversarial re-derivation.
+
+### 4. Present Verified Findings
+
+- Present `{verified_findings}` to the user: confirmed Highs with evidence, withdrawn or downgraded Highs with the reason, and the confirmation status of the Medium findings.
+
+## Rules
+
+### refute-by-default
+
+A High finding is confirmed only when independently re-derived from the construct it cites; an unreproduced finding is withdrawn, never carried into remediation on the strength of the originating pass alone.
+
+### verify-before-remediation
+
+Verification precedes remediation. Only findings that survive this pass — confirmed Highs and confirmed Mediums — are eligible to drive fixes; the pass runs before findings are classified for the fix cycle.


### PR DESCRIPTION
Issue #160 retrospective follow-ups (RE-2, RE-3, RE-4) landing in `workflow-design`'s `quality-review` activity.

## Changes
- **RE-2** — New `verify-high-findings` technique + gated step in `08-quality-review.yaml`, positioned after `enforcement-confirmed` and before `classify-audit-findings`. Adversarially re-derives each High finding (refute-by-default), recalibrates severity, lightly confirms surviving Mediums, and outputs `verified_findings` — so only independently-confirmed findings feed the remediation decision.
- **RE-3** — Activity rule: "High findings must be independently verified before they drive remediation," structurally backed by the RE-2 step and its position.
- **RE-4** — `enforcement-confirmed` checkpoint re-labelled/re-defaulted so the recorded disposition matches the enforcement actually shipped: `defaultOption: add-enforcement`, sharpened labels/descriptions, and `add-enforcement` now sets `needs_audit_fixes: true`. Both option ids preserved. `classify-audit-findings` set-messages updated to classify on `verified_findings`.
- Version bump `quality-review` 1.4.0 → 1.5.0; technique index rows in `README.md` and `techniques/README.md`.

## Out of scope (companion parent-repo deliverables, not in this PR)
- **#1** — Path-parameterize the guard scripts (`check-all-refs.ts`, `check-binding-fidelity.ts`) so they can validate a worktree instead of the hardwired main checkout.
- **#2 / RE-1** — Checkpoint-replay fix: it requires a server engine change (the loader matches checkpoint ids statically), so it ships as a parent-repo change together with its coupled `03-requirements-refinement.yaml` dynamic-id edit.

## Validation
All schema + ref-integrity + binding-fidelity + `check:*` guards pass against the worktree content (schema/activities validated directly; the hardwired guards run via a staging-root symlink workaround — the exact friction follow-up #1 removes). Scope manifest 6/6 addressed; no content removals.
