### PR TITLE
fix(content): correct planning_folder_path universal-artifact claim (#166 B2)

### DIFF
--- a/meta/workflow.yaml
+++ b/meta/workflow.yaml
@@ -56,7 +56,7 @@ variables:
     defaultValue: false
   - name: planning_folder_path
     type: string
-    description: Canonical absolute path to the client workflow's planning folder, as resolved by the server under its own workspace .engineering root. Returned by create-session/dispatch_child (and start_session on resume); the single artifact location, never composed by the agent or anchored to target_path/CWD
+    description: Canonical absolute path to the client workflow's planning folder, as resolved by the server under its own workspace .engineering root. Returned by create-session/dispatch_child (and start_session on resume); the single location for planning artifacts, never composed by the agent or anchored to target_path/CWD
   - name: client_session_index
     type: string
     description: 6-character base32 session_index for the dispatched client workflow (returned by start_session when initialize-session creates or resumes the session)

--- a/work-package/techniques/TECHNIQUE.md
+++ b/work-package/techniques/TECHNIQUE.md
@@ -11,7 +11,7 @@ Base contract inherited by sibling techniques. Any Inputs, Outputs, Rules, or Er
 
 ### planning_folder_path
 
-Path to this work package's planning folder under `.engineering/artifacts/planning/` — the common location every technique reads prior artifacts from and writes its own artifact into (the server-provided `artifactPrefix` is applied to the filename).
+Path to this work package's planning folder under `.engineering/artifacts/planning/` — where techniques that persist planning artifacts read prior artifacts and write their own (the server-provided `artifactPrefix` is applied to the filename); not every technique produces one.
 
 ### requirements
 


### PR DESCRIPTION
Content half of #166 B2 (scope-annotate inherited inputs).

- `work-package/techniques/TECHNIQUE.md`: `planning_folder_path` no longer claims every technique writes an artifact — now "where techniques that persist planning artifacts read prior artifacts and write their own … not every technique produces one".
- `meta/workflow.yaml`: "the single artifact location" → "the single location for planning artifacts" (same over-claim family; the anti-composition guidance is unchanged).

Evidence: F4 in the 2026-07-03 evaluation report — the universal-artifact claim was independently flagged by probes as contradicted by techniques with no artifact output.

Companion server PR (inherited_inputs/inherited_outputs delivery blocks) follows; merge this first per the usual content-before-server order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
