### PR TITLE
fix(workflow-design): per-iteration id for assumption-decision checkpoint (#160)

### DIFF
--- a/workflow-design/activities/03-requirements-refinement.yaml
+++ b/workflow-design/activities/03-requirements-refinement.yaml
@@ -82,7 +82,7 @@ steps:
         id: present-assumption
         technique: work-package::review-assumptions::interview
       - kind: checkpoint
-        id: assumption-decision
+        id: assumption-decision#{current_assumption.id}
         message: "Assumption {current_assumption.id}: {current_assumption.statement}"
         blocking: true
         options:


### PR DESCRIPTION
Issue #160 follow-up **#2 / RE-1 [Medium]** — workflows side (coupled to the engine PR).

## Change
`workflow-design`'s `03-requirements-refinement.yaml` assumption-interview loop reused one static checkpoint id (`assumption-decision`) across N assumptions. Because checkpoint responses are keyed by `` `<activity>-<checkpoint>` ``, after the first response iterations 2..N **replayed** it — so each assumption's disposition was not recorded distinctly. Template the id per iteration:

```
id: assumption-decision#{current_assumption.id}
```

The worker interpolates `{current_assumption.id}` (exactly as it already interpolates the checkpoint `message`), yielding a distinct id per assumption (`assumption-decision#RE-1`, `assumption-decision#RE-2`, …), so each records its own response.

## Dependency
Requires the engine change that resolves an instance-qualified checkpoint id (`<base>#<instance>`) to its single base definition — **workflow-server PR #164**. The two land together; on its own this id template would not resolve against the pre-#164 loader.

## Validation
Full guard suite green against this worktree via the new `--root` flag (workflow-server PR #163): `validate-workflow-yaml`, `check-all-refs`, `check-binding-fidelity` (0 new drift), `check-identifier-qualification` (templated id accepted), `check-bound-step-purity`, `check-artifact-description`, `check-self-provisioned-input`, `check-activity-technique-overlap`, `check-resource-anchors` — all OK.

Companion to #162 (RE-2/3/4, already merged), #163 (worktree-aware guards), #164 (engine).
