### PR TITLE
fix: generated-schema recursion + surfaced activity-load failures (#166 B5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ This repo is an **MCP server** for AI agent workflow orchestration (TypeScript, 
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **workflow-server** (9319 symbols, 11826 relationships, 237 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **workflow-server** (9480 symbols, 12333 relationships, 211 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ This repo is an **MCP server** for AI agent workflow orchestration (TypeScript, 
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **workflow-server** (9319 symbols, 11826 relationships, 237 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **workflow-server** (9480 symbols, 12333 relationships, 211 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/schemas/condition.schema.json
+++ b/schemas/condition.schema.json
@@ -54,7 +54,9 @@
             },
             "conditions": {
               "type": "array",
-              "items": {},
+              "items": {
+                "$ref": "#/definitions/condition"
+              },
               "minItems": 2
             }
           },
@@ -73,7 +75,9 @@
             },
             "conditions": {
               "type": "array",
-              "items": {},
+              "items": {
+                "$ref": "#/definitions/condition"
+              },
               "minItems": 2
             }
           },
@@ -90,7 +94,9 @@
               "type": "string",
               "const": "not"
             },
-            "condition": {}
+            "condition": {
+              "$ref": "#/definitions/condition"
+            }
           },
           "required": [
             "type",

--- a/schemas/session-file.schema.json
+++ b/schemas/session-file.schema.json
@@ -272,7 +272,9 @@
                 "type": "object",
                 "additionalProperties": {}
               },
-              "state": {}
+              "state": {
+                "$ref": "#/definitions/session-file"
+              }
             },
             "required": [
               "workflowId",
@@ -304,7 +306,9 @@
             }
           }
         },
-        "parentSession": {}
+        "parentSession": {
+          "$ref": "#/definitions/session-file"
+        }
       },
       "required": [
         "schemaVersion",

--- a/schemas/workflow.schema.json
+++ b/schemas/workflow.schema.json
@@ -352,7 +352,9 @@
                                       },
                                       "conditions": {
                                         "type": "array",
-                                        "items": {},
+                                        "items": {
+                                          "$ref": "#/definitions/workflow/properties/activities/items/properties/steps/items/anyOf/0/properties/actions/items/properties/condition"
+                                        },
                                         "minItems": 2
                                       }
                                     },
@@ -371,7 +373,9 @@
                                       },
                                       "conditions": {
                                         "type": "array",
-                                        "items": {},
+                                        "items": {
+                                          "$ref": "#/definitions/workflow/properties/activities/items/properties/steps/items/anyOf/0/properties/actions/items/properties/condition"
+                                        },
                                         "minItems": 2
                                       }
                                     },
@@ -388,7 +392,9 @@
                                         "type": "string",
                                         "const": "not"
                                       },
