### PR TITLE
fix(variables): make the corpus coherent with the seeded variable model (#166 B7)

### DIFF
--- a/prism-update/workflow.yaml
+++ b/prism-update/workflow.yaml
@@ -1,5 +1,5 @@
 id: prism-update
-version: 1.1.0
+version: 1.1.1
 title: Prism Update Workflow
 description: Sync the prism workflow's resources, techniques, and documentation with upstream changes from the agi-in-md project.
 author: m2ux
@@ -35,7 +35,7 @@ variables:
   - name: exclusions
     type: array
     description: Prism filenames to exclude from import (e.g., arc_code.md, codegen.md)
-    defaultValue: "[]"
+    defaultValue: []
   - name: next_index
     type: number
     description: Next available resource index, derived from highest existing index + 1

--- a/prism/workflow.yaml
+++ b/prism/workflow.yaml
@@ -1,5 +1,5 @@
 id: prism
-version: 2.1.0
+version: 2.2.0
 title: Structural Analysis Prism Workflow
 description: Apply cognitive lenses to code or text through isolated sub-agent passes. Each pass runs in a fresh context window to guarantee analytical independence. For security audit use cases, use the prism-audit workflow which triggers prism and adds audit-specific post-processing.
 author: m2ux
@@ -38,8 +38,7 @@ variables:
     defaultValue: code
   - name: pipeline_mode
     type: string
-    description: "Analysis mode: 'single' (L12), 'full-prism' (3-pass), 'portfolio' (multiple lenses), 'behavioral' (4+1 behavioral pipeline), 'dispute' (2 orthogonal prisms + disagreement synthesis), 'subsystem' (per-region prism assignment + cross-subsystem synthesis), 'verified' (L12 + gap detection + re-analysis with corrections), 'reflect' (L12 + meta-analysis + constraint synthesis), 'smart' (adaptive chain: prereq + analysis + dispute + profile), or 'adaptive' (depth escalation: SDL -> L12 -> full-prism)"
-    defaultValue: single
+    description: "Analysis mode: 'single' (L12), 'full-prism' (3-pass), 'portfolio' (multiple lenses), 'behavioral' (4+1 behavioral pipeline), 'dispute' (2 orthogonal prisms + disagreement synthesis), 'subsystem' (per-region prism assignment + cross-subsystem synthesis), 'verified' (L12 + gap detection + re-analysis with corrections), 'reflect' (L12 + meta-analysis + constraint synthesis), 'smart' (adaptive chain: prereq + analysis + dispute + profile), or 'adaptive' (depth escalation: SDL -> L12 -> full-prism). No default — absence means the caller did not preset a mode, which is what select-mode's confirm-mode checkpoint gate (notExists) tests; select-mode then resolves the mode from its recommendation or the option the user picks"
   - name: output_path
     type: string
     description: Directory to write analysis artifacts

--- a/work-package/workflow.yaml
+++ b/work-package/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: work-package
-version: 3.16.0
+version: 3.16.1
 title: Work Package Implementation Workflow
 description: Defines how to plan and implement ONE work package from inception to merged PR. A work package is a discrete unit of work such as a feature, bug-fix, enhancement, refactoring, or any other deliverable change. For multiple related work packages, use the work-packages workflow to create a roadmap first.
 author: m2ux
@@ -34,8 +34,7 @@ variables:
     description: Path to the working directory where edits, branch creation, builds, and PR operations occur. As of work-package 3.10, this is a dedicated git worktree of the component repo at the canonical path '~/projects/work/{component_name}/{wp-slug}/' — NOT the component's checkout inside the reference monorepo. Set by start-work-package's compute-canonical-target-path step after the work-package slug is known. All downstream activities (cargo-operations, manage-git, validate, strategic-review, etc.) operate on this path.
   - name: reference_path
     type: string
-    description: Path to the reference checkout used for codebase comprehension, GitNexus indexing, and code-resolvable assumption analysis. When the component is a submodule of a monorepo, this is the monorepo root; when the component is a standalone repo, this equals the component's primary checkout. NOT used for edits — edits happen in target_path. Resolved by start-work-package's resolve-target step from the path the user originally pointed at.
-    defaultValue: ""
+    description: Path to the reference checkout used for codebase comprehension, GitNexus indexing, and code-resolvable assumption analysis. When the component is a submodule of a monorepo, this is the monorepo root; when the component is a standalone repo, this equals the component's primary checkout. NOT used for edits — edits happen in target_path. Resolved by start-work-package's resolve-target step from the path the user originally pointed at. No default — absence drives the start-work-package exists gate on reference-dependent steps.
   - name: component_name
     type: string
     description: Basename of the component being worked on (e.g., 'midnight-node'). When the reference is a monorepo, this is the submodule directory name; when the reference is a standalone repo, this is the basename of reference_path. Used in the canonical worktree path formula '~/projects/work/{component_name}/{wp-slug}/'.
@@ -57,6 +56,12 @@ variables:
   - name: issue_platform
     type: string
     description: Issue tracking platform (github|jira)
+  - name: jira_project
+    type: string
+    description: How the Jira project was resolved during issue creation ('selected' from the project list, or 'specified' directly by the user). Set by start-work-package's jira-project-selection checkpoint.
+  - name: is_review_mode
+    type: boolean
+    description: True when the work package reviews an existing PR instead of producing a new implementation. Detected agent-side by start-work-package's detect-review-mode step and confirmed via the review-mode-detection checkpoint; gates the review-mode steps across the workflow.
   - name: pr_number
     type: string
     description: Pull request number
@@ -349,7 +354,7 @@ variables:
   - name: body_findings
     type: array
     description: "List of pr-body-conformance violations. Each entry is { rule_id: string, detail: string }."
-    defaultValue: "[]"
+    defaultValue: []
   - name: body_override_recorded
     type: boolean
     description: True when proceed-with-override was selected on body-non-conformant.


### PR DESCRIPTION
Part of #166 (B7). **Merge this before the server PR** — the server's new hard-zero `check:variable-model` guard and the seeding engine change assume this corpus state.

The server now seeds every declared `defaultValue` into the session variable bag at session creation, which makes two authoring patterns defective. This PR removes the collisions and pre-declares what the new guard enforces:

- **prism `pipeline_mode`** loses its `single` default: select-mode's confirm-mode checkpoint gates on `notExists` ("caller did not preset a mode") — a seeded default would make that checkpoint unreachable. The `pipeline_mode ==` transitions behave identically for unset (`isDefault` fallback).
- **work-package `reference_path`** loses its `""` default: start-work-package's `update-reference-submodules` step gates on `exists`, so absence is the signal.
- **Two string `"[]"` defaults on array-typed variables** become real arrays (prism-update `exclusions`, work-package `body_findings`) — seeding would otherwise deliver the literal string `"[]"`.
- **work-package declares `is_review_mode` and `jira_project`**, the two checkpoint `setVariable` targets that workflow.yaml never declared, so type validation has declarations to check against.

Versions: prism 2.2.0 (checkpoint-reachability semantics restored), work-package 3.16.1, prism-update 1.1.1.

Verified: `check:variable-model` (new) plus the full existing guard suite green against this worktree; all three workflows pass `validate-workflow-yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
