### PR TITLE
feat(scripts): make ref/binding guards worktree-aware via --root (#160)

### DIFF
--- a/scripts/check-activity-technique-overlap.ts
+++ b/scripts/check-activity-technique-overlap.ts
@@ -17,9 +17,11 @@ import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { parseDefinition } from '../src/utils/serialization.js';
+import { resolveWorkflowsRoot } from './workflows-root.js';
 
 const DIR = fileURLToPath(new URL('.', import.meta.url));
-const ROOT = join(DIR, '..', 'workflows');
+// Defaults to ../workflows; --root <path> or WORKFLOWS_DIR redirects to a worktree (issue #160 #1).
+const ROOT = resolveWorkflowsRoot(join(DIR, '..', 'workflows'));
 
 export interface ActivityTechniqueOverlapViolation { site: string; detail: string }
 

--- a/scripts/check-all-refs.ts
+++ b/scripts/check-all-refs.ts
@@ -6,12 +6,16 @@
  * work-package Layer 2 lint to the whole repo.
  *
  *   npx tsx scripts/check-all-refs.ts
+ *   npx tsx scripts/check-all-refs.ts --root /path/to/worktree/workflows
  */
 import { resolve } from 'node:path';
 import { listWorkflows, loadWorkflow } from '../src/loaders/workflow-loader.js';
 import { resolveTechniques } from '../src/loaders/technique-loader.js';
+import { resolveWorkflowsRoot } from './workflows-root.js';
 
-const WF_DIR = resolve(import.meta.dirname, '../workflows');
+// Defaults to the repo's own ../workflows; pass `--root <path>` or set WORKFLOWS_DIR to
+// validate a dedicated worktree's workflows instead (issue #160 follow-up #1).
+const WF_DIR = resolveWorkflowsRoot(resolve(import.meta.dirname, '../workflows'));
 
 interface ActivityLike { id: string; techniques?: string[] }
 

--- a/scripts/check-artifact-description.ts
+++ b/scripts/check-artifact-description.ts
@@ -14,9 +14,11 @@ import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { parseDefinition } from '../src/utils/serialization.js';
+import { resolveWorkflowsRoot } from './workflows-root.js';
 
 const DIR = fileURLToPath(new URL('.', import.meta.url));
-const ROOT = join(DIR, '..', 'workflows');
+// Defaults to ../workflows; --root <path> or WORKFLOWS_DIR redirects to a worktree (issue #160 #1).
+const ROOT = resolveWorkflowsRoot(join(DIR, '..', 'workflows'));
 
 export interface ArtifactHit { where: string; count: number }
 

--- a/scripts/check-binding-fidelity.ts
+++ b/scripts/check-binding-fidelity.ts
@@ -27,16 +27,25 @@
  * Plain run (used by CI / the workflow-design validation step):
  *
  *   npx tsx scripts/check-binding-fidelity.ts
+ *
+ * To check a dedicated worktree's workflows instead of the repo's own ../workflows, pass
+ * `--root <path>` (or set WORKFLOWS_DIR) — issue #160 follow-up #1:
+ *
+ *   npx tsx scripts/check-binding-fidelity.ts --root /path/to/worktree/workflows
  */
 import { readFileSync, readdirSync, existsSync, statSync, writeFileSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseDefinition } from '../src/utils/serialization.js';
+import { resolveWorkflowsRoot } from './workflows-root.js';
 
 // Resolve paths from this file's own URL (reliable under both tsx CLI and the vitest runner,
 // where import.meta.dirname is not populated).
 const DIR = fileURLToPath(new URL('.', import.meta.url));
-const ROOT = join(DIR, '..', 'workflows');
+// Corpus root defaults to the repo's own ../workflows; pass `--root <path>` or set WORKFLOWS_DIR
+// to check a dedicated worktree's workflows instead (issue #160 follow-up #1). The baseline stays
+// resolved against this script's own directory — it snapshots corpus content regardless of root.
+const ROOT = resolveWorkflowsRoot(join(DIR, '..', 'workflows'));
 const BASELINE = join(DIR, 'binding-fidelity-baseline.json');
 const META = 'meta';
 

--- a/scripts/check-bound-step-purity.ts
+++ b/scripts/check-bound-step-purity.ts
@@ -24,9 +24,11 @@ import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { parseDefinition } from '../src/utils/serialization.js';
+import { resolveWorkflowsRoot } from './workflows-root.js';
 
 const DIR = fileURLToPath(new URL('.', import.meta.url));
-const ROOT = join(DIR, '..', 'workflows');
+// Defaults to ../workflows; --root <path> or WORKFLOWS_DIR redirects to a worktree (issue #160 #1).
+const ROOT = resolveWorkflowsRoot(join(DIR, '..', 'workflows'));
 
 export interface StepPurityViolation { site: string; detail: string }
 

--- a/scripts/check-identifier-qualification.ts
+++ b/scripts/check-identifier-qualification.ts
@@ -31,9 +31,11 @@ import { readFileSync, readdirSync, existsSync, statSync, writeFileSync } from '
 import { join, relative } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { parseDefinition } from '../src/utils/serialization.js';
+import { resolveWorkflowsRoot } from './workflows-root.js';
 
 const DIR = fileURLToPath(new URL('.', import.meta.url));
-const ROOT = join(DIR, '..', 'workflows');
+// Defaults to ../workflows; --root <path> or WORKFLOWS_DIR redirects to a worktree (issue #160 #1).
+const ROOT = resolveWorkflowsRoot(join(DIR, '..', 'workflows'));
 
 /** A single word: lowercase, alphanumeric, no separator (`_` or `-`). */
 const isSingleWord = (id: string): boolean => /^[a-z][a-z0-9]*$/.test(id);

--- a/scripts/check-resource-anchors.ts
+++ b/scripts/check-resource-anchors.ts
@@ -19,9 +19,11 @@
 import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
 import { join, dirname, resolve, relative, sep } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { resolveWorkflowsRoot } from './workflows-root.js';
 
 const DIR = fileURLToPath(new URL('.', import.meta.url));
-const ROOT = resolve(join(DIR, '..', 'workflows'));
+// Defaults to ../workflows; --root <path> or WORKFLOWS_DIR redirects to a worktree (issue #160 #1).
+const ROOT = resolveWorkflowsRoot(resolve(join(DIR, '..', 'workflows')));
 
 export interface BrokenAnchor {
   /** File containing the link, relative to the workflows root. */

--- a/scripts/check-self-provisioned-input.ts
+++ b/scripts/check-self-provisioned-input.ts
@@ -23,9 +23,11 @@ import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { parseDefinition } from '../src/utils/serialization.js';
+import { resolveWorkflowsRoot } from './workflows-root.js';
 
 const DIR = fileURLToPath(new URL('.', import.meta.url));
-const ROOT = join(DIR, '..', 'workflows');
+// Defaults to ../workflows; --root <path> or WORKFLOWS_DIR redirects to a worktree (issue #160 #1).
+const ROOT = resolveWorkflowsRoot(join(DIR, '..', 'workflows'));
 
 export interface SelfProvisionedInputViolation { site: string; detail: string }
 

--- a/scripts/workflows-root.ts
+++ b/scripts/workflows-root.ts
@@ -1,0 +1,22 @@
+/**
+ * Resolve the workflows corpus root for the guard scripts.
+ *
+ * By default the guards validate the repo's own `../workflows` checkout. That is the wrong
+ * target when edits live in a dedicated git worktree: the guards would validate the stale
+ * main copy, not the change under review (issue #160 follow-up #1). Pass `--root <path>` or
+ * `--root=<path>`, or set the `WORKFLOWS_DIR` env var, to point the guards at a worktree's
+ * workflows directory instead. `validate-workflow-yaml.ts` already accepts a path argument;
+ * this brings the corpus-wide guards (check-all-refs, check-binding-fidelity) to parity.
+ *
+ * Precedence: `--root` flag > `WORKFLOWS_DIR` env var > the built-in default.
+ */
+import { resolve } from 'node:path';
+
+export function resolveWorkflowsRoot(defaultDir: string, argv: string[] = process.argv.slice(2)): string {
+  const eq = argv.find((a) => a.startsWith('--root='));
+  if (eq) return resolve(eq.slice('--root='.length));
+  const flag = argv.indexOf('--root');
+  if (flag !== -1 && argv[flag + 1]) return resolve(argv[flag + 1]!);
+  if (process.env.WORKFLOWS_DIR) return resolve(process.env.WORKFLOWS_DIR);
+  return defaultDir;
+}

--- a/tests/workflows-root.test.ts
+++ b/tests/workflows-root.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { resolve } from 'node:path';
+import { resolveWorkflowsRoot } from '../scripts/workflows-root.js';
+
+/**
+ * The guard scripts default to the repo's own ../workflows but must be redirectable to a
+ * dedicated worktree so they validate the change under review, not the stale main copy
+ * (issue #160 follow-up #1). Precedence: --root flag > WORKFLOWS_DIR env > default.
+ */
+describe('resolveWorkflowsRoot', () => {
+  const DEFAULT = '/repo/workflows';
+
+  afterEach(() => {
+    delete process.env.WORKFLOWS_DIR;
+  });
+
+  it('returns the default when no override is given', () => {
+    expect(resolveWorkflowsRoot(DEFAULT, [])).toBe(DEFAULT);
+  });
+
+  it('honors --root <path> (space form), resolved to absolute', () => {
+    expect(resolveWorkflowsRoot(DEFAULT, ['--root', '/wt/workflows'])).toBe('/wt/workflows');
+  });
+
+  it('honors --root=<path> (equals form)', () => {
+    expect(resolveWorkflowsRoot(DEFAULT, ['--root=/wt/workflows'])).toBe('/wt/workflows');
+  });
+
+  it('resolves a relative --root against cwd', () => {
+    expect(resolveWorkflowsRoot(DEFAULT, ['--root', 'rel/workflows'])).toBe(resolve('rel/workflows'));
+  });
+
+  it('falls back to WORKFLOWS_DIR when no flag is present', () => {
+    process.env.WORKFLOWS_DIR = '/env/workflows';
+    expect(resolveWorkflowsRoot(DEFAULT, [])).toBe('/env/workflows');
+  });
+
+  it('prefers --root over WORKFLOWS_DIR', () => {
+    process.env.WORKFLOWS_DIR = '/env/workflows';
+    expect(resolveWorkflowsRoot(DEFAULT, ['--root', '/wt/workflows'])).toBe('/wt/workflows');
+  });
+
+  it('ignores an unrelated flag like --update-baseline', () => {
+    expect(resolveWorkflowsRoot(DEFAULT, ['--update-baseline'])).toBe(DEFAULT);
+  });
+});

--- a/tests/workflows-root.test.ts
+++ b/tests/workflows-root.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { resolve } from 'node:path';
 import { resolveWorkflowsRoot } from '../scripts/workflows-root.js';
 
@@ -9,9 +9,17 @@ import { resolveWorkflowsRoot } from '../scripts/workflows-root.js';
  */
 describe('resolveWorkflowsRoot', () => {
   const DEFAULT = '/repo/workflows';
+  const savedEnv = process.env.WORKFLOWS_DIR;
+
+  // Isolate from any ambient WORKFLOWS_DIR (e.g. when the guard test suites are run with it set to
+  // point at a real corpus) so the default/precedence assertions are hermetic.
+  beforeEach(() => {
+    delete process.env.WORKFLOWS_DIR;
+  });
 
   afterEach(() => {
-    delete process.env.WORKFLOWS_DIR;
+    if (savedEnv === undefined) delete process.env.WORKFLOWS_DIR;
+    else process.env.WORKFLOWS_DIR = savedEnv;
   });
 
   it('returns the default when no override is given', () => {


### PR DESCRIPTION
Issue #160 follow-up **#1 [High]** — make the reference / binding-fidelity guards worktree-aware.

## Problem
`scripts/check-all-refs.ts` (`WF_DIR = resolve(import.meta.dirname, '../workflows')`) and `scripts/check-binding-fidelity.ts` (`ROOT = join(DIR, '..', 'workflows')`) hardwired the workflows corpus to the repo's own `../workflows`. Running them from the repo validated the **stale main copy**, not edits made in a dedicated git worktree — a silent correctness hazard. During the #159 remediation, validating a worktree required a scratch staging-root workaround (copy guard scripts + baselines, symlink `src`/`node_modules`/`schemas`, populate `workflows/` with symlinks to every real workflow plus the worktree copy).

## Change
- New `scripts/workflows-root.ts` — `resolveWorkflowsRoot(default, argv?)`: honors a `--root <path>` / `--root=<path>` flag, then a `WORKFLOWS_DIR` env var, else the built-in `../workflows` default (precedence: flag > env > default). Relative paths resolve against cwd.
- `check-all-refs.ts` and `check-binding-fidelity.ts` resolve their corpus root through it. This brings the corpus-wide guards to parity with `validate-workflow-yaml.ts`, which already accepts a path argument.
- `check-binding-fidelity`'s baseline stays resolved against the script directory — it snapshots corpus content independent of the corpus root.

## Validation
- New unit test `tests/workflows-root.test.ts` (7 cases: default, `--root` space/equals forms, relative resolution, `WORKFLOWS_DIR` fallback, flag-over-env precedence, unrelated-flag isolation).
- Existing `tests/binding-fidelity.test.ts` unchanged and passing on the default root (verified against the real corpus via `WORKFLOWS_DIR`).
- Both guards run green against the real corpus via `--root`, and `--root` at a bogus path discovers 0 workflows (proving the override is honored, not silently falling back to main).
- `npm run typecheck` clean.

## Usage
```
npx tsx scripts/check-all-refs.ts --root /path/to/worktree/workflows
npx tsx scripts/check-binding-fidelity.ts --root /path/to/worktree/workflows
# or: WORKFLOWS_DIR=/path/to/worktree/workflows npx tsx scripts/check-all-refs.ts
```

Companion to PR #162 (workflow-design RE-2/3/4). This is one of two parent-repo follow-ups; #2/RE-1 (loop-body checkpoint-id replay) ships separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
