### PR TITLE
feat(guards): normative technique-template lint (#166 B9)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -170,9 +170,15 @@ npx tsx scripts/check-all-refs.ts
 # scripts/binding-fidelity-baseline.json (re-snapshot intentional changes with
 # --update-baseline).
 npm run check:binding
+
+# Normative technique template: metadata.version-only frontmatter, no H1 title,
+# the canonical H2 set in order (Capability, Inputs, Outputs, Protocol, Rules —
+# Outputs before Protocol), snake_case entry ids (camelCase tool-parameter
+# mirrors allowed), kebab-case rule names, snake_case {$name} sigils. Hard-zero.
+npm run check:technique-template
 ```
 
-The binding-fidelity guard also runs as a Vitest test (`tests/binding-fidelity.test.ts`), so `npm test` fails on new binding drift.
+The binding-fidelity and technique-template guards also run as Vitest tests (`tests/binding-fidelity.test.ts`, `tests/technique-template.test.ts`), so `npm test` fails on new binding drift or a template deviation.
 
 ## Branch Structure
 

--- a/docs/technique-protocol-specification.md
+++ b/docs/technique-protocol-specification.md
@@ -447,3 +447,10 @@ failure it logs a warning and treats the technique as unloadable. A technique de
 `metadata.version` and `## Capability`; a technique that does work declares a `## Protocol`. An
 activity's `::` references resolve to a technique or rule — an `unresolved` entry in a bundle is a
 definition defect, which the definition-lint gate enforces.
+
+The file shape of §3 is normative, and the `check:technique-template` guard
+(`scripts/check-technique-template.ts`, also a Vitest test) enforces it corpus-wide: frontmatter
+carries `metadata.version` and nothing else; no H1 title; the H2 sections are the canonical five in
+canonical order (Outputs precede Protocol); entry ids are `snake_case` (a tool-parameter mirror
+keeps the tool's spelling, §3.2); rule names are `kebab-case`; every `{$name}` binding is
+`snake_case`. `README.md` navigation docs inside `techniques/` are exempt.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "check:self-input": "tsx scripts/check-self-provisioned-input.ts",
     "check:activity-tech": "tsx scripts/check-activity-technique-overlap.ts",
     "check:prism-lenses": "tsx scripts/check-prism-lens-reachability.ts",
-    "check:anchors": "tsx scripts/check-resource-anchors.ts"
+    "check:anchors": "tsx scripts/check-resource-anchors.ts",
+    "check:technique-template": "tsx scripts/check-technique-template.ts"
   },
   "license": "MIT",
   "devDependencies": {

--- a/scripts/check-technique-template.ts
+++ b/scripts/check-technique-template.ts
@@ -1,0 +1,183 @@
+/**
+ * Technique-template guard (B9, issue #166).
+ *
+ * Every technique file under `<workflow>/techniques/` follows the normative template
+ * (docs/technique-protocol-specification.md §3):
+ *
+ * - Frontmatter carries `metadata.version` and nothing else — identity comes from the path,
+ *   and the loader reads no other key.
+ * - No H1 title: the file opens at `## Capability` (the loader discards everything before
+ *   the first H2, so an H1 is dead weight that drifts from the slug).
+ * - H2 sections are exactly the canonical five — Capability, Inputs, Outputs, Protocol,
+ *   Rules — each at most once, in that order (Outputs precede Protocol: the interface reads
+ *   as a whole before the procedure).
+ * - `###` entry ids under Inputs/Outputs are snake_case; an id that mirrors an external
+ *   tool parameter may be camelCase (spec §3.2 — Atlassian's `cloudId` binds natively).
+ *   `###` rule names under Rules are kebab-case, optionally dot-grouped (`commit.signed`).
+ * - Every `{$name}` protocol-variable binding is snake_case (spec §3.3; AP-55).
+ *
+ * `README.md` files inside `techniques/` are navigation docs, not techniques — skipped.
+ * Headings and sigils inside fenced code blocks are illustrative — skipped.
+ *
+ * Hard-zero: every violation is a defect in the file, not the guard.
+ *
+ * Run: npx tsx scripts/check-technique-template.ts [--root <workflows-dir>]
+ */
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { resolveWorkflowsRoot } from './workflows-root.js';
+
+const DIR = fileURLToPath(new URL('.', import.meta.url));
+const ROOT = resolveWorkflowsRoot(resolve(join(DIR, '..', 'workflows')));
+
+export interface TemplateViolation {
+  /** File, relative to the workflows root. */
+  file: string;
+  /** Which template rule the file breaks. */
+  rule:
+    | 'frontmatter-missing'
+    | 'frontmatter-extra-key'
+    | 'version-missing'
+    | 'h1-title'
+    | 'unknown-section'
+    | 'duplicate-section'
+    | 'section-order'
+    | 'entry-id-casing'
+    | 'rule-name-casing'
+    | 'sigil-casing';
+  /** The offending token or the observed shape. */
+  detail: string;
+}
+
+const CANONICAL = ['Capability', 'Inputs', 'Outputs', 'Protocol', 'Rules'];
+
+const SNAKE = /^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$/;
+/** External-tool parameter mirror (spec §3.2): lowerCamelCase, no underscores. */
+const CAMEL = /^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)+$/;
+/** Kebab rule name, optionally dot-grouped: `index-freshness-first`, `commit.signed`. */
+const RULE_NAME = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*(?:\.[a-z][a-z0-9]*(?:-[a-z0-9]+)*)*$/;
+
+interface Line {
+  text: string;
+  inFence: boolean;
+}
+
+/** Split a body into lines annotated with fenced-code membership. */
+function annotateFences(body: string): Line[] {
+  const lines: Line[] = [];
+  let inFence = false;
+  for (const text of body.split(/\r?\n/)) {
+    if (/^\s*(```|~~~)/.test(text)) {
+      lines.push({ text, inFence: true });
+      inFence = !inFence;
+      continue;
+    }
+    lines.push({ text, inFence });
+  }
+  return lines;
+}
+
+/** Lint one technique file; returns its violations. */
+export function lintTechniqueFile(raw: string, file: string): TemplateViolation[] {
+  const violations: TemplateViolation[] = [];
+
+  // --- Frontmatter: exactly `metadata:` with exactly `version:` beneath it. ---
+  const fm = raw.match(/^---\s*\r?\n([\s\S]*?)\r?\n---\s*\r?\n([\s\S]*)$/);
+  if (!fm) {
+    violations.push({ file, rule: 'frontmatter-missing', detail: 'no `---` frontmatter block' });
+  } else {
+    let sawVersion = false;
+    for (const line of (fm[1] ?? '').split(/\r?\n/)) {
+      if (!line.trim() || line.trim().startsWith('#')) continue;
+      const key = /^( *)([A-Za-z_][\w-]*)\s*:/.exec(line);
+      if (!key) continue;
+      const name = key[2]!;
+      const nested = (key[1] ?? '').length > 0;
+      if (nested && name === 'version') sawVersion = true;
+      else if (!(nested === false && name === 'metadata')) {
+        violations.push({ file, rule: 'frontmatter-extra-key', detail: name });
+      }
+    }
+    if (!sawVersion) violations.push({ file, rule: 'version-missing', detail: 'metadata.version' });
+  }
+  const body = fm ? (fm[2] ?? '') : raw;
+
+  // --- Headings, section order, entry-id casing. ---
+  const seen: string[] = [];
+  let section: string | null = null;
+  for (const { text, inFence } of annotateFences(body)) {
+    if (inFence) continue;
+    const h1 = /^# (?!#)(.*)$/.exec(text);
+    if (h1) violations.push({ file, rule: 'h1-title', detail: `# ${h1[1]!.trim()}` });
+    const h2 = /^## (?!#)(.*)$/.exec(text);
+    if (h2) {
+      const title = h2[1]!.trim();
+      if (!CANONICAL.includes(title)) {
+        violations.push({ file, rule: 'unknown-section', detail: `## ${title}` });
+        section = null;
+        continue;
+      }
+      if (seen.includes(title)) violations.push({ file, rule: 'duplicate-section', detail: `## ${title}` });
+      seen.push(title);
+      section = title;
+      continue;
+    }
+    const h3 = /^### (?!#)(.*)$/.exec(text);
+    if (h3) {
+      const id = h3[1]!.trim();
+      if ((section === 'Inputs' || section === 'Outputs') && !SNAKE.test(id) && !CAMEL.test(id)) {
+        violations.push({ file, rule: 'entry-id-casing', detail: `${section}: ### ${id}` });
+      }
+      if (section === 'Rules' && !RULE_NAME.test(id)) {
+        violations.push({ file, rule: 'rule-name-casing', detail: `Rules: ### ${id}` });
+      }
+    }
+  }
+  const inOrder = [...seen].sort((a, b) => CANONICAL.indexOf(a) - CANONICAL.indexOf(b));
+  if (seen.join(' > ') !== inOrder.join(' > ')) {
+    violations.push({ file, rule: 'section-order', detail: seen.join(' > ') });
+  }
+
+  // --- `{$name}` sigil casing (code spans included — designators are backticked). ---
+  for (const { text, inFence } of annotateFences(body)) {
+    if (inFence) continue;
+    for (const m of text.matchAll(/\{\$([^}]*)\}/g)) {
+      if (!SNAKE.test(m[1]!)) violations.push({ file, rule: 'sigil-casing', detail: `{$${m[1]!}}` });
+    }
+  }
+
+  return violations;
+}
+
+function* walkFiles(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir).sort()) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) yield* walkFiles(p);
+    else if (entry.endsWith('.md') && entry !== 'README.md') yield p;
+  }
+}
+
+export function collectTemplateViolations(root: string = ROOT): TemplateViolation[] {
+  const violations: TemplateViolation[] = [];
+  for (const workflow of readdirSync(root).sort()) {
+    const techniquesDir = join(root, workflow, 'techniques');
+    if (!existsSync(techniquesDir) || !statSync(techniquesDir).isDirectory()) continue;
+    for (const path of walkFiles(techniquesDir)) {
+      violations.push(...lintTechniqueFile(readFileSync(path, 'utf-8'), relative(root, path)));
+    }
+  }
+  return violations;
+}
+
+const isMain = !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  const violations = collectTemplateViolations();
+  if (violations.length === 0) {
+    process.stdout.write('technique-template: OK — every technique file follows the normative template\n');
+    process.exit(0);
+  }
+  process.stdout.write(`technique-template: ${violations.length} violation(s):\n`);
+  for (const v of violations) process.stdout.write(`  [${v.rule}] ${v.file}: ${v.detail}\n`);
+  process.exit(1);
+}

