### PR TITLE
docs(meta): context_mode decision guidance for reference delivery (B1, #166)

### DIFF
--- a/meta/resources/bootstrap-protocol.md
+++ b/meta/resources/bootstrap-protocol.md
@@ -18,6 +18,8 @@ IMPORTANT: YOU *MUST* *ALWAYS* EXECUTE ALL OF THESE STEPS
 
    Omit `planning_folder` for the meta bootstrap when the slug isn't known yet: the server mints a transitional slug from a UUID and parks the session in `os.tmpdir()`, and `dispatch_child` later supplies the real slug and promotes the session to its workspace folder.
 
+   `context_mode` declares the session's delivery context model, decided by execution topology. The default (omit, or `"fresh"`) delivers full content on every call and is correct whenever activities are dispatched to spawned workers ([dispatch-activity](../techniques/workflow-engine/dispatch-activity.md)) — each worker is a fresh context that relies on the repeated delivery. Pass `context_mode: "persistent"` only when this same agent context executes every activity itself (no worker spawning): bundle and technique content already delivered to this session then arrives as `{ unchanged: true, content_hash }` references instead of being repeated, and `get_activity { bundle: "full" }` / `get_technique { full: true }` re-fetch anything this context no longer holds. `dispatch_child` accepts the same parameter for a child session, under the same test applied to the child's activities.
+
 3. `get_workflow { session_index }`. The response carries the workflow's resolved operations bundle ahead of the workflow definition (separated by `\n\n---\n\n`). Follow the operations and rules in the bundle to drive execution.
 
 Pass `session_index` on every subsequent authenticated tool call. The index is stable across the entire session — there is no token rotation, adoption, or recovery protocol for the agent to manage.

--- a/meta/techniques/workflow-engine/dispatch-activity.md
+++ b/meta/techniques/workflow-engine/dispatch-activity.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -57,3 +57,7 @@ Workflow orchestrators NEVER call `get_activity`. The activity definition is the
 ### no-pre-load-techniques
 
 NEVER call `get_technique` to pre-load techniques for the worker. `get_activity` bundles only the activity's cross-cutting operations (strategy and core-worker techniques); the worker then loads each step's bound operation on demand via `get_technique { session_index, step_id }` — progressively, one per step as it reaches it. Pre-fetching step techniques from the orchestrator duplicates that work and defeats the progressive disclosure that step-level binding exists to provide.
+
+### workers-need-full-delivery
+
+Dispatched workers are fresh contexts with no prior deliveries. Leave a worker-dispatched session in its default (`fresh`) delivery mode — never set `context_mode: "persistent"` on it, and never instruct a worker to pass `bundle: "reference"`: an unchanged-reference points at content the new worker has never received. Reference delivery is reserved for the solo topology where one agent context executes every activity itself.


### PR DESCRIPTION
Companion to m2ux/workflow-server#167 (B1, #166). The server accepts `context_mode` on `start_session`/`dispatch_child`, but no workflow content told an agent when the persistent mode applies — an agent following the workflows would never opt in (or worse, could opt in for a worker-dispatched session). This encodes the decision rule at the two places the choice is made:

- **`meta/resources/bootstrap-protocol.md`** (step 2, the `start_session` moment): `context_mode` is decided by execution topology. Default (fresh) whenever activities are dispatched to spawned workers — each worker is a fresh context that relies on the repeated delivery. `persistent` only when the same agent context executes every activity itself, with the full-content escapes (`bundle: "full"`, `full: true`) named in place. Same test applies to `dispatch_child` for a child's activities.
- **`meta/techniques/workflow-engine/dispatch-activity.md`** (v1.2.0): new `workers-need-full-delivery` rule — dispatched workers are fresh contexts with no prior deliveries; never set `context_mode: "persistent"` on a worker-dispatched session, never instruct a worker to pass `bundle: "reference"`.

**Merge order:** m2ux/workflow-server#167 (server) first — this guidance describes parameters that exist only with that change.

Guards: `check:anchors`, `check:binding`, `check:steps`, `check:identifiers` green against this worktree (two pre-existing `write-report` read-resolution warnings on the branch tip, untouched by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
