### PR TITLE
fix(substrate-node-security-audit): declare derived finding-block locals

### DIFF
--- a/substrate-node-security-audit/techniques/write-report.md
+++ b/substrate-node-security-audit/techniques/write-report.md
@@ -88,7 +88,7 @@ Count of table-derived findings auto-elevated, adversarial refutations integrate
 
 **Suggested Remediation:** `{remediation}`
 
-The explanatory paragraph (`{description}`) is FIRST — immediately after the header, before `**Impact:**`. When a finding cites multiple files or extra line ranges, hyperlink each `` `{file}`#L… `` reference the same way; trailing bare line numbers after the first range may stay plain text. A single line renders as `#L{n}` (no range).
+The explanatory paragraph (`{description}`) is FIRST — immediately after the header, before `**Impact:**`; derive `{$remediation}` as the concrete suggested fix for the finding. When a finding cites multiple files or extra line ranges, hyperlink each `` `{file}`#L… `` reference the same way, deriving `{$start}`/`{$end}` as the cited range's first and last line; trailing bare line numbers after the first range may stay plain text. A single line renders as `#L{n}` (no range).
 
 #### finding_block_note
 
@@ -96,7 +96,7 @@ Each field MUST be separated by a blank line (double newline) so that markdown r
 
 #### affected_files_hyperlink
 
-Every source reference in `**Affected Files:**` MUST be a markdown hyperlink to the exact file and line range in the target repository at the audited commit, so a reviewer is one click from the reviewed code. Construct `{source_blob_base}` as `https://github.com/{org}/{repo}/blob/{target_commit}`, where `{org}/{repo}` is the target submodule's GitHub remote (from `git remote get-url origin` in `{target_path}`, normalised from SSH/HTTPS to `github.com/{org}/{repo}`) and `{target_commit}` is the audited revision recorded at scope-setup. Pin the links to `{target_commit}` — never to a mutable branch — so they always resolve to the reviewed source.
+Every source reference in `**Affected Files:**` MUST be a markdown hyperlink to the exact file and line range in the target repository at the audited commit, so a reviewer is one click from the reviewed code. Construct `{$source_blob_base}` as `https://github.com/{$org}/{$repo}/blob/{target_commit}`, where `{org}/{repo}` is the target submodule's GitHub remote (from `git remote get-url origin` in `{target_path}`, normalised from SSH/HTTPS to `github.com/{org}/{repo}`) and `{target_commit}` is the audited revision recorded at scope-setup. Pin the links to `{target_commit}` — never to a mutable branch — so they always resolve to the reviewed source.
 
 ## Rules
 


### PR DESCRIPTION
Fixes the 10 read-resolution findings that currently put the server repo's binding-fidelity drift guard in the red against the corpus tip.

The finding-block template in `substrate-node-security-audit/techniques/write-report.md` reads five tokens nothing produces — they are per-run values the report writer derives (`remediation`, `start`, `end`, `source_blob_base`, `org`). This declares them as file-locals using the `{$name}` sigil at each token's defining sentence (the same convention as `create-adr`'s "deriving `{$decision_title}`"):

- post-template paragraph: derives `{$remediation}` (the finding's concrete suggested fix) and `{$start}`/`{$end}` (the cited range's first and last line)
- `affected_files_hyperlink` construct sentence: `{$source_blob_base}`/`{$org}`/`{$repo}` (`repo` resolved today only by cross-corpus accident; sigiled for robustness)

The copyable template block itself is unchanged.

Guard result against this branch: 0 NEW, 1 previously-baselined violation also fixed — after the server repo's submodule pin advances past this, `check-binding-fidelity --update-baseline` shrinks the baseline by one (handled in the companion server PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