-                                      "condition": {}
+                                      "condition": {
+                                        "$ref": "#/definitions/workflow/properties/activities/items/properties/steps/items/anyOf/0/properties/actions/items/properties/condition"
+                                      }
                                     },
                                     "required": [
                                       "type",
@@ -411,100 +417,7 @@
                           "description": "Inline boolean expression that gates this step. Examples: \"has_saved_state == true\", \"is_monorepo == true\", \"client_workflow_completed == false\". Evaluated against current variable state at runtime."
                         },
                         "condition": {
-                          "anyOf": [
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "const": "simple"
-                                },
-                                "variable": {
-                                  "type": "string"
-                                },
-                                "operator": {
-                                  "type": "string",
-                                  "enum": [
-                                    "==",
-                                    "!=",
-                                    ">",
-                                    "<",
-                                    ">=",
-                                    "<=",
-                                    "exists",
-                                    "notExists"
-                                  ]
-                                },
-                                "value": {
-                                  "type": [
-                                    "string",
-                                    "number",
-                                    "boolean",
-                                    "null"
-                                  ]
-                                }
-                              },
-                              "required": [
-                                "type",
-                                "variable",
-                                "operator"
-                              ],
-                              "additionalProperties": false
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "const": "and"
-                                },
-                                "conditions": {
-                                  "type": "array",
-                                  "items": {},
-                                  "minItems": 2
-                                }
-                              },
-                              "required": [
-                                "type",
-                                "conditions"
-                              ],
-                              "additionalProperties": false
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "const": "or"
-                                },
-                                "conditions": {
-                                  "type": "array",
-                                  "items": {},
-                                  "minItems": 2
-                                }
-                              },
-                              "required": [
-                                "type",
-                                "conditions"
-                              ],
-                              "additionalProperties": false
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "const": "not"
-                                },
-                                "condition": {}
-                              },
-                              "required": [
-                                "type",
-                                "condition"
-                              ],
-                              "additionalProperties": false
-                            }
-                          ],
+                          "$ref": "#/definitions/workflow/properties/activities/items/properties/steps/items/anyOf/0/properties/actions/items/properties/condition",
                           "description": "LEGACY: Structured condition that must be true for this step to execute. Prefer the `when` inline expression for simple comparisons."
                         },
                         "required": {
@@ -534,239 +447,18 @@
                         "actions": {
                           "type": "array",
                           "items": {
-                            "type": "object",
-                            "properties": {
-                              "action": {
-                                "type": "string",
-                                "enum": [
-                                  "log",
-                                  "validate",
-                                  "set",
-                                  "emit",
-                                  "message"
-                                ]
-                              },
-                              "target": {
-                                "type": "string"
-                              },
-                              "message": {
-                                "type": "string"
-                              },
-                              "value": {},
-                              "description": {
-                                "type": "string",
-                                "description": "Human-readable description of what this action does"
-                              },
-                              "condition": {
-                                "anyOf": [
-                                  {
-                                    "type": "object",
-                                    "properties": {
-                                      "type": {
-                                        "type": "string",
-                                        "const": "simple"
-                                      },
-                                      "variable": {
-                                        "type": "string"
-                                      },
-                                      "operator": {
-                                        "type": "string",
-                                        "enum": [
-                                          "==",
-                                          "!=",
-                                          ">",
-                                          "<",
-                                          ">=",
-                                          "<=",
-                                          "exists",
-                                          "notExists"
-                                        ]
-                                      },
-                                      "value": {
-                                        "type": [
-                                          "string",
-                                          "number",
-                                          "boolean",
-                                          "null"
-                                        ]
-                                      }
-                                    },
-                                    "required": [
-                                      "type",
-                                      "variable",
-                                      "operator"
-                                    ],
-                                    "additionalProperties": false
-                                  },
-                                  {
-                                    "type": "object",
-                                    "properties": {
-                                      "type": {
-                                        "type": "string",
-                                        "const": "and"
-                                      },
-                                      "conditions": {
-                                        "type": "array",
-                                        "items": {},
-                                        "minItems": 2
-                                      }
-                                    },
-                                    "required": [
-                                      "type",
-                                      "conditions"
-                                    ],
-                                    "additionalProperties": false
-                                  },
-                                  {
-                                    "type": "object",
-                                    "properties": {
-                                      "type": {
-                                        "type": "string",
-                                        "const": "or"
-                                      },
-                                      "conditions": {
-                                        "type": "array",
-                                        "items": {},
-                                        "minItems": 2
-                                      }
-                                    },
-                                    "required": [
-                                      "type",
-                                      "conditions"
-                                    ],
-                                    "additionalProperties": false
-                                  },
-                                  {
-                                    "type": "object",
-                                    "properties": {
-                                      "type": {
-                                        "type": "string",
-                                        "const": "not"
-                                      },
-                                      "condition": {}
-                                    },
-                                    "required": [
-                                      "type",
-                                      "condition"
-                                    ],
-                                    "additionalProperties": false
-                                  }
-                                ],
-                                "description": "Condition that must be true for this action to execute"
-                              }
-                            },
-                            "required": [
-                              "action"
-                            ],
-                            "additionalProperties": false
+                            "$ref": "#/definitions/workflow/properties/activities/items/properties/steps/items/anyOf/0/properties/actions/items"
                           },
                           "description": "Control actions; may be empty for marker steps."
                         },
                         "when": {
-                          "type": "string",
-                          "description": "Inline boolean expression that gates this step. Examples: \"has_saved_state == true\", \"is_monorepo == true\", \"client_workflow_completed == false\". Evaluated against current variable state at runtime."
+                          "$ref": "#/definitions/workflow/properties/activities/items/properties/steps/items/anyOf/0/properties/when"
                         },
                         "condition": {
-                          "anyOf": [
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "const": "simple"
-                                },
-                                "variable": {
-                                  "type": "string"
-                                },
-                                "operator": {
-                                  "type": "string",
-                                  "enum": [
-                                    "==",
-                                    "!=",
-                                    ">",
-                                    "<",
-                                    ">=",
-                                    "<=",
-                                    "exists",
-                                    "notExists"
-                                  ]
-                                },
-                                "value": {
-                                  "type": [
-                                    "string",
-                                    "number",
-                                    "boolean",
-                                    "null"
-                                  ]
-                                }
-                              },
-                              "required": [
-                                "type",
-                                "variable",
-                                "operator"
-                              ],
-                              "additionalProperties": false
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "const": "and"
-                                },
-                                "conditions": {
-                                  "type": "array",
-                                  "items": {},
-                                  "minItems": 2
-                                }
-                              },
-                              "required": [
-                                "type",
-                                "conditions"
-                              ],
-                              "additionalProperties": false
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "const": "or"
-                                },
-                                "conditions": {
-                                  "type": "array",
-                                  "items": {},
-                                  "minItems": 2
-                                }
-                              },
-                              "required": [
-                                "type",
-                                "conditions"
-                              ],
-                              "additionalProperties": false
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "const": "not"
-                                },
-                                "condition": {}
-                              },
-                              "required": [
-                                "type",
-                                "condition"
-                              ],
-                              "additionalProperties": false
-                            }
-                          ],
-                          "description": "LEGACY: Structured condition that must be true for this step to execute. Prefer the `when` inline expression for simple comparisons."
+                          "$ref": "#/definitions/workflow/properties/activities/items/properties/steps/items/anyOf/0/properties/condition"
                         },
                         "required": {
-                          "type": "boolean",
-                          "const": false,
-                          "description": "Declared only when false (an optional step). An omitted `required` means the step is required; `required: true` is redundant and rejected (AP-64)."
+                          "$ref": "#/definitions/workflow/properties/activities/items/properties/steps/items/anyOf/0/properties/required"
                         }
                       },
                       "required": [
@@ -850,110 +542,13 @@
                           "description": "True requires explicit user selection (no auto-advance)."
                         },
                         "when": {
-                          "type": "string",
-                          "description": "Inline boolean expression that gates this step. Examples: \"has_saved_state == true\", \"is_monorepo == true\", \"client_workflow_completed == false\". Evaluated against current variable state at runtime."
+                          "$ref": "#/definitions/workflow/properties/activities/items/properties/steps/items/anyOf/0/properties/when"
                         },
                         "condition": {
-                          "anyOf": [
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "const": "simple"
-                                },
-                                "variable": {
-                                  "type": "string"
-                                },
-                                "operator": {
-                                  "type": "string",
-                                  "enum": [
-                                    "==",
-                                    "!=",
-                                    ">",
-                                    "<",
-                                    ">=",
-                                    "<=",
-                                    "exists",
-                                    "notExists"
-                                  ]
-                                },
-                                "value": {
-                                  "type": [
-                                    "string",
-                                    "number",
-                                    "boolean",
-                                    "null"
-                                  ]
-                                }
-                              },
-                              "required": [
-                                "type",
-                                "variable",
-                                "operator"
-                              ],
-                              "additionalProperties": false
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "const": "and"
-                                },
-                                "conditions": {
-                                  "type": "array",
-                                  "items": {},
-                                  "minItems": 2
-                                }
-                              },
-                              "required": [
-                                "type",
-                                "conditions"
-                              ],
-                              "additionalProperties": false
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "const": "or"
-                                },
-                                "conditions": {
-                                  "type": "array",
-                                  "items": {},
-                                  "minItems": 2
-                                }
-                              },
-                              "required": [
-                                "type",
-                                "conditions"
-                              ],
-                              "additionalProperties": false
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "const": "not"
-                                },
-                                "condition": {}
-                              },
-                              "required": [
-                                "type",
-                                "condition"
-                              ],
-                              "additionalProperties": false
-                            }
-                          ],
-                          "description": "LEGACY: Structured condition that must be true for this step to execute. Prefer the `when` inline expression for simple comparisons."
+                          "$ref": "#/definitions/workflow/properties/activities/items/properties/steps/items/anyOf/0/properties/condition"
                         },
                         "required": {
-                          "type": "boolean",
-                          "const": false,
-                          "description": "Declared only when false (an optional step). An omitted `required` means the step is required; `required: true` is redundant and rejected (AP-64)."
+                          "$ref": "#/definitions/workflow/properties/activities/items/properties/steps/items/anyOf/0/properties/required"
                         }
                       },
                       "required": [
@@ -998,100 +593,7 @@
                           "description": "Collection expression iterated by a forEach loop."
                         },
                         "breakCondition": {
-                          "anyOf": [
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "const": "simple"
-                                },
-                                "variable": {
-                                  "type": "string"
-                                },
-                                "operator": {
-                                  "type": "string",
-                                  "enum": [
-                                    "==",
-                                    "!=",
-                                    ">",
-                                    "<",
-                                    ">=",
-                                    "<=",
-                                    "exists",
-                                    "notExists"
-                                  ]
-                                },
-                                "value": {
-                                  "type": [
-                                    "string",
-                                    "number",
-                                    "boolean",
-                                    "null"
-                                  ]
-                                }
-                              },
-                              "required": [
-                                "type",
-                                "variable",
-                                "operator"
-                              ],
-                              "additionalProperties": false
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "const": "and"
-                                },
-                                "conditions": {
-                                  "type": "array",
-                                  "items": {},
-                                  "minItems": 2
-                                }
-                              },
-                              "required": [
-                                "type",
-                                "conditions"
-                              ],
-                              "additionalProperties": false
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "const": "or"
-                                },
-                                "conditions": {
-                                  "type": "array",
-                                  "items": {},
-                                  "minItems": 2
-                                }
-                              },
-                              "required": [
-                                "type",
-                                "conditions"
-                              ],
-                              "additionalProperties": false
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "const": "not"
-                                },
-                                "condition": {}
-                              },
-                              "required": [
-                                "type",
-                                "condition"
-                              ],
-                              "additionalProperties": false
-                            }
-                          ],
+                          "$ref": "#/definitions/workflow/properties/activities/items/properties/steps/items/anyOf/0/properties/actions/items/properties/condition",
                           "description": "Early-exit condition evaluated each iteration."
                         },
                         "maxIterations": {
@@ -1101,114 +603,19 @@
                         },
                         "steps": {
                           "type": "array",
-                          "items": {},
+                          "items": {
+                            "$ref": "#/definitions/workflow/properties/activities/items/properties/steps/items"
+                          },
                           "description": "The loop body, a nested ordered list of steps."
                         },
                         "when": {
-                          "type": "string",
-                          "description": "Inline boolean expression that gates this step. Examples: \"has_saved_state == true\", \"is_monorepo == true\", \"client_workflow_completed == false\". Evaluated against current variable state at runtime."
+                          "$ref": "#/definitions/workflow/properties/activities/items/properties/steps/items/anyOf/0/properties/when"
                         },
                         "condition": {
-                          "anyOf": [
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "const": "simple"
-                                },
-                                "variable": {
-                                  "type": "string"
-                                },
-                                "operator": {
-                                  "type": "string",
-                                  "enum": [
-                                    "==",
-                                    "!=",
-                                    ">",
-                                    "<",
-                                    ">=",
-                                    "<=",
-                                    "exists",
-                                    "notExists"
-                                  ]
-                                },
-                                "value": {
-                                  "type": [
-                                    "string",
-                                    "number",
-                                    "boolean",
-                                    "null"
-                                  ]
-                                }
-                              },
-                              "required": [
-                                "type",
-                                "variable",
-                                "operator"
-                              ],
-                              "additionalProperties": false
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "const": "and"
-                                },
-                                "conditions": {
-                                  "type": "array",
-                                  "items": {},
-                                  "minItems": 2
-                                }
-                              },
-                              "required": [
-                                "type",
-                                "conditions"
-                              ],
-                              "additionalProperties": false
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "const": "or"
-                                },
-                                "conditions": {
-                                  "type": "array",
-                                  "items": {},
-                                  "minItems": 2
-                                }
-                              },
-                              "required": [
-                                "type",
-                                "conditions"
-                              ],
-                              "additionalProperties": false
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "const": "not"
-                                },
-                                "condition": {}
-                              },
-                              "required": [
-                                "type",
-                                "condition"
-                              ],
-                              "additionalProperties": false
-                            }
-                          ],
-                          "description": "LEGACY: Structured condition that must be true for this step to execute. Prefer the `when` inline expression for simple comparisons."
+                          "$ref": "#/definitions/workflow/properties/activities/items/properties/steps/items/anyOf/0/properties/condition"
                         },
                         "required": {
-                          "type": "boolean",
-                          "const": false,
-                          "description": "Declared only when false (an optional step). An omitted `required` means the step is required; `required: true` is redundant and rejected (AP-64)."
+                          "$ref": "#/definitions/workflow/properties/activities/items/properties/steps/items/anyOf/0/properties/required"
                         }
                       },
                       "required": [
@@ -1249,100 +656,7 @@
                             "type": "string"
                           },
                           "condition": {
-                            "anyOf": [
-                              {
-                                "type": "object",
-                                "properties": {
-                                  "type": {
-                                    "type": "string",
-                                    "const": "simple"
-                                  },
-                                  "variable": {
-                                    "type": "string"
-                                  },
-                                  "operator": {
-                                    "type": "string",
-                                    "enum": [
-                                      "==",
-                                      "!=",
-                                      ">",
-                                      "<",
-                                      ">=",
-                                      "<=",
-                                      "exists",
-                                      "notExists"
-                                    ]
-                                  },
-                                  "value": {
-                                    "type": [
-                                      "string",
-                                      "number",
-                                      "boolean",
-                                      "null"
-                                    ]
-                                  }
-                                },
-                                "required": [
-                                  "type",
-                                  "variable",
-                                  "operator"
-                                ],
-                                "additionalProperties": false
-                              },
-                              {
-                                "type": "object",
-                                "properties": {
-                                  "type": {
-                                    "type": "string",
-                                    "const": "and"
-                                  },
-                                  "conditions": {
-                                    "type": "array",
-                                    "items": {},
-                                    "minItems": 2
-                                  }
-                                },
-                                "required": [
-                                  "type",
-                                  "conditions"
-                                ],
-                                "additionalProperties": false
-                              },
-                              {
-                                "type": "object",
-                                "properties": {
-                                  "type": {
-                                    "type": "string",
-                                    "const": "or"
-                                  },
-                                  "conditions": {
-                                    "type": "array",
-                                    "items": {},
-                                    "minItems": 2
-                                  }
-                                },
-                                "required": [
-                                  "type",
-                                  "conditions"
-                                ],
-                                "additionalProperties": false
-                              },
-                              {
-                                "type": "object",
-                                "properties": {
-                                  "type": {
-                                    "type": "string",
-                                    "const": "not"
-                                  },
-                                  "condition": {}
-                                },
-                                "required": [
-                                  "type",
-                                  "condition"
-                                ],
-                                "additionalProperties": false
-                              }
-                            ]
+                            "$ref": "#/definitions/workflow/properties/activities/items/properties/steps/items/anyOf/0/properties/actions/items/properties/condition"
                           },
                           "transitionTo": {
                             "type": "string",
@@ -1381,100 +695,7 @@
                       "description": "Activity ID to transition to"
                     },
                     "condition": {
-                      "anyOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "const": "simple"
-                            },
-                            "variable": {
-                              "type": "string"
-                            },
-                            "operator": {
-                              "type": "string",
-                              "enum": [
-                                "==",
-                                "!=",
-                                ">",
-                                "<",
-                                ">=",
-                                "<=",
-                                "exists",
-                                "notExists"
-                              ]
-                            },
-                            "value": {
-                              "type": [
-                                "string",
-                                "number",
-                                "boolean",
-                                "null"
-                              ]
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "variable",
-                            "operator"
-                          ],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "const": "and"
-                            },
-                            "conditions": {
-                              "type": "array",
-                              "items": {},
-                              "minItems": 2
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "conditions"
-                          ],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "const": "or"
-                            },
-                            "conditions": {
-                              "type": "array",
-                              "items": {},
-                              "minItems": 2
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "conditions"
-                          ],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "const": "not"
-                            },
-                            "condition": {}
-                          },
-                          "required": [
-                            "type",
-                            "condition"
-                          ],
-                          "additionalProperties": false
-                        }
-                      ]
+                      "$ref": "#/definitions/workflow/properties/activities/items/properties/steps/items/anyOf/0/properties/actions/items/properties/condition"
                     },
                     "isDefault": {
                       "type": "boolean",

--- a/scripts/generate-schemas.ts
+++ b/scripts/generate-schemas.ts
@@ -12,7 +12,9 @@ const schemasDir = join(import.meta.dirname, '..', 'schemas');
 mkdirSync(schemasDir, { recursive: true });
 
 // `none` inlines fully (no $ref); `root` emits $defs for recursive schemas (the loop-kind step's
-// nested steps[] body references StepSchema), which `none` cannot represent.
+// nested steps[] body references StepSchema, and the and/or/not condition combinators reference
+// ConditionSchema), which `none` cannot represent — it silently degrades each cycle to the empty
+// schema `{}` (accept-anything), so any schema embedding ConditionSchema must use `root`.
 function generate(schema: Parameters<typeof zodToJsonSchema>[0], name: string, desc: string, refStrategy: 'none' | 'root' = 'none'): void {
   const json = zodToJsonSchema(schema, { name, $refStrategy: refStrategy });
   writeFileSync(join(schemasDir, `${name}.schema.json`), JSON.stringify({ $schema: 'https://json-schema.org/draft/2020-12/schema', title: name, description: desc, ...json }, null, 2) + '\n');
@@ -20,9 +22,9 @@ function generate(schema: Parameters<typeof zodToJsonSchema>[0], name: string, d
 }
 
 console.log('Generating JSON Schema files...\n');
-generate(WorkflowSchema, 'workflow', 'Workflow definition schema');
+generate(WorkflowSchema, 'workflow', 'Workflow definition schema', 'root');
 generate(WorkflowStateSchema, 'state', 'Workflow state schema');
-generate(ConditionSchema, 'condition', 'Condition expression schema');
-generate(SessionFileSchema, 'session-file', 'Server-managed session file (session.json) — canonical session state owned by the workflow server.');
+generate(ConditionSchema, 'condition', 'Condition expression schema', 'root');
+generate(SessionFileSchema, 'session-file', 'Server-managed session file (session.json) — canonical session state owned by the workflow server.', 'root');
 generate(ActivitySchema, 'activity', 'Activity definition schema — unified ordered, kind-tagged steps[] (technique | action | checkpoint | loop).', 'root');
 console.log('\n[PASS] Done');

--- a/src/loaders/workflow-loader.ts
+++ b/src/loaders/workflow-loader.ts
@@ -11,6 +11,20 @@ import { parseActivityFilename } from './filename-utils.js';
 
 export interface WorkflowManifestEntry { id: string; title: string; version: string; tags?: string[] | undefined; }
 
+/**
+ * A definition file that failed to load (unreadable, unparsable, or schema-invalid) and was
+ * excluded from the result. Loaders collect these instead of only logging, so `get_workflow` /
+ * `list_workflows` can surface the failure in their payloads rather than silently skipping
+ * (issue #166 B5 — a dropped activity otherwise resurfaces much later as "Activity not found").
+ */
+export interface DefinitionLoadError { file: string; activity_id?: string | undefined; error: string; }
+
+/** A loaded workflow plus the per-file activity-load failures excluded from it. */
+export interface WorkflowWithDiagnostics { workflow: Workflow; activityLoadErrors: DefinitionLoadError[]; }
+
+const formatZodIssues = (issues: Array<{ path: PropertyKey[]; message: string }>): string =>
+  issues.map(i => `${i.path.join('.')}: ${i.message}`).join('; ');
+
 const META_WORKFLOW_ID = 'meta';
 
 /** Raw workflow before activity loading */
@@ -27,23 +41,25 @@ interface RawWorkflow {
 /**
  * Load activities from a directory
  */
-async function loadActivitiesFromDir(activitiesPath: string): Promise<Activity[]> {
-  if (!existsSync(activitiesPath)) return [];
-  
+async function loadActivitiesFromDir(activitiesPath: string): Promise<{ activities: Activity[]; errors: DefinitionLoadError[] }> {
+  if (!existsSync(activitiesPath)) return { activities: [], errors: [] };
+
   const files = await readdir(activitiesPath);
   const activities: Activity[] = [];
-  
+  const errors: DefinitionLoadError[] = [];
+
   for (const file of files) {
     const parsed = parseActivityFilename(file);
     if (!parsed) continue;
-    
+
     try {
       const content = await readFile(join(activitiesPath, file), 'utf-8');
       const decoded = parseDefinition(content);
-      
+
       const validation = safeValidateActivity(decoded);
       if (!validation.success) {
         logWarn('Skipping invalid activity', { activityId: parsed.id, errors: validation.error.issues });
+        errors.push({ file, activity_id: parsed.id, error: formatZodIssues(validation.error.issues) });
         continue;
       }
       const activity = validation.data;
@@ -52,12 +68,14 @@ async function loadActivitiesFromDir(activitiesPath: string): Promise<Activity[]
       activities.push(activity);
     } catch (error) {
       logWarn('Failed to load activity', { file, error: error instanceof Error ? error.message : 'Unknown error' });
+      errors.push({ file, activity_id: parsed.id, error: error instanceof Error ? error.message : 'Unknown error' });
     }
   }
-  
-  return activities.sort((a, b) =>
+
+  activities.sort((a, b) =>
     (a.artifactPrefix ?? '').localeCompare(b.artifactPrefix ?? '')
   );
+  return { activities, errors };
 }
 
 /** Definition file extensions, in resolution priority. */
@@ -142,6 +160,16 @@ async function resolveActivityReference(workflowDir: string, workflowId: string,
 }
 
 export async function loadWorkflow(workflowDir: string, workflowId: string): Promise<Result<Workflow, WorkflowNotFoundError | WorkflowValidationError>> {
+  const result = await loadWorkflowWithDiagnostics(workflowDir, workflowId);
+  return result.success ? ok(result.value.workflow) : result;
+}
+
+/**
+ * Load a workflow and report the activity files that failed to load alongside it. Same contract
+ * as `loadWorkflow`, but per-file activity failures (which do not fail the workflow) are returned
+ * instead of only logged.
+ */
+export async function loadWorkflowWithDiagnostics(workflowDir: string, workflowId: string): Promise<Result<WorkflowWithDiagnostics, WorkflowNotFoundError | WorkflowValidationError>> {
   const filePath = resolveWorkflowPath(workflowDir, workflowId);
   if (!filePath) return err(new WorkflowNotFoundError(workflowId));
   
@@ -158,7 +186,7 @@ export async function loadWorkflow(workflowDir: string, workflowId: string): Pro
     const activitiesDirName = rawWorkflow.activitiesDir ?? 'activities';
     const activitiesPath = join(workflowDirPath, activitiesDirName);
     
-    const localActivities = await loadActivitiesFromDir(activitiesPath);
+    const { activities: localActivities, errors: activityLoadErrors } = await loadActivitiesFromDir(activitiesPath);
     if (localActivities.length > 0) {
       resolvedActivities = [...localActivities];
       logInfo('Loaded local activities from directory', { workflowId, activitiesDir: activitiesDirName, count: localActivities.length });
@@ -200,9 +228,9 @@ export async function loadWorkflow(workflowDir: string, workflowId: string): Pro
     if (!result.success) {
       return err(new WorkflowValidationError(workflowId, result.error.issues.map(i => `${i.path.join('.')}: ${i.message}`)));
     }
-    
+
     logInfo('Workflow loaded', { workflowId, version: result.data.version, activityCount: result.data.activities?.length ?? 0 });
-    return ok(result.data);
+    return ok({ workflow: result.data, activityLoadErrors });
   } catch (error) {
     logError('Failed to load workflow', error instanceof Error ? error : undefined, { workflowId });
     return err(new WorkflowValidationError(workflowId, [error instanceof Error ? error.message : 'Unknown error']));
@@ -210,11 +238,21 @@ export async function loadWorkflow(workflowDir: string, workflowId: string): Pro
 }
 
 export async function listWorkflows(workflowDir: string): Promise<WorkflowManifestEntry[]> {
-  if (!existsSync(workflowDir)) return [];
+  return (await listWorkflowsWithDiagnostics(workflowDir)).workflows;
+}
+
+/**
+ * List workflow manifests and report the definition files that failed to yield one — unreadable
+ * or unparsable `workflow.yaml`, or a manifest missing the required id/title/version fields —
+ * instead of silently skipping them.
+ */
+export async function listWorkflowsWithDiagnostics(workflowDir: string): Promise<{ workflows: WorkflowManifestEntry[]; errors: DefinitionLoadError[] }> {
+  if (!existsSync(workflowDir)) return { workflows: [], errors: [] };
+  const errors: DefinitionLoadError[] = [];
   try {
     const entries = await readdir(workflowDir);
     const manifests: WorkflowManifestEntry[] = [];
-    
+
     for (const entry of entries) {
       if (entry === META_WORKFLOW_ID) continue;
       const entryPath = join(workflowDir, entry);
@@ -239,17 +277,22 @@ export async function listWorkflows(workflowDir: string): Promise<WorkflowManife
           const raw = parseDefinition(content) as RawWorkflow;
           if (raw.id && raw.title && raw.version) {
             manifests.push({ id: raw.id, title: raw.title, version: raw.version, tags: Array.isArray(raw['tags']) ? raw['tags'] as string[] : undefined });
+          } else {
+            logWarn('Workflow manifest missing required fields', { path: defPath });
+            errors.push({ file: defPath, error: 'manifest missing required fields (id, title, version)' });
           }
         } catch (error) {
           logWarn('Failed to read workflow manifest', { path: defPath, error: error instanceof Error ? error.message : String(error) });
+          errors.push({ file: defPath, error: error instanceof Error ? error.message : String(error) });
         }
       }
     }
-    
-    return manifests;
+
+    return { workflows: manifests, errors };
   } catch (error) {
     logWarn('Failed to list workflows', { workflowDir, error: error instanceof Error ? error.message : String(error), code: error instanceof Error && 'code' in error ? (error as NodeJS.ErrnoException).code : undefined });
-    return [];
+    errors.push({ file: workflowDir, error: error instanceof Error ? error.message : String(error) });
+    return { workflows: [], errors };
   }
 }
 

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ServerConfig } from '../config.js';
-import { listWorkflows, loadWorkflow, getActivity, getCheckpoint, readActivityRaw, TERMINAL_SENTINEL } from '../loaders/workflow-loader.js';
+import { listWorkflows, listWorkflowsWithDiagnostics, loadWorkflow, loadWorkflowWithDiagnostics, getActivity, getCheckpoint, readActivityRaw, TERMINAL_SENTINEL } from '../loaders/workflow-loader.js';
 import { resolveTechniques, formatTechniqueBundle } from '../loaders/technique-loader.js';
 import { CORE_ORCHESTRATOR_TECHNIQUES, CORE_WORKER_TECHNIQUES } from '../loaders/core-ops.js';
 import { readResourceRaw } from '../loaders/resource-loader.js';
@@ -120,12 +120,15 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
     }));
 
