### PR TITLE
chore(techniques): conform the corpus to the normative template (#166 B9)

### DIFF
--- a/cicd-pipeline-security-audit/techniques/dispatch-scanners/TECHNIQUE.md
+++ b/cicd-pipeline-security-audit/techniques/dispatch-scanners/TECHNIQUE.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 4
-  legacy_id: 4
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/dispatch-scanners/act-on-gap-report.md
+++ b/cicd-pipeline-security-audit/techniques/dispatch-scanners/act-on-gap-report.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 6
-  legacy_id: 6
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/dispatch-scanners/collect-results.md
+++ b/cicd-pipeline-security-audit/techniques/dispatch-scanners/collect-results.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 3
-  legacy_id: 3
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/dispatch-scanners/dispatch-all.md
+++ b/cicd-pipeline-security-audit/techniques/dispatch-scanners/dispatch-all.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 1
-  legacy_id: 1
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/dispatch-scanners/dispatch-merge.md
+++ b/cicd-pipeline-security-audit/techniques/dispatch-scanners/dispatch-merge.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 7
-  legacy_id: 7
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/dispatch-scanners/dispatch-verification.md
+++ b/cicd-pipeline-security-audit/techniques/dispatch-scanners/dispatch-verification.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 5
-  legacy_id: 5
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/dispatch-scanners/verify-dispatch-completeness.md
+++ b/cicd-pipeline-security-audit/techniques/dispatch-scanners/verify-dispatch-completeness.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 2
-  legacy_id: 2
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/dispatch-scanners/verify-output-files.md
+++ b/cicd-pipeline-security-audit/techniques/dispatch-scanners/verify-output-files.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 4
-  legacy_id: 4
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/dispatch-scanners/verify-reconciliation.md
+++ b/cicd-pipeline-security-audit/techniques/dispatch-scanners/verify-reconciliation.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 8
-  legacy_id: 8
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/execute-cicd-audit.md
+++ b/cicd-pipeline-security-audit/techniques/execute-cicd-audit.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 0
-  legacy_id: 0
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/execute-sub-agent.md
+++ b/cicd-pipeline-security-audit/techniques/execute-sub-agent.md
@@ -1,37 +1,11 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 8
-  legacy_id: 8
 ---
 
 ## Capability
 
 Bootstrap the workflow-server MCP from a dispatched session, load an assigned activity definition (from the activity_id passed in the spawn prompt), follow its steps sequentially with verifiable outputs, and return structured output.
-
-## Protocol
-
-### 1. Bootstrap
-
-- Call `start_session(session_token, agent_id)` to inherit the dispatched session and obtain a session token. The workflow is derived from the token.
-  - If the MCP tool calls fail and the workflow-server is unavailable, fall back to the prompt instructions provided by the orchestrator and note in output that workflow-server was not available.
-- Call `next_activity({ activity_id: '<assigned-activity-id>' })` to load the activity definition with its steps.
-  - If `next_activity` returns an error and the activity cannot be found, fall back to the prompt instructions provided by the orchestrator and note in output that the activity was not loaded.
-
-### 2. Execute Steps
-
-- Read the activity's steps array in order.
-- For each step, call `get_technique({ technique_id: step.technique, workflow_id: 'cicd-pipeline-security-audit' })` and read the technique's `## Capability` to understand what the step produces and its `## Protocol` for how to produce it.
-- Follow that protocol for the step, producing the technique's declared `## Outputs` before proceeding to the next step.
-- If a step cannot be completed because it requires data or context that is unavailable, record the step as completed with output 'INCOMPLETE — [reason]', continue to the next step, and flag it in the self-verification — do not silently skip.
-- Track which steps have been completed in a steps-completed list.
-
-### 3. Verify Output
-
-- Confirm `{sub_agent_output.steps_completed}` matches the activity's step ids — no steps omitted.
-- Assemble and return `{sub_agent_output}`: confirm it is well-formed JSON carrying all fields required by the [sub-agent output schema](../resources/sub-agent-output-schema.md#schema).
 
 ## Outputs
 
@@ -62,3 +36,25 @@ structured list of findings with required fields per finding
 #### coverage
 
 per-file, per-pattern scan confirmation
+
+## Protocol
+
+### 1. Bootstrap
+
+- Call `start_session(session_token, agent_id)` to inherit the dispatched session and obtain a session token. The workflow is derived from the token.
+  - If the MCP tool calls fail and the workflow-server is unavailable, fall back to the prompt instructions provided by the orchestrator and note in output that workflow-server was not available.
+- Call `next_activity({ activity_id: '<assigned-activity-id>' })` to load the activity definition with its steps.
+  - If `next_activity` returns an error and the activity cannot be found, fall back to the prompt instructions provided by the orchestrator and note in output that the activity was not loaded.
+
+### 2. Execute Steps
+
+- Read the activity's steps array in order.
+- For each step, call `get_technique({ technique_id: step.technique, workflow_id: 'cicd-pipeline-security-audit' })` and read the technique's `## Capability` to understand what the step produces and its `## Protocol` for how to produce it.
+- Follow that protocol for the step, producing the technique's declared `## Outputs` before proceeding to the next step.
+- If a step cannot be completed because it requires data or context that is unavailable, record the step as completed with output 'INCOMPLETE — [reason]', continue to the next step, and flag it in the self-verification — do not silently skip.
+- Track which steps have been completed in a steps-completed list.
+
+### 3. Verify Output
+
+- Confirm `{sub_agent_output.steps_completed}` matches the activity's step ids — no steps omitted.
+- Assemble and return `{sub_agent_output}`: confirm it is well-formed JSON carrying all fields required by the [sub-agent output schema](../resources/sub-agent-output-schema.md#schema).

--- a/cicd-pipeline-security-audit/techniques/inventory-workflows/TECHNIQUE.md
+++ b/cicd-pipeline-security-audit/techniques/inventory-workflows/TECHNIQUE.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 2
-  legacy_id: 2
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/inventory-workflows/assign-scanner-agents.md
+++ b/cicd-pipeline-security-audit/techniques/inventory-workflows/assign-scanner-agents.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 10
-  legacy_id: 10
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/inventory-workflows/build-summary.md
+++ b/cicd-pipeline-security-audit/techniques/inventory-workflows/build-summary.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 6
-  legacy_id: 6
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/inventory-workflows/classify-triggers.md
+++ b/cicd-pipeline-security-audit/techniques/inventory-workflows/classify-triggers.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 3
-  legacy_id: 3
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/inventory-workflows/confirm-targets.md
+++ b/cicd-pipeline-security-audit/techniques/inventory-workflows/confirm-targets.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 1
-  legacy_id: 1
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/inventory-workflows/discover-files.md
+++ b/cicd-pipeline-security-audit/techniques/inventory-workflows/discover-files.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 2
-  legacy_id: 2
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/inventory-workflows/identify-checkouts.md
+++ b/cicd-pipeline-security-audit/techniques/inventory-workflows/identify-checkouts.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 5
-  legacy_id: 5
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/inventory-workflows/initialize-planning-folder.md
+++ b/cicd-pipeline-security-audit/techniques/inventory-workflows/initialize-planning-folder.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 9
-  legacy_id: 9
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/inventory-workflows/inventory-ai-configs.md
+++ b/cicd-pipeline-security-audit/techniques/inventory-workflows/inventory-ai-configs.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 7
-  legacy_id: 7
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/inventory-workflows/map-permissions.md
+++ b/cicd-pipeline-security-audit/techniques/inventory-workflows/map-permissions.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 4
-  legacy_id: 4
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/inventory-workflows/record-codeowners.md
+++ b/cicd-pipeline-security-audit/techniques/inventory-workflows/record-codeowners.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 8
-  legacy_id: 8
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/merge-scan-findings/TECHNIQUE.md
+++ b/cicd-pipeline-security-audit/techniques/merge-scan-findings/TECHNIQUE.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 6
-  legacy_id: 6
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/merge-scan-findings/correlate-patterns.md
+++ b/cicd-pipeline-security-audit/techniques/merge-scan-findings/correlate-patterns.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 3
-  legacy_id: 3
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/merge-scan-findings/deduplicate.md
+++ b/cicd-pipeline-security-audit/techniques/merge-scan-findings/deduplicate.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 2
-  legacy_id: 2
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/merge-scan-findings/load-outputs.md
+++ b/cicd-pipeline-security-audit/techniques/merge-scan-findings/load-outputs.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 1
-  legacy_id: 1
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/merge-scan-findings/reconcile.md
+++ b/cicd-pipeline-security-audit/techniques/merge-scan-findings/reconcile.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 4
-  legacy_id: 4
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/merge-scan-findings/write-output.md
+++ b/cicd-pipeline-security-audit/techniques/merge-scan-findings/write-output.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 5
-  legacy_id: 5
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/scan-injection-patterns/TECHNIQUE.md
+++ b/cicd-pipeline-security-audit/techniques/scan-injection-patterns/TECHNIQUE.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 3
-  legacy_id: 3
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/scan-injection-patterns/assemble-results.md
+++ b/cicd-pipeline-security-audit/techniques/scan-injection-patterns/assemble-results.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 9
-  legacy_id: 9
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/scan-injection-patterns/load-patterns.md
+++ b/cicd-pipeline-security-audit/techniques/scan-injection-patterns/load-patterns.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 1
-  legacy_id: 1
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/scan-injection-patterns/scan-p1.md
+++ b/cicd-pipeline-security-audit/techniques/scan-injection-patterns/scan-p1.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 2
-  legacy_id: 2
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/scan-injection-patterns/scan-p2.md
+++ b/cicd-pipeline-security-audit/techniques/scan-injection-patterns/scan-p2.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 3
-  legacy_id: 3
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/scan-injection-patterns/scan-p3.md
+++ b/cicd-pipeline-security-audit/techniques/scan-injection-patterns/scan-p3.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 4
-  legacy_id: 4
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/scan-injection-patterns/scan-p4.md
+++ b/cicd-pipeline-security-audit/techniques/scan-injection-patterns/scan-p4.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 5
-  legacy_id: 5
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/scan-injection-patterns/scan-p5.md
+++ b/cicd-pipeline-security-audit/techniques/scan-injection-patterns/scan-p5.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 6
-  legacy_id: 6
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/scan-injection-patterns/scan-p6.md
+++ b/cicd-pipeline-security-audit/techniques/scan-injection-patterns/scan-p6.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 7
-  legacy_id: 7
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/scan-injection-patterns/scan-p7.md
+++ b/cicd-pipeline-security-audit/techniques/scan-injection-patterns/scan-p7.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 8
-  legacy_id: 8
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/score-cicd-severity/TECHNIQUE.md
+++ b/cicd-pipeline-security-audit/techniques/score-cicd-severity/TECHNIQUE.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 1
-  legacy_id: 1
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/score-cicd-severity/apply-severity.md
+++ b/cicd-pipeline-security-audit/techniques/score-cicd-severity/apply-severity.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 1
-  legacy_id: 1
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/score-cicd-severity/calibrate.md
+++ b/cicd-pipeline-security-audit/techniques/score-cicd-severity/calibrate.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 2
-  legacy_id: 2
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/verify-scan-output/TECHNIQUE.md
+++ b/cicd-pipeline-security-audit/techniques/verify-scan-output/TECHNIQUE.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 5
-  legacy_id: 5
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/verify-scan-output/produce-gap-report.md
+++ b/cicd-pipeline-security-audit/techniques/verify-scan-output/produce-gap-report.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 4
-  legacy_id: 4
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/verify-scan-output/validate-structure.md
+++ b/cicd-pipeline-security-audit/techniques/verify-scan-output/validate-structure.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 1
-  legacy_id: 1
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/verify-scan-output/verify-file-coverage.md
+++ b/cicd-pipeline-security-audit/techniques/verify-scan-output/verify-file-coverage.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 2
-  legacy_id: 2
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/verify-scan-output/verify-pattern-coverage.md
+++ b/cicd-pipeline-security-audit/techniques/verify-scan-output/verify-pattern-coverage.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 3
-  legacy_id: 3
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/write-cicd-report/TECHNIQUE.md
+++ b/cicd-pipeline-security-audit/techniques/write-cicd-report/TECHNIQUE.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 7
-  legacy_id: 7
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/write-cicd-report/attach-remediation.md
+++ b/cicd-pipeline-security-audit/techniques/write-cicd-report/attach-remediation.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 1
-  legacy_id: 1
 ---
 
 ## Capability

--- a/cicd-pipeline-security-audit/techniques/write-cicd-report/write-report.md
+++ b/cicd-pipeline-security-audit/techniques/write-cicd-report/write-report.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 2
-  legacy_id: 2
 ---
 
 ## Capability

--- a/codebase-wiki/techniques/TECHNIQUE.md
+++ b/codebase-wiki/techniques/TECHNIQUE.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/codebase-wiki/techniques/collect-scope.md
+++ b/codebase-wiki/techniques/collect-scope.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/codebase-wiki/techniques/compose-overview.md
+++ b/codebase-wiki/techniques/compose-overview.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/codebase-wiki/techniques/cross-link.md
+++ b/codebase-wiki/techniques/cross-link.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 
@@ -19,6 +17,12 @@ The pages whose relationships are being maintained — the pages an ingest creat
 
 The pages the subject pages relate to — callers, callees, sibling concepts, source-summaries of the same area, and comparisons that reference them. The other end of each relationship.
 
+## Outputs
+
+### linked_pages
+
+The pages whose `[[wikilink]]` body links and `related[]` frontmatter were inserted or refreshed, in sync on both ends of each relationship.
+
 ## Protocol
 
 ### 1. Identify Relationships
@@ -34,12 +38,6 @@ The pages the subject pages relate to — callers, callees, sibling concepts, so
 
 - Update the `related[]` frontmatter on both ends to list the linked pages, so the frontmatter is a faithful summary of the body links and `query`/`lint` can rely on it.
 - Remove a `related[]` entry only when the corresponding body link is gone — frontmatter follows the body, never the reverse.
-
-## Outputs
-
-### linked_pages
-
-The pages whose `[[wikilink]]` body links and `related[]` frontmatter were inserted or refreshed, in sync on both ends of each relationship.
 
 ## Rules
 

--- a/codebase-wiki/techniques/ingest.md
+++ b/codebase-wiki/techniques/ingest.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
 ---
 
@@ -22,6 +20,28 @@ The single source area to ingest — a module, package, subsystem, or file set n
 #### default
 
 `""`
+
+## Outputs
+
+### wiki_pages
+
+The typed wiki pages created or updated for `{target_area}` — each with cited, confidence-scored claims and maintained `[[wikilink]]` relationships.
+
+#### artifact
+
+`{$page_slug}.md`
+
+#### page_slugs
+
+The kebab-case slugs of every page this ingest created or updated, used by `maintain-index-log` to update the catalog and append the ledger.
+
+#### cascaded_pages
+
+The related pages whose `[[wikilinks]]` or claims were updated as a consequence of this ingest.
+
+### ingest_summary
+
+A one-line description of this ingest for the log ledger — the area covered (`{target_area}`), whether the pass was code-driven or task-driven, and the page count. Consumed by `maintain-index-log` as its `operation_summary`.
 
 ## Protocol
 
@@ -56,28 +76,6 @@ The single source area to ingest — a module, package, subsystem, or file set n
 ### 6. Write Pages
 
 - Write each page by delegating to [`work-package::manage-artifacts::write-artifact`](../../work-package/techniques/manage-artifacts/write-artifact.md), binding `bare_filename` to the page's `{$page_slug}.md`, `artifact_content` to the page body, and `target_dir` to `{wiki_path}` (or the typed subfolder beneath it). The find-or-create behavior of `write-artifact` augments an existing page in place and creates a new one otherwise.
-
-## Outputs
-
-### wiki_pages
-
-The typed wiki pages created or updated for `{target_area}` — each with cited, confidence-scored claims and maintained `[[wikilink]]` relationships.
-
-#### artifact
-
-`{$page_slug}.md`
-
-#### page_slugs
-
-The kebab-case slugs of every page this ingest created or updated, used by `maintain-index-log` to update the catalog and append the ledger.
-
-#### cascaded_pages
-
-The related pages whose `[[wikilinks]]` or claims were updated as a consequence of this ingest.
-
-### ingest_summary
-
-A one-line description of this ingest for the log ledger — the area covered (`{target_area}`), whether the pass was code-driven or task-driven, and the page count. Consumed by `maintain-index-log` as its `operation_summary`.
 
 ## Rules
 

--- a/codebase-wiki/techniques/lint.md
+++ b/codebase-wiki/techniques/lint.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 
@@ -12,6 +10,16 @@ Run a single-shot integrity pass over the whole wiki, applying each check in the
 ## Inputs
 
 This technique consumes the workflow-root contract inputs (`wiki_path`, `raw_baseline_commit`) and reads the wiki tree at `{wiki_path}`; it takes no additional inputs.
+
+## Outputs
+
+### lint_findings_count
+
+The number of findings from the pass — `0` means the wiki passed every check. Drives the `lint-findings-confirmed` checkpoint and the re-ingest decision.
+
+### lint_findings
+
+The per-finding report grouped by check, each entry naming the page(s) and the specific failure.
 
 ## Protocol
 
@@ -34,16 +42,6 @@ This technique consumes the workflow-root contract inputs (`wiki_path`, `raw_bas
 
 - Compile the findings into a report grouped by check, each finding naming the offending page(s) and the specific failure, and count them.
 - Contradictions are reported as findings for the user to resolve at re-ingest; lint never reconciles them itself.
-
-## Outputs
-
-### lint_findings_count
-
-The number of findings from the pass — `0` means the wiki passed every check. Drives the `lint-findings-confirmed` checkpoint and the re-ingest decision.
-
-### lint_findings
-
-The per-finding report grouped by check, each entry naming the page(s) and the specific failure.
 
 ## Rules
 

--- a/codebase-wiki/techniques/maintain-index-log.md
+++ b/codebase-wiki/techniques/maintain-index-log.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 
@@ -19,6 +17,16 @@ The pages created or updated in the mutation being recorded — the `page_slugs`
 
 A one-line description of the mutation for the log entry — the area ingested, the trigger (build pass or task-driven update), and the page count.
 
+## Outputs
+
+### index_log
+
+The refreshed catalog and the appended ledger for the wiki.
+
+#### artifact
+
+`index.md` and `log.md`
+
 ## Protocol
 
 ### 1. Update The Index
@@ -33,16 +41,6 @@ A one-line description of the mutation for the log entry — the area ingested, 
 ### 3. Write Both Files
 
 - Write `index.md` and `log.md` by delegating to [`work-package::manage-artifacts::write-artifact`](../../work-package/techniques/manage-artifacts/write-artifact.md), binding `bare_filename` to `index.md` / `log.md`, `artifact_content` to the composed content, and `target_dir` to `{wiki_path}`.
-
-## Outputs
-
-### index_log
-
-The refreshed catalog and the appended ledger for the wiki.
-
-#### artifact
-
-`index.md` and `log.md`
 
 ## Rules
 

--- a/codebase-wiki/techniques/query.md
+++ b/codebase-wiki/techniques/query.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
 ---
 
@@ -22,6 +20,20 @@ The question to answer against the wiki — a natural-language query about the c
 #### default
 
 `false`
+
+## Outputs
+
+### wiki_answer
+
+The synthesized answer to `{wiki_question}`, with `[[wikilink]]` citations to the pages it rests on and the confidence carried from those pages.
+
+#### coverage_gaps
+
+Parts of the question the wiki does not cover, surfaced so the caller can decide whether to ingest the missing area.
+
+#### answer_page
+
+*(present only when `persist_answer` is true)* The slug of the page the answer was persisted to.
 
 ## Protocol
 
@@ -44,20 +56,6 @@ The question to answer against the wiki — a natural-language query about the c
 ### 4. Persist If Requested
 
 - When `{persist_answer}` is true, write the answer as a typed page (`comparison` for a cross-cutting synthesis, `concept` for a single subject) via [`work-package::manage-artifacts::write-artifact`](../../work-package/techniques/manage-artifacts/write-artifact.md) into `{wiki_path}`, then apply [maintain-index-log](./maintain-index-log.md) so the new page enters the catalog and ledger.
-
-## Outputs
-
-### wiki_answer
-
-The synthesized answer to `{wiki_question}`, with `[[wikilink]]` citations to the pages it rests on and the confidence carried from those pages.
-
-#### coverage_gaps
-
-Parts of the question the wiki does not cover, surfaced so the caller can decide whether to ingest the missing area.
-
-#### answer_page
-
-*(present only when `persist_answer` is true)* The slug of the page the answer was persisted to.
 
 ## Rules
 

--- a/meta/techniques/agent-conduct.md
+++ b/meta/techniques/agent-conduct.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 4.1.0
-  order: 1
-  legacy_id: 1
 ---
 
 ## Capability

--- a/meta/techniques/atlassian-operations/TECHNIQUE.md
+++ b/meta/techniques/atlassian-operations/TECHNIQUE.md
@@ -1,13 +1,7 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 3.0.0
-  order: 5
-  legacy_id: 5
 ---
-
-# Atlassian Operations
 
 ## Capability
 

--- a/meta/techniques/cargo-operations/TECHNIQUE.md
+++ b/meta/techniques/cargo-operations/TECHNIQUE.md
@@ -1,13 +1,7 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.2.0
-  order: 24
-  legacy_id: 24
 ---
-
-# Cargo Operations
 
 ## Capability
 

--- a/meta/techniques/github-cli-protocol/TECHNIQUE.md
+++ b/meta/techniques/github-cli-protocol/TECHNIQUE.md
@@ -1,13 +1,7 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 3.0.0
-  order: 3
-  legacy_id: 3
 ---
-
-# Github CLI Protocol
 
 ## Capability
 

--- a/meta/techniques/gitnexus-operations/TECHNIQUE.md
+++ b/meta/techniques/gitnexus-operations/TECHNIQUE.md
@@ -1,13 +1,7 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 3.2.0
-  order: 6
-  legacy_id: 6
 ---
-
-# Gitnexus Operations
 
 ## Capability
 

--- a/meta/techniques/harness-compat/TECHNIQUE.md
+++ b/meta/techniques/harness-compat/TECHNIQUE.md
@@ -1,13 +1,7 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 3.0.0
-  order: 7
-  legacy_id: 7
 ---
-
-# Harness Compat
 
 ## Capability
 

--- a/meta/techniques/knowledge-base-search/TECHNIQUE.md
+++ b/meta/techniques/knowledge-base-search/TECHNIQUE.md
@@ -1,13 +1,7 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 3.0.0
-  order: 4
-  legacy_id: 4
 ---
-
-# Knowledge Base Search
 
 ## Capability
 

--- a/meta/techniques/version-control/TECHNIQUE.md
+++ b/meta/techniques/version-control/TECHNIQUE.md
@@ -1,13 +1,7 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 5.0.0
-  order: 2
-  legacy_id: 2
 ---
-
-# Version Control
 
 ## Capability
 

--- a/meta/techniques/workflow-engine/TECHNIQUE.md
+++ b/meta/techniques/workflow-engine/TECHNIQUE.md
@@ -1,13 +1,7 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 6.1.0
-  order: 0
-  legacy_id: 0
 ---
-
-# Workflow Engine
 
 ## Capability
 

--- a/ponytail/techniques/TECHNIQUE.md
+++ b/ponytail/techniques/TECHNIQUE.md
@@ -3,8 +3,6 @@ metadata:
   version: 1.0.0
 ---
 
-# Ponytail Operations
-
 ## Capability
 
 Own the lean-coding capability — capture and trace the task, climb the lazy [ladder](../resources/the-ladder.md#rungs) to the minimal solution that still clears the [safety floor](../resources/the-ladder.md#safety-floor), review and audit for over-engineering, harvest the deliberate-simplification debt, and report the honest gain. Operations inherit the shared inputs and rules below.

--- a/prism-audit/techniques/audit-finalize/TECHNIQUE.md
+++ b/prism-audit/techniques/audit-finalize/TECHNIQUE.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 0
-  legacy_id: 0
 ---
 
 ## Capability

--- a/prism-audit/techniques/audit-finalize/apply-formatting-rules.md
+++ b/prism-audit/techniques/audit-finalize/apply-formatting-rules.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 6
-  legacy_id: 6
 ---
 
 ## Capability

--- a/prism-audit/techniques/audit-finalize/create-detailed-findings.md
+++ b/prism-audit/techniques/audit-finalize/create-detailed-findings.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 4
-  legacy_id: 4
 ---
 
 ## Capability
@@ -16,6 +12,16 @@ Create the detailed-findings document from prism's DEFINITIVE-FINDINGS.md contra
 ### completed_analyses
 
 The triggered prism runs, each carrying its scope's `definitive_findings_path` (the DEFINITIVE-FINDINGS.md the run produced). The findings source for every scope.
+
+## Outputs
+
+### detailed_findings_path
+
+Filesystem path to the written DETAILED-FINDINGS.md (the detailed-findings document).
+
+#### artifact
+
+`DETAILED-FINDINGS.md`
 
 ## Protocol
 
@@ -33,16 +39,6 @@ The triggered prism runs, each carrying its scope's `definitive_findings_path` (
 - Group findings within each severity section under audit-domain sub-headings.
 - Format each finding heading as a level-3 markdown heading carrying the finding's ID followed by its title: `### ID: Title`. IDs are prism's report IDs, unchanged.
 - Where DEFINITIVE-FINDINGS.md records a finding's Blast radius, carry it through as that finding's Graph Evidence subsection (blast-radius metrics and execution-flow participation) — prism computed it, the audit does not recompute it.
-
-## Outputs
-
-### detailed_findings_path
-
-Filesystem path to the written DETAILED-FINDINGS.md (the detailed-findings document).
-
-#### artifact
-
-`DETAILED-FINDINGS.md`
 
 ## Rules
 

--- a/prism-audit/techniques/audit-finalize/create-trade-off-analysis.md
+++ b/prism-audit/techniques/audit-finalize/create-trade-off-analysis.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 5
-  legacy_id: 5
 ---
 
 ## Capability
@@ -17,16 +13,6 @@ Distil the conservation laws prism recorded into a design trade-off analysis: a 
 
 The triggered prism runs, each carrying its scope's `definitive_findings_path`. The Conservation Laws & Design Trade-offs section of each DEFINITIVE-FINDINGS.md is the source of laws.
 
-## Protocol
-
-### 1. Create Trade-Off Analysis
-
-- Read the "Conservation Laws & Design Trade-offs" section from each scope's DEFINITIVE-FINDINGS.md at the `definitive_findings_path` in `{completed_analyses}` — not the raw synthesis documents. Every law recorded there survived or was refined through prism's adversarial challenge; rejected laws are already absent.
-- Write the analysis to `{trade_offs_path}` in three parts.
-- Part 1 — Trade-Off Catalogue: one entry per domain with its constraint, current operating point, shift prediction, and design questions. Each entry must have a falsifiable constraint, code-level evidence for the operating point (citing specific finding IDs), concrete shift predictions, and actionable design questions.
-- Part 2 — Cross-Domain Interactions: map which trade-offs compound.
-- Part 3 — Design Decision Register: a table of implicit decisions that should be made explicit, with current choice, alternative, governing trade-off, and documentation status.
-
 ## Outputs
 
 ### trade_offs_path
@@ -36,3 +22,13 @@ Filesystem path to the written DESIGN-TRADE-OFFS.md (the design trade-off analys
 #### artifact
 
 `DESIGN-TRADE-OFFS.md`
+
+## Protocol
+
+### 1. Create Trade-Off Analysis
+
+- Read the "Conservation Laws & Design Trade-offs" section from each scope's DEFINITIVE-FINDINGS.md at the `definitive_findings_path` in `{completed_analyses}` — not the raw synthesis documents. Every law recorded there survived or was refined through prism's adversarial challenge; rejected laws are already absent.
+- Write the analysis to `{trade_offs_path}` in three parts.
+- Part 1 — Trade-Off Catalogue: one entry per domain with its constraint, current operating point, shift prediction, and design questions. Each entry must have a falsifiable constraint, code-level evidence for the operating point (citing specific finding IDs), concrete shift predictions, and actionable design questions.
+- Part 2 — Cross-Domain Interactions: map which trade-offs compound.
+- Part 3 — Design Decision Register: a table of implicit decisions that should be made explicit, with current choice, alternative, governing trade-off, and documentation status.

--- a/prism-audit/techniques/audit-finalize/split-report.md
+++ b/prism-audit/techniques/audit-finalize/split-report.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 3
-  legacy_id: 3
 ---
 
 ## Capability
@@ -17,16 +13,6 @@ Transform prism's report(s) into a summary-focused audit report: retain every se
 
 The triggered prism runs, each carrying its scope's `report_path` (the REPORT.md the run produced). The report source.
 
-## Protocol
-
-### 1. Split Report
-
-- Locate the source report(s) from the `report_path` in `{completed_analyses}`. For a single-scope audit, that one REPORT.md is the source; for a multi-scope audit, merge the per-scope REPORT.md summaries (executive summaries, domain tables, systemic patterns) into one.
-- Write the summary report to `{audit_report_path}` containing everything except the inline detailed findings section.
-- Replace that section with a reference line: `*Detailed write-ups for all findings organised by severity are in [DETAILED-FINDINGS.md](DETAILED-FINDINGS.md).*`
-- Renumber subsequent sections to fill the section-number gap.
-- Fix internal cross-references that point to the old section numbers.
-
 ## Outputs
 
 ### audit_report_path
@@ -36,3 +22,13 @@ Filesystem path to the written AUDIT-REPORT.md (the summary report).
 #### artifact
 
 `AUDIT-REPORT.md`
+
+## Protocol
+
+### 1. Split Report
+
+- Locate the source report(s) from the `report_path` in `{completed_analyses}`. For a single-scope audit, that one REPORT.md is the source; for a multi-scope audit, merge the per-scope REPORT.md summaries (executive summaries, domain tables, systemic patterns) into one.
+- Write the summary report to `{audit_report_path}` containing everything except the inline detailed findings section.
+- Replace that section with a reference line: `*Detailed write-ups for all findings organised by severity are in [DETAILED-FINDINGS.md](DETAILED-FINDINGS.md).*`
+- Renumber subsequent sections to fill the section-number gap.
+- Fix internal cross-references that point to the old section numbers.

--- a/prism-audit/techniques/audit-finalize/verify-audit-consistency.md
+++ b/prism-audit/techniques/audit-finalize/verify-audit-consistency.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 7
-  legacy_id: 7
 ---
 
 ## Capability

--- a/prism-audit/techniques/compose-audit-prompt/TECHNIQUE.md
+++ b/prism-audit/techniques/compose-audit-prompt/TECHNIQUE.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 0
-  legacy_id: 0
 ---
 
 ## Capability

--- a/prism-audit/techniques/compose-audit-prompt/build-audit-scopes.md
+++ b/prism-audit/techniques/compose-audit-prompt/build-audit-scopes.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 7
-  legacy_id: 7
 ---
 
 ## Capability

--- a/prism-audit/techniques/compose-audit-prompt/compose-prompt.md
+++ b/prism-audit/techniques/compose-audit-prompt/compose-prompt.md
@@ -1,15 +1,17 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 6
-  legacy_id: 6
 ---
 
 ## Capability
 
 Compose the full, self-contained audit prompt document from the surveyed structure, mapped domains, trust-boundary map, and cross-cutting concerns — a five-section document readable and actionable from only the prompt and the codebase path.
+
+## Outputs
+
+### audit_prompt_path
+
+File path to the written audit prompt artifact
 
 ## Protocol
 
@@ -23,9 +25,3 @@ Compose the full, self-contained audit prompt document from the surveyed structu
 - Section 5: Output Requirements — 'Produce findings with: ID, severity (using Impact x Feasibility rubric), description, location (file:line), impact, recommendation. Organise by domain and severity.'
 - The prompt must be self-contained: readable and actionable without additional context beyond the codebase path
 - Write the completed audit prompt as its declared `audit-prompt.md` artifact into `{output_path}`; record the written path as `{audit_prompt_path}`
-
-## Outputs
-
-### audit_prompt_path
-
-File path to the written audit prompt artifact

--- a/prism-audit/techniques/compose-audit-prompt/identify-cross-cutting-concerns.md
+++ b/prism-audit/techniques/compose-audit-prompt/identify-cross-cutting-concerns.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 5
-  legacy_id: 5
 ---
 
 ## Capability

--- a/prism-audit/techniques/compose-audit-prompt/identify-security-characteristics.md
+++ b/prism-audit/techniques/compose-audit-prompt/identify-security-characteristics.md
@@ -1,15 +1,17 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 2
-  legacy_id: 2
 ---
 
 ## Capability
 
 Scan the codebase for security-relevant patterns — cryptography, authentication/authorisation, network-exposed surfaces, state management, untrusted-input deserialisation, unsafe code, WASM targets, security-gating feature flags, and custom VMs — and record each characteristic with its location and severity relevance.
+
+## Outputs
+
+### security_characteristics_count
+
+Count of security-relevant patterns found in the target. `0` signals a codebase with no security surface.
 
 ## Protocol
 
@@ -26,9 +28,3 @@ Scan the codebase for security-relevant patterns — cryptography, authenticatio
 - Search for custom VMs or interpreters: bytecode execution, instruction dispatch, gas/cost metering
 - Record each characteristic: `{ category, location (file:line), description, severity_relevance }`
 - Set `{security_characteristics_count}` to the number of characteristics found. When it is 0, the codebase appears purely presentational or data-only; record that observation.
-
-## Outputs
-
-### security_characteristics_count
-
-Count of security-relevant patterns found in the target. `0` signals a codebase with no security surface.

--- a/prism-audit/techniques/compose-audit-prompt/map-audit-domains.md
+++ b/prism-audit/techniques/compose-audit-prompt/map-audit-domains.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 4
-  legacy_id: 4
 ---
 
 ## Capability

--- a/prism-audit/techniques/compose-audit-prompt/map-trust-boundaries.md
+++ b/prism-audit/techniques/compose-audit-prompt/map-trust-boundaries.md
@@ -1,24 +1,11 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 3
-  legacy_id: 3
 ---
 
 ## Capability
 
 Map trust boundaries from the indexed graph: find cross-community call edges (where validation may be absent), compute the blast radius of each security-critical symbol, and record the trust-boundary crossings and blast radii that elevate domain risk.
-
-## Protocol
-
-### 1. Map Trust Boundaries
-
-- If GitNexus is unavailable (`gitnexus_available` is false), skip this step entirely.
-- Use [gitnexus-operations](../../../meta/techniques/gitnexus-operations/TECHNIQUE.md)::[cypher](../../../meta/techniques/gitnexus-operations/cypher.md) to find cross-community call edges: `MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(callee), (caller)-[:CodeRelation {type: 'MEMBER_OF'}]->(c1:Community), (callee)-[:CodeRelation {type: 'MEMBER_OF'}]->(c2:Community) WHERE c1 <> c2 RETURN c1.heuristicLabel, c2.heuristicLabel, caller.name, callee.name`. These edges represent trust boundary crossings where validation may be absent.
-- Use [gitnexus-operations](../../../meta/techniques/gitnexus-operations/TECHNIQUE.md)::[impact](../../../meta/techniques/gitnexus-operations/impact.md)`(direction: 'upstream')` on each security-critical symbol identified during characteristic scanning to map its blast radius — every upstream caller is a potential attack vector. Record `{security_blast_radii}`: a map of symbol to `{ direct_callers, affected_processes, affected_modules, risk }`.
-- Record `{trust_boundaries}`: an array of `{ from_community, to_community, crossing_symbols }`. Domains containing trust-boundary-crossing code will receive elevated risk during domain mapping.
 
 ## Outputs
 
@@ -29,3 +16,12 @@ Array of trust-boundary crossings, each `{ from_community, to_community, crossin
 ### security_blast_radii
 
 Map of each security-critical symbol to its blast radius `{ direct_callers, affected_processes, affected_modules, risk }`
+
+## Protocol
+
+### 1. Map Trust Boundaries
+
+- If GitNexus is unavailable (`gitnexus_available` is false), skip this step entirely.
+- Use [gitnexus-operations](../../../meta/techniques/gitnexus-operations/TECHNIQUE.md)::[cypher](../../../meta/techniques/gitnexus-operations/cypher.md) to find cross-community call edges: `MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(callee), (caller)-[:CodeRelation {type: 'MEMBER_OF'}]->(c1:Community), (callee)-[:CodeRelation {type: 'MEMBER_OF'}]->(c2:Community) WHERE c1 <> c2 RETURN c1.heuristicLabel, c2.heuristicLabel, caller.name, callee.name`. These edges represent trust boundary crossings where validation may be absent.
+- Use [gitnexus-operations](../../../meta/techniques/gitnexus-operations/TECHNIQUE.md)::[impact](../../../meta/techniques/gitnexus-operations/impact.md)`(direction: 'upstream')` on each security-critical symbol identified during characteristic scanning to map its blast radius — every upstream caller is a potential attack vector. Record `{security_blast_radii}`: a map of symbol to `{ direct_callers, affected_processes, affected_modules, risk }`.
+- Record `{trust_boundaries}`: an array of `{ from_community, to_community, crossing_symbols }`. Domains containing trust-boundary-crossing code will receive elevated risk during domain mapping.

--- a/prism-audit/techniques/compose-audit-prompt/survey-structure.md
+++ b/prism-audit/techniques/compose-audit-prompt/survey-structure.md
@@ -1,15 +1,17 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 1
-  legacy_id: 1
 ---
 
 ## Capability
 
 Survey the target codebase to produce a structural inventory: primary language and build system, module/crate/package layout, total and per-module size, dependency graph, and test coverage structure, optionally enriched with GitNexus functional areas and fan-in.
+
+## Outputs
+
+### total_loc
+
+Total lines of code across the surveyed modules, excluding tests, docs, and generated files
 
 ## Protocol
 
@@ -24,9 +26,3 @@ Survey the target codebase to produce a structural inventory: primary language a
 - If GitNexus is available: use [gitnexus-operations](../../../meta/techniques/gitnexus-operations/TECHNIQUE.md)::[context](../../../meta/techniques/gitnexus-operations/context.md) on high-risk modules to check fan-in (number of callers) — high fan-in modules have larger blast radius and should be elevated in risk classification
 - Record: language, `build_system`, modules (array of `{ name, path, line_count, purpose, fan_in (if GitNexus available) }`), `{total_loc}`, `{gitnexus_available}` (boolean)
 - If `{target_path}` contains no analysable source files, verify the path is correct and check whether submodules need initialisation before proceeding.
-
-## Outputs
-
-### total_loc
-
-Total lines of code across the surveyed modules, excluding tests, docs, and generated files

--- a/prism-audit/techniques/deliver-audit.md
+++ b/prism-audit/techniques/deliver-audit.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 0
-  legacy_id: 0
 ---
 
 ## Capability

--- a/prism-audit/techniques/execute-analysis/TECHNIQUE.md
+++ b/prism-audit/techniques/execute-analysis/TECHNIQUE.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 0
-  legacy_id: 0
 ---
 
 ## Capability

--- a/prism-audit/techniques/execute-analysis/compose-trigger-context.md
+++ b/prism-audit/techniques/execute-analysis/compose-trigger-context.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 1
-  legacy_id: 1
 ---
 
 ## Capability
@@ -33,14 +29,14 @@ The prism pipeline mode for the scope, taken from `{current_scope}`.
 
 The scope's analysis focus, taken from `{current_scope}` — the audit prompt content describing the scope's security focus areas. Naming the scope's security domain(s) here lets prism assign domain-prefixed finding IDs, so the audit does not re-number findings downstream.
 
-## Rules
-
-### pipeline-mode-selection
-
-`pipeline_mode` defaults to `full-prism` (3-pass structural → adversarial → synthesis) for the depth a security audit needs; an individual scope may override to `behavioral` or `portfolio` when the prompt-generation activity determined a different mode fits that scope.
-
 ## Protocol
 
 - Set `{target}`, `{pipeline_mode}`, and `{analysis_focus}` from the corresponding fields of `{current_scope}`.
 - Set `{target_description}` to a short description of the scope derived from its focus.
 - Set `{output_path}` to the scope's output location (its `output_subdir` under the audit output directory).
+
+## Rules
+
+### pipeline-mode-selection
+
+`pipeline_mode` defaults to `full-prism` (3-pass structural → adversarial → synthesis) for the depth a security audit needs; an individual scope may override to `behavioral` or `portfolio` when the prompt-generation activity determined a different mode fits that scope.

--- a/prism-audit/techniques/execute-analysis/read-run-manifest.md
+++ b/prism-audit/techniques/execute-analysis/read-run-manifest.md
@@ -1,24 +1,11 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 2
-  legacy_id: 2
 ---
 
 ## Capability
 
 Read the triggered prism run's RUN-MANIFEST.md and record the run into the audit's accumulators — its report, definitive findings, artifact paths, and prism-reported completion status — without re-scanning the output directory. The scope's `output_subdir` (from the inherited `{current_scope}`) locates the run's `RUN-MANIFEST.md`.
-
-## Protocol
-
-### 1. Read Run Manifest
-
-- Read `RUN-MANIFEST.md` from the scope's output location (its `output_subdir` under the audit output directory).
-- From the manifest, take the run's `report_path`, `definitive_findings_path`, listed artifact paths, and its `status` (`complete` / `partial` / `error`) — prism has already verified completion, so no directory re-scan or per-artifact existence check is needed here.
-- Append the run's reference — `report_path`, `definitive_findings_path`, and the manifest `status` — to `{completed_analyses}`, and append the manifest's artifact paths to `{all_analysis_artifact_paths}`.
-  > When the manifest reports `partial` or `error`, carry that status through on the run's `{completed_analyses}` entry so finalization surfaces the incomplete run rather than silently consolidating a gap.
 
 ## Outputs
 
@@ -29,3 +16,12 @@ Array of completed prism analysis references, each with its report path, definit
 ### all_analysis_artifact_paths
 
 Accumulated paths to all analysis artifacts across triggered prism runs, taken from each run's manifest.
+
+## Protocol
+
+### 1. Read Run Manifest
+
+- Read `RUN-MANIFEST.md` from the scope's output location (its `output_subdir` under the audit output directory).
+- From the manifest, take the run's `report_path`, `definitive_findings_path`, listed artifact paths, and its `status` (`complete` / `partial` / `error`) — prism has already verified completion, so no directory re-scan or per-artifact existence check is needed here.
+- Append the run's reference — `report_path`, `definitive_findings_path`, and the manifest `status` — to `{completed_analyses}`, and append the manifest's artifact paths to `{all_analysis_artifact_paths}`.
+  > When the manifest reports `partial` or `error`, carry that status through on the run's `{completed_analyses}` entry so finalization surfaces the incomplete run rather than silently consolidating a gap.

--- a/prism-audit/techniques/scope-definition/TECHNIQUE.md
+++ b/prism-audit/techniques/scope-definition/TECHNIQUE.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 0
-  legacy_id: 0
 ---
 
 ## Capability

--- a/prism-audit/techniques/scope-definition/collect-inputs.md
+++ b/prism-audit/techniques/scope-definition/collect-inputs.md
@@ -1,24 +1,11 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 1
-  legacy_id: 1
 ---
 
 ## Capability
 
 Extract the audit parameters — target path, audit description, and output path — from the user's request, deriving the output path from the target name and current date when the user did not specify one.
-
-## Protocol
-
-### 1. Collect Inputs
-
-- Extract `{target_path}` from the user's request: the path to the codebase or directory to audit.
-- Extract `{audit_description}` from the user's request: what to audit and any focus areas or specific concerns.
-- Extract `{output_path}` from the user's request: the directory for all audit artifacts.
-- If the user did not specify an output path, derive `{output_path}` from the target's base name and the current date.
 
 ## Outputs
 
@@ -33,3 +20,12 @@ User's description of what to audit, focus areas, and specific concerns
 ### output_path
 
 Directory to write all audit artifacts, derived from the target name and current date when the user did not specify one
+
+## Protocol
+
+### 1. Collect Inputs
+
+- Extract `{target_path}` from the user's request: the path to the codebase or directory to audit.
+- Extract `{audit_description}` from the user's request: what to audit and any focus areas or specific concerns.
+- Extract `{output_path}` from the user's request: the directory for all audit artifacts.
+- If the user did not specify an output path, derive `{output_path}` from the target's base name and the current date.

--- a/prism-audit/techniques/scope-definition/create-output-folder.md
+++ b/prism-audit/techniques/scope-definition/create-output-folder.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 4
-  legacy_id: 4
 ---
 
 ## Capability

--- a/prism-audit/techniques/scope-definition/summarize-scope.md
+++ b/prism-audit/techniques/scope-definition/summarize-scope.md
@@ -1,15 +1,17 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 3
-  legacy_id: 3
 ---
 
 ## Capability
 
 Assemble a comprehensive summary of the audit scope — target codebase, detected language and framework, estimated size, GitNexus indexing status, the user's audit description and focus areas, and the output directory — for user confirmation.
+
+## Outputs
+
+### scope_summary
+
+Formatted summary of the audit scope covering target, language, size, indexing status, description, and output directory
 
 ## Protocol
 
@@ -17,9 +19,3 @@ Assemble a comprehensive summary of the audit scope — target codebase, detecte
 
 - Assemble the scope summary from the target codebase path, `{target_metadata}` (detected language/framework, estimated size, top-level structure), `{gitnexus_available}` indexing status, the user's `{audit_description}` and focus areas, and the `{output_path}`.
 - Format the assembled `{scope_summary}` for user review.
-
-## Outputs
-
-### scope_summary
-
-Formatted summary of the audit scope covering target, language, size, indexing status, description, and output directory

--- a/prism-audit/techniques/scope-definition/validate-target.md
+++ b/prism-audit/techniques/scope-definition/validate-target.md
@@ -1,26 +1,11 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 2
-  legacy_id: 2
 ---
 
 ## Capability
 
 Confirm the target is an analysable codebase and gather its structural metadata: verify the path exists and holds source files, detect project markers to identify the build system and primary language, and report the top-level structure and estimated size.
-
-## Protocol
-
-### 1. Validate Target
-
-- Verify `{target_path}` exists and contains analysable source files.
-- Check for project markers to confirm it is a codebase: `Cargo.toml` (Rust), `package.json` (JS/TS), `go.mod` (Go), `pyproject.toml` (Python), and equivalents.
-- Identify the primary language and build system from the detected markers.
-- Report the top-level directory structure.
-- Estimate the codebase size (lines of code, excluding tests, docs, and generated files).
-  > If `{target_path}` does not exist or contains no analysable source files, surface the path as invalid and request a corrected target before proceeding.
 
 ## Outputs
 
@@ -39,3 +24,14 @@ Estimated codebase size in lines of code
 #### top_level_structure
 
 The target's top-level directory layout
+
+## Protocol
+
+### 1. Validate Target
+
+- Verify `{target_path}` exists and contains analysable source files.
+- Check for project markers to confirm it is a codebase: `Cargo.toml` (Rust), `package.json` (JS/TS), `go.mod` (Go), `pyproject.toml` (Python), and equivalents.
+- Identify the primary language and build system from the detected markers.
+- Report the top-level directory structure.
+- Estimate the codebase size (lines of code, excluding tests, docs, and generated files).
+  > If `{target_path}` does not exist or contains no analysable source files, surface the path as invalid and request a corrected target before proceeding.

--- a/prism-evaluate/techniques/compose-evaluation-report/TECHNIQUE.md
+++ b/prism-evaluate/techniques/compose-evaluation-report/TECHNIQUE.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.3.0
-  order: 1
-  legacy_id: 1
 ---
 
 ## Capability

--- a/prism-evaluate/techniques/compose-evaluation-report/compile-and-present.md
+++ b/prism-evaluate/techniques/compose-evaluation-report/compile-and-present.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 5
-  legacy_id: 5
 ---
 
 ## Capability

--- a/prism-evaluate/techniques/compose-evaluation-report/compose-report.md
+++ b/prism-evaluate/techniques/compose-evaluation-report/compose-report.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 3
-  legacy_id: 3
 ---
 
 ## Capability

--- a/prism-evaluate/techniques/compose-evaluation-report/extract-findings.md
+++ b/prism-evaluate/techniques/compose-evaluation-report/extract-findings.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 1
-  legacy_id: 1
 ---
 
 ## Capability

--- a/prism-evaluate/techniques/compose-evaluation-report/identify-patterns.md
+++ b/prism-evaluate/techniques/compose-evaluation-report/identify-patterns.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 2
-  legacy_id: 2
 ---
 
 ## Capability

--- a/prism-evaluate/techniques/compose-evaluation-report/verify-report.md
+++ b/prism-evaluate/techniques/compose-evaluation-report/verify-report.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 4
-  legacy_id: 4
 ---
 
 ## Capability

--- a/prism-evaluate/techniques/execute-analysis/TECHNIQUE.md
+++ b/prism-evaluate/techniques/execute-analysis/TECHNIQUE.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 0
-  legacy_id: 0
 ---
 
 ## Capability

--- a/prism-evaluate/techniques/execute-analysis/read-run-manifest.md
+++ b/prism-evaluate/techniques/execute-analysis/read-run-manifest.md
@@ -1,24 +1,11 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 1
-  legacy_id: 1
 ---
 
 ## Capability
 
 Read the triggered prism run's RUN-MANIFEST.md and record the run into the evaluation's accumulators — its report, definitive findings, artifact paths, and prism-reported completion status — without re-scanning the output directory. The group's `output_subdir` (from the inherited `{current_group}`) locates the run's `RUN-MANIFEST.md`.
-
-## Protocol
-
-### 1. Read Run Manifest
-
-- Read `RUN-MANIFEST.md` from the group's output location (its `output_subdir` under the evaluation output directory).
-- From the manifest, take the run's `report_path`, `definitive_findings_path`, listed artifact paths, and its `status` (`complete` / `partial` / `error`) — prism has already verified completion, so no directory re-scan or per-artifact existence check is needed here.
-- Append the run's reference — `report_path`, `definitive_findings_path`, and the manifest `status` — to `{completed_analyses}`, and append the manifest's artifact paths to `{all_artifact_paths}`.
-  > When the manifest reports `partial` or `error`, carry that status through on the run's `{completed_analyses}` entry so consolidation surfaces the incomplete run rather than silently dropping a dimension.
 
 ## Outputs
 
@@ -29,3 +16,12 @@ Array of completed prism run references, each with its report path, definitive-f
 ### all_artifact_paths
 
 Accumulated paths to all analysis artifacts across triggered prism runs, taken from each run's manifest.
+
+## Protocol
+
+### 1. Read Run Manifest
+
+- Read `RUN-MANIFEST.md` from the group's output location (its `output_subdir` under the evaluation output directory).
+- From the manifest, take the run's `report_path`, `definitive_findings_path`, listed artifact paths, and its `status` (`complete` / `partial` / `error`) — prism has already verified completion, so no directory re-scan or per-artifact existence check is needed here.
+- Append the run's reference — `report_path`, `definitive_findings_path`, and the manifest `status` — to `{completed_analyses}`, and append the manifest's artifact paths to `{all_artifact_paths}`.
+  > When the manifest reports `partial` or `error`, carry that status through on the run's `{completed_analyses}` entry so consolidation surfaces the incomplete run rather than silently dropping a dimension.

--- a/prism-evaluate/techniques/plan-evaluation/TECHNIQUE.md
+++ b/prism-evaluate/techniques/plan-evaluation/TECHNIQUE.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.3.0
-  order: 0
-  legacy_id: 0
 ---
 
 ## Capability

--- a/prism-evaluate/techniques/plan-evaluation/classify-target.md
+++ b/prism-evaluate/techniques/plan-evaluation/classify-target.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 0
-  legacy_id: 0
 ---
 
 ## Capability

--- a/prism-evaluate/techniques/plan-evaluation/collect-scope.md
+++ b/prism-evaluate/techniques/plan-evaluation/collect-scope.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 0
-  legacy_id: 0
 ---
 
 ## Capability

--- a/prism-evaluate/techniques/plan-evaluation/create-output-folder.md
+++ b/prism-evaluate/techniques/plan-evaluation/create-output-folder.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 6
-  legacy_id: 6
 ---
 
 ## Capability

--- a/prism-evaluate/techniques/plan-evaluation/derive-dimensions.md
+++ b/prism-evaluate/techniques/plan-evaluation/derive-dimensions.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 1
-  legacy_id: 1
 ---
 
 ## Capability

--- a/prism-evaluate/techniques/plan-evaluation/group-for-execution.md
+++ b/prism-evaluate/techniques/plan-evaluation/group-for-execution.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 4
-  legacy_id: 4
 ---
 
 ## Capability

--- a/prism-evaluate/techniques/plan-evaluation/map-dimensions-to-lenses.md
+++ b/prism-evaluate/techniques/plan-evaluation/map-dimensions-to-lenses.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 3
-  legacy_id: 3
 ---
 
 ## Capability

--- a/prism-evaluate/techniques/plan-evaluation/summarize-scope.md
+++ b/prism-evaluate/techniques/plan-evaluation/summarize-scope.md
@@ -1,15 +1,17 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 7
-  legacy_id: 7
 ---
 
 ## Capability
 
 Assemble a comprehensive summary of the evaluation scope — target path, classified target type, the evaluation dimensions, the user's evaluation description and focus areas, and the output directory — for user confirmation.
+
+## Outputs
+
+### scope_summary
+
+Formatted summary of the evaluation scope covering target, target type, dimensions, description, and output directory
 
 ## Protocol
 
@@ -17,9 +19,3 @@ Assemble a comprehensive summary of the evaluation scope — target path, classi
 
 - Assemble the scope summary from `{target_path}`, the classified `{target_type}`, the `{dimensions}` array, the user's `{evaluation_description}` and focus areas, and the `{output_path}`.
 - Format the assembled `{scope_summary}` for user review.
-
-## Outputs
-
-### scope_summary
-
-Formatted summary of the evaluation scope covering target, target type, dimensions, description, and output directory

--- a/prism-evaluate/techniques/plan-evaluation/survey-target.md
+++ b/prism-evaluate/techniques/plan-evaluation/survey-target.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 2
-  legacy_id: 2
 ---
 
 ## Capability

--- a/prism-evaluate/techniques/plan-evaluation/write-evaluation-plan.md
+++ b/prism-evaluate/techniques/plan-evaluation/write-evaluation-plan.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 5
-  legacy_id: 5
 ---
 
 ## Capability

--- a/prism-evaluate/techniques/resolve-findings/TECHNIQUE.md
+++ b/prism-evaluate/techniques/resolve-findings/TECHNIQUE.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.3.0
-  order: 2
-  legacy_id: 2
 ---
 
 ## Capability

--- a/prism-evaluate/techniques/resolve-findings/apply-changes.md
+++ b/prism-evaluate/techniques/resolve-findings/apply-changes.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 4
-  legacy_id: 4
 ---
 
 ## Capability

--- a/prism-evaluate/techniques/resolve-findings/compile-plan.md
+++ b/prism-evaluate/techniques/resolve-findings/compile-plan.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 3
-  legacy_id: 3
 ---
 
 ## Capability

--- a/prism-evaluate/techniques/resolve-findings/load-and-classify.md
+++ b/prism-evaluate/techniques/resolve-findings/load-and-classify.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 0
-  legacy_id: 0
 ---
 
 ## Capability

--- a/prism-evaluate/techniques/resolve-findings/present-and-collect-per-finding.md
+++ b/prism-evaluate/techniques/resolve-findings/present-and-collect-per-finding.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 2
-  legacy_id: 2
 ---
 
 ## Capability

--- a/prism-evaluate/techniques/resolve-findings/propose-mitigation-by-tier.md
+++ b/prism-evaluate/techniques/resolve-findings/propose-mitigation-by-tier.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 1
-  legacy_id: 1
 ---
 
 ## Capability

--- a/prism-update/techniques/diff-upstream.md
+++ b/prism-update/techniques/diff-upstream.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 0
-  legacy_id: 0
 ---
 
 ## Capability
@@ -20,6 +16,32 @@ Diff an upstream prisms directory against current resources, producing a categor
 #### default
 
 `[]`
+
+## Outputs
+
+### change_set
+
+Categorized changes ready for review and import.
+
+#### new
+
+Array of `{ name, upstream_file, family, optimal_model, quality_baseline, words }`.
+
+#### modified
+
+Array of `{ name, resource_file, upstream_file }`.
+
+#### renamed
+
+Array of `{ old_name, new_name, old_resource_file, upstream_file }`.
+
+#### deleted
+
+Array of `{ name, resource_file }`.
+
+### next_index
+
+Next available resource index.
 
 ## Protocol
 
@@ -49,29 +71,3 @@ Diff an upstream prisms directory against current resources, producing a categor
 - Set `{next_index}` to the maximum existing resource index plus one.
 - Assemble the categorized new, modified, renamed, and deleted entries together with `{next_index}` into `{change_set}`.
   > When no differences are found across all categories, report that resources are up to date; the workflow can end early.
-
-## Outputs
-
-### change_set
-
-Categorized changes ready for review and import.
-
-#### new
-
-Array of `{ name, upstream_file, family, optimal_model, quality_baseline, words }`.
-
-#### modified
-
-Array of `{ name, resource_file, upstream_file }`.
-
-#### renamed
-
-Array of `{ old_name, new_name, old_resource_file, upstream_file }`.
-
-#### deleted
-
-Array of `{ name, resource_file }`.
-
-### next_index
-
-Next available resource index.

--- a/prism-update/techniques/review-change-set/TECHNIQUE.md
+++ b/prism-update/techniques/review-change-set/TECHNIQUE.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 5
-  legacy_id: 5
 ---
 
 ## Capability

--- a/prism-update/techniques/review-change-set/apply-exclusions.md
+++ b/prism-update/techniques/review-change-set/apply-exclusions.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 1
-  legacy_id: 1
 ---
 
 ## Capability

--- a/prism-update/techniques/review-change-set/present-summary.md
+++ b/prism-update/techniques/review-change-set/present-summary.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 0
-  legacy_id: 0
 ---
 
 ## Capability

--- a/prism-update/techniques/submit-update.md
+++ b/prism-update/techniques/submit-update.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 6
-  legacy_id: 6
 ---
 
 ## Capability

--- a/prism-update/techniques/sync-resources.md
+++ b/prism-update/techniques/sync-resources.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 1
-  legacy_id: 1
 ---
 
 ## Capability

--- a/prism-update/techniques/update-prism-docs.md
+++ b/prism-update/techniques/update-prism-docs.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 3
-  legacy_id: 3
 ---
 
 ## Capability

--- a/prism-update/techniques/update-skill-routing.md
+++ b/prism-update/techniques/update-skill-routing.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 2
-  legacy_id: 2
 ---
 
 ## Capability

--- a/prism-update/techniques/verify-prism-consistency.md
+++ b/prism-update/techniques/verify-prism-consistency.md
@@ -1,45 +1,11 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 4
-  legacy_id: 4
 ---
 
 ## Capability
 
 Verify consistency across prism resources, techniques, and documentation, flagging content drift, stale references, routing mismatches, count discrepancies, and duplicate indices into a consistency report.
-
-## Protocol
-
-### 1. Verify Content Integrity
-
-- For each entry in `{change_set}.modified` and `{change_set}.new`, diff the imported resource against its upstream original and flag any content difference beyond the expected filename change.
-
-### 2. Check Stale References
-
-- Build the stale name list from the `old_name` of each `{change_set}.renamed` entry and the `name` of each `{change_set}.deleted` entry.
-- Grep all files under `prism/techniques/` and `prism/activities/` for each stale name and record the matches into `{verification_report.stale_references}`.
-
-### 3. Verify Prompt Routing
-
-- Parse the Prompt Guide table from `{prism_readme}` and the goal-mapping-matrix from `{plan_analysis_technique}`.
-  > If either the prompt guide table or the goal-mapping matrix cannot be parsed, read the raw file content and extract the sections manually.
-- For each prompt, verify the matrix routes to the claimed prism and flag mismatches into `{verification_report.routing_mismatches}`.
-
-### 4. Verify Resource Counts
-
-- Count the `.md` files in `{resource_path}` excluding `README.md`.
-- Compare against the stated counts in `{prism_readme}` and `{prism_resources_readme}` and flag mismatches into `{verification_report.count_mismatches}`.
-
-### 5. Check Duplicate Indices
-
-- Extract numeric prefixes from the resource filenames and flag any that appear more than once into `{verification_report.duplicate_indices}`.
-
-### 6. Compile Findings
-
-- Assemble `{verification_report}` from the five checks and set both `{verification_report.has_issues}` and the top-level `{has_issues}` to `true` when any check produced a finding, `false` otherwise.
 
 ## Outputs
 
@@ -70,3 +36,33 @@ Array of `{ index, files }`.
 ### has_issues
 
 `true` when any consistency check produced a finding, `false` otherwise.
+
+## Protocol
+
+### 1. Verify Content Integrity
+
+- For each entry in `{change_set}.modified` and `{change_set}.new`, diff the imported resource against its upstream original and flag any content difference beyond the expected filename change.
+
+### 2. Check Stale References
+
+- Build the stale name list from the `old_name` of each `{change_set}.renamed` entry and the `name` of each `{change_set}.deleted` entry.
+- Grep all files under `prism/techniques/` and `prism/activities/` for each stale name and record the matches into `{verification_report.stale_references}`.
+
+### 3. Verify Prompt Routing
+
+- Parse the Prompt Guide table from `{prism_readme}` and the goal-mapping-matrix from `{plan_analysis_technique}`.
+  > If either the prompt guide table or the goal-mapping matrix cannot be parsed, read the raw file content and extract the sections manually.
+- For each prompt, verify the matrix routes to the claimed prism and flag mismatches into `{verification_report.routing_mismatches}`.
+
+### 4. Verify Resource Counts
+
+- Count the `.md` files in `{resource_path}` excluding `README.md`.
+- Compare against the stated counts in `{prism_readme}` and `{prism_resources_readme}` and flag mismatches into `{verification_report.count_mismatches}`.
+
+### 5. Check Duplicate Indices
+
+- Extract numeric prefixes from the resource filenames and flag any that appear more than once into `{verification_report.duplicate_indices}`.
+
+### 6. Compile Findings
+
+- Assemble `{verification_report}` from the five checks and set both `{verification_report.has_issues}` and the top-level `{has_issues}` to `true` when any check produced a finding, `false` otherwise.

--- a/prism/techniques/adaptive-analysis/TECHNIQUE.md
+++ b/prism/techniques/adaptive-analysis/TECHNIQUE.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 12
-  legacy_id: 12
 ---
 
 ## Capability

--- a/prism/techniques/adaptive-analysis/stage-1-sdl.md
+++ b/prism/techniques/adaptive-analysis/stage-1-sdl.md
@@ -1,14 +1,17 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 1
 ---
 
 ## Capability
 
 Run the cheapest SDL scan on Haiku and assess signal quality to decide whether escalation is needed
+
+## Outputs
+
+### adaptive_signal_quality
+
+Signal-quality assessment at the current stage.
 
 ## Protocol
 
@@ -21,9 +24,3 @@ Run the cheapest SDL scan on Haiku and assess signal quality to decide whether e
 ### 2. Assess Signal
 
 - If all three signals are present — conservation law (regex: 'conservation law' or '= constant'), word count > 300, and a bug table — set `{adaptive_signal_quality}` to `adequate` and stop escalation. Otherwise set it to `insufficient` and continue.
-
-## Outputs
-
-### adaptive_signal_quality
-
-Signal-quality assessment at the current stage.

--- a/prism/techniques/adaptive-analysis/stage-2-l12.md
+++ b/prism/techniques/adaptive-analysis/stage-2-l12.md
@@ -1,14 +1,17 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 2
 ---
 
 ## Capability
 
 Escalate to a full L12 pass on Sonnet and re-assess signal quality
+
+## Outputs
+
+### adaptive_signal_quality
+
+Signal-quality assessment at the current stage.
 
 ## Protocol
 
@@ -17,9 +20,3 @@ Escalate to a full L12 pass on Sonnet and re-assess signal quality
 - Dispatch [L12](../../resources/l12.md) to a fresh worker on Sonnet
 - Worker writes `{adaptive_result.artifact_paths}` stage-2 entry into `{output_path}`
 - Re-assess signal quality with same criteria
-
-## Outputs
-
-### adaptive_signal_quality
-
-Signal-quality assessment at the current stage.

--- a/prism/techniques/adaptive-analysis/stage-3-full.md
+++ b/prism/techniques/adaptive-analysis/stage-3-full.md
@@ -1,9 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 3
 ---
 
 ## Capability

--- a/prism/techniques/behavioral-pipeline.md
+++ b/prism/techniques/behavioral-pipeline.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.2.0
-  order: 5
-  legacy_id: 5
 ---
 
 ## Capability
@@ -20,6 +16,24 @@ Execute the behavioral pipeline — 4 independent behavioral lenses followed by 
 ### prior_artifact_paths
 
 *(optional)* For synthesis pass only: map of role labels to artifact file paths. Keys: ERRORS, COSTS, CHANGES, PROMISES. Empty for independent lens passes.
+
+## Outputs
+
+### behavioral_artifact
+
+Behavioral analysis artifact written to the filesystem
+
+#### artifact
+
+`behavioral-errors.md` (`error-resilience`) / `behavioral-costs.md` (`optimize`) / `behavioral-changes.md` (`evolution`) / `behavioral-promises.md` (`api-surface`) / `behavioral-synthesis.md` (`synthesis`)
+
+#### artifact_path
+
+Full filesystem path to the written artifact
+
+#### role_label
+
+The role label for this pass (ERRORS, COSTS, CHANGES, PROMISES, or SYNTHESIS)
 
 ## Protocol
 
@@ -64,24 +78,6 @@ Execute the behavioral pipeline — 4 independent behavioral lenses followed by 
 
 - Write the complete analysis as `{behavioral_artifact}` into `{output_path}`. If the write fails, verify `{output_path}` exists and is writable.
 
-## Outputs
-
-### behavioral_artifact
-
-Behavioral analysis artifact written to the filesystem
-
-#### artifact
-
-`behavioral-errors.md` (`error-resilience`) / `behavioral-costs.md` (`optimize`) / `behavioral-changes.md` (`evolution`) / `behavioral-promises.md` (`api-surface`) / `behavioral-synthesis.md` (`synthesis`)
-
-#### artifact_path
-
-Full filesystem path to the written artifact
-
-#### role_label
-
-The role label for this pass (ERRORS, COSTS, CHANGES, PROMISES, or SYNTHESIS)
-
 ## Rules
 
 ### label-mapping
@@ -95,4 +91,3 @@ The behavioral pipeline is code-only. `optimize` uses strongly code-oriented voc
 ### independent-lenses-parallel
 
 The four independent behavioral lenses (`error-resilience`, `optimize`, `evolution`, `api-surface`) share no context and may be dispatched concurrently, up to four at once. Only the `synthesis` lens depends on their outputs.
-

--- a/prism/techniques/dispute-analysis.md
+++ b/prism/techniques/dispute-analysis.md
@@ -1,37 +1,11 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 7
-  legacy_id: 7
 ---
 
 ## Capability
 
 Run 2 maximally orthogonal prisms against the same target and synthesize their disagreements for lightweight self-correction
-
-## Protocol
-
-### 1. Select Pair
-
-- Branch on `{target_type}`: for `code`, [l12](../resources/l12.md) (00) + [identity](../resources/identity.md) (17) — the pair with highest pairwise uniqueness; for `general`, [l12-universal](../resources/l12-universal.md) (18) + [claim](../resources/claim.md) (07). Each pair maximizes analytical divergence.
-- Identify the chosen lens identities `{$prism_a}` (the first lens) and `{$prism_b}` (the second lens)
-
-### 2. Execute Lenses
-
-- Dispatch prism A to a fresh worker with its resource index, passing `{target_content}` as the material to analyze  
-  > Each lens runs in a fresh context; neither sees the other's output.
-- Dispatch prism B to a fresh worker against the same `{target_content}` (can be parallel)
-- Each worker writes its lens artifact (`{dispute_result.lens_a_path}` / `{dispute_result.lens_b_path}`) into `{output_path}`; capture the lens A artifact content as `{$output_a}` and the lens B artifact content as `{$output_b}`
-
-### 3. Synthesize Disagreements
-
-- Dispatch synthesis to a fresh worker with [dispute-synthesis](../resources/dispute-synthesis.md) resource (62)
-- Worker constructs input: "# LENS A: `{prism_a}`\n\n`{output_a}`\n\n---\n\n# LENS B: `{prism_b}`\n\n`{output_b}`"
-- Worker writes `{dispute_result.synthesis_path}` into `{output_path}`
-- The synthesis focuses on DISAGREEMENTS, not agreements. Convergence is noted only to test implicit shared assumptions.
-- Return `{dispute_result}`: the three artifact paths and the prism pair selected in step 1
 
 ## Outputs
 
@@ -59,6 +33,28 @@ Filesystem path to the disagreement-synthesis artifact
 
 Resource indices and lens identities used for A and B
 
+## Protocol
+
+### 1. Select Pair
+
+- Branch on `{target_type}`: for `code`, [l12](../resources/l12.md) (00) + [identity](../resources/identity.md) (17) — the pair with highest pairwise uniqueness; for `general`, [l12-universal](../resources/l12-universal.md) (18) + [claim](../resources/claim.md) (07). Each pair maximizes analytical divergence.
+- Identify the chosen lens identities `{$prism_a}` (the first lens) and `{$prism_b}` (the second lens)
+
+### 2. Execute Lenses
+
+- Dispatch prism A to a fresh worker with its resource index, passing `{target_content}` as the material to analyze  
+  > Each lens runs in a fresh context; neither sees the other's output.
+- Dispatch prism B to a fresh worker against the same `{target_content}` (can be parallel)
+- Each worker writes its lens artifact (`{dispute_result.lens_a_path}` / `{dispute_result.lens_b_path}`) into `{output_path}`; capture the lens A artifact content as `{$output_a}` and the lens B artifact content as `{$output_b}`
+
+### 3. Synthesize Disagreements
+
+- Dispatch synthesis to a fresh worker with [dispute-synthesis](../resources/dispute-synthesis.md) resource (62)
+- Worker constructs input: "# LENS A: `{prism_a}`\n\n`{output_a}`\n\n---\n\n# LENS B: `{prism_b}`\n\n`{output_b}`"
+- Worker writes `{dispute_result.synthesis_path}` into `{output_path}`
+- The synthesis focuses on DISAGREEMENTS, not agreements. Convergence is noted only to test implicit shared assumptions.
+- Return `{dispute_result}`: the three artifact paths and the prism pair selected in step 1
+
 ## Rules
 
 ### synthesis-never-sees-target
@@ -68,4 +64,3 @@ The synthesis worker receives both lens outputs but has never seen the target an
 ### automatic-pair-selection
 
 The orthogonal prism pair is selected automatically for maximum analytical divergence; it is not user-configurable.
-

--- a/prism/techniques/emit-run-manifest.md
+++ b/prism/techniques/emit-run-manifest.md
@@ -29,6 +29,36 @@ The ordered analysis units for this run — each carries its `pipeline_mode` and
 
 The run's pipeline mode, recorded so a caller knows which artifacts to expect.
 
+## Outputs
+
+### run_manifest
+
+Machine-readable manifest of the run's artifacts and completion status.
+
+#### artifact
+
+`RUN-MANIFEST.md`
+
+### run_manifest_path
+
+Full filesystem path to `RUN-MANIFEST.md`.
+
+### run_status
+
+Completion status of the run.
+
+#### complete
+
+Report, definitive findings, and every unit's expected artifacts are present.
+
+#### partial
+
+Reports exist but one or more units are missing expected artifacts.
+
+#### error
+
+REPORT.md or DEFINITIVE-FINDINGS.md is missing or empty.
+
 ## Protocol
 
 ### 1. Verify Completion
@@ -61,36 +91,6 @@ The run's pipeline mode, recorded so a caller knows which artifacts to expect.
 
   - [{artifact filename}]({artifact path})
   ```
-
-## Outputs
-
-### run_manifest
-
-Machine-readable manifest of the run's artifacts and completion status.
-
-#### artifact
-
-`RUN-MANIFEST.md`
-
-### run_manifest_path
-
-Full filesystem path to `RUN-MANIFEST.md`.
-
-### run_status
-
-Completion status of the run.
-
-#### complete
-
-Report, definitive findings, and every unit's expected artifacts are present.
-
-#### partial
-
-Reports exist but one or more units are missing expected artifacts.
-
-#### error
-
-REPORT.md or DEFINITIVE-FINDINGS.md is missing or empty.
 
 ## Rules
 

--- a/prism/techniques/full-prism.md
+++ b/prism/techniques/full-prism.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 2.3.0
-  order: 1
-  legacy_id: 1
 ---
 
 ## Capability
@@ -20,6 +16,24 @@ Which lens to apply: `adversarial` or `synthesis`. Each names the lens resource 
 ### prior_artifact_paths
 
 *(optional)* Ordered file paths to the prior-pass artifacts this pass consumes as context; empty for the first pass.
+
+## Outputs
+
+### pass_artifact
+
+Analysis artifact written to the filesystem
+
+#### artifact
+
+`adversarial-analysis.md` (`{lens_name}` `adversarial`) / `synthesis.md` (`synthesis`)
+
+#### artifact_path
+
+Full filesystem path to the written artifact
+
+#### analysis_text
+
+The full analysis output following the lens operations
 
 ## Protocol
 
@@ -59,24 +73,6 @@ Which lens to apply: `adversarial` or `synthesis`. Each names the lens resource 
 - Structure `{pass_artifact}.analysis_text` with clear section headers matching the lens operations
 - For adversarial: wrong predictions, overclaims, underclaims, revised findings table
 - For synthesis: refined conservation law, refined meta-law, definitive classification, deepest finding
-
-## Outputs
-
-### pass_artifact
-
-Analysis artifact written to the filesystem
-
-#### artifact
-
-`adversarial-analysis.md` (`{lens_name}` `adversarial`) / `synthesis.md` (`synthesis`)
-
-#### artifact_path
-
-Full filesystem path to the written artifact
-
-#### analysis_text
-
-The full analysis output following the lens operations
 
 ## Rules
 

--- a/prism/techniques/generate-report.md
+++ b/prism/techniques/generate-report.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 6
-  legacy_id: 6
 ---
 
 ## Capability
@@ -28,6 +24,40 @@ Array of filesystem paths to the analysis artifacts available for this report.
 ### target_description
 
 Description of what was analysed — used in the report's Executive Summary scope statement
+
+## Outputs
+
+### analysis_report
+
+Clean final [report](../resources/final-output-template.md#reportmd-template) artifact
+
+#### artifact
+
+`REPORT.md`
+
+#### finding_count
+
+Total findings by severity
+
+#### core_finding
+
+Summary of the core finding (if any)
+
+### report_path
+
+Full filesystem path to `REPORT.md`
+
+### definitive_findings
+
+Detailed [definitive findings](../resources/definitive-findings-template.md#definitive-findingsmd-template) artifact carrying the full per-finding field set (Impact, Recommendation, Adversarial confirmation, and more) and the surviving conservation laws. The stable contract consumer workflows read instead of the raw pass artifacts.
+
+#### artifact
+
+`DEFINITIVE-FINDINGS.md`
+
+### definitive_findings_path
+
+Full filesystem path to `DEFINITIVE-FINDINGS.md`
 
 ## Protocol
 
@@ -103,40 +133,6 @@ Description of what was analysed — used in the report's Executive Summary scop
 - Include every finding from step 3 with its complete field set — Severity, Classification, Description, Impact, Location, Recommendation, Blast radius (where graph data exists), and Adversarial confirmation (full-prism only). Finding IDs are the same unified report IDs assigned in step 6, so DEFINITIVE-FINDINGS.md and REPORT.md agree exactly.
 - Add the Conservation Laws & Design Trade-offs section from the surviving laws captured in step 3 (present for full-prism and behavioral). Omit the section when no law survived.
 - The voice remains factual: adversarial confirmation and conservation laws are recorded as evidence and constraints, never as process narration (no "ANALYSIS 1", "the adversarial pass", scorecards, or overclaim/underclaim tables).
-
-## Outputs
-
-### analysis_report
-
-Clean final [report](../resources/final-output-template.md#reportmd-template) artifact
-
-#### artifact
-
-`REPORT.md`
-
-#### finding_count
-
-Total findings by severity
-
-#### core_finding
-
-Summary of the core finding (if any)
-
-### report_path
-
-Full filesystem path to `REPORT.md`
-
-### definitive_findings
-
-Detailed [definitive findings](../resources/definitive-findings-template.md#definitive-findingsmd-template) artifact carrying the full per-finding field set (Impact, Recommendation, Adversarial confirmation, and more) and the surviving conservation laws. The stable contract consumer workflows read instead of the raw pass artifacts.
-
-#### artifact
-
-`DEFINITIVE-FINDINGS.md`
-
-### definitive_findings_path
-
-Full filesystem path to `DEFINITIVE-FINDINGS.md`
 
 ## Rules
 

--- a/prism/techniques/plan-analysis.md
+++ b/prism/techniques/plan-analysis.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 3
-  legacy_id: 3
 ---
 
 ## Capability
@@ -32,6 +28,52 @@ standard
 ### depth_preference
 
 *(optional)* Override for pipeline mode when scope is query or file: 'single', 'pipeline', 'portfolio', or 'behavioral'. Ignored for multi-unit scopes where mode is determined per-unit by risk classification.
+
+## Outputs
+
+### analysis_plan
+
+Human-readable analysis plan artifact
+
+#### artifact
+
+`analysis-plan.md`
+
+#### scope_type
+
+Detected scope type (query, file, module, codebase, document-set)
+
+#### strategy_summary
+
+Overall strategy description
+
+#### units_summary
+
+Per-unit plan summary: target, role, risk, pipeline-mode, lenses, rationale
+
+#### execution_order
+
+Prioritised and grouped execution sequence (multi-unit scopes only)
+
+#### parallelism_plan
+
+Which units can run concurrently (multi-unit scopes only)
+
+#### estimated_cost
+
+Total sub-agent dispatches (multi-unit scopes only)
+
+#### skipped_units
+
+Units below budget threshold with justification (multi-unit scopes only)
+
+### analysis_units
+
+Machine-readable ordered array of analysis unit objects, each specifying a target, mode, and lens selection to execute
+
+#### unit_specs
+
+Array of `{ target, target_type, pipeline_mode, lens_name, lenses, role, risk, rationale, unit_output_subdir }`
 
 ## Protocol
 
@@ -109,52 +151,6 @@ standard
 - Produce `{analysis_plan}` as structured output and expose `{analysis_units}` as the ordered execution collection
 - If `{output_path}` is provided, write the human-readable plan as `{analysis_plan}` into `{output_path}`
 - A single-unit `{analysis_units}` array runs one analysis pass; a multi-unit array runs one pass per unit in order
-
-## Outputs
-
-### analysis_plan
-
-Human-readable analysis plan artifact
-
-#### artifact
-
-`analysis-plan.md`
-
-#### scope_type
-
-Detected scope type (query, file, module, codebase, document-set)
-
-#### strategy_summary
-
-Overall strategy description
-
-#### units_summary
-
-Per-unit plan summary: target, role, risk, pipeline-mode, lenses, rationale
-
-#### execution_order
-
-Prioritised and grouped execution sequence (multi-unit scopes only)
-
-#### parallelism_plan
-
-Which units can run concurrently (multi-unit scopes only)
-
-#### estimated_cost
-
-Total sub-agent dispatches (multi-unit scopes only)
-
-#### skipped_units
-
-Units below budget threshold with justification (multi-unit scopes only)
-
-### analysis_units
-
-Machine-readable ordered array of analysis unit objects, each specifying a target, mode, and lens selection to execute
-
-#### unit_specs
-
-Array of `{ target, target_type, pipeline_mode, lens_name, lenses, role, risk, rationale, unit_output_subdir }`
 
 ## Rules
 

--- a/prism/techniques/portfolio-analysis.md
+++ b/prism/techniques/portfolio-analysis.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 2
-  legacy_id: 2
 ---
 
 ## Capability
@@ -20,6 +16,44 @@ Apply two or more complementary portfolio lenses to the same artifact to produce
 ### analytical_goal
 
 *(optional)* What the caller wants to understand (e.g., 'trade-off analysis', 'maintainability risks', 'hidden assumptions'). Used for lens selection when `{selected_lenses}` is not provided.
+
+## Outputs
+
+### per_lens_artifacts
+
+Individual analysis artifact per lens
+
+#### artifact
+
+`portfolio-{lens_name}.md`
+
+#### per_lens_findings
+
+Complete findings from each lens, labelled by lens name
+
+#### artifact_paths
+
+File paths to each per-lens artifact
+
+### portfolio_synthesis
+
+Cross-lens convergence/divergence synthesis
+
+#### artifact
+
+`portfolio-synthesis.md`
+
+#### convergent_findings
+
+Structural properties found by multiple lenses (high confidence)
+
+#### unique_findings
+
+Properties found by only one lens (the value-add of portfolio analysis)
+
+#### summary_table
+
+All findings with lens attribution and convergent/unique classification
 
 ## Protocol
 
@@ -60,44 +94,6 @@ Apply two or more complementary portfolio lenses to the same artifact to produce
 - Produce a summary table: finding, which lens(es) found it, convergent or unique
 - Write the synthesis as `{portfolio_synthesis}` into `{output_path}`
 
-## Outputs
-
-### per_lens_artifacts
-
-Individual analysis artifact per lens
-
-#### artifact
-
-`portfolio-{lens_name}.md`
-
-#### per_lens_findings
-
-Complete findings from each lens, labelled by lens name
-
-#### artifact_paths
-
-File paths to each per-lens artifact
-
-### portfolio_synthesis
-
-Cross-lens convergence/divergence synthesis
-
-#### artifact
-
-`portfolio-synthesis.md`
-
-#### convergent_findings
-
-Structural properties found by multiple lenses (high confidence)
-
-#### unique_findings
-
-Properties found by only one lens (the value-add of portfolio analysis)
-
-#### summary_table
-
-All findings with lens attribution and convergent/unique classification
-
 ## Rules
 
 ### code-only-lenses
@@ -107,4 +103,3 @@ The following lenses are code-specific — do not apply to non-code input: contr
 ### model-sensitivity
 
 Behavioral lenses (19-22) produce higher quality on Sonnet (+0.5-1.3 over Haiku). SDL and structural lenses are model-independent.
-

--- a/prism/techniques/reflect-analysis.md
+++ b/prism/techniques/reflect-analysis.md
@@ -1,37 +1,11 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 10
-  legacy_id: 10
 ---
 
 ## Capability
 
 Apply recursive meta-analysis to L12 output using the claim prism, then synthesize findings with constraint history
-
-## Protocol
-
-### 1. Structural Analysis
-
-- Dispatch [L12](../resources/l12.md) to a fresh worker, passing `{target_content}` as the analysis target and `{target_type}` to frame the L12 pass
-- Worker writes `{reflect_result.l12_path}` into `{output_path}`
-
-### 2. Meta Analysis
-
-- Dispatch [claim](../resources/claim.md) to a fresh worker
-- Worker receives the L12 OUTPUT as its analysis target (not source code)
-- Worker writes `{reflect_result.meta_path}` into `{output_path}`
-
-### 3. Constraint Synthesis
-
-- Dispatch synthesis to a fresh worker
-- Worker receives: L12 output + meta output + constraint history (if available)
-- Worker produces: RECURRING PATTERNS, UNEXPLORED DIMENSIONS, KNOWN FALSE POSITIVES, NEXT BEST SCAN
-- Worker writes `{reflect_result.synthesis_path}` into `{output_path}`
-- Synthesis must produce exactly 4 sections: RECURRING PATTERNS, UNEXPLORED DIMENSIONS, KNOWN FALSE POSITIVES, NEXT BEST SCAN
-- Return `{reflect_result}` — its `{reflect_result.l12_path}`, `{reflect_result.meta_path}`, and `{reflect_result.synthesis_path}` sub-fields hold the three pipeline artifact paths.
 
 ## Outputs
 
@@ -54,6 +28,28 @@ Filesystem path to the claim meta-analysis artifact
 #### synthesis_path
 
 Filesystem path to the constraint-synthesis artifact
+
+## Protocol
+
+### 1. Structural Analysis
+
+- Dispatch [L12](../resources/l12.md) to a fresh worker, passing `{target_content}` as the analysis target and `{target_type}` to frame the L12 pass
+- Worker writes `{reflect_result.l12_path}` into `{output_path}`
+
+### 2. Meta Analysis
+
+- Dispatch [claim](../resources/claim.md) to a fresh worker
+- Worker receives the L12 OUTPUT as its analysis target (not source code)
+- Worker writes `{reflect_result.meta_path}` into `{output_path}`
+
+### 3. Constraint Synthesis
+
+- Dispatch synthesis to a fresh worker
+- Worker receives: L12 output + meta output + constraint history (if available)
+- Worker produces: RECURRING PATTERNS, UNEXPLORED DIMENSIONS, KNOWN FALSE POSITIVES, NEXT BEST SCAN
+- Worker writes `{reflect_result.synthesis_path}` into `{output_path}`
+- Synthesis must produce exactly 4 sections: RECURRING PATTERNS, UNEXPLORED DIMENSIONS, KNOWN FALSE POSITIVES, NEXT BEST SCAN
+- Return `{reflect_result}` — its `{reflect_result.l12_path}`, `{reflect_result.meta_path}`, and `{reflect_result.synthesis_path}` sub-fields hold the three pipeline artifact paths.
 
 ## Rules
 

--- a/prism/techniques/single-lens-analysis.md
+++ b/prism/techniques/single-lens-analysis.md
@@ -1,9 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 6
 ---
 
 ## Capability
@@ -19,6 +16,20 @@ The lens resource to apply, named by its slug (e.g. `reachability`, `state-audit
 ### analysis_focus
 
 *(optional)* Optional focus area to guide the analysis (e.g. 'error handling', 'state management', 'concurrency'). Noted as a framing constraint; it does not narrow the lens — the lens operations are exhaustive.
+
+## Outputs
+
+### lens_analysis
+
+The applied lens's complete output following its own operations
+
+#### artifact
+
+`{lens_name}-analysis.md`
+
+#### findings
+
+The lens's findings, in the structure the lens defines
 
 ## Protocol
 
@@ -53,20 +64,6 @@ The lens resource to apply, named by its slug (e.g. `reachability`, `state-audit
 
 - Structure `{lens_analysis}` with the section headers the lens's own operations produce — a lens defines its own output shape (a bug table, a trust map, a dead-code list, an alternative-architecture set, …). Do not force an L12 conservation-law structure onto a non-L12 lens.
 - Include file paths, line numbers, and specific names for every finding, per `evidence-required`
-
-## Outputs
-
-### lens_analysis
-
-The applied lens's complete output following its own operations
-
-#### artifact
-
-`{lens_name}-analysis.md`
-
-#### findings
-
-The lens's findings, in the structure the lens defines
 
 ## Rules
 

--- a/prism/techniques/smart-analysis/TECHNIQUE.md
+++ b/prism/techniques/smart-analysis/TECHNIQUE.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 11
-  legacy_id: 11
 ---
 
 ## Capability

--- a/prism/techniques/smart-analysis/dispute-correction.md
+++ b/prism/techniques/smart-analysis/dispute-correction.md
@@ -1,9 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 5
 ---
 
 ## Capability

--- a/prism/techniques/smart-analysis/knowledge-fill.md
+++ b/prism/techniques/smart-analysis/knowledge-fill.md
@@ -1,9 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 2
 ---
 
 ## Capability

--- a/prism/techniques/smart-analysis/prereq-scan.md
+++ b/prism/techniques/smart-analysis/prereq-scan.md
@@ -1,9 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 1
 ---
 
 ## Capability

--- a/prism/techniques/smart-analysis/run-analysis.md
+++ b/prism/techniques/smart-analysis/run-analysis.md
@@ -1,9 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 4
 ---
 
 ## Capability

--- a/prism/techniques/smart-analysis/select-mode.md
+++ b/prism/techniques/smart-analysis/select-mode.md
@@ -1,14 +1,17 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 3
 ---
 
 ## Capability
 
 Compose the smart pipeline from the target characteristics and the analytical goal: decompose multi-region code into per-subsystem prisms; otherwise route the goal to a concern-specific lens or pipeline through the single canonical goal-mapping matrix, falling back to L12 when no goal is given
+
+## Outputs
+
+### smart_pipeline_steps
+
+The composed pipeline steps.
 
 ## Protocol
 
@@ -26,9 +29,3 @@ Compose the smart pipeline from the target characteristics and the analytical go
 ### 3. Record Steps
 
 - Record the resulting composed pipeline steps — including the selected lens slug for each step — as `{smart_pipeline_steps}`
-
-## Outputs
-
-### smart_pipeline_steps
-
-The composed pipeline steps.

--- a/prism/techniques/structural-analysis.md
+++ b/prism/techniques/structural-analysis.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 0
-  legacy_id: 0
 ---
 
 ## Capability
@@ -16,6 +12,36 @@ Apply L12 structural analysis lens to code for deep structural findings, conserv
 ### analysis_focus
 
 *(optional)* Optional focus area to guide the analysis (e.g., 'error handling', 'state management', 'concurrency')
+
+## Outputs
+
+### structural_analysis
+
+L12 structural analysis with conservation law, meta-law, and classified bug table
+
+#### artifact
+
+`structural-analysis.md`
+
+#### conservation_law
+
+The named conservation law between original and inverted impossibilities, carrying the producer/clearer ledger — the set-wide enumeration of every producer of each conserved resource against its clearers, with the matched/unmatched verdict per termination path
+
+#### meta_law
+
+What the conservation law itself conceals — the deeper finding
+
+#### bug_table
+
+Every concrete bug with location, severity, and fixable/structural classification — including each unmatched producer surfaced by the producer/clearer ledger
+
+#### concealment_mechanism
+
+How the code hides its real problems
+
+#### structural_invariant
+
+The property that persists through every improvement
 
 ## Protocol
 
@@ -67,36 +93,6 @@ The conservation law names a resource the code must conserve (a storage record, 
 - Render the producer/clearer ledger as a table within the Conservation Law section — one row per resource with its producers, clearers, and the matched/unmatched verdict per termination path
 - In the Bug Table, classify each finding as fixable or structural based on whether the conservation law predicts it can be resolved; every unmatched producer from the ledger appears as a Bug-Table entry
 - Include file paths, line numbers, and specific function names for every finding
-
-## Outputs
-
-### structural_analysis
-
-L12 structural analysis with conservation law, meta-law, and classified bug table
-
-#### artifact
-
-`structural-analysis.md`
-
-#### conservation_law
-
-The named conservation law between original and inverted impossibilities, carrying the producer/clearer ledger — the set-wide enumeration of every producer of each conserved resource against its clearers, with the matched/unmatched verdict per termination path
-
-#### meta_law
-
-What the conservation law itself conceals — the deeper finding
-
-#### bug_table
-
-Every concrete bug with location, severity, and fixable/structural classification — including each unmatched producer surfaced by the producer/clearer ledger
-
-#### concealment_mechanism
-
-How the code hides its real problems
-
-#### structural_invariant
-
-The property that persists through every improvement
 
 ## Rules
 

--- a/prism/techniques/subsystem-analysis/TECHNIQUE.md
+++ b/prism/techniques/subsystem-analysis/TECHNIQUE.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 8
-  legacy_id: 8
 ---
 
 ## Capability

--- a/prism/techniques/subsystem-analysis/calibrate.md
+++ b/prism/techniques/subsystem-analysis/calibrate.md
@@ -1,14 +1,17 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 2
 ---
 
 ## Capability
 
 Assign an optimal, diversity-maximizing prism to each subsystem via a calibration worker
+
+## Outputs
+
+### subsystem_assignments
+
+Map of subsystem to assigned prism.
 
 ## Protocol
 
@@ -18,9 +21,3 @@ Assign an optimal, diversity-maximizing prism to each subsystem via a calibratio
 - Send prism catalog + subsystem summaries to calibration worker
 - Parse JSON assignments into the subsystem-to-prism map — fallback to L12 for unassigned subsystems
 - Prism assignments MUST maximize diversity — the calibration prompt enforces this
-
-## Outputs
-
-### subsystem_assignments
-
-Map of subsystem to assigned prism.

--- a/prism/techniques/subsystem-analysis/decompose.md
+++ b/prism/techniques/subsystem-analysis/decompose.md
@@ -1,9 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 1
 ---
 
 ## Capability

--- a/prism/techniques/subsystem-analysis/execute.md
+++ b/prism/techniques/subsystem-analysis/execute.md
@@ -1,14 +1,17 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 3
 ---
 
 ## Capability
 
 Analyze each subsystem with its assigned prism in a fresh worker, prefixing the region with a context header naming its neighbours
+
+## Outputs
+
+### subsystem_outputs
+
+Per-subsystem analysis outputs.
 
 ## Protocol
 
@@ -16,9 +19,3 @@ Analyze each subsystem with its assigned prism in a fresh worker, prefixing the 
 
 - For each subsystem, dispatch a fresh worker with its assigned prism, prefixing the subsystem content with a context header that names the region and its neighbours: ``# SUBSYSTEM: {code_subsystem.subsystem_name} (lines {code_subsystem.start_line}-{code_subsystem.end_line} of {code_subsystem.source_filename})`` then ``# OTHER SUBSYSTEMS: {code_subsystem.other_subsystem_names}``
 - Each worker writes one `{subsystem_result.subsystem_paths}` entry into `{output_path}`, collecting the per-subsystem analysis outputs
-
-## Outputs
-
-### subsystem_outputs
-
-Per-subsystem analysis outputs.

--- a/prism/techniques/subsystem-analysis/synthesize.md
+++ b/prism/techniques/subsystem-analysis/synthesize.md
@@ -1,9 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 4
 ---
 
 ## Capability

--- a/prism/techniques/verified-analysis/TECHNIQUE.md
+++ b/prism/techniques/verified-analysis/TECHNIQUE.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 9
-  legacy_id: 9
 ---
 
 ## Capability

--- a/prism/techniques/verified-analysis/corrected-analysis.md
+++ b/prism/techniques/verified-analysis/corrected-analysis.md
@@ -1,9 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 4
 ---
 
 ## Capability

--- a/prism/techniques/verified-analysis/gap-detection.md
+++ b/prism/techniques/verified-analysis/gap-detection.md
@@ -1,9 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 2
 ---
 
 ## Capability

--- a/prism/techniques/verified-analysis/gap-extraction.md
+++ b/prism/techniques/verified-analysis/gap-extraction.md
@@ -1,14 +1,17 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 3
 ---
 
 ## Capability
 
 Extract structured gap data from the gap analysis into a context block for re-analysis
+
+## Outputs
+
+### gap_data
+
+Structured gap data extracted from the gap analysis, injected as the `verified_knowledge` context block for the corrected re-analysis.
 
 ## Protocol
 
@@ -16,9 +19,3 @@ Extract structured gap data from the gap analysis into a context block for re-an
 
 - Parse the structured claims `{gap_data}` from the gap output
 - Construct `verified_knowledge` context block with `{gap_data}`
-
-## Outputs
-
-### gap_data
-
-Structured gap data extracted from the gap analysis, injected as the `verified_knowledge` context block for the corrected re-analysis.

--- a/prism/techniques/verified-analysis/initial-analysis.md
+++ b/prism/techniques/verified-analysis/initial-analysis.md
@@ -1,9 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 1
 ---
 
 ## Capability

--- a/requirements-refinement/techniques/finalize-specification.md
+++ b/requirements-refinement/techniques/finalize-specification.md
@@ -17,20 +17,6 @@ The validation-passed specification document.
 
 The structured analysis of requirement changes, used to compose the change summary.
 
-## Protocol
-
-### 1. Assemble Final Specification
-
-- Copy the validation-passed `{working_specification}` into `{final_specification}` in `{planning_folder_path}`.
-
-### 2. Write Change Summary
-
-- Summarize the applied changes — new, updated, and deprecated requirements and added sources — from `{requirements_analysis}` into `{change_summary}` using the [change-summary](../resources/change-summary.md) structure.
-
-### 3. Present for Promotion
-
-- Present `{final_specification}` and `{change_summary}` for the user to review and promote to `{target_doc_path}`.
-
 ## Outputs
 
 ### final_specification
@@ -48,6 +34,20 @@ Human-readable summary of all applied changes and the validation status.
 #### artifact
 
 `change-summary.md`
+
+## Protocol
+
+### 1. Assemble Final Specification
+
+- Copy the validation-passed `{working_specification}` into `{final_specification}` in `{planning_folder_path}`.
+
+### 2. Write Change Summary
+
+- Summarize the applied changes — new, updated, and deprecated requirements and added sources — from `{requirements_analysis}` into `{change_summary}` using the [change-summary](../resources/change-summary.md) structure.
+
+### 3. Present for Promotion
+
+- Present `{final_specification}` and `{change_summary}` for the user to review and promote to `{target_doc_path}`.
 
 ## Rules
 

--- a/requirements-refinement/techniques/report-failure.md
+++ b/requirements-refinement/techniques/report-failure.md
@@ -13,6 +13,16 @@ Compile a failure report describing the unresolved critical issues, the correcti
 
 Categorized validation findings carrying the critical or unresolved issues.
 
+## Outputs
+
+### failure_report
+
+Failure report carrying the critical issues, correction history, and manual-resolution guidance.
+
+#### artifact
+
+`failure-report.md`
+
 ## Protocol
 
 ### 1. Summarize Failure
@@ -30,16 +40,6 @@ Categorized validation findings carrying the critical or unresolved issues.
 ### 4. Present Failure Report
 
 - Present `{failure_report}` and the manual intervention it requires to the user.
-
-## Outputs
-
-### failure_report
-
-Failure report carrying the critical issues, correction history, and manual-resolution guidance.
-
-#### artifact
-
-`failure-report.md`
 
 ## Rules
 

--- a/requirements-refinement/techniques/update-specification.md
+++ b/requirements-refinement/techniques/update-specification.md
@@ -21,6 +21,16 @@ Structured analysis of the requirement changes to apply on the initial pass.
 
 `true` when the target specification already exists and its section structure is preserved; `false` when the full specification structure is instantiated from scratch.
 
+## Outputs
+
+### working_specification
+
+The complete updated specification document for this pass.
+
+#### artifact
+
+`working-spec-{correction_iteration}.md`
+
 ## Protocol
 
 ### 1. Register Correction Pass
@@ -44,13 +54,3 @@ Structured analysis of the requirement changes to apply on the initial pass.
 ### 5. Write Working Specification
 
 - Write the complete `{working_specification}` to `{planning_folder_path}`.
-
-## Outputs
-
-### working_specification
-
-The complete updated specification document for this pass.
-
-#### artifact
-
-`working-spec-{correction_iteration}.md`

--- a/requirements-refinement/techniques/validate-specification.md
+++ b/requirements-refinement/techniques/validate-specification.md
@@ -17,31 +17,6 @@ The updated specification document to validate.
 
 The structured analysis whose source-coverage matrix is the completeness reference for validation.
 
-## Protocol
-
-### 1. Run Conformance Checks
-
-- Validate `{working_specification}` against the checks in [validation-rubric](../resources/validation-rubric.md): section structure, requirement-identifier uniqueness, source-reference accuracy, markdown syntax, and cross-section consistency.
-
-### 2. Check Source Coverage
-
-- Using `{requirements_analysis.source_coverage_matrix}`, confirm every normative source statement maps to a requirement present in `{working_specification}`, and record any uncovered statement per [validation-rubric](../resources/validation-rubric.md#source-coverage).
-
-### 3. Categorize Issues
-
-- Assign each issue a severity and type per [validation-rubric](../resources/validation-rubric.md#issue-categorization), treating critical or irreconcilable issues as blocking and the remainder — including coverage gaps — as correctable.
-
-### 4. Compile Verdict
-
-- Write `{validation_report}` to `{planning_folder_path}`, recording the overall verdict (passed, correctable, or critical), the categorized issues, the source-coverage result, and the correction-pass number.
-
-### 5. Derive Routing Verdict
-
-- Set `{source_coverage_complete}` to `true` when every normative source statement maps to at least one requirement.
-- Set `{has_critical_issues}` to `true` when any issue is critical or irreconcilable.
-- Set `{has_correctable_issues}` to `true` when correctable issues remain — including source-coverage gaps — and no critical issue is present.
-- Set `{validation_passed}` to `true` when no critical or correctable issues remain and `{source_coverage_complete}` is `true`.
-
 ## Outputs
 
 ### validation_report
@@ -67,6 +42,31 @@ Categorized validation findings with an overall verdict and the source-coverage 
 ### validation_passed
 
 `true` when no critical or correctable issues remain and `{source_coverage_complete}` is `true`.
+
+## Protocol
+
+### 1. Run Conformance Checks
+
+- Validate `{working_specification}` against the checks in [validation-rubric](../resources/validation-rubric.md): section structure, requirement-identifier uniqueness, source-reference accuracy, markdown syntax, and cross-section consistency.
+
+### 2. Check Source Coverage
+
+- Using `{requirements_analysis.source_coverage_matrix}`, confirm every normative source statement maps to a requirement present in `{working_specification}`, and record any uncovered statement per [validation-rubric](../resources/validation-rubric.md#source-coverage).
+
+### 3. Categorize Issues
+
+- Assign each issue a severity and type per [validation-rubric](../resources/validation-rubric.md#issue-categorization), treating critical or irreconcilable issues as blocking and the remainder — including coverage gaps — as correctable.
+
+### 4. Compile Verdict
+
+- Write `{validation_report}` to `{planning_folder_path}`, recording the overall verdict (passed, correctable, or critical), the categorized issues, the source-coverage result, and the correction-pass number.
+
+### 5. Derive Routing Verdict
+
+- Set `{source_coverage_complete}` to `true` when every normative source statement maps to at least one requirement.
+- Set `{has_critical_issues}` to `true` when any issue is critical or irreconcilable.
+- Set `{has_correctable_issues}` to `true` when correctable issues remain — including source-coverage gaps — and no critical issue is present.
+- Set `{validation_passed}` to `true` when no critical or correctable issues remain and `{source_coverage_complete}` is `true`.
 
 ## Rules
 

--- a/substrate-node-security-audit/techniques/apply-checklist.md
+++ b/substrate-node-security-audit/techniques/apply-checklist.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.3.0
-  order: 7
-  legacy_id: 7
 ---
 
 ## Capability
@@ -24,6 +20,24 @@ The enumerated items to evaluate against the checklist (e.g., function list, cra
 ### scope_files
 
 Source files to read for evidence gathering
+
+## Outputs
+
+### verdict_matrix
+
+Complete verdict matrix and coverage attestation.
+
+#### matrix_rows
+
+one row per item, one column per checklist entry, each cell is PASS/FAIL/NA with evidence
+
+#### required_analysis_tables
+
+any structured tables mandated by specific checklist entries
+
+#### coverage_attestation
+
+total items, total reviewed, coverage percentage, gaps list
 
 ## Protocol
 
@@ -62,21 +76,3 @@ Source files to read for evidence gathering
 ### 5. Produce Verdict Matrix
 
 - Output the `{verdict_matrix}`: the complete item x checklist matrix with its coverage attestation.
-
-## Outputs
-
-### verdict_matrix
-
-Complete verdict matrix and coverage attestation.
-
-#### matrix_rows
-
-one row per item, one column per checklist entry, each cell is PASS/FAIL/NA with evidence
-
-#### required_analysis_tables
-
-any structured tables mandated by specific checklist entries
-
-#### coverage_attestation
-
-total items, total reviewed, coverage percentage, gaps list

--- a/substrate-node-security-audit/techniques/build-function-registry.md
+++ b/substrate-node-security-audit/techniques/build-function-registry.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 9
-  legacy_id: 9
 ---
 
 ## Capability
@@ -25,22 +21,6 @@ List of `.rs` files to enumerate (a crate, a set of crates, or a full scope)
 
 true
 
-## Protocol
-
-### 1. Read And Enumerate
-
-- For every file in `{source_files}`, enumerate: (1) pallet hooks (`on_initialize`, `on_finalize`, `on_idle`, `offchain_worker`), (2) `ProvideInherent` methods (`create_inherent`, `check_inherent`, `is_inherent_required`), (3) dispatchable extrinsics (`#[pallet::call]`), (4) public functions and trait implementations, (5) storage declarations (`StorageMap`, `StorageValue`, `StorageDoubleMap`), (6) event types (`Event` enum variants). When `{include_subdirectories}` is set, also descend into submodules (`versions/`, `common/`, `api/`, `internal/`, `impl/`) and enumerate the files found there.
-
-> When `{gitnexus_available}`, seed the enumeration from the symbol graph via [gitnexus-operations](../../meta/techniques/gitnexus-operations/TECHNIQUE.md)::[cypher](../../meta/techniques/gitnexus-operations/cypher.md) (query the `Function` nodes for `{source_files}`, by type and visibility) rather than deriving the function set by manual read — the graph is the authoritative, exact registry of what exists. Reading the bodies of priority-1/2 functions for the downstream review is unchanged; this step establishes the complete inventory, not the comprehension.
-
-### 2. Assign Priority
-
-- Classify each function by priority based on reachability: priority-1 (consensus-critical hooks, inherents, block production), priority-2 (service startup, RPC, CLI), priority-3 (off-chain tooling, utilities).
-
-### 3. Produce Registry
-
-- Assemble the `{function_registry}` as a structured table with one row per function. Format: | Function | File:Line | Type (hook/extrinsic/public/storage/event) | Priority |
-
 ## Outputs
 
 ### function_registry
@@ -58,6 +38,22 @@ one row per function with file location, type classification, and priority
 #### file_manifest
 
 every file read with line count and read status
+
+## Protocol
+
+### 1. Read And Enumerate
+
+- For every file in `{source_files}`, enumerate: (1) pallet hooks (`on_initialize`, `on_finalize`, `on_idle`, `offchain_worker`), (2) `ProvideInherent` methods (`create_inherent`, `check_inherent`, `is_inherent_required`), (3) dispatchable extrinsics (`#[pallet::call]`), (4) public functions and trait implementations, (5) storage declarations (`StorageMap`, `StorageValue`, `StorageDoubleMap`), (6) event types (`Event` enum variants). When `{include_subdirectories}` is set, also descend into submodules (`versions/`, `common/`, `api/`, `internal/`, `impl/`) and enumerate the files found there.
+
+> When `{gitnexus_available}`, seed the enumeration from the symbol graph via [gitnexus-operations](../../meta/techniques/gitnexus-operations/TECHNIQUE.md)::[cypher](../../meta/techniques/gitnexus-operations/cypher.md) (query the `Function` nodes for `{source_files}`, by type and visibility) rather than deriving the function set by manual read — the graph is the authoritative, exact registry of what exists. Reading the bodies of priority-1/2 functions for the downstream review is unchanged; this step establishes the complete inventory, not the comprehension.
+
+### 2. Assign Priority
+
+- Classify each function by priority based on reachability: priority-1 (consensus-critical hooks, inherents, block production), priority-2 (service startup, RPC, CLI), priority-3 (off-chain tooling, utilities).
+
+### 3. Produce Registry
+
+- Assemble the `{function_registry}` as a structured table with one row per function. Format: | Function | File:Line | Type (hook/extrinsic/public/storage/event) | Priority |
 
 ## Rules
 

--- a/substrate-node-security-audit/techniques/decompose-safety-claims.md
+++ b/substrate-node-security-audit/techniques/decompose-safety-claims.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.2.0
-  order: 11
-  legacy_id: 11
 ---
 
 ## Capability
@@ -24,6 +20,20 @@ Code files to read for independent verification
 ### verification_report
 
 *(optional)* Gap report listing §3 categories with incomplete coverage, missing tables, or unmet target profile obligations. PASS items in flagged categories are auto-included in the adversarial queue.
+
+## Outputs
+
+### decomposition_results
+
+Decomposition table with per-instance verification results.
+
+#### decomposition_table
+
+| PASS Item | Property | Instance | Verified? | Evidence |
+
+#### verdict_summary
+
+CONFIRMED count, REFUTED count (each becomes a finding), INSUFFICIENT count
 
 ## Protocol
 
@@ -49,20 +59,6 @@ Code files to read for independent verification
 - For each decomposed property, read the cited code location in the `{source_files}` and search for the specific implementation. Output CONFIRMED (all instances verified with citations), REFUTED (any instance lacks implementation — becomes a new finding), or INSUFFICIENT (cannot determine).  
   > A PASS that says 'cursor is set correctly' must verify: is there an `ensure!(new > old)` guard? If not, the PASS is invalid regardless of whether the code 'works'.
 - CONFIRMED only when ALL decomposed properties are verified with code citations. Record each verdict in the `{decomposition_results}` table, completing the per-instance Verified? and Evidence columns.
-
-## Outputs
-
-### decomposition_results
-
-Decomposition table with per-instance verification results.
-
-#### decomposition_table
-
-| PASS Item | Property | Instance | Verified? | Evidence |
-
-#### verdict_summary
-
-CONFIRMED count, REFUTED count (each becomes a finding), INSUFFICIENT count
 
 ## Rules
 

--- a/substrate-node-security-audit/techniques/dispatch-sub-agents/TECHNIQUE.md
+++ b/substrate-node-security-audit/techniques/dispatch-sub-agents/TECHNIQUE.md
@@ -1,13 +1,7 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 2.0.0
-  order: 4
-  legacy_id: 4
 ---
-
-# Dispatch Sub-Agents
 
 ## Capability
 

--- a/substrate-node-security-audit/techniques/execute-sub-agent.md
+++ b/substrate-node-security-audit/techniques/execute-sub-agent.md
@@ -1,41 +1,11 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 2
-  legacy_id: 2
 ---
 
 ## Capability
 
 Bootstrap the workflow-server, load an assigned activity, follow its steps sequentially, and return structured output
-
-## Protocol
-
-### 1. Bootstrap
-
-- Call `start_session(session_token, agent_id)` to inherit the dispatched session and obtain a session token. The workflow is derived from the token.  
-  > If these MCP tool calls fail because the workflow-server is unavailable, fall back to the prompt instructions provided by the orchestrator and note in the output that workflow-server was not available.
-- Call `next_activity({ activity_id: '<assigned-activity-id>' })` to load the activity definition with its steps.  
-  > If `next_activity` returns an error and the activity cannot be loaded, fall back to the prompt instructions provided by the orchestrator and note in the output that the activity was not loaded.
-
-### 2. Execute Steps
-
-- Read the activity's steps array in order.
-- For each step, load its bound technique via `get_technique` and read that technique's `## Capability` (what the step does) and `## Protocol` (how to do it).
-- Produce the output the bound technique defines in its `## Output(s)` before proceeding to the next step.
-- If a step cannot be completed (e.g., no `StorageMap`s in the crate for the lifecycle scan), record an explicit N/A with justification — do not silently skip.
-- If a step requires data or context that is unavailable, record the step as completed with output 'INCOMPLETE — [reason]', continue to the next step, and flag it in the self-verification.
-- Track which steps have been completed in `{sub_agent_output.steps_completed}`.
-
-### 3. Verify Output
-
-- Assemble `{sub_agent_output}` and verify it against the checks below before returning it.
-- `{sub_agent_output.steps_completed}` matches the activity's step IDs — no steps omitted.
-- Every FAIL in `{sub_agent_output.checklist_coverage}` has a corresponding finding in `{sub_agent_output.findings}`.
-- Every `{sub_agent_output.mandatory_tables}` entry is either populated or null with justification.
-- `{sub_agent_output}` is well-formed JSON and contains all required fields.
 
 ## Outputs
 
@@ -74,6 +44,32 @@ all tables the steps produce, or null with justification
 #### reconnaissance_leads
 
 observations not formal findings but for orchestrator review (optional)
+
+## Protocol
+
+### 1. Bootstrap
+
+- Call `start_session(session_token, agent_id)` to inherit the dispatched session and obtain a session token. The workflow is derived from the token.  
+  > If these MCP tool calls fail because the workflow-server is unavailable, fall back to the prompt instructions provided by the orchestrator and note in the output that workflow-server was not available.
+- Call `next_activity({ activity_id: '<assigned-activity-id>' })` to load the activity definition with its steps.  
+  > If `next_activity` returns an error and the activity cannot be loaded, fall back to the prompt instructions provided by the orchestrator and note in the output that the activity was not loaded.
+
+### 2. Execute Steps
+
+- Read the activity's steps array in order.
+- For each step, load its bound technique via `get_technique` and read that technique's `## Capability` (what the step does) and `## Protocol` (how to do it).
+- Produce the output the bound technique defines in its `## Output(s)` before proceeding to the next step.
+- If a step cannot be completed (e.g., no `StorageMap`s in the crate for the lifecycle scan), record an explicit N/A with justification — do not silently skip.
+- If a step requires data or context that is unavailable, record the step as completed with output 'INCOMPLETE — [reason]', continue to the next step, and flag it in the self-verification.
+- Track which steps have been completed in `{sub_agent_output.steps_completed}`.
+
+### 3. Verify Output
+
+- Assemble `{sub_agent_output}` and verify it against the checks below before returning it.
+- `{sub_agent_output.steps_completed}` matches the activity's step IDs — no steps omitted.
+- Every FAIL in `{sub_agent_output.checklist_coverage}` has a corresponding finding in `{sub_agent_output.findings}`.
+- Every `{sub_agent_output.mandatory_tables}` entry is either populated or null with justification.
+- `{sub_agent_output}` is well-formed JSON and contains all required fields.
 
 ## Rules
 

--- a/substrate-node-security-audit/techniques/extract-invariants.md
+++ b/substrate-node-security-audit/techniques/extract-invariants.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 12
-  legacy_id: 12
 ---
 
 ## Capability
@@ -21,16 +17,6 @@ Registry of priority functions to analyze, classified by type and priority
 
 Source files containing the functions
 
-## Protocol
-
-### 1. Extract Per Function
-
-- For each priority-1 function in the `{function_registry}`, read its definition in the `{source_files}` and enumerate: (a) Preconditions — what must be true about inputs; (b) Postconditions — what must be true after execution; (c) Cross-function invariants — what must hold between this function and its inverse; (d) Data source invariants — what must be true about external data consumed.
-
-### 2. Produce Table
-
-- Collect the enumerated invariants into the `{invariant_table}`, a structured table: | Function | Invariant | Category (pre/post/cross/data) | Expected Enforcement | Found? | Evidence |
-
 ## Outputs
 
 ### invariant_table
@@ -40,3 +26,13 @@ Structured invariant table.
 #### invariant_rows
 
 one row per function-invariant pair with category, expected enforcement, and evidence
+
+## Protocol
+
+### 1. Extract Per Function
+
+- For each priority-1 function in the `{function_registry}`, read its definition in the `{source_files}` and enumerate: (a) Preconditions — what must be true about inputs; (b) Postconditions — what must be true after execution; (c) Cross-function invariants — what must hold between this function and its inverse; (d) Data source invariants — what must be true about external data consumed.
+
+### 2. Produce Table
+
+- Collect the enumerated invariants into the `{invariant_table}`, a structured table: | Function | Invariant | Category (pre/post/cross/data) | Expected Enforcement | Found? | Evidence |

--- a/substrate-node-security-audit/techniques/map-codebase.md
+++ b/substrate-node-security-audit/techniques/map-codebase.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 13
-  legacy_id: 13
 ---
 
 ## Capability
@@ -24,6 +20,32 @@ Paths to include in the analysis
 ### out_of_scope
 
 *(optional)* Paths to exclude
+
+## Outputs
+
+### codebase_map
+
+Structured codebase map.
+
+#### artifact
+
+`r-crate-map.json` (component inventory and crate classification) / `r-reconnaissance-data.json` (trust boundaries, critical paths, hooks, data flows, safety overrides)
+
+#### component_inventory
+
+every crate/module with classification and priority
+
+#### trust_boundary_map
+
+every entry point with boundary type
+
+#### critical_path_map
+
+consensus-relevant code paths
+
+#### data_flow_traces
+
+forward and backward traces for priority-1 paths
 
 ## Protocol
 
@@ -62,32 +84,6 @@ Paths to include in the analysis
 ### 7. Identify Safety Overrides
 
 - Search for patterns that override language or framework safety analysis (e.g., `unsafe impl Send/Sync` in Rust, `#[allow]` attributes on safety lints). Each occurrence requires manual verification of the overridden invariant.
-
-## Outputs
-
-### codebase_map
-
-Structured codebase map.
-
-#### artifact
-
-`r-crate-map.json` (component inventory and crate classification) / `r-reconnaissance-data.json` (trust boundaries, critical paths, hooks, data flows, safety overrides)
-
-#### component_inventory
-
-every crate/module with classification and priority
-
-#### trust_boundary_map
-
-every entry point with boundary type
-
-#### critical_path_map
-
-consensus-relevant code paths
-
-#### data_flow_traces
-
-forward and backward traces for priority-1 paths
 
 ## Rules
 

--- a/substrate-node-security-audit/techniques/map-vulnerability-domains.md
+++ b/substrate-node-security-audit/techniques/map-vulnerability-domains.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 2.0.0
-  order: 17
-  legacy_id: 17
 ---
 
 > The `§X.Y` identifiers used throughout this technique (e.g. `§3.2`, `§3.4`) refer to the audit checklist taxonomy indexed in [audit-template-reference](../resources/audit-template-reference.md).
@@ -27,24 +23,6 @@ Classification of crates by category and priority
 
 *(optional)* [target-profile](../resources/target-profile.md) — target-specific domain hints to supplement architectural analysis
 
-## Protocol
-
-### 1. Bind Interactions To Checklist
-
-- For each component interaction in `{architectural_analysis.interaction_model}`, match the required security property to the §3 item that verifies it. Mapping rules: data consistency across boundaries → §3.2; partial-success event paths → §3.3; asymmetric provider sets → §3.4; genesis state sources → §3.5; unvalidated external input → §3.6; shared resources with mixed consumers → §3.8; cross-chain timestamp propagation → §3.10; typed enum dispatch → §3.14. Interactions with no matching §3 item are flagged as emergent domains.
-
-### 2. Bind Privilege To Checklist
-
-- For each privilege entry in `{architectural_analysis.privilege_map}`, match to: weight/metering → §3.1; access control → §3.13; upgrade safety → §3.12; genesis consistency → §3.5. Entries where authority verification is absent or inconsistent become priority review targets.
-
-### 3. Incorporate Emergent Domains
-
-- For each entry in `{architectural_analysis.emergent_domains}` (or for interactions with no §3 match), create an ad-hoc review entry with: domain description, affected components, suggested verification approach. These are distributed to the relevant Group A agents as additional review items beyond §3.
-
-### 4. Partition By Crate
-
-- Group all entries by crate, using the `{crate_map}` classification to assign each entry to its owning crate. Each crate's partition includes: §3 entries with specific locations and verification targets, the `{architectural_analysis.candidate_points}` ranked by security relevance, and any ad-hoc emergent domain review items. Merge in the optional `{target_profile}` domain hints where available. The result is the `{domain_map}`, partitioned by crate and ready for sub-agent distribution.
-
 ## Outputs
 
 ### domain_map
@@ -62,3 +40,21 @@ location, complexity-reason, trust-boundary-proximity
 #### per_crate_emergent_domains
 
 domain-description, affected-components, suggested-verification
+
+## Protocol
+
+### 1. Bind Interactions To Checklist
+
+- For each component interaction in `{architectural_analysis.interaction_model}`, match the required security property to the §3 item that verifies it. Mapping rules: data consistency across boundaries → §3.2; partial-success event paths → §3.3; asymmetric provider sets → §3.4; genesis state sources → §3.5; unvalidated external input → §3.6; shared resources with mixed consumers → §3.8; cross-chain timestamp propagation → §3.10; typed enum dispatch → §3.14. Interactions with no matching §3 item are flagged as emergent domains.
+
+### 2. Bind Privilege To Checklist
+
+- For each privilege entry in `{architectural_analysis.privilege_map}`, match to: weight/metering → §3.1; access control → §3.13; upgrade safety → §3.12; genesis consistency → §3.5. Entries where authority verification is absent or inconsistent become priority review targets.
+
+### 3. Incorporate Emergent Domains
+
+- For each entry in `{architectural_analysis.emergent_domains}` (or for interactions with no §3 match), create an ad-hoc review entry with: domain description, affected components, suggested verification approach. These are distributed to the relevant Group A agents as additional review items beyond §3.
+
+### 4. Partition By Crate
+
+- Group all entries by crate, using the `{crate_map}` classification to assign each entry to its owning crate. Each crate's partition includes: §3 entries with specific locations and verification targets, the `{architectural_analysis.candidate_points}` ranked by security relevance, and any ad-hoc emergent domain review items. Merge in the optional `{target_profile}` domain hints where available. The result is the `{domain_map}`, partitioned by crate and ready for sub-agent distribution.

--- a/substrate-node-security-audit/techniques/merge-findings.md
+++ b/substrate-node-security-audit/techniques/merge-findings.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 6
-  legacy_id: 6
 ---
 
 ## Capability
@@ -28,37 +24,6 @@ One of: structured-merge (concat + dedup), integrate (add to existing), union-me
 ### observation_sources
 
 *(optional)* Architectural and reconnaissance artifacts carrying emergent vulnerability domains and reconnaissance leads to be dispositioned during elevation.
-
-## Protocol
-
-### 1. Concatenate
-
-- Combine every list in `{finding_sources}` into a single flat table. Every agent finding becomes a row with fields: agent-id, finding-id, file, line, title, severity, checklist-item, evidence. No agent output is discarded.
-
-### 2. Deduplicate
-
-- For each row, identify whether another row describes the same root cause. Rows with the same root cause receive the same report finding number with a note: 'merged: same root cause as Finding X — [justification]'. Every row must have a mapping — unmapped rows are automatically promoted to new findings.
-
-### 3. Elevate Observations
-
-- Review every reconnaissance lead and additional observation across `{finding_sources}`, plus every emergent vulnerability domain and reconnaissance lead in `{observation_sources}`. Each must be dispositioned as captured by an existing finding, elevated to a new finding, or not-applicable with justification, recording the `{observation_dispositions}` table. Observations describing divergent code paths, missing validation, error-path state persistence, silent error consumption, or trust boundary amplification are always security-relevant and are elevated.
-
-### 4. Apply Strategy
-
-- Branch on `{merge_strategy}`. For structured-merge: assign sequential report finding numbers. For integrate: append the new rows to the `{existing_table}` and update its elevation mapping. For union-merge: classify each finding as consensus (present in both runs), single-source (one run only), or escalated (PASS in primary, FAIL in secondary).
-
-### 5. Score With Calibration
-
-- Score every finding using the [severity rubric](../resources/severity-rubric.md). For every finding (not just High/Critical), search the [calibration benchmarks](../resources/target-profile.md#severity-calibration-benchmark) for a matching pattern; flag a divergence of one level and treat a divergence of two or more levels as a floor at the benchmark severity. Record the `{calibration_crosscheck}` table.
-
-### 6. Reconcile
-
-- For each agent compute Findings Submitted, In Merge Table, Explicitly Deduplicated, Elevated from Observations, and Unaccounted, recording the `{reconciliation_table}`. Unaccounted must equal zero for every agent.
-
-### 7. Verify Completeness
-
-- Confirm every row has a report finding number. Count merged rows (with justification), promoted rows, and total findings. Emit the completed `{merge_table}` with its flat table, elevation summary, and any union-merge classification.
-- If a row still lacks a report finding number, auto-promote it to a new finding and note the promotion in the elevation summary.
 
 ## Outputs
 
@@ -93,6 +58,37 @@ Per-finding calibration comparison: our score, benchmark match, benchmark score,
 ### observation_dispositions
 
 Per-observation table: source, agent, observation, disposition, finding reference.
+
+## Protocol
+
+### 1. Concatenate
+
+- Combine every list in `{finding_sources}` into a single flat table. Every agent finding becomes a row with fields: agent-id, finding-id, file, line, title, severity, checklist-item, evidence. No agent output is discarded.
+
+### 2. Deduplicate
+
+- For each row, identify whether another row describes the same root cause. Rows with the same root cause receive the same report finding number with a note: 'merged: same root cause as Finding X — [justification]'. Every row must have a mapping — unmapped rows are automatically promoted to new findings.
+
+### 3. Elevate Observations
+
+- Review every reconnaissance lead and additional observation across `{finding_sources}`, plus every emergent vulnerability domain and reconnaissance lead in `{observation_sources}`. Each must be dispositioned as captured by an existing finding, elevated to a new finding, or not-applicable with justification, recording the `{observation_dispositions}` table. Observations describing divergent code paths, missing validation, error-path state persistence, silent error consumption, or trust boundary amplification are always security-relevant and are elevated.
+
+### 4. Apply Strategy
+
+- Branch on `{merge_strategy}`. For structured-merge: assign sequential report finding numbers. For integrate: append the new rows to the `{existing_table}` and update its elevation mapping. For union-merge: classify each finding as consensus (present in both runs), single-source (one run only), or escalated (PASS in primary, FAIL in secondary).
+
+### 5. Score With Calibration
+
+- Score every finding using the [severity rubric](../resources/severity-rubric.md). For every finding (not just High/Critical), search the [calibration benchmarks](../resources/target-profile.md#severity-calibration-benchmark) for a matching pattern; flag a divergence of one level and treat a divergence of two or more levels as a floor at the benchmark severity. Record the `{calibration_crosscheck}` table.
+
+### 6. Reconcile
+
+- For each agent compute Findings Submitted, In Merge Table, Explicitly Deduplicated, Elevated from Observations, and Unaccounted, recording the `{reconciliation_table}`. Unaccounted must equal zero for every agent.
+
+### 7. Verify Completeness
+
+- Confirm every row has a report finding number. Count merged rows (with justification), promoted rows, and total findings. Emit the completed `{merge_table}` with its flat table, elevation summary, and any union-merge classification.
+- If a row still lacks a report finding number, auto-promote it to a new finding and note the promotion in the elevation summary.
 
 ## Rules
 

--- a/substrate-node-security-audit/techniques/scan-storage-lifecycle.md
+++ b/substrate-node-security-audit/techniques/scan-storage-lifecycle.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 10
-  legacy_id: 10
 ---
 
 ## Capability
@@ -29,6 +25,20 @@ false
 
 *(optional)* The table shape the pairing results are rendered in.
 
+## Outputs
+
+### storage_lifecycle
+
+Storage lifecycle pairing table with optional invariant comparison.
+
+#### pairing_table
+
+| `StorageMap` | Crate | `insert()` Sites | `remove()` Sites | Paired? | Cap Enforced? |
+
+#### invariant_table
+
+| `StorageMap` | `insert()` Callers | `remove()` Callers | Paired? | Cross-function Consistent? | (optional)
+
 ## Protocol
 
 ### 1. Find Storage Declarations
@@ -50,17 +60,3 @@ false
 - If `{verify_invariants}` is true: for pairs of functions that operate on the same storage (e.g., `handle_create` and `handle_redemption_create`), verify they maintain the same invariants — if one inserts, the other should too under the same conditions.
 
 > When `{gitnexus_available}`, enumerate the function set operating on a given map from the graph via [gitnexus-operations](../../meta/techniques/gitnexus-operations/TECHNIQUE.md)::[cypher](../../meta/techniques/gitnexus-operations/cypher.md) so no operating function is missed from the cross-function comparison; the invariant judgement itself is made by reading the paired bodies.
-
-## Outputs
-
-### storage_lifecycle
-
-Storage lifecycle pairing table with optional invariant comparison.
-
-#### pairing_table
-
-| `StorageMap` | Crate | `insert()` Sites | `remove()` Sites | Paired? | Cap Enforced? |
-
-#### invariant_table
-
-| `StorageMap` | `insert()` Callers | `remove()` Callers | Paired? | Cross-function Consistent? | (optional)

--- a/substrate-node-security-audit/techniques/score-severity.md
+++ b/substrate-node-security-audit/techniques/score-severity.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.2.0
-  order: 1
-  legacy_id: 1
 ---
 
 ## Capability

--- a/substrate-node-security-audit/techniques/search-pattern-catalog.md
+++ b/substrate-node-security-audit/techniques/search-pattern-catalog.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 3
-  legacy_id: 3
 ---
 
 ## Capability
@@ -32,6 +28,20 @@ Codebase paths to search against
 ### output_format
 
 *(optional)* The table shape the results are rendered in.
+
+## Outputs
+
+### pattern_results
+
+A structured results table and zero-hit verdicts.
+
+#### results_table
+
+one row per hit, with fields determined by `{output_format}` (typically: category/check ID, pattern, file:line, hit content, triage/verdict)
+
+#### zero_hit_verdicts
+
+one row per zero-hit pattern, with fields: pattern, category, hits (0), verdict (True Negative / Flag for Follow-up), justification
 
 ## Protocol
 
@@ -62,20 +72,6 @@ Codebase paths to search against
 ### 6. Format Results
 
 - Assemble the `{pattern_results}`: a structured results table with one row per pattern hit (or per pattern for zero-hit entries), rendered in `{output_format}`. Include zero-hit verdicts as a separate section or integrated into the main table.
-
-## Outputs
-
-### pattern_results
-
-A structured results table and zero-hit verdicts.
-
-#### results_table
-
-one row per hit, with fields determined by `{output_format}` (typically: category/check ID, pattern, file:line, hit content, triage/verdict)
-
-#### zero_hit_verdicts
-
-one row per zero-hit pattern, with fields: pattern, category, hits (0), verdict (True Negative / Flag for Follow-up), justification
 
 ## Rules
 

--- a/substrate-node-security-audit/techniques/setup-audit-target.md
+++ b/substrate-node-security-audit/techniques/setup-audit-target.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 14
-  legacy_id: 14
 ---
 
 ## Capability
@@ -28,6 +24,36 @@ Path to the audit prompt template whose accessibility is confirmed during setup.
 ### target_submodule
 
 The target component name used to build the planning-folder name.
+
+## Outputs
+
+### audit_target
+
+Initialized target ready for analysis.
+
+#### confirmed_target
+
+Confirmed target component and revision
+
+#### dependency_scan_results
+
+Dependency scan results or fallback manifest
+
+#### file_inventory
+
+File inventory sorted by size
+
+#### reference_documents
+
+Reference document paths (if any, quarantined for later phases)
+
+### start_here
+
+Session overview with audit target, commit, methodology, and artifact index.
+
+#### artifact
+
+`START-HERE.md`
 
 ## Protocol
 
@@ -63,34 +89,3 @@ The target component name used to build the planning-folder name.
 ### 8. Load Template
 
 - Confirm the audit prompt template is accessible at `{audit_prompt_template}`. If it is not at its expected path, fail with an error showing the expected path.
-
-## Outputs
-
-### audit_target
-
-Initialized target ready for analysis.
-
-#### confirmed_target
-
-Confirmed target component and revision
-
-#### dependency_scan_results
-
-Dependency scan results or fallback manifest
-
-#### file_inventory
-
-File inventory sorted by size
-
-#### reference_documents
-
-Reference document paths (if any, quarantined for later phases)
-
-### start_here
-
-Session overview with audit target, commit, methodology, and artifact index.
-
-#### artifact
-
-`START-HERE.md`
-

--- a/substrate-node-security-audit/techniques/verify-sub-agent-output.md
+++ b/substrate-node-security-audit/techniques/verify-sub-agent-output.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.4.0
-  order: 5
-  legacy_id: 5
 ---
 
 ## Capability
@@ -32,6 +28,28 @@ Per-agent list of required tables, coverage criteria, and completeness checks
 ### agent_assignments
 
 *(optional)* Crate-to-agent-group assignments
+
+## Outputs
+
+### verification_report
+
+Verification report with gap list and re-dispatch recommendations.
+
+#### dispatch_manifest
+
+crate, assigned-group, dispatched, returned, status
+
+#### coverage_table
+
+file, lines, agent, agent-type (group-a/recon/none), COVERED/RECON-ONLY/UNREAD
+
+#### missing_tables
+
+agent-id, table-id, reason
+
+#### redispatch_recommendations
+
+agent-id, scope, specific check to perform
 
 ## Protocol
 
@@ -80,28 +98,6 @@ Per-agent list of required tables, coverage criteria, and completeness checks
 ### 11. Produce Verification Report
 
 - Emit the `{verification_report}` as a structured report listing: dispatch completeness status, all coverage gaps (files not read by §3-agents), all missing tables (agent + table ID), all structural issues, cross-chain timestamp check status, the table-derived findings, event construction site coverage status. For each gap, recommend a targeted follow-up dispatch.
-
-## Outputs
-
-### verification_report
-
-Verification report with gap list and re-dispatch recommendations.
-
-#### dispatch_manifest
-
-crate, assigned-group, dispatched, returned, status
-
-#### coverage_table
-
-file, lines, agent, agent-type (group-a/recon/none), COVERED/RECON-ONLY/UNREAD
-
-#### missing_tables
-
-agent-id, table-id, reason
-
-#### redispatch_recommendations
-
-agent-id, scope, specific check to perform
 
 ## Rules
 

--- a/substrate-node-security-audit/techniques/write-gap-analysis.md
+++ b/substrate-node-security-audit/techniques/write-gap-analysis.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 16
-  legacy_id: 16
 ---
 
 ## Capability
@@ -16,13 +12,6 @@ Produce the gap analysis report comparing AI audit findings against a profession
 ### reference_report
 
 Path to the reference report artifact.
-
-## Protocol
-
-1. Load reference report from input `{reference_report}` (first and only time).
-2. Extract reference finding list with severities and affected files.
-3. Map each reference finding to the closest AI finding, classify each as matched/partial/gap, and severity-calibrate the matched findings.
-4. Write the `{gap_analysis}` report, assembling the `{gap_analysis.summary_metrics}`, `{gap_analysis.finding_mapping}`, `{gap_analysis.gaps}`, `{gap_analysis.severity_calibration}`, `{gap_analysis.ai_only_findings}`, and `{gap_analysis.recommendations}` sections into the artifact.
 
 ## Outputs
 
@@ -57,6 +46,13 @@ Findings in the AI report not present in the reference. Assess whether novel or 
 #### recommendations
 
 Workflow improvement suggestions derived from gap root causes
+
+## Protocol
+
+1. Load reference report from input `{reference_report}` (first and only time).
+2. Extract reference finding list with severities and affected files.
+3. Map each reference finding to the closest AI finding, classify each as matched/partial/gap, and severity-calibrate the matched findings.
+4. Write the `{gap_analysis}` report, assembling the `{gap_analysis.summary_metrics}`, `{gap_analysis.finding_mapping}`, `{gap_analysis.gaps}`, `{gap_analysis.severity_calibration}`, `{gap_analysis.ai_only_findings}`, and `{gap_analysis.recommendations}` sections into the artifact.
 
 ## Rules
 

--- a/substrate-node-security-audit/techniques/write-report.md
+++ b/substrate-node-security-audit/techniques/write-report.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.3.0
-  order: 15
-  legacy_id: 15
 ---
 
 ## Capability
@@ -16,13 +12,6 @@ Produce the final audit report artifact from the scored and elevation-verified m
 ### merge_table
 
 The canonical finding flat table with elevation mapping, with every row severity-scored and assigned a report finding number.
-
-## Protocol
-
-1. Verify every row in `{merge_table}` has a severity score and a finding number.
-2. Organize findings by severity (Critical first, then High, Medium, Low).
-3. Assemble the `{audit_report}` sections — `{audit_report.header_table}`, `{audit_report.executive_summary}`, `{audit_report.methodology_notes}`, `{audit_report.crate_inventory}`, `{audit_report.findings}`, `{audit_report.severity_distribution}`, `{audit_report.coverage_gate}`, `{audit_report.elevation_summary}`, and `{audit_report.dependency_scan}` — into the `{audit_report}` artifact.
-4. Verify the finding count in `{audit_report.executive_summary}` matches `{audit_report.findings}`.
 
 ## Outputs
 
@@ -72,21 +61,23 @@ Count of table-derived findings auto-elevated, adversarial refutations integrate
 
 #### finding_block_format
 
-### Issue `{number}`: `{title}`
+```markdown
+### Issue {number}: {title}
 
-`{description}`
+{description}
 
-**Impact:** `{impact}` — `{justification}`
+**Impact:** {impact} — {justification}
 
-**Feasibility:** `{feasibility}` — `{justification}`
+**Feasibility:** {feasibility} — {justification}
 
-**Severity:** `{level}` (I=`{impact}`, F=`{feasibility}`, avg=`{average}`)
+**Severity:** {level} (I={impact}, F={feasibility}, avg={average})
 
-**Category:** `{category}`
+**Category:** {category}
 
-**Affected Files:** [`` `{file}`#L{start}-L{end} ``](`{source_blob_base}`/`{file}`#L`{start}`-L`{end}`)
+**Affected Files:** [{file}#L{start}-L{end}]({source_blob_base}/{file}#L{start}-L{end})
 
-**Suggested Remediation:** `{remediation}`
+**Suggested Remediation:** {remediation}
+```
 
 The explanatory paragraph (`{description}`) is FIRST — immediately after the header, before `**Impact:**`; derive `{$remediation}` as the concrete suggested fix for the finding. When a finding cites multiple files or extra line ranges, hyperlink each `` `{file}`#L… `` reference the same way, deriving `{$start}`/`{$end}` as the cited range's first and last line; trailing bare line numbers after the first range may stay plain text. A single line renders as `#L{n}` (no range).
 
@@ -97,6 +88,13 @@ Each field MUST be separated by a blank line (double newline) so that markdown r
 #### affected_files_hyperlink
 
 Every source reference in `**Affected Files:**` MUST be a markdown hyperlink to the exact file and line range in the target repository at the audited commit, so a reviewer is one click from the reviewed code. Construct `{$source_blob_base}` as `https://github.com/{$org}/{$repo}/blob/{target_commit}`, where `{org}/{repo}` is the target submodule's GitHub remote (from `git remote get-url origin` in `{target_path}`, normalised from SSH/HTTPS to `github.com/{org}/{repo}`) and `{target_commit}` is the audited revision recorded at scope-setup. Pin the links to `{target_commit}` — never to a mutable branch — so they always resolve to the reviewed source.
+
+## Protocol
+
+1. Verify every row in `{merge_table}` has a severity score and a finding number.
+2. Organize findings by severity (Critical first, then High, Medium, Low).
+3. Assemble the `{audit_report}` sections — `{audit_report.header_table}`, `{audit_report.executive_summary}`, `{audit_report.methodology_notes}`, `{audit_report.crate_inventory}`, `{audit_report.findings}`, `{audit_report.severity_distribution}`, `{audit_report.coverage_gate}`, `{audit_report.elevation_summary}`, and `{audit_report.dependency_scan}` — into the `{audit_report}` artifact.
+4. Verify the finding count in `{audit_report.executive_summary}` matches `{audit_report.findings}`.
 
 ## Rules
 

--- a/work-package/techniques/apply-review-fixes.md
+++ b/work-package/techniques/apply-review-fixes.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/work-package/techniques/codebase-comprehension/TECHNIQUE.md
+++ b/work-package/techniques/codebase-comprehension/TECHNIQUE.md
@@ -1,13 +1,7 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 22
-  legacy_id: 22
 ---
-
-# Build Comprehension
 
 ## Capability
 

--- a/work-package/techniques/conduct-retrospective/TECHNIQUE.md
+++ b/work-package/techniques/conduct-retrospective/TECHNIQUE.md
@@ -1,13 +1,7 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 2.1.0
-  order: 19
-  legacy_id: 19
 ---
-
-# Conduct Retrospective
 
 ## Capability
 

--- a/work-package/techniques/create-adr.md
+++ b/work-package/techniques/create-adr.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 21
-  legacy_id: 21
 ---
 
 ## Capability
@@ -29,6 +25,16 @@ Directory holding the project's ADR files
 
 `.engineering/artifacts/adr/`
 
+## Outputs
+
+### adr_document
+
+[Architecture Decision Record](../resources/architecture-review.md#adr-template)
+
+#### artifact
+
+`NNNN-{decision_title}.md`
+
 ## Protocol
 
 ### 1. Gate On Complexity
@@ -52,16 +58,6 @@ Directory holding the project's ADR files
 - Write the `{adr_document}` as `NNNN-{$decision_title}.md` in `{adr_dir}`, deriving `{$decision_title}` as a slugified short title of the decision
 - Use standard ADR format (Title, Status, Context, Decision, Consequences)
 - Set the `{adr_document}` status to Proposed; acceptance is recorded later in a separate finalization step
-
-## Outputs
-
-### adr_document
-
-[Architecture Decision Record](../resources/architecture-review.md#adr-template)
-
-#### artifact
-
-`NNNN-{decision_title}.md`
 
 ## Rules
 

--- a/work-package/techniques/create-issue.md
+++ b/work-package/techniques/create-issue.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 3.1.0
-  order: 3
-  legacy_id: 3
 ---
 
 ## Capability
@@ -28,6 +24,28 @@ Target submodule for the work package (e.g., midnight-node, midnight-ledger)
 ### jira_project
 
 *(optional)* Jira project chosen at the `jira-project-selection` gate — the project the new Jira issue is created in. Absent for GitHub issues.
+
+## Outputs
+
+### needs_issue_creation
+
+Boolean gate — `false` when step 1 verified an existing issue, otherwise `true` (a new issue must be created). Gates steps 2 and 3.
+
+### created_issue
+
+Issue created on the selected platform
+
+#### issue_number
+
+Issue number (GitHub #N or Jira KEY-N)
+
+#### issue_url
+
+URL to the created issue
+
+#### jira_cloud_id
+
+Atlassian cloud ID for subsequent Jira operations (Jira only)
 
 ## Protocol
 
@@ -57,28 +75,6 @@ Target submodule for the work package (e.g., midnight-node, midnight-ledger)
 - Create the issue with mapped type using the issue-type mapping below — the resulting issue is the `{created_issue}`. Capture `{issue_number}` and `{issue_url}`.
 - Jira issue type mapping: `feature->Story`, `bug->Bug`, `task->Task`, `enhancement->Story`, `epic->Epic`
 - If any Atlassian API call fails (auth, permissions, or invalid request — including the `getJiraIssue` verification in step 1), verify the cloudId and project access, and check the Jira issue type and required fields before retrying.
-
-## Outputs
-
-### needs_issue_creation
-
-Boolean gate — `false` when step 1 verified an existing issue, otherwise `true` (a new issue must be created). Gates steps 2 and 3.
-
-### created_issue
-
-Issue created on the selected platform
-
-#### issue_number
-
-Issue number (GitHub #N or Jira KEY-N)
-
-#### issue_url
-
-URL to the created issue
-
-#### jira_cloud_id
-
-Atlassian cloud ID for subsequent Jira operations (Jira only)
 
 ## Rules
 

--- a/work-package/techniques/create-test-plan.md
+++ b/work-package/techniques/create-test-plan.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 9
-  legacy_id: 9
 ---
 
 ## Capability
@@ -16,6 +12,16 @@ Create test strategy and test plan with cases and acceptance criteria
 ### plan_tasks
 
 Atomic task breakdown with dependencies and ordering for the work package
+
+## Outputs
+
+### test_plan_document
+
+Test [strategy](../resources/test-plan.md#test-plan-structure) and acceptance criteria
+
+#### artifact
+
+`test-plan.md`
 
 ## Protocol
 
@@ -41,16 +47,6 @@ Atomic task breakdown with dependencies and ordering for the work package
 
 - Create the `{test_plan_document}` artifact in `{planning_folder_path}`
 - Structure with strategy, test cases, and acceptance criteria matrix
-
-## Outputs
-
-### test_plan_document
-
-Test [strategy](../resources/test-plan.md#test-plan-structure) and acceptance criteria
-
-#### artifact
-
-`test-plan.md`
 
 ## Rules
 

--- a/work-package/techniques/dco-provenance/TECHNIQUE.md
+++ b/work-package/techniques/dco-provenance/TECHNIQUE.md
@@ -1,13 +1,7 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 2.0.0
-  order: 25
-  legacy_id: 25
 ---
-
-# Dco Provenance
 
 ## Capability
 

--- a/work-package/techniques/design-philosophy/TECHNIQUE.md
+++ b/work-package/techniques/design-philosophy/TECHNIQUE.md
@@ -1,13 +1,7 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 2.0.0
-  order: 4
-  legacy_id: 4
 ---
-
-# Classify Problem
 
 ## Capability
 

--- a/work-package/techniques/finalize-documentation/TECHNIQUE.md
+++ b/work-package/techniques/finalize-documentation/TECHNIQUE.md
@@ -1,13 +1,7 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.2.1
-  order: 17
-  legacy_id: 17
 ---
-
-# Finalize Documentation
 
 ## Capability
 

--- a/work-package/techniques/findings-classification.md
+++ b/work-package/techniques/findings-classification.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/work-package/techniques/implement-task.md
+++ b/work-package/techniques/implement-task.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 2.2.0
-  order: 10
-  legacy_id: 10
 ---
 
 ## Capability
@@ -24,6 +20,12 @@ A single atomic task to implement (description, affected files, dependencies)
 ### target_symbol
 
 The primary edit target — the function, class, or method this task changes — derived from `{current_task}` in Protocol §1 and read by the impact/context checks in §2.
+
+## Outputs
+
+### task_implementation
+
+Code changes for a single task
 
 ## Protocol
 
@@ -57,12 +59,6 @@ The primary edit target — the function, class, or method this task changes —
 
 - Apply [gitnexus-operations](../../meta/techniques/gitnexus-operations/TECHNIQUE.md)::[detect-changes](../../meta/techniques/gitnexus-operations/detect-changes.md) before commit to confirm the changes affect only the expected symbols and execution flows
 - Record the `{task_implementation}` for this task, capturing the files changed and a brief summary of the approach taken
-
-## Outputs
-
-### task_implementation
-
-Code changes for a single task
 
 ## Rules
 

--- a/work-package/techniques/implementation-analysis/TECHNIQUE.md
+++ b/work-package/techniques/implementation-analysis/TECHNIQUE.md
@@ -1,13 +1,7 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 2.0.0
-  order: 7
-  legacy_id: 7
 ---
-
-# Analyze Implementation
 
 ## Capability
 

--- a/work-package/techniques/issue-reference-detection.md
+++ b/work-package/techniques/issue-reference-detection.md
@@ -13,13 +13,6 @@ Detect whether the user supplied an issue reference and, when one is present, de
 
 The user-supplied issue reference or request — the issue key, URL, or surrounding text the user provided when starting the work package.
 
-## Protocol
-
-1. Scan `{issue_request}` for an issue reference (a key, a URL, or a bare number).
-2. When no reference is found, set `{issue_present}` to false and leave `{issue_platform}` and `{issue_number}` unset; the missing-issue case is handled downstream.
-3. When a reference is found, set `{issue_present}` to true and detect the platform from the key format: `#N` or a bare number is GitHub; `PROJ-N` (a project prefix and a hyphen) is Jira.
-4. Set `{issue_platform}` to `github` or `jira` accordingly, and parse the issue id into `{issue_number}`.
-
 ## Outputs
 
 ### issue_present
@@ -33,3 +26,10 @@ Boolean — true when the user supplied an issue reference, false otherwise.
 ### issue_number
 
 The parsed issue id (GitHub `#N` / bare number, or Jira `PROJ-N` key).
+
+## Protocol
+
+1. Scan `{issue_request}` for an issue reference (a key, a URL, or a bare number).
+2. When no reference is found, set `{issue_present}` to false and leave `{issue_platform}` and `{issue_number}` unset; the missing-issue case is handled downstream.
+3. When a reference is found, set `{issue_present}` to true and detect the platform from the key format: `#N` or a bare number is GitHub; `PROJ-N` (a project prefix and a hyphen) is Jira.
+4. Set `{issue_platform}` to `github` or `jira` accordingly, and parse the issue id into `{issue_number}`.

--- a/work-package/techniques/manage-artifacts/TECHNIQUE.md
+++ b/work-package/techniques/manage-artifacts/TECHNIQUE.md
@@ -1,13 +1,7 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 3.2.0
-  order: 14
-  legacy_id: 14
 ---
-
-# Manage Artifacts
 
 ## Capability
 

--- a/work-package/techniques/manage-git/TECHNIQUE.md
+++ b/work-package/techniques/manage-git/TECHNIQUE.md
@@ -1,13 +1,7 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 2.0.0
-  order: 15
-  legacy_id: 15
 ---
-
-# Manage Git
 
 ## Capability
 

--- a/work-package/techniques/manage-git/verify-feature-branch.md
+++ b/work-package/techniques/manage-git/verify-feature-branch.md
@@ -13,14 +13,14 @@ Inside the target worktree, verify the checkout is on a feature branch rather th
 
 The worktree root the work package operates inside.
 
-## Protocol
-
-1. Inside `{target_path}`, run `git branch --show-current`.
-2. Compare the result against `main` and `master`.
-3. Set `on_feature_branch` to true when the current branch is neither `main` nor `master`, false otherwise.
-
 ## Outputs
 
 ### on_feature_branch
 
 Boolean — true when the worktree is on a feature branch, false when on `main`/`master`.
+
+## Protocol
+
+1. Inside `{target_path}`, run `git branch --show-current`.
+2. Compare the result against `main` and `master`.
+3. Set `on_feature_branch` to true when the current branch is neither `main` nor `master`, false otherwise.

--- a/work-package/techniques/naming-conventions.md
+++ b/work-package/techniques/naming-conventions.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 
@@ -35,15 +33,6 @@ The server's canonical planning folder for this work package. Its basename is th
 
 *(optional)* When `true`, the branch name is already captured from the PR reference, so branch derivation is skipped and the work-package slug is derived from the PR title or branch name.
 
-## Protocol
-
-1. Skip branch derivation when `{is_review_mode}` is `true` — `{branch_name}` was already captured from the PR reference.
-2. Derive the branch-name type prefix from `{issue_type}`: feature → `feat`, bug → `fix`, task/enhancement → `chore`/`refactor` as appropriate.
-3. Slugify `{issue_title}` (lowercase, dashes, max ~40 chars) for the description segment.
-4. Set `{branch_name}` to `{type}/{issue_number}-{slugified-title}` per the convention `type/issue-number-short-description`.
-5. Determine the work-package slug as the basename of `{planning_folder_path}` (the planning slug `YYYY-MM-DD-{initiative-name}`), so the worktree name stays aligned with the server's planning folder. In review mode, derive the slug from the PR title or branch name instead.
-6. Set `{target_path}` to the canonical worktree path `~/projects/work/{component_name}/{wp-slug}/`. From this point on, "inside `{target_path}`" refers to this worktree (not the component's checkout inside the monorepo); it is distinct from `{planning_folder_path}`, which always lives under the server's workspace `.engineering` root.
-
 ## Outputs
 
 ### branch_name
@@ -53,6 +42,15 @@ Derived feature branch name `{type}/{issue_number}-{slugified-title}`. In review
 ### target_path
 
 Canonical worktree path `~/projects/work/{component_name}/{wp-slug}/`, distinct from the planning folder.
+
+## Protocol
+
+1. Skip branch derivation when `{is_review_mode}` is `true` — `{branch_name}` was already captured from the PR reference.
+2. Derive the branch-name type prefix from `{issue_type}`: feature → `feat`, bug → `fix`, task/enhancement → `chore`/`refactor` as appropriate.
+3. Slugify `{issue_title}` (lowercase, dashes, max ~40 chars) for the description segment.
+4. Set `{branch_name}` to `{type}/{issue_number}-{slugified-title}` per the convention `type/issue-number-short-description`.
+5. Determine the work-package slug as the basename of `{planning_folder_path}` (the planning slug `YYYY-MM-DD-{initiative-name}`), so the worktree name stays aligned with the server's planning folder. In review mode, derive the slug from the PR title or branch name instead.
+6. Set `{target_path}` to the canonical worktree path `~/projects/work/{component_name}/{wp-slug}/`. From this point on, "inside `{target_path}`" refers to this worktree (not the component's checkout inside the monorepo); it is distinct from `{planning_folder_path}`, which always lives under the server's workspace `.engineering` root.
 
 ## Rules
 

--- a/work-package/techniques/plan-prepare/TECHNIQUE.md
+++ b/work-package/techniques/plan-prepare/TECHNIQUE.md
@@ -1,13 +1,7 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 2.1.0
-  order: 8
-  legacy_id: 8
 ---
-
-# Create Plan
 
 ## Capability
 

--- a/work-package/techniques/project-type-detection.md
+++ b/work-package/techniques/project-type-detection.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 
@@ -19,14 +17,14 @@ The reference checkout root holding the component's source. Detection runs here 
 
 Basename of the component within `{reference_path}`.
 
-## Protocol
-
-1. Inspect the component's source under `{reference_path}`/`{component_name}` (the component as it appears in the reference checkout).
-2. Check for a `Cargo.toml` with Substrate dependencies (`sp-*`, `frame-*`, `pallet-*`).
-3. Set `project_type` to `rust-substrate` when those Substrate dependencies are found, otherwise `other`.
-
 ## Outputs
 
 ### project_type
 
 Detected project type: `rust-substrate` when Substrate dependencies are present, otherwise `other`.
+
+## Protocol
+
+1. Inspect the component's source under `{reference_path}`/`{component_name}` (the component as it appears in the reference checkout).
+2. Check for a `Cargo.toml` with Substrate dependencies (`sp-*`, `frame-*`, `pallet-*`).
+3. Set `project_type` to `rust-substrate` when those Substrate dependencies are found, otherwise `other`.

--- a/work-package/techniques/reference-resolution.md
+++ b/work-package/techniques/reference-resolution.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 
@@ -15,13 +13,6 @@ Resolve the reference checkout used for comprehension, GitNexus indexing, and re
 
 The path the user originally pointed at — the value resolved by start-workflow's target discovery.
 
-## Protocol
-
-1. Read `{discovered_path}` — the path the user originally pointed at.
-2. Determine the repository shape: it is a monorepo submodule when the parent directory has a `.gitmodules` file listing the path's basename; otherwise it is a standalone repository.
-3. Set `{reference_path}`: the monorepo root when `{discovered_path}` is a submodule, the discovered path itself when standalone.
-4. Set `{component_name}` to the basename of `{discovered_path}` (e.g. `midnight-node`) in both cases.
-
 ## Outputs
 
 ### reference_path
@@ -31,3 +22,10 @@ The reference checkout root: the monorepo root when the discovered path is a sub
 ### component_name
 
 Basename of the discovered path (e.g. `midnight-node`).
+
+## Protocol
+
+1. Read `{discovered_path}` — the path the user originally pointed at.
+2. Determine the repository shape: it is a monorepo submodule when the parent directory has a `.gitmodules` file listing the path's basename; otherwise it is a standalone repository.
+3. Set `{reference_path}`: the monorepo root when `{discovered_path}` is a submodule, the discovered path itself when standalone.
+4. Set `{component_name}` to the basename of `{discovered_path}` (e.g. `midnight-node`) in both cases.

--- a/work-package/techniques/requirements-elicitation/TECHNIQUE.md
+++ b/work-package/techniques/requirements-elicitation/TECHNIQUE.md
@@ -1,13 +1,7 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 2.0.0
-  order: 5
-  legacy_id: 5
 ---
-
-# Elicit Requirements
 
 ## Capability
 

--- a/work-package/techniques/research/TECHNIQUE.md
+++ b/work-package/techniques/research/TECHNIQUE.md
@@ -1,13 +1,7 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 2.0.0
-  order: 6
-  legacy_id: 6
 ---
-
-# Research Knowledge Base
 
 ## Capability
 

--- a/work-package/techniques/respond-to-pr-review.md
+++ b/work-package/techniques/respond-to-pr-review.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 2.2.0
-  order: 2
-  legacy_id: 2
 ---
 
 ## Capability
@@ -16,6 +12,20 @@ Analyze and respond to PR review comments systematically — categorizing commen
 ### review_comments
 
 Review comments fetched from PR
+
+## Outputs
+
+### review_analysis
+
+PR review [analysis](../resources/pr-review-response.md#review-document-template) document
+
+#### artifact
+
+`{YYYY-MM-DD}-pr{pr_number}-review-analysis.md`
+
+#### requires_replan
+
+Whether the changes are significant enough to require substantial rework
 
 ## Protocol
 
@@ -73,20 +83,6 @@ Review comments fetched from PR
 - After applying reviewer-requested changes, apply [gitnexus-operations](../../meta/techniques/gitnexus-operations/TECHNIQUE.md)::[detect-changes](../../meta/techniques/gitnexus-operations/detect-changes.md) to inform the 'minor fix' vs 'significant change' classification — small symbol/process deltas suggest minor; broad fan-out suggests significant.
 - Determine if re-review is needed (significant changes) or minor fixes suffice
 - Capture the categorized dispositions, changes made, and re-review decision as the `{review_analysis}` document
-
-## Outputs
-
-### review_analysis
-
-PR review [analysis](../resources/pr-review-response.md#review-document-template) document
-
-#### artifact
-
-`{YYYY-MM-DD}-pr{pr_number}-review-analysis.md`
-
-#### requires_replan
-
-Whether the changes are significant enough to require substantial rework
 
 ## Rules
 

--- a/work-package/techniques/review-assumptions/TECHNIQUE.md
+++ b/work-package/techniques/review-assumptions/TECHNIQUE.md
@@ -1,13 +1,7 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 3.0.0
-  order: 13
-  legacy_id: 13
 ---
-
-# Review Assumptions
 
 ## Capability
 

--- a/work-package/techniques/review-code.md
+++ b/work-package/techniques/review-code.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 2.0.0
-  order: 0
-  legacy_id: 0
 ---
 
 ## Capability
@@ -24,6 +20,16 @@ List of files changed in the work package (from `git diff`)
 ### planning_folder_path
 
 Folder where the code review report is written
+
+## Outputs
+
+### code_review_report
+
+Code review [report](../resources/rust-substrate-code-review.md#report-template) documenting findings by severity
+
+#### artifact
+
+`code-review.md`
 
 ## Protocol
 
@@ -63,16 +69,6 @@ When the diff changes a `Config` impl, an associated type, or any trait-implemen
 ### 5. Present Summary
 
 - Summarize critical and high findings
-
-## Outputs
-
-### code_review_report
-
-Code review [report](../resources/rust-substrate-code-review.md#report-template) documenting findings by severity
-
-#### artifact
-
-`code-review.md`
 
 ## Rules
 

--- a/work-package/techniques/review-diff.md
+++ b/work-package/techniques/review-diff.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
-  order: 11
-  legacy_id: 11
 ---
 
 ## Capability
@@ -20,6 +16,40 @@ Feature branch whose diff is reviewed (synced via `git pull`, parsed via `git di
 ### planning_folder_path
 
 Folder where the change block index and manual diff review report are written
+
+## Outputs
+
+### change_block_index
+
+[Index](../resources/manual-diff-review.md#file-index-generation) of changed blocks for external diff review, with per-block rationale paragraphs hyperlinked from the index table to aid manual review
+
+#### artifact
+
+`change-block-index.md`
+
+#### index_table
+
+Row (hyperlinked to rationale) | Path | File with review time estimate
+
+#### block_rationale
+
+Per-block descriptive paragraphs explaining intent, context, and non-obvious design choices
+
+### manual_diff_review_report
+
+Manual diff review [findings](../resources/manual-diff-review.md#manual-diff-review-report-template) from user-flagged blocks
+
+#### artifact
+
+`manual-diff-review.md`
+
+#### block_findings
+
+Per-block issues with interview responses
+
+#### has_critical_blocker
+
+True if any block marked as critical blocker
 
 ## Protocol
 
@@ -75,37 +105,3 @@ Each Block Rationale paragraph is 3–5 sentences covering intent, context, and 
 ### review-conduct
 
 Work systematically (top-to-bottom or by logical grouping); reference surrounding code when describing an issue; be specific — include line numbers or code snippets in finding descriptions.
-
-## Outputs
-
-### change_block_index
-
-[Index](../resources/manual-diff-review.md#file-index-generation) of changed blocks for external diff review, with per-block rationale paragraphs hyperlinked from the index table to aid manual review
-
-#### artifact
-
-`change-block-index.md`
-
-#### index_table
-
-Row (hyperlinked to rationale) | Path | File with review time estimate
-
-#### block_rationale
-
-Per-block descriptive paragraphs explaining intent, context, and non-obvious design choices
-
-### manual_diff_review_report
-
-Manual diff review [findings](../resources/manual-diff-review.md#manual-diff-review-report-template) from user-flagged blocks
-
-#### artifact
-
-`manual-diff-review.md`
-
-#### block_findings
-
-Per-block issues with interview responses
-
-#### has_critical_blocker
-
-True if any block marked as critical blocker

--- a/work-package/techniques/review-mode-detection.md
+++ b/work-package/techniques/review-mode-detection.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 
@@ -18,15 +16,6 @@ The originating user request and any context gathered so far — the signal sour
 ### pr_reference
 
 *(optional)* A pull-request number or URL supplied by the user. When absent in review mode, it is prompted for.
-
-## Protocol
-
-1. Inspect `{user_request}` for signals that it is a review of an existing PR rather than new work (an explicit "review", a PR number or URL, "is this safe to merge", and similar). Decide whether review mode applies.
-2. Set `is_review_mode` to `true` when review is indicated, otherwise `false`. When the signal is ambiguous, confirm with the user before committing the value.
-3. When `is_review_mode` is `true`, obtain the PR reference: take `{pr_reference}` if supplied, otherwise prompt the user for the PR number or URL. Record `review_pr_url`.
-4. Resolve the PR number from the reference and record `pr_number`.
-5. Check out the PR branch and record `branch_name` from it so downstream steps that skip branch derivation in review mode have it available.
-6. Extract the associated tracker ticket from the PR body or commit messages (e.g. a Jira key or GitHub issue reference) and record it as `review_ticket_ref` when present.
 
 ## Outputs
 
@@ -49,3 +38,12 @@ The originating user request and any context gathered so far — the signal sour
 ### review_ticket_ref
 
 *(optional)* The tracker ticket (Jira key or GitHub issue) extracted from the PR body or commits, when present.
+
+## Protocol
+
+1. Inspect `{user_request}` for signals that it is a review of an existing PR rather than new work (an explicit "review", a PR number or URL, "is this safe to merge", and similar). Decide whether review mode applies.
+2. Set `is_review_mode` to `true` when review is indicated, otherwise `false`. When the signal is ambiguous, confirm with the user before committing the value.
+3. When `is_review_mode` is `true`, obtain the PR reference: take `{pr_reference}` if supplied, otherwise prompt the user for the PR number or URL. Record `review_pr_url`.
+4. Resolve the PR number from the reference and record `pr_number`.
+5. Check out the PR branch and record `branch_name` from it so downstream steps that skip branch derivation in review mode have it available.
+6. Extract the associated tracker ticket from the PR body or commit messages (e.g. a Jira key or GitHub issue reference) and record it as `review_ticket_ref` when present.

--- a/work-package/techniques/review-test-suite.md
+++ b/work-package/techniques/review-test-suite.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 2.0.0
-  order: 1
-  legacy_id: 1
 ---
 
 ## Capability
@@ -24,6 +20,16 @@ Folder where the test suite review report is written
 ### prior_feedback_triage
 
 *(optional)* The triage of prior PR feedback, when present. Its entries tagged as reported runtime failures are the input to reported-failure triage — each is traced to a code path and state precondition here rather than re-read from the PR thread.
+
+## Outputs
+
+### test_suite_review_report
+
+Test suite review [report](../resources/test-suite-review.md#test-suite-review-report-template) documenting quality assessment
+
+#### artifact
+
+`test-suite-review.md`
 
 ## Protocol
 
@@ -75,16 +81,6 @@ When `{prior_feedback_triage}` is present, every entry tagged as a reported runt
 ### 6. Present Summary
 
 - Summarize coverage gaps and critical issues
-
-## Outputs
-
-### test_suite_review_report
-
-Test suite review [report](../resources/test-suite-review.md#test-suite-review-report-template) documenting quality assessment
-
-#### artifact
-
-`test-suite-review.md`
 
 ## Rules
 

--- a/work-package/techniques/stakeholder-overview.md
+++ b/work-package/techniques/stakeholder-overview.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 
@@ -23,6 +21,12 @@ The README section to write into (e.g. `## Problem Overview`, `## Solution Overv
 
 Path to the planning folder whose `README.md` holds the section.
 
+## Outputs
+
+### stakeholder_overview
+
+The two-paragraph plain-language overview written under `{readme_section_heading}` in the planning folder README.
+
 ## Protocol
 
 1. Synthesize a plain-language overview from `{source_material}`.
@@ -30,12 +34,6 @@ Path to the planning folder whose `README.md` holds the section.
 3. Frame the first paragraph as the situation or what the work does, and the second paragraph as the consequences or guarantees — what matters and why — tailoring the framing to `{readme_section_heading}` and `{source_material}`.
 4. Present the overview to the user.
 5. Write it into `{planning_folder_path}`/`README.md` by replacing the placeholder text under the `{readme_section_heading}` section.
-
-## Outputs
-
-### stakeholder_overview
-
-The two-paragraph plain-language overview written under `{readme_section_heading}` in the planning folder README.
 
 ## Rules
 

--- a/work-package/techniques/strategic-review/TECHNIQUE.md
+++ b/work-package/techniques/strategic-review/TECHNIQUE.md
@@ -1,13 +1,7 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 2.1.0
-  order: 12
-  legacy_id: 12
 ---
-
-# Review Strategy
 
 ## Capability
 

--- a/work-package/techniques/summarize-architecture.md
+++ b/work-package/techniques/summarize-architecture.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 20
-  legacy_id: 20
 ---
 
 ## Capability
@@ -24,6 +20,16 @@ List of files changed in the implementation
 ### planning_folder_path
 
 Folder where the architecture summary is written
+
+## Outputs
+
+### architecture_summary
+
+Stakeholder-facing architecture [summary](../resources/architecture-summary.md#architecture-summary-artifact-template) with diagrams
+
+#### artifact
+
+`architecture-summary.md`
 
 ## Protocol
 
@@ -62,16 +68,6 @@ Folder where the architecture summary is written
 - Focus on impact, scope, and risk, drawing scope and rationale from `{design_philosophy_doc}` when it is provided
 - Follow the architecture-summary template in [architecture-summary](../resources/architecture-summary.md)
 - Write for management stakeholders — not implementation details
-
-## Outputs
-
-### architecture_summary
-
-Stakeholder-facing architecture [summary](../resources/architecture-summary.md#architecture-summary-artifact-template) with diagrams
-
-#### artifact
-
-`architecture-summary.md`
 
 ## Rules
 

--- a/work-package/techniques/update-pr/TECHNIQUE.md
+++ b/work-package/techniques/update-pr/TECHNIQUE.md
@@ -1,13 +1,7 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 2.1.0
-  order: 18
-  legacy_id: 18
 ---
-
-# Update PR
 
 ## Capability
 

--- a/work-package/techniques/validate-build/TECHNIQUE.md
+++ b/work-package/techniques/validate-build/TECHNIQUE.md
@@ -1,13 +1,7 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 2.1.0
-  order: 16
-  legacy_id: 16
 ---
-
-# Validate Build
 
 ## Capability
 

--- a/work-packages/techniques/analyze-initiative-context.md
+++ b/work-packages/techniques/analyze-initiative-context.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 1
-  legacy_id: 1
 ---
 
 ## Capability
@@ -16,6 +12,24 @@ Perform completion or context analysis for a multi-package initiative
 ### analysis_type
 
 Type of analysis to perform: 'completion' or 'context'.
+
+## Outputs
+
+### analysis_document
+
+Analysis document with findings and recommendations, persisted as [01-COMPLETION-ANALYSIS.md](../resources/completion-analysis-guide.md#4-document-findings) (completion) or [02-CONTEXT-ANALYSIS.md](../resources/context-analysis-guide.md#5-document-findings) (context)
+
+#### artifact
+
+`01-COMPLETION-ANALYSIS.md` (when `analysis_type` is completion) / `02-CONTEXT-ANALYSIS.md` (when `analysis_type` is context)
+
+### key_findings
+
+Summary of analysis findings
+
+### planning_recommendation
+
+Suggested approach for planning and prioritization
 
 ## Protocol
 
@@ -47,24 +61,6 @@ Type of analysis to perform: 'completion' or 'context'.
 ### 5. Present Findings
 
 - Summarize `{key_findings}` for user review
-
-## Outputs
-
-### analysis_document
-
-Analysis document with findings and recommendations, persisted as [01-COMPLETION-ANALYSIS.md](../resources/completion-analysis-guide.md#4-document-findings) (completion) or [02-CONTEXT-ANALYSIS.md](../resources/context-analysis-guide.md#5-document-findings) (context)
-
-#### artifact
-
-`01-COMPLETION-ANALYSIS.md` (when `analysis_type` is completion) / `02-CONTEXT-ANALYSIS.md` (when `analysis_type` is context)
-
-### key_findings
-
-Summary of analysis findings
-
-### planning_recommendation
-
-Suggested approach for planning and prioritization
 
 ## Rules
 

--- a/work-packages/techniques/assess-initiative-scope.md
+++ b/work-packages/techniques/assess-initiative-scope.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 0
-  legacy_id: 0
 ---
 
 ## Capability
@@ -16,6 +12,20 @@ Identify and categorize work packages from a multi-package initiative descriptio
 ### user_initiative_description
 
 Free-form description of the initiative from the user
+
+## Outputs
+
+### initiative_name
+
+Name for the overall initiative
+
+### work_packages
+
+List of identified packages with names and one-sentence descriptions
+
+### package_count
+
+Total number of identified packages
 
 ## Protocol
 
@@ -39,20 +49,6 @@ Free-form description of the initiative from the user
 - Highlight any packages that seem too large (should be split) or too small (should be merged)  
   > Packages should be 2-8 hours of agentic work. Larger packages should be split; smaller ones merged.
 - Set `{initiative_name}` based on the overall theme of the packages, per the [planning-folder-template](../resources/planning-folder-template.md#folder-location)
-
-## Outputs
-
-### initiative_name
-
-Name for the overall initiative
-
-### work_packages
-
-List of identified packages with names and one-sentence descriptions
-
-### package_count
-
-Total number of identified packages
 
 ## Rules
 

--- a/work-packages/techniques/document-roadmap.md
+++ b/work-packages/techniques/document-roadmap.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 4
-  legacy_id: 4
 ---
 
 ## Capability
@@ -20,6 +16,28 @@ Ordered list of work packages with execution priority
 ### package_plans
 
 List of completed package [plan documents](../resources/package-plan-template.md#template)
+
+## Outputs
+
+### start_here
+
+Completed [START-HERE.md](../resources/roadmap-template.md#start-heremd-final-format) with executive summary, status, timeline, and criteria
+
+#### artifact
+
+`START-HERE.md`
+
+### planning_readme
+
+Updated [README.md](../resources/roadmap-template.md#readmemd-final-format) with navigation links
+
+#### artifact
+
+`README.md`
+
+### timeline_estimate
+
+Overall timeline span for the initiative, derived from phase durations
 
 ## Protocol
 
@@ -50,25 +68,3 @@ List of completed package [plan documents](../resources/package-plan-template.md
 ### 5. Present Roadmap
 
 - Present the completed `{start_here}` roadmap to the user for final review
-
-## Outputs
-
-### start_here
-
-Completed [START-HERE.md](../resources/roadmap-template.md#start-heremd-final-format) with executive summary, status, timeline, and criteria
-
-#### artifact
-
-`START-HERE.md`
-
-### planning_readme
-
-Updated [README.md](../resources/roadmap-template.md#readmemd-final-format) with navigation links
-
-#### artifact
-
-`README.md`
-
-### timeline_estimate
-
-Overall timeline span for the initiative, derived from phase durations

--- a/work-packages/techniques/orchestrate-package-execution/TECHNIQUE.md
+++ b/work-packages/techniques/orchestrate-package-execution/TECHNIQUE.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 5
-  legacy_id: 5
 ---
 
 ## Capability

--- a/work-packages/techniques/orchestrate-package-execution/execute-package.md
+++ b/work-packages/techniques/orchestrate-package-execution/execute-package.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 
@@ -14,6 +12,28 @@ Select the highest-priority unstarted package, trigger its work-package workflow
 ### remaining_packages
 
 Ordered list of packages not yet started
+
+## Outputs
+
+### completed_packages
+
+List of completed package names
+
+### remaining_packages
+
+List of remaining package names
+
+### overall_progress
+
+Progress indicator (e.g., '3/7 complete'), written into the updated START-HERE.md status table
+
+#### artifact
+
+`START-HERE.md`
+
+### package_planning_paths
+
+Map of package name to the child work-package's planning-folder path, captured as each child workflow completes
 
 ## Protocol
 
@@ -38,28 +58,6 @@ Ordered list of packages not yet started
 ### 4. Check Remaining
 
 - Remove the completed package from `{remaining_packages}`, add it to `{completed_packages}`
-
-## Outputs
-
-### completed_packages
-
-List of completed package names
-
-### remaining_packages
-
-List of remaining package names
-
-### overall_progress
-
-Progress indicator (e.g., '3/7 complete'), written into the updated START-HERE.md status table
-
-#### artifact
-
-`START-HERE.md`
-
-### package_planning_paths
-
-Map of package name to the child work-package's planning-folder path, captured as each child workflow completes
 
 ## Rules
 

--- a/work-packages/techniques/orchestrate-package-execution/initialize-iteration.md
+++ b/work-packages/techniques/orchestrate-package-execution/initialize-iteration.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 
@@ -19,14 +17,6 @@ Full priority order for reference
 
 Completed package names; arrives populated if provided
 
-## Protocol
-
-### 1. Initialize Iteration
-
-- Derive `{remaining_packages}` from `{priority_order}` minus `{completed_packages}`
-- Count the packages in `{priority_order}` as `{$total}` and `{completed_packages}` as `{$completed}`
-- Set `{overall_progress}` to '`{completed}`/`{total}` complete'
-
 ## Outputs
 
 ### remaining_packages
@@ -36,3 +26,11 @@ Ordered list of packages not yet started
 ### overall_progress
 
 Progress indicator (e.g., '3/7 complete')
+
+## Protocol
+
+### 1. Initialize Iteration
+
+- Derive `{remaining_packages}` from `{priority_order}` minus `{completed_packages}`
+- Count the packages in `{priority_order}` as `{$total}` and `{completed_packages}` as `{$completed}`
+- Set `{overall_progress}` to '`{completed}`/`{total}` complete'

--- a/work-packages/techniques/plan-work-package-scope/TECHNIQUE.md
+++ b/work-packages/techniques/plan-work-package-scope/TECHNIQUE.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 2
-  legacy_id: 2
 ---
 
 ## Capability

--- a/work-packages/techniques/plan-work-package-scope/plan-package.md
+++ b/work-packages/techniques/plan-work-package-scope/plan-package.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 
@@ -14,6 +12,36 @@ Define scope, dependencies, effort, and success criteria for a single package wi
 ### current_package
 
 The work package currently being planned
+
+## Outputs
+
+### package_plan
+
+Work package [plan document](../../resources/package-plan-template.md#template)
+
+#### artifact
+
+`{package_name}-plan.md`
+
+#### scope_definitions
+
+In-scope and out-of-scope definitions
+
+#### dependencies
+
+Blocker and soft dependency list
+
+#### effort
+
+Effort estimate with rationale
+
+#### success_criteria
+
+Measurable success criteria with verification methods
+
+### package_name
+
+Kebab-case identifier for the work package, derived from `{current_package}`.
 
 ## Protocol
 
@@ -47,33 +75,3 @@ The work package currently being planned
 
 - Derive the kebab-case package name `{package_name}` from `{current_package}`
 - Create `{package_plan}` in `{planning_folder_path}` using the [package-plan-template](../../resources/package-plan-template.md#template)
-
-## Outputs
-
-### package_plan
-
-Work package [plan document](../../resources/package-plan-template.md#template)
-
-#### artifact
-
-`{package_name}-plan.md`
-
-#### scope_definitions
-
-In-scope and out-of-scope definitions
-
-#### dependencies
-
-Blocker and soft dependency list
-
-#### effort
-
-Effort estimate with rationale
-
-#### success_criteria
-
-Measurable success criteria with verification methods
-
-### package_name
-
-Kebab-case identifier for the work package, derived from `{current_package}`.

--- a/work-packages/techniques/plan-work-package-scope/present-overview.md
+++ b/work-packages/techniques/plan-work-package-scope/present-overview.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/work-packages/techniques/prioritize-packages.md
+++ b/work-packages/techniques/prioritize-packages.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
-  order: 3
-  legacy_id: 3
 ---
 
 ## Capability
@@ -20,6 +16,24 @@ List of completed package [plan documents](../resources/package-plan-template.md
 ### dependency_map
 
 Inter-package dependency map describing which packages block or depend on which others
+
+## Outputs
+
+### priority_order
+
+Ordered list of work packages by execution priority, with prioritization rationale
+
+#### artifact
+
+`priority-ranking.md`
+
+### dependency_graph
+
+Dependency graph representation
+
+### prioritization_rationale
+
+Per-package rationale for the ordering
 
 ## Protocol
 
@@ -48,24 +62,6 @@ Inter-package dependency map describing which packages block or depend on which 
 - Present the `{dependency_graph}` (text or mermaid diagram)
 - Present the priority table with `{prioritization_rationale}` for the proposed order, forming `{priority_order}`
 - Note alternative orderings if multiple valid sequences exist
-
-## Outputs
-
-### priority_order
-
-Ordered list of work packages by execution priority, with prioritization rationale
-
-#### artifact
-
-`priority-ranking.md`
-
-### dependency_graph
-
-Dependency graph representation
-
-### prioritization_rationale
-
-Per-package rationale for the ordering
 
 ## Rules
 

--- a/work-packages/techniques/setup-planning-folder.md
+++ b/work-packages/techniques/setup-planning-folder.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
 ---
 

--- a/workflow-design/techniques/apply-audit-fixes.md
+++ b/workflow-design/techniques/apply-audit-fixes.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/audit-anti-patterns.md
+++ b/workflow-design/techniques/audit-anti-patterns.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/audit-conformance.md
+++ b/workflow-design/techniques/audit-conformance.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/audit-consistency.md
+++ b/workflow-design/techniques/audit-consistency.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/audit-expressiveness.md
+++ b/workflow-design/techniques/audit-expressiveness.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/audit-principles.md
+++ b/workflow-design/techniques/audit-principles.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/audit-rule-enforcement.md
+++ b/workflow-design/techniques/audit-rule-enforcement.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/audit-rule-hygiene.md
+++ b/workflow-design/techniques/audit-rule-hygiene.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/audit-schema-validation.md
+++ b/workflow-design/techniques/audit-schema-validation.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/commit-verification.md
+++ b/workflow-design/techniques/commit-verification.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/compile-report.md
+++ b/workflow-design/techniques/compile-report.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/conduct-retrospective.md
+++ b/workflow-design/techniques/conduct-retrospective.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.1.0
 ---
 

--- a/workflow-design/techniques/content-drafting.md
+++ b/workflow-design/techniques/content-drafting.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/context-loading.md
+++ b/workflow-design/techniques/context-loading.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/create-completion-doc.md
+++ b/workflow-design/techniques/create-completion-doc.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/elicitation.md
+++ b/workflow-design/techniques/elicitation.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 2.0.0
 ---
 

--- a/workflow-design/techniques/impact-analysis.md
+++ b/workflow-design/techniques/impact-analysis.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/intake-classification.md
+++ b/workflow-design/techniques/intake-classification.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/pattern-analysis.md
+++ b/workflow-design/techniques/pattern-analysis.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/persist-report.md
+++ b/workflow-design/techniques/persist-report.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 2.0.0
 ---
 

--- a/workflow-design/techniques/prepare-workflow-branch.md
+++ b/workflow-design/techniques/prepare-workflow-branch.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/publish-workflow-pr.md
+++ b/workflow-design/techniques/publish-workflow-pr.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/readme-authoring.md
+++ b/workflow-design/techniques/readme-authoring.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/reconcile-design-assumptions.md
+++ b/workflow-design/techniques/reconcile-design-assumptions.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/reload-workflow.md
+++ b/workflow-design/techniques/reload-workflow.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/review-draft-yaml.md
+++ b/workflow-design/techniques/review-draft-yaml.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/run-audit-passes.md
+++ b/workflow-design/techniques/run-audit-passes.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/scope-audit.md
+++ b/workflow-design/techniques/scope-audit.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/scope-definition.md
+++ b/workflow-design/techniques/scope-definition.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/scope-verification.md
+++ b/workflow-design/techniques/scope-verification.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/summarize-findings.md
+++ b/workflow-design/techniques/summarize-findings.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/verify-high-findings.md
+++ b/workflow-design/techniques/verify-high-findings.md
@@ -1,7 +1,5 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 1.0.0
 ---
 

--- a/workflow-design/techniques/yaml-authoring.md
+++ b/workflow-design/techniques/yaml-authoring.md
@@ -1,10 +1,6 @@
 ---
 metadata:
-  ontology: workflow-canonical
-  kind: technique
   version: 2.0.0
-  order: 1
-  legacy_id: 1
 ---
 
 ## Capability
@@ -20,6 +16,12 @@ Which schema applies to this file — one of: workflow (`schemas/workflow.schema
 ### reference_file
 
 *(optional)* Path to an existing valid YAML file of the same type to use as a syntax reference
+
+## Outputs
+
+### yaml_file
+
+A syntactically valid YAML file that passes schema validation
 
 ## Protocol
 
@@ -49,12 +51,6 @@ Which schema applies to this file — one of: workflow (`schemas/workflow.schema
 - Fix any validation errors and re-check
 - If the parser cannot handle the file because it uses invalid syntax, compare the failing line against the same construct in an existing valid YAML file and fix the syntax
 - If the file parses but does not conform to the schema, read the schema definition for the failing field and fix the content
-
-## Outputs
-
-### yaml_file
-
-A syntactically valid YAML file that passes schema validation
 
 ## Rules
 


### PR DESCRIPTION
Content half of **#166 B9** (normative technique template + lint). Mechanical sweep bringing every technique file to the modal shape the 2026-07-03 structural census identified, which the server's new `check:technique-template` guard (companion PR) enforces corpus-wide, hard-zero.

## Changes (250 files)

- **Front matter reduced to `metadata.version`** in 242 files — the legacy `ontology`/`kind`/`order`/`legacy_id` keys are read by nothing; identity comes from the path.
- **Canonical H2 order restored** in 80 files: Capability, Inputs, Outputs, Protocol, Rules — the interface reads as a whole before the procedure (Outputs before Protocol).
- **H1 titles removed** from 25 group/root `TECHNIQUE.md` contracts — the loader discards everything before the first H2, and several titles had drifted from their slug (`design-philosophy` was titled "Classify Problem").
- **One delivered-payload fix:** `substrate-node-security-audit/techniques/write-report.md` fences the `finding_block_format` template — its unfenced `### Issue …` heading parsed as a bogus output entry and detached the two following `####` components from `audit_report`.

`techniques/README.md` navigation docs are exempt from the template.

## Verification

Full server suite (477/0) plus binding/anchor/identifier guards green against this tree; binding baseline unchanged at 267 (0 new, 0 fixed). The census counts (16 ordering + 40 front-matter) were scoped to meta/work-package/ponytail; the full 14-workflow corpus carried 80 + 242.

**Merge order:** this PR merges FIRST; the server PR's corpus test is hard-zero against the `workflows` tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