--- a/tests/technique-template.test.ts
+++ b/tests/technique-template.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { collectTemplateViolations, lintTechniqueFile } from '../scripts/check-technique-template.js';
+
+/**
+ * Technique-template guard (B9, issue #166): every technique file follows the normative
+ * template — `metadata.version`-only frontmatter, no H1, the canonical H2 set in order
+ * (Outputs before Protocol), snake_case entry ids (camelCase tool mirrors allowed),
+ * kebab-case rule names, snake_case `{$name}` sigils. Hard-zero over the corpus.
+ */
+
+const CONFORMANT = `---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Does one thing.
+
+## Inputs
+
+### target_path
+
+Where to act.
+
+### cloudId
+
+Tool-parameter mirror.
+
+## Outputs
+
+### lint_diagnostics
+
+What was found.
+
+## Protocol
+
+1. Read \`{target_path}\` and capture \`{$scan_result}\`.
+2. Report \`{scan_result}\`.
+
+## Rules
+
+### commit.signed
+
+Every commit is signed.
+`;
+
+describe('technique-template guard', () => {
+  it('accepts the normative template', () => {
+    expect(lintTechniqueFile(CONFORMANT, 'x.md')).toEqual([]);
+  });
+
+  it('flags legacy frontmatter keys', () => {
+    const raw = CONFORMANT.replace('metadata:\n', 'metadata:\n  ontology: workflow-canonical\n  kind: technique\n');
+    expect(lintTechniqueFile(raw, 'x.md').map((v) => v.detail)).toEqual(['ontology', 'kind']);
+  });
+
+  it('flags a missing metadata.version', () => {
+    const raw = CONFORMANT.replace('  version: 1.0.0\n', '');
+    expect(lintTechniqueFile(raw, 'x.md').map((v) => v.rule)).toEqual(['version-missing']);
+  });
+
+  it('flags an H1 title', () => {
+    const raw = CONFORMANT.replace('## Capability', '# Version Control\n\n## Capability');
+    expect(lintTechniqueFile(raw, 'x.md').map((v) => v.rule)).toEqual(['h1-title']);
+  });
+
+  it('flags Outputs after Protocol as section-order', () => {
+    const outputs = '## Outputs\n\n### lint_diagnostics\n\nWhat was found.\n\n';
+    const raw = CONFORMANT.replace(outputs, '').replace('## Rules', `${outputs}## Rules`);
+    expect(lintTechniqueFile(raw, 'x.md').map((v) => v.rule)).toEqual(['section-order']);
+  });
+
+  it('flags an unknown H2 section', () => {
+    const raw = CONFORMANT.replace('## Rules', '## Notes\n\nStray.\n\n## Rules');
+    expect(lintTechniqueFile(raw, 'x.md').map((v) => v.rule)).toEqual(['unknown-section']);
+  });
+
+  it('flags a duplicate H2 section', () => {
+    const raw = `${CONFORMANT}\n## Capability\n\nAgain.\n`;
+    expect(lintTechniqueFile(raw, 'x.md').map((v) => v.rule)).toEqual(['duplicate-section', 'section-order']);
+  });
+
+  it('flags non-snake, non-camel entry ids and non-kebab rule names', () => {
+    const raw = CONFORMANT.replace('### target_path', '### Target Path').replace(
+      '### commit.signed',
+      '### Commit_Signed',
+    );
+    expect(lintTechniqueFile(raw, 'x.md').map((v) => v.rule)).toEqual(['entry-id-casing', 'rule-name-casing']);
+  });
+
+  it('flags a non-snake sigil but ignores fenced examples', () => {
+    const raw = `${CONFORMANT}\n\`\`\`\n### Issue {number}: {title}\n{$Not-Snake}\n\`\`\`\n`;
+    expect(lintTechniqueFile(raw, 'x.md')).toEqual([]);
+    const bad = CONFORMANT.replace('{$scan_result}', '{$scan-result}');
+    expect(lintTechniqueFile(bad, 'x.md').map((v) => v.rule)).toEqual(['sigil-casing']);
+  });
+
+  it('every technique file in the corpus follows the template', () => {
+    expect(collectTemplateViolations().map((v) => `[${v.rule}] ${v.file}: ${v.detail}`)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Server half of **#166 B9** (normative technique template + lint). Companion to #179 (merged first — the corpus test is hard-zero against the `workflows` tip; the submodule pin moves to that merge, `cf185d25`).

## New guard: `check:technique-template`

`scripts/check-technique-template.ts` + `tests/technique-template.test.ts` + npm script. Enforces the normative technique file shape of `docs/technique-protocol-specification.md` §3 across the corpus, hard-zero:

- front matter carries `metadata.version` and nothing else
- no H1 title (the loader discards everything before the first H2)
- H2 sections are the canonical five, each at most once, in canonical order: Capability, Inputs, Outputs, Protocol, Rules (Outputs precede Protocol)
- `###` entry ids under Inputs/Outputs are snake_case, with camelCase external-tool parameter mirrors allowed (§3.2, e.g. Atlassian's `cloudId`); rule names under Rules are kebab-case, optionally dot-grouped (`commit.signed`)
- every `{$name}` protocol-variable binding is snake_case (§3.3)

`README.md` navigation docs inside `techniques/` and fenced code blocks are exempt.

The `{$var}` sigil itself was already documented (spec §3.3, AP-54/55/58/59) — B9's documentation half needed no new prose; spec §9 and `docs/development.md` now register the guard as the shape's enforcement.

## Verification

- Suite 477/0 (`npx vitest run`) against the swept corpus; e2e snapshots unchanged
- `npm run typecheck` clean; `check:binding` baseline unchanged (267, 0 new / 0 fixed); anchors + identifiers green; site fresh
- GitNexus: no indexed symbols touched (additive files only)

Closes the B9 checkbox on #166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
