### PR TITLE
fix(engine): resolve loop-body checkpoint instance ids to their base definition (#160)

### DIFF
--- a/src/loaders/workflow-loader.ts
+++ b/src/loaders/workflow-loader.ts
@@ -258,11 +258,40 @@ export function getActivity(workflow: Workflow, activityId: string): Activity | 
   return workflow.activities?.find(a => a.id === activityId);
 }
 
-/** Get a checkpoint from an activity (the inline kind:checkpoint step). */
+/**
+ * The separator between a loop-body checkpoint's base id and its per-iteration instance
+ * discriminator. A checkpoint inside a forEach/while loop is defined once but reached N times;
+ * yielding it as `<baseId>#<instance>` (e.g. `assumption-decision#RE-1`) gives each iteration a
+ * distinct checkpoint id — so the response key (`<activity>-<checkpoint>`) no longer collides and
+ * iterations 2..N are recorded/prompted distinctly instead of replaying iteration 1's response
+ * (issue #160 follow-up #2). The base is what matches the single checkpoint definition.
+ */
+export const CHECKPOINT_INSTANCE_SEPARATOR = '#';
+
+/** The base checkpoint id — the portion before the per-iteration instance discriminator, if any. */
+export function checkpointBaseId(checkpointId: string): string {
+  const i = checkpointId.indexOf(CHECKPOINT_INSTANCE_SEPARATOR);
+  return i === -1 ? checkpointId : checkpointId.slice(0, i);
+}
+
+/**
+ * Get a checkpoint from an activity (the inline kind:checkpoint step). An exact id match wins;
+ * otherwise an instance-qualified id (`<baseId>#<instance>`) resolves to its base definition, so a
+ * loop-body checkpoint yielded once per iteration shares one definition while recording a distinct
+ * response per instance. The definition's own id may itself be a plain base (`assumption-decision`)
+ * or a template (`assumption-decision#{current_assumption.id}`); both compare on their base.
+ */
 export function getCheckpoint(workflow: Workflow, activityId: string, checkpointId: string) {
   const activity = getActivity(workflow, activityId);
   if (!activity) return undefined;
-  return activityCheckpoints(activity).find(c => c.id === checkpointId);
+  const defs = activityCheckpoints(activity);
+  const exact = defs.find(c => c.id === checkpointId);
+  if (exact) return exact;
+  // No exact match: compare on base ids, so an instance-qualified query resolves to its base
+  // definition (and a plain base query resolves to a templated definition). A base that matches no
+  // definition still returns undefined — base equality is on the full pre-`#` segment, not a prefix.
+  const base = checkpointBaseId(checkpointId);
+  return defs.find(c => checkpointBaseId(c.id) === base);
 }
 
 /** Get all valid transitions from an activity */

--- a/tests/workflow-loader.test.ts
+++ b/tests/workflow-loader.test.ts
@@ -6,6 +6,7 @@ import {
   getCheckpoint,
   getValidTransitions,
   getTransitionList,
+  checkpointBaseId,
 } from '../src/loaders/workflow-loader.js';
 import type { Workflow } from '../src/schema/workflow.schema.js';
 import { resolve } from 'node:path';