-  server.tool('list_workflows', 'List all available workflow definitions with their ID, title, version, and tags. Use this when you need to discover or filter available workflows. Returns an array of workflow summaries with tag-based categorization. Does not require a session_index.', {},
-    withAuditLog('list_workflows', async () => ({
-      content: [{ type: 'text' as const, text: stringifyForResponse(await listWorkflows(config.workflowDir)) }],
-    })));
+  server.tool('list_workflows', 'List all available workflow definitions with their ID, title, version, and tags. Use this when you need to discover or filter available workflows. Returns an array of workflow summaries with tag-based categorization. If any workflow definition fails to load (unreadable file or manifest missing id/title/version), the response is instead an object with `workflows` (the loadable entries) and `load_errors` (one entry per failed file). Does not require a session_index.', {},
+    withAuditLog('list_workflows', async () => {
+      const { workflows, errors } = await listWorkflowsWithDiagnostics(config.workflowDir);
+      // Additive shape: the payload stays a plain array unless something failed to load.
+      const payload = errors.length > 0 ? { workflows, load_errors: errors } : workflows;
+      return { content: [{ type: 'text' as const, text: stringifyForResponse(payload) }] };
+    }));
 
-  server.tool('get_workflow', 'Load the workflow definition for the current session. The response begins with the resolved orchestrator technique bundle, then a `---` separator, then lightweight workflow metadata: rules, variables, the initialActivity field (which activity to load first), and a stub list of all activities with their IDs and names. Call this after start_session to learn the workflow structure — the initialActivity field in the response tells you which activity_id to pass to your first next_activity call. This is the only tool that provides initialActivity. The response also carries `planning_folder_path`: the canonical absolute planning folder for this session under THIS server\'s workspace `.engineering` root — bind it as the single artifact location and never recompose it relative to your CWD or the target component repo.',
+  server.tool('get_workflow', 'Load the workflow definition for the current session. The response begins with the resolved orchestrator technique bundle, then a `---` separator, then lightweight workflow metadata: rules, variables, the initialActivity field (which activity to load first), and a stub list of all activities with their IDs and names. If any activity file failed to load (invalid or unparsable YAML), the response includes `activity_load_errors` listing each failed file with its error — those activities are absent from the activity list. Call this after start_session to learn the workflow structure — the initialActivity field in the response tells you which activity_id to pass to your first next_activity call. This is the only tool that provides initialActivity. The response also carries `planning_folder_path`: the canonical absolute planning folder for this session under THIS server\'s workspace `.engineering` root — bind it as the single artifact location and never recompose it relative to your CWD or the target component repo.',
     {
       ...sessionIndexParam,
     },
@@ -135,9 +138,9 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       assertNoActiveCheckpoint(state);
       const workflow_id = state.workflowId;
 
-      const result = await loadWorkflow(config.workflowDir, workflow_id);
+      const result = await loadWorkflowWithDiagnostics(config.workflowDir, workflow_id);
       if (!result.success) throw result.error;
-      const wf = result.value;
+      const { workflow: wf, activityLoadErrors } = result.value;
 
       const view = sessionView(state);
       const validation = buildValidation(
@@ -177,6 +180,10 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
         variables: wf.variables,
         initialActivity: wf.initialActivity,
         activities: wf.activities?.map((a: { id: string; name?: string; required?: boolean; artifactPrefix?: string | undefined }) => ({ id: a.id, name: a.name, required: a.required, artifactPrefix: a.artifactPrefix })) ?? [],
+        // Activity files that failed to load and are missing from `activities` — surfaced here
+        // instead of silently skipped, so a broken definition is visible at workflow load rather
+        // than as a later "Activity not found". Omitted when every activity loaded.
+        activity_load_errors: activityLoadErrors.length > 0 ? activityLoadErrors : undefined,
         session_index,
         // Canonical absolute planning folder for this session, resolved by the
         // server under its own workspace `.engineering` root. This is the single

--- a/tests/generated-schemas.test.ts
+++ b/tests/generated-schemas.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const SCHEMAS_DIR = resolve(import.meta.dirname, '../schemas');
+
+/**
+ * Guardrail for the generated JSON Schema files (issue #166 B5).
+ *
+ * zod-to-json-schema with `$refStrategy: 'none'` cannot represent recursive schemas: each cycle
+ * (the and/or/not condition combinators, the loop-kind step's nested steps[], the session file's
+ * parentSession) silently degrades to the empty schema `{}` — accept-anything — so authoring-time
+ * validation passes garbage that Zod then rejects at load. These tests fail if a regeneration
+ * reintroduces an empty-schema recursion point.
+ */
+
+/** Collect JSON paths of every empty-object schema found at a recursion-prone keyword. */
+function findEmptySubschemas(node: unknown, path: string, out: string[]): void {
+  if (Array.isArray(node)) {
+    node.forEach((item, i) => findEmptySubschemas(item, `${path}[${i}]`, out));
+    return;
+  }
+  if (node === null || typeof node !== 'object') return;
+  for (const [key, value] of Object.entries(node)) {
+    const childPath = `${path}.${key}`;
+    const isEmptyObject = typeof value === 'object' && value !== null && !Array.isArray(value) && Object.keys(value).length === 0;
+    // `items` always holds a schema; a `condition` under `properties` is a schema position too.
+    if (isEmptyObject && (key === 'items' || (key === 'condition' && path.endsWith('.properties')))) {
+      out.push(childPath);
+      continue;
+    }
+    findEmptySubschemas(value, childPath, out);
+  }
+}
+
+describe('generated-schemas', () => {
+  const schemaFiles = readdirSync(SCHEMAS_DIR).filter(f => f.endsWith('.schema.json'));
+
+  it('should find the generated schema files', () => {
+    expect(schemaFiles).toContain('condition.schema.json');
+    expect(schemaFiles).toContain('workflow.schema.json');
+  });
+
+  it.each(schemaFiles)('%s has no empty-schema recursion points', (file) => {
+    const schema = JSON.parse(readFileSync(join(SCHEMAS_DIR, file), 'utf-8'));
+    const empties: string[] = [];
+    findEmptySubschemas(schema, '$', empties);
+    expect(empties, `empty subschemas (lost recursion) in ${file}`).toEqual([]);
+  });
+
+  it('condition combinators reference the condition definition', () => {
+    const schema = JSON.parse(readFileSync(join(SCHEMAS_DIR, 'condition.schema.json'), 'utf-8'));
+    const variants: Array<{ properties: Record<string, { $ref?: string; items?: { $ref?: string } }> }> =
+      schema.definitions.condition.anyOf;
+    const byType = (t: string) => variants.find(v => (v.properties['type'] as { const?: string }).const === t)!;
+    expect(byType('and').properties['conditions']!.items!.$ref).toBe('#/definitions/condition');
+    expect(byType('or').properties['conditions']!.items!.$ref).toBe('#/definitions/condition');
+    expect(byType('not').properties['condition']!.$ref).toBe('#/definitions/condition');
+  });
+});

--- a/tests/workflow-loader.test.ts
+++ b/tests/workflow-loader.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import {
   loadWorkflow,
+  loadWorkflowWithDiagnostics,
   listWorkflows,
+  listWorkflowsWithDiagnostics,
   getActivity,
   getCheckpoint,
   getValidTransitions,
@@ -9,7 +11,9 @@ import {
   checkpointBaseId,
 } from '../src/loaders/workflow-loader.js';
 import type { Workflow } from '../src/schema/workflow.schema.js';
-import { resolve } from 'node:path';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 
 const WORKFLOW_DIR = resolve(import.meta.dirname, '../workflows');
 
@@ -79,6 +83,100 @@ describe('workflow-loader', () => {
     it('should return empty array for non-existent directory', async () => {
       const result = await listWorkflows('/tmp/no-such-workflow-dir-xyz');
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('load diagnostics (#166 B5)', () => {
+    let fixtureDir: string;
+
+    const VALID_ACTIVITY = [
+      'id: good-activity',
+      'version: 1.0.0',
+      'name: Good Activity',
+    ].join('\n');
+
+    beforeAll(() => {
+      fixtureDir = mkdtempSync(join(tmpdir(), 'workflow-loader-diagnostics-'));
+
+      // Workflow whose activities dir holds one valid, one schema-invalid, and one unparsable file.
+      const brokenActivitiesDir = join(fixtureDir, 'broken-activities-wf', 'activities');
+      mkdirSync(brokenActivitiesDir, { recursive: true });
+      writeFileSync(join(fixtureDir, 'broken-activities-wf', 'workflow.yaml'), [
+        'id: broken-activities-wf',
+        'version: 1.0.0',
+        'title: Broken Activities Workflow',
+        'initialActivity: good-activity',
+      ].join('\n'));
+      writeFileSync(join(brokenActivitiesDir, '01-good-activity.yaml'), VALID_ACTIVITY);
+      writeFileSync(join(brokenActivitiesDir, '02-invalid-activity.yaml'), 'id: invalid-activity\n');
+      writeFileSync(join(brokenActivitiesDir, '03-unparsable-activity.yaml'), 'id: [unclosed\n  nonsense: {');
+
+      // Workflow whose definition file is unparsable YAML.
+      mkdirSync(join(fixtureDir, 'unparsable-wf'));
+      writeFileSync(join(fixtureDir, 'unparsable-wf', 'workflow.yaml'), 'id: [unclosed\n  nonsense: {');
+
+      // Workflow whose manifest lacks the required title/version fields.
+      mkdirSync(join(fixtureDir, 'missing-fields-wf'));
+      writeFileSync(join(fixtureDir, 'missing-fields-wf', 'workflow.yaml'), 'id: missing-fields-wf\n');
+    });
+
+    afterAll(() => {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    });
+
+    it('loadWorkflowWithDiagnostics reports schema-invalid and unparsable activity files', async () => {
+      const result = await loadWorkflowWithDiagnostics(fixtureDir, 'broken-activities-wf');
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.value.workflow.activities?.map(a => a.id)).toEqual(['good-activity']);
+
+        const errors = result.value.activityLoadErrors;
+        expect(errors).toHaveLength(2);
+
+        const invalid = errors.find(e => e.file === '02-invalid-activity.yaml');
+        expect(invalid?.activity_id).toBe('invalid-activity');
+        expect(invalid?.error).toContain('version');
+
+        const unparsable = errors.find(e => e.file === '03-unparsable-activity.yaml');
+        expect(unparsable?.activity_id).toBe('unparsable-activity');
+        expect(unparsable?.error).toBeTruthy();
+      }
+    });
+
+    it('loadWorkflowWithDiagnostics returns no errors for a clean workflow', async () => {
+      const result = await loadWorkflowWithDiagnostics(WORKFLOW_DIR, 'meta');
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.value.activityLoadErrors).toEqual([]);
+      }
+    });
+
+    it('loadWorkflow keeps its workflow-only contract', async () => {
+      const result = await loadWorkflow(fixtureDir, 'broken-activities-wf');
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.value.id).toBe('broken-activities-wf');
+      }
+    });
+
+    it('listWorkflowsWithDiagnostics reports unparsable and incomplete manifests', async () => {
+      const { workflows, errors } = await listWorkflowsWithDiagnostics(fixtureDir);
+
+      expect(workflows.map(w => w.id)).toEqual(['broken-activities-wf']);
+      expect(errors).toHaveLength(2);
+
+      const unparsable = errors.find(e => e.file.includes('unparsable-wf'));
+      expect(unparsable?.error).toBeTruthy();
+
+      const missingFields = errors.find(e => e.file.includes('missing-fields-wf'));
+      expect(missingFields?.error).toContain('missing required fields');
+    });
+
+    it('listWorkflows still returns a plain manifest array', async () => {
+      const manifests = await listWorkflows(fixtureDir);
+      expect(Array.isArray(manifests)).toBe(true);
+      expect(manifests.map(m => m.id)).toEqual(['broken-activities-wf']);
     });
   });
 


### PR DESCRIPTION
Implements **B5** from #166: fix generated-schema condition recursion and surface activity-load failures instead of silently skipping.

## Part 1 — schema generation (fix)

`generate-schemas.ts` generated `workflow`/`condition`/`session-file` schemas with `refStrategy: 'none'`, which cannot represent recursive `z.lazy()` schemas: each cycle silently degraded to the accept-anything empty schema (`items: {}` at 19 sites in workflow, 3 in condition; the generator itself warned "Defaulting to any" for session-file's `parentSession`/`triggeredWorkflows[].state`). Authoring-time validation therefore accepted garbage inside and/or/not combinators that Zod only rejected at load — where the activity then vanished (Part 2).

- Switch the three schemas to `refStrategy: 'root'`, matching `activity.schema.json` (the existing correct precedent). Compound conditions now reference `#/definitions/condition`; `workflow.schema.json` deduplicates by ~800 lines.
- New `tests/generated-schemas.test.ts` guardrail walks every generated schema and fails on any empty-schema recursion point, plus asserts the three condition combinators reference the condition definition.

> Scope note: the plan assumed session-file was non-recursive; regeneration proved otherwise (generator warning), so it got the same one-word fix — same defect class, same file.

## Part 2 — surfaced load failures (feat)

Per field-ledger risk 8, a definition file that failed to load was log-warned and dropped, surfacing much later as "Activity not found".

- `loadWorkflow` / `listWorkflows` keep their exact signatures (11 call sites untouched; gitnexus rated the symbols CRITICAL, hence signature-preserving twins). New `loadWorkflowWithDiagnostics` / `listWorkflowsWithDiagnostics` collect per-file `DefinitionLoadError { file, activity_id?, error }` entries — including the previously log-less "manifest missing id/title/version" skip.
- `get_workflow` adds `activity_load_errors` when any activity file failed (omitted otherwise — clean-corpus payloads byte-identical, e2e snapshots unchanged).
- `list_workflows` stays a plain array normally; with failures it returns `{ workflows, load_errors }`. Tool descriptions updated.

## Verification

- `npm run build:schemas` — no recursion warnings, no empty `items` remain
- `npm run typecheck` — clean
- `npx vitest run` — 447 passed, 14 skipped, 0 failed; e2e snapshots unchanged
- New fixture tests cover: schema-invalid activity, unparsable activity, unparsable workflow.yaml, manifest missing required fields

Tick the B5 checkbox on #166 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