@@ -112,6 +113,58 @@ describe('workflow-loader', () => {
     it('should return undefined for a non-existent checkpoint', async () => {
       const workflow = await loadMetaWorkflow();
       expect(getCheckpoint(workflow, 'discover-session', 'no-such-checkpoint')).toBeUndefined();
+    });
+  });
+
+  // Loop-body checkpoint instance ids (issue #160 follow-up #2): a checkpoint inside a forEach
+  // loop is defined once but reached N times. Yielding it as `<baseId>#<instance>` gives each
+  // iteration a distinct id (and thus a distinct `<activity>-<checkpoint>` response key, so
+  // iterations 2..N no longer replay iteration 1's response) while resolving to the one definition.
+  describe('getCheckpoint — loop-body instance ids', () => {
+    // Minimal fixture: a requirements-refinement-shaped activity whose assumption-interview loop
+    // holds one templated-id checkpoint, mirroring the workflows-side 03 edit.
+    const wf = {
+      id: 'wd', version: '1.0.0', title: 'WD',
+      activities: [{
+        id: 'requirements-refinement', version: '1.0.0', name: 'RR',
+        steps: [{
+          kind: 'loop', id: 'assumption-interview-loop', loopType: 'forEach',
+          variable: 'current_assumption', over: 'open_assumptions',
+          steps: [{
+            kind: 'checkpoint', id: 'assumption-decision#{current_assumption.id}',
+            message: 'Assumption {current_assumption.id}: decide.',
+            options: [{ id: 'accept', label: 'Accept' }, { id: 'reject', label: 'Reject' }],
+          }],
+        }],
+      }],
+    } as unknown as Workflow;
+
+    it('checkpointBaseId strips the per-iteration instance discriminator', () => {
+      expect(checkpointBaseId('assumption-decision#RE-1')).toBe('assumption-decision');
+      expect(checkpointBaseId('assumption-decision#{current_assumption.id}')).toBe('assumption-decision');
+      expect(checkpointBaseId('enforcement-confirmed')).toBe('enforcement-confirmed');
+    });
+
+    it('resolves an instance-qualified id to the single base definition', () => {
+      const c1 = getCheckpoint(wf, 'requirements-refinement', 'assumption-decision#RE-1');
+      const c2 = getCheckpoint(wf, 'requirements-refinement', 'assumption-decision#RE-2');
+      expect(c1?.id).toBe('assumption-decision#{current_assumption.id}');
+      expect(c2?.id).toBe(c1?.id); // both instances share one definition
+      expect(c1?.options.map(o => o.id)).toEqual(['accept', 'reject']);
+    });
+
+    it('matches the definition on its base id even when queried with the bare base', () => {
+      expect(getCheckpoint(wf, 'requirements-refinement', 'assumption-decision')?.id)
+        .toBe('assumption-decision#{current_assumption.id}');
+    });
+
+    it('does not resolve an instance id whose base has no definition', () => {
+      expect(getCheckpoint(wf, 'requirements-refinement', 'no-such#RE-1')).toBeUndefined();
+    });
+
+    it('still resolves a plain non-loop checkpoint by exact id (no regression)', async () => {
+      const workflow = await loadMetaWorkflow();
+      expect(getCheckpoint(workflow, 'discover-session', 'resume-session')?.id).toBe('resume-session');
     });
   });
 


### PR DESCRIPTION
Issue #160 follow-up **#2 / RE-1 [Medium]** — engine side. Fixes the `assumption-decision` (and, generally, any loop-body) checkpoint-id replay.

## Problem
A checkpoint inside a `forEach`/`while` loop is defined once but reached N times. Checkpoint responses are keyed by `` `<activity>-<checkpoint>` `` (`workflow-tools.ts`), and `getCheckpoint` matched the checkpoint id **exactly** (`workflow-loader.ts`). So every iteration shared one response key: after the first response, iterations 2..N **replayed** iteration 1's recorded response instead of prompting distinctly. The `#160` design session demonstrated this live three times — `assumption-decision` (4 assumptions), `dimension-confirmed` (5 dimensions), and a re-yielded `impact-confirmed` all replayed a single stored response.

The impact-analysis for #160 (RE-5) confirmed there is **no YAML-only fix**: both the dynamic-id and namespacing mechanisms require an engine change, because the loader resolves checkpoint ids statically.

## Change (additive, minimal)
Let a loop-body checkpoint be **yielded** as `` `<baseId>#<instance>` `` (e.g. `assumption-decision#RE-1`). `getCheckpoint` now:
1. matches an exact id (unchanged path for every non-loop checkpoint), then
2. falls back to comparing **base ids** — the segment before `#` — so an instance-qualified id resolves to its single base definition.

Because the id carries the instance, the response key `` `<activity>-<checkpoint>` `` is naturally distinct per iteration, so iterations 2..N no longer collide. `getCheckpoint` is the one choke point shared by `yield_checkpoint`, `present_checkpoint`, and `respond_checkpoint`, so the fix flows through all three with a single edit. Base equality is on the full pre-`#` segment (not a prefix), so a base that matches no definition still returns `undefined`.

- `workflow-loader.ts`: export `CHECKPOINT_INSTANCE_SEPARATOR` + `checkpointBaseId`; add the base-id fallback to `getCheckpoint`.
- `tests/workflow-loader.test.ts`: instance-id resolution, base stripping, bare-base ↔ templated-definition, unknown base, and a no-regression exact-match case.

## Validation
`npm run typecheck` clean; full suite **370 passed, 0 failed** (14 skipped).

## Coupled change
The workflows-side edit — `03-requirements-refinement.yaml`'s assumption interview yields `assumption-decision#{current_assumption.id}` per iteration — ships as a separate PR against the `workflows` branch and lands together with this one. Companion to #162 (RE-2/3/4) and #163 (worktree-aware guards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
