### PR TITLE
feat(docs): server internals, design rationale, and protocol-in-practice site sections (#132)

### DIFF
--- a/docs/documentation-system.md
+++ b/docs/documentation-system.md
@@ -8,6 +8,8 @@ How this repository's documentation is organized: what each source is for, who i
 
 **The HTML site renders it.** [`site/`](../site/) is a hand-authored static documentation site — semantic HTML, one shared stylesheet, inline SVG diagrams, no site-generator toolchain — that presents the same material as a navigable, illustrated view. Site pages link back to their canonical markdown sources. Two site pages contain machine-generated regions derived from the server source and the JSON schemas (`npm run build:site` regenerates them); `tests/site.test.ts` fails when those regions drift from the code, and `npm run check:site` verifies every internal link and anchor.
 
+Two site sections have no markdown counterpart because their canonical source is not markdown: `site/internals/` documents the server implementation (canonical source: the code in `src/`, `scripts/`, and `tests/`, which every page links to), and `site/design/` records design rationale distilled from the decision records on the engineering branch. When the implementation or a recorded decision changes, those pages are updated in the same change.
+
 ## Source map
 
 | Source | Purpose | Audience |
@@ -23,7 +25,7 @@ How this repository's documentation is organized: what each source is for, who i
 | [`docs/development.md`](development.md) | Contributing to the server: build, test, conventions | Contributors |
 | [`schemas/README.md`](../schemas/README.md) | Schema guide for authoring workflow definitions | Workflow authors |
 | `schemas/*.schema.json` | JSON Schemas generated from the Zod sources (`npm run build:schemas`) | Authoring-time validation and tooling |
-| [`site/`](../site/) | The rendered documentation site: user guide, technical specs, API reference | Readers in a browser |
+| [`site/`](../site/) | The rendered documentation site: user guide, technical specs, API reference, server internals, design rationale | Readers in a browser |
 | `AGENTS.md`, `CLAUDE.md`, `.claude/rules/` | Instructions for AI agents working in this repository | AI agents |
 | `.engineering/` | Planning artifacts, work packages, ADRs — engineering process, not product documentation | Project engineering |
 
@@ -35,10 +37,12 @@ Workflow definitions themselves (the `workflows` branch, checked out as a worktr
 - **A new architecture model or a change to one** → a `docs/*_model.md` document, linked from the [`docs/architecture.md`](architecture.md) hub, with a matching page under `site/specs/`.
 - **Tool or schema surface changes** → the code and Zod schemas are the source; regenerate `schemas/` (`npm run build:schemas`) and the site's API pages (`npm run build:site`), and update [`docs/api-reference.md`](api-reference.md) prose where guidance changes.
 - **Workflow-authoring contracts** → the normative specifications ([`technique-protocol-specification.md`](technique-protocol-specification.md), [`orchestra-specification.md`](orchestra-specification.md)) and [`schemas/README.md`](../schemas/README.md).
-- **Engineering process artifacts** (plans, analyses, reviews, ADRs) → `.engineering/artifacts/` on the engineering branch. These are never product documentation and are not linked from it.
+- **Implementation documentation** (module structure, request handling, on-disk state, the guard and test system) → a page under `site/internals/`, linking to the source files it describes.
+- **Design rationale** (why an architectural decision stands) → record the decision as an ADR on the engineering branch first, then surface the distilled rationale on `site/design/rationale.html`.
+- **Engineering process artifacts** (plans, analyses, reviews, ADRs) → `.engineering/artifacts/` on the engineering branch. These are never product documentation and are not linked from it; the rationale page restates decisions in its own words rather than linking there.
 
 ## Conventions
 
-- **Describe the system as it is.** Documentation states current behaviour in plain present tense; evolution and rationale belong in `.engineering/` planning artifacts.
+- **Describe the system as it is.** Documentation states current behaviour in plain present tense; evolution narratives belong in `.engineering/` planning artifacts. Rationale is the one exception: the standing reasons behind current decisions are product documentation, kept on the site's design-rationale page — still present tense, never a changelog.
 - **Filenames are stable.** Documents are heavily cross-linked (from this repository and beyond), so structure changes are expressed through linking and navigation, never by renaming or moving existing files.
 - **Everything is reachable.** Every document is linked from an entry point — the README's navigation strip, the [`docs/architecture.md`](architecture.md) hub, or the site's landing page — so no document depends on full-text search to be found.

--- a/site/README.md
+++ b/site/README.md
@@ -2,6 +2,6 @@
 
 Hand-authored static HTML documentation for the workflow-server: semantic HTML pages, one shared stylesheet ([style.css](style.css)), and inline SVG diagrams. No site-generator toolchain.
 
-The markdown files in the repository (`README.md`, `SETUP.md`, `docs/`, `schemas/README.md`) are the **canonical documentation source**; the pages here are the navigable, illustrated view over them and link back to their sources. Open [index.html](index.html) directly in a browser to preview.
+The markdown files in the repository (`README.md`, `SETUP.md`, `docs/`, `schemas/README.md`) are the **canonical documentation source**; the pages under `guide/`, `specs/`, and `api/` are the navigable, illustrated view over them and link back to their sources. Two sections go beyond the markdown: `internals/` documents the server implementation (its canonical source is the code in `src/`, which every page links to), and `design/` records design rationale distilled from the engineering branch's decision records. Open [index.html](index.html) directly in a browser to preview.
 
 How the whole documentation system fits together — every source's purpose and audience, and where new documentation belongs — is described in [docs/documentation-system.md](../docs/documentation-system.md).

--- a/site/api/protocol.html
+++ b/site/api/protocol.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>The protocol in practice — Workflow Server</title>
+<meta name="description" content="The agent-server conversation beyond tool signatures: call ordering, the error and warning taxonomy, trace tokens, reference delivery, and dispatch in practice.">
+<link rel="stylesheet" href="../style.css">
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+
+<header class="site-header">
+  <div class="site-header__inner">
+    <a class="site-title" href="../">Workflow Server</a>
+    <nav class="site-nav" aria-label="Site">
+      <ul>
+        <li><a href="../">Home</a></li>
+        <li><a href="./tools.html">Tools</a></li>
+        <li><a href="./schemas.html">Schemas</a></li>
+        <li><a href="./protocol.html" aria-current="page">Protocol</a></li>
+        <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
+<main id="main">
+  <h1>The protocol in practice</h1>
+  <p class="lede">The <a href="./tools.html">tool reference</a> gives the signatures; this page gives the conversation — what order calls must come in, what errors and warnings actually mean, how the trace works, and the delivery behaviour an agent will observe on the wire.</p>
+  <p>Prose guidance per tool is in the canonical <a href="https://github.com/m2ux/workflow-server/blob/main/docs/api-reference.md">API reference</a>; the machinery behind each behaviour here is described in the <a href="../internals/server-anatomy.html">internals section</a>.</p>
+
+  <h2 id="ordering">Call order and authentication</h2>
+  <p>Three tools are callable cold — <code>discover</code>, <code>list_workflows</code>, and <code>health_check</code>. Everything else requires the <code>session_index</code> issued by <code>start_session</code>, and a few ordering rules carry the whole protocol:</p>
+  <ul>
+    <li><strong><code>get_workflow</code> is the only source of <code>initialActivity</code></strong> — the first <code>next_activity</code> call needs it, so the sequence <code>start_session → get_workflow → next_activity</code> is fixed.</li>
+    <li><strong><code>next_activity</code> moves; <code>get_activity</code> reads.</strong> The orchestrator advances the session and gets back only the new activity's id; the worker then loads the full definition. Later transitions come from the <code>transitions</code> field of the current activity, validated server-side against the definition.</li>
+    <li><strong>An active checkpoint locks the session.</strong> Between <code>yield_checkpoint</code> and <code>respond_checkpoint</code>, navigation <em>and</em> content reads (<code>next_activity</code>, <code>get_activity</code>, <code>get_technique</code>, <code>get_resource</code>, <code>get_trace</code>) are refused; only the checkpoint tools and <code>get_workflow_status</code> proceed. <code>respond_checkpoint</code> with a user choice is additionally rejected if it arrives less than three seconds after the yield — a response that fast did not involve a person.</li>
+    <li><strong>Replays are safe.</strong> Yielding a checkpoint that was already resolved returns the cached response instead of pausing again, so a worker resumed with stale context cannot double-ask.</li>
+  </ul>
+
+  <h2 id="errors">Errors: the call failed</h2>
+  <p>Errors mean the call did not take effect. The useful distinction for an agent is <em>what to do next</em>:</p>
+  <div class="table-wrap">
+    <table>
+      <thead>
+        <tr><th scope="col">Error</th><th scope="col">Meaning</th><th scope="col">Sensible reaction</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Parameter validation failure</td><td>The call violated the tool's schema; it never reached a handler.</td><td>Fix the call — never retry verbatim.</td></tr>
+        <tr><td><code>WorkflowNotFoundError</code>, <code>ActivityNotFoundError</code>, <code>TechniqueNotFoundError</code>, <code>ResourceNotFoundError</code></td><td>A definition referenced by id does not exist in the mounted corpus.</td><td>Re-check the reference against <code>list_workflows</code> / the activity's declared steps; a typo is far likelier than a missing file.</td></tr>
+        <tr><td><code>SessionStoreError: NOT_FOUND</code> / <code>INVALID_INDEX</code></td><td>No session behind that index, or the token isn't a session index at all.</td><td>Resume by planning-folder slug via <code>start_session</code> rather than guessing indexes.</td></tr>
+        <tr><td><code>SessionStoreError: SEAL_MISMATCH</code></td><td>The state file is not what the server last wrote — edited, corrupted, or restored.</td><td>Stop and surface to the user; the server will not act on state it cannot vouch for.</td></tr>
+        <tr><td><code>SessionStoreError: COLLISION</code> / <code>WORKSPACE_INVALID</code></td><td>Two folders derived the same index, or the workspace path is unusable.</td><td>Both are setup problems for a human, not something to retry around.</td></tr>
+        <tr><td>Checkpoint gate refusals</td><td>Navigation attempted while a checkpoint is active, or a response arrived too fast.</td><td>Resolve the checkpoint properly; the gate is the feature.</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h2 id="warnings">Warnings: the call succeeded, and left evidence</h2>
+  <p>Validation that requires interpretation never blocks — it lands in <code>_meta.validation</code> as <code>{ status, warnings }</code> on the successful response, and is recorded in the trace. Warnings an orchestrator should expect to read:</p>
+  <div class="table-wrap">
+    <table>
+      <thead>
+        <tr><th scope="col">Warning</th><th scope="col">What it signals</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Missing / unexpected steps in manifest</td><td>The reported <code>step_manifest</code> doesn't match the activity's declared steps — work was skipped, invented, or renamed.</td></tr>
+        <tr><td>Step order mismatch, empty step output</td><td>Steps reported out of declared order, or a step claimed complete with nothing to show.</td></tr>
+        <tr><td>Technique not fetched</td><td>A manifested technique step has no <code>technique_fetched</code> event — the step was summarized from memory, not executed from its definition.</td></tr>
+        <tr><td>Workflow version drift</td><td>The definition changed on disk since <code>start_session</code>; the run continues under the new definition.</td></tr>
+        <tr><td>Parent chain depth</td><td>More than five levels of nested dispatch — usually a sign the dispatch topology has gone wrong.</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p>Why deviations warn instead of block is a deliberate stance — see <a href="../design/rationale.html#detection">detection over prevention</a>.</p>
+
+  <h2 id="trace">The trace</h2>
+  <p>Every tool call appends an event — tool, timing, outcome, workflow, activity, agent, and any validation warnings — to an in-process, per-session buffer (up to 1,000 sessions; the oldest is evicted beyond that). Each <code>next_activity</code> response additionally carries <code>_meta.trace_token</code>: the events since the previous transition, HMAC-signed into a compact token. The tokens are the durable half of the design — an orchestrator that accumulates them can hand the set to <a href="./tools.html#get_trace"><code>get_trace</code></a> and reconstruct a tamper-evident account of the run even after the in-memory buffer is gone. Calling <code>get_trace</code> with no tokens returns the live buffer for the session.</p>
+
+  <h2 id="delivery">Reference delivery</h2>
+  <p>Sessions run in one of two delivery modes, recorded as <code>contextMode</code>. In <code>fresh</code> mode (the default) every fetch returns full content — right for disposable workers that start with empty context. In <code>persistent</code> mode the server keeps a per-agent ledger of content hashes and replaces anything already delivered with a short marker:</p>
+
+  <figure class="diagram">
+    <svg viewBox="0 0 960 250" role="img" aria-labelledby="rd-title rd-desc">
+      <title id="rd-title">Reference delivery</title>
+      <desc id="rd-desc">A fetch through get_activity or get_technique reaches a decision: is the content hash already in the session's delivered ledger? If yes, the response is a short unchanged marker with the content hash. If no, the full content is delivered and its hash is recorded in the ledger.</desc>
+      <defs>
+        <marker id="arrowrd" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--diagram-edge)"/>
+        </marker>
+      </defs>
+      <g font-size="14.5" font-weight="600" text-anchor="middle">
+        <rect x="20" y="90" width="260" height="56" rx="10" fill="var(--diagram-node-alt-fill)" stroke="var(--diagram-node-alt-stroke)" stroke-width="2"/>
+        <text x="150" y="114" fill="var(--diagram-label)" font-family="ui-monospace, Menlo, Consolas, monospace" font-size="13.5">get_activity / get_technique</text>
+        <text x="150" y="134" fill="var(--diagram-note)" font-size="12.5" font-weight="400">in persistent context mode</text>
+        <rect x="330" y="90" width="280" height="56" rx="10" fill="var(--diagram-node-fill)" stroke="var(--diagram-node-stroke)" stroke-width="2"/>
+        <text x="470" y="114" fill="var(--diagram-label)">hash already in the ledger?</text>
+        <text x="470" y="134" fill="var(--diagram-note)" font-size="12.5" font-weight="400">deliveredContent, per agent</text>
+        <rect x="670" y="30" width="270" height="64" rx="10" fill="var(--diagram-node-fill)" stroke="var(--diagram-node-stroke)" stroke-width="2"/>
+        <text x="805" y="56" fill="var(--diagram-label)" font-family="ui-monospace, Menlo, Consolas, monospace" font-size="13">{ unchanged: true,</text>
+        <text x="805" y="76" fill="var(--diagram-label)" font-family="ui-monospace, Menlo, Consolas, monospace" font-size="13">content_hash }</text>
+        <rect x="670" y="160" width="270" height="64" rx="10" fill="var(--diagram-node-fill)" stroke="var(--diagram-node-stroke)" stroke-width="2"/>
+        <text x="805" y="186" fill="var(--diagram-label)">full content delivered</text>
+        <text x="805" y="208" fill="var(--diagram-note)" font-size="12.5" font-weight="400">hash recorded in the ledger</text>
+      </g>
+      <g font-size="13" fill="var(--diagram-note)" text-anchor="middle">
+        <text x="655" y="52">yes</text>
+        <text x="655" y="158">no</text>
+      </g>
+      <g stroke="var(--diagram-edge)" stroke-width="2" fill="none">
+        <line x1="280" y1="118" x2="326" y2="118" marker-end="url(#arrowrd)"/>
+        <path d="M 610 106 L 640 106 L 640 62 L 666 62" marker-end="url(#arrowrd)"/>
+        <path d="M 610 130 L 640 130 L 640 192 L 666 192" marker-end="url(#arrowrd)"/>
+      </g>
+    </svg>
+    <figcaption>Reference delivery in <code>persistent</code> mode. The ledger is keyed per agent and per channel (technique bundles, rules, individual techniques), so an orchestrator and a worker on the same session have independent delivery state. An agent that has lost its context can force re-delivery with <code>get_activity { bundle: "full" }</code> or <code>get_technique { full: true }</code>.</figcaption>
+  </figure>
+
+  <p>The marker is a contract, not a hint: <code>unchanged: true</code> asserts the content is byte-identical to what this agent already received, which the server can promise because payload composition is deterministic. If your context no longer contains the earlier copy, ask for full delivery rather than proceeding from a summary.</p>
+
+  <h2 id="dispatch">Dispatch in practice</h2>
+  <p>A typical work package starts before any planning folder exists: the meta session created by <code>start_session</code> for workflow selection is <em>transient</em>, living in the system temp directory. The first <code>dispatch_child</code> that commits to real work does three things at once — promotes the transient session into <code>.engineering/artifacts/planning/&lt;slug&gt;/</code> (the slug from your request, or a dated fallback), creates the child session embedded in the parent's file, and returns the child's own <code>session_index</code> for the worker. From there:</p>
+    <ul>
+    <li><code>get_workflow_status</code> is the orchestrator's poll — position, active checkpoint, and child statuses without touching execution.</li>
+    <li>A child reaching its terminal activity flips its entry in the parent's <code>triggeredWorkflows</code> to <code>completed</code>; the parent discovers this on its next status read rather than by callback.</li>
+    <li>Because children are <a href="../internals/session-store.html#nesting">embedded, not separate files</a>, resuming the parent by folder name resumes the entire tree.</li>
+  </ul>
+
+  <h2 id="next">Next</h2>
+  <p>Signatures for every tool are on the <a href="./tools.html">tool reference</a>; the server-side mechanics of a call are in <a href="../internals/request-lifecycle.html">the request lifecycle</a>.</p>
+</main>
+
+<footer class="site-footer">
+  <div class="site-footer__inner">
+    <span>Markdown in the <a href="https://github.com/m2ux/workflow-server">repository</a> is the canonical documentation source.</span>
+    <span><a href="https://github.com/m2ux/workflow-server/blob/main/LICENSE">MIT License</a></span>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/site/api/schemas.html
+++ b/site/api/schemas.html
@@ -18,6 +18,7 @@
         <li><a href="../">Home</a></li>
         <li><a href="./tools.html">Tools</a></li>
         <li><a href="./schemas.html" aria-current="page">Schemas</a></li>
+        <li><a href="./protocol.html">Protocol</a></li>
         <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
       </ul>
     </nav>

--- a/site/api/tools.html
+++ b/site/api/tools.html
@@ -18,6 +18,7 @@
         <li><a href="../">Home</a></li>
         <li><a href="./tools.html" aria-current="page">Tools</a></li>
         <li><a href="./schemas.html">Schemas</a></li>
+        <li><a href="./protocol.html">Protocol</a></li>
         <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
       </ul>
     </nav>

--- a/site/design/rationale.html
+++ b/site/design/rationale.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Design rationale — Workflow Server</title>
+<meta name="description" content="Why the workflow-server is shaped the way it is: the reasoning behind server-owned state, determinism, progressive disclosure, checkpoints, and the project's guard-driven engineering culture.">
+<link rel="stylesheet" href="../style.css">
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+
+<header class="site-header">
+  <div class="site-header__inner">
+    <a class="site-title" href="../">Workflow Server</a>
+    <nav class="site-nav" aria-label="Site">
+      <ul>
+        <li><a href="../">Home</a></li>
+        <li><a href="./rationale.html" aria-current="page">Design rationale</a></li>
+        <li><a href="../specs/architecture.html">Architecture</a></li>
+        <li><a href="../internals/server-anatomy.html">Internals</a></li>
+        <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
+<main id="main">
+  <h1>Design rationale</h1>
+  <p class="lede">The <a href="../specs/architecture.html">specifications</a> describe the system as it is; this page records <em>why</em> it is that way. Every position here traces to a real force — usually a failure mode observed while running agents against earlier versions — and most accept a visible cost in exchange.</p>
+  <p>The material is distilled from the project's architecture decision records and engineering history, which live on the engineering branch alongside the code. Where a decision is implemented, the internals pages show the mechanism.</p>
+
+  <h2 id="state-ownership">Who holds the truth</h2>
+
+  <h3 id="state">The server owns the state, not the agent</h3>
+  <p>Early designs had agents carry session state in opaque tokens and transcribe them between calls. That failed in the mundane way everything agent-transcribed eventually fails: tokens drifted, got truncated, or were reconstructed from memory. The recorded decision (ADR-0003, server-managed session state) moves the whole record into a <a href="../internals/session-store.html">sealed <code>session.json</code></a> the server alone writes, with agents holding only a six-character index. Authority and write capability now sit in the same place as the HMAC secret; a server restart is invisible because the disk, not the process, is the memory. The accepted costs: the server must be told its workspace at launch, and every authenticated call pays filesystem I/O.</p>
+
+  <h3 id="integrity">Integrity, not security</h3>
+  <p>The cryptography invites overreading, so the threat model is worth stating plainly: the HMAC seals exist to detect <em>incoherence</em> — a corrupted file, a hand-edit, a restored backup, two writers racing — not to resist an adversary, who could simply delete the folder. Framing it honestly keeps the mechanism proportionate: one server key, cheap digests, hard failure on mismatch, and no pretence that a workspace file is a security boundary.</p>
+
+  <h3 id="determinism">Determinism over model judgment</h3>
+  <p>Wherever a choice can be resolved from the definition and the state, the system resolves it mechanically: transitions evaluate first-matching-condition, artifact contracts are synthesized from technique outputs rather than restated, binding provenance is computed statically, and identical inputs produce byte-identical payloads. The reasoning is that model judgment is the scarce, expensive, variable ingredient — spending it on plumbing wastes it and makes runs unreproducible. Given the same definition and state, any conforming agent follows the same path; creativity is confined to the work itself.</p>
+
+  <h2 id="agent-experience">How agents experience the system</h2>
+
+  <h3 id="mcp">One narrow surface: MCP tools</h3>
+  <p>Everything crosses a single boundary — sixteen MCP tools with schema-validated parameters. No side channel, no shared files as API, no prompt-injection-by-convention. A narrow, typed surface is what makes the <a href="../internals/request-lifecycle.html">uniform lifecycle</a> possible: because every interaction is a tool call, every interaction can be authenticated, validated, traced, and audited by the same three functions. It also keeps the server client-agnostic: anything that speaks MCP gets the full system.</p>
+
+  <h3 id="disclosure">Progressive disclosure: context is the scarce resource</h3>
+  <p>An agent's context window is the system's real budget constraint, and the delivery design treats it that way. Definitions arrive at the granularity of need: workflow metadata at <code>get_workflow</code>, one activity at a time at <code>get_activity</code>, one technique per step at <code>get_technique</code>, resources only when a technique actually cites them. Two refinements came from watching real runs. Reference-not-repeat delivery replaces already-delivered content with <code>unchanged</code> hash markers for persistent-context agents, because re-sending identical bundles was the single largest token waste. And fetch recording makes laziness observable — since the server cannot force an agent to read, it records what was fetched and warns when a manifested step was never loaded, converting silent corner-cutting into a visible signal.</p>
+
+  <h3 id="checkpoints">Checkpoints yield first, present later</h3>
+  <p>A checkpoint's pause and its presentation are different concerns with different owners. The worker that hits a checkpoint records the pause (<code>yield_checkpoint</code>) and steps aside; the user-facing agent later loads the decision (<code>present_checkpoint</code>) and submits the answer (<code>respond_checkpoint</code>). Splitting the two lets a pause bubble up through any number of dispatch layers while the server enforces the invariant that matters — nothing advances past an unresolved checkpoint, wherever it was raised. The minimum-response-time check exists for the same reason the gate does: a checkpoint answered in under three seconds was answered by a model, not a person.</p>
+
+  <h3 id="dispatch">Three layers of dispatch</h3>
+  <p>The meta orchestrator, workflow orchestrator, and activity workers (<a href="../specs/dispatch.html">the dispatch model</a>) are separated by what they must not share: user conversation, workflow state, and task context. Fresh workers per activity keep each execution's context clean and disposable; the embedded child-session design keeps the whole work package in one resumable file despite the layering. The design deliberately tolerates hosts without sub-agent support — dispatch degrades to inline execution — because portability across MCP clients mattered more than mandating an execution topology.</p>
+
+  <h2 id="defining-behaviour">How behaviour is defined</h2>
+
+  <h3 id="techniques">Techniques are markdown with a contract</h3>
+  <p>Process knowledge is written in markdown files with declared inputs, outputs, protocol, and rules — parseable enough for the server to compose, validate, and bind them; readable enough for a human to review in a pull request and an agent to follow verbatim. The alternative poles were both rejected: free-form prose cannot be checked, and a rigid programmatic format cannot hold the judgment-laden guidance that makes techniques worth having. The contract layer (typed identifiers, binding provenance, inheritance) grew precisely at the seams where prose had proven unreliable.</p>
+
+  <h3 id="orphan-branch">Workflow data on an orphan branch</h3>
+  <p>Workflow definitions live on a <code>workflows</code> branch with no shared history with <code>main</code>, checked out as a worktree. The two bodies change for different reasons on different cadences: server releases are code events; workflow edits are content events, often several per day while a process is being tuned. Separate histories mean content changes never entangle server review, a deployment can pin either side independently, and the same server can mount a different corpus per project. The cost is a two-step setup (<code>git worktree add</code>) and the standing rule that content PRs and server PRs stay separate.</p>
+
+  <h2 id="honesty">How the project keeps itself honest</h2>
+
+  <h3 id="detection">Detection over prevention</h3>
+  <p>Of the seven <a href="../specs/workflow-fidelity.html">fidelity layers</a>, only the cheap-and-certain ones block: seal verification and the checkpoint gate. Everything that requires interpretation — manifest completeness, version drift, fetch coverage — warns instead. The stance is deliberate humility about what a server can know: it cannot verify that work was done well, only that the observable record is consistent. Hard-blocking on heuristics would teach agents to game the heuristic; surfacing warnings in <code>_meta</code> and the trace gives the orchestrator and the human the evidence and leaves judgment where it belongs. The fidelity page's "honest limitations" section is part of the design, not an apology.</p>
+
+  <h3 id="guards">Guards, anti-patterns, baselines</h3>
+  <p>Recurring authoring mistakes get codified three ways: a named anti-pattern in the engineering catalogue, a mechanical guard that detects it, and a baseline that ratchets existing violations toward zero (<a href="../internals/quality-system.html">the quality system</a>). The insight is that in a system whose "code" is largely YAML and markdown, convention enforcement cannot live in reviewer vigilance — reviewers tire, agents don't reread style guides, but a failing check is unarguable. The same move recurs at every level of the project: turn a lesson into a machine that remembers it.</p>
+
+  <h3 id="docs-site">A hand-authored documentation site</h3>
+  <p>This site replaced a static-site-generator pipeline with plain HTML, one stylesheet, and inline SVG. For a documentation set this size, the toolchain cost more than it gave: themes fought the content, and nothing guaranteed the rendered site matched the source of truth. The current arrangement inverts that — markdown in the repository stays canonical, pages that mirror the code are <a href="../internals/quality-system.html#pipelines">generated and drift-tested</a>, and link and diagram integrity are enforced by the same guard suite as everything else. The docs are treated like the workflows: content with executable invariants.</p>
+
+  <h2 id="next">Next</h2>
+  <p>See these decisions as running code in the <a href="../internals/server-anatomy.html">internals section</a>, or as guarantees in the <a href="../specs/architecture.html">architecture models</a>.</p>
+</main>
+
+<footer class="site-footer">
+  <div class="site-footer__inner">
+    <span>Markdown in the <a href="https://github.com/m2ux/workflow-server">repository</a> is the canonical documentation source.</span>
+    <span><a href="https://github.com/m2ux/workflow-server/blob/main/LICENSE">MIT License</a></span>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -128,7 +128,7 @@
 
   <section id="documentation" aria-labelledby="documentation-h">
     <h2 id="documentation-h">Documentation</h2>
-    <p>The markdown files in the repository are the canonical documentation source; this site is the navigable, illustrated view over them. Three sections cover the material:</p>
+    <p>The markdown files in the repository are the canonical documentation source; this site is the navigable, illustrated view over them, extended with two sections derived from the server source and the project's decision records. Five sections cover the material:</p>
     <ul class="card-grid">
       <li class="card">
         <h3>User guide</h3>
@@ -142,8 +142,18 @@
       </li>
       <li class="card">
         <h3>API usage</h3>
-        <p>Full signatures for the 16 MCP tools, the JSON schemas that define workflows, activities, and techniques, and the conventions for authoring workflow definitions.</p>
-        <span class="card-cta"><a href="api/tools.html">Tool reference</a> · <a href="api/schemas.html">Schema reference</a></span>
+        <p>Full signatures for the 16 MCP tools, the JSON schemas that define workflows, activities, and techniques, and the protocol in practice — call ordering, errors, warnings, traces, and delivery.</p>
+        <span class="card-cta"><a href="api/tools.html">Tool reference</a> · <a href="api/schemas.html">Schema reference</a> · <a href="api/protocol.html">Protocol in practice</a></span>
+      </li>
+      <li class="card">
+        <h3>Server internals</h3>
+        <p>The implementation view for contributors: how the code is organized, what happens inside one tool call, how session state stays trustworthy on disk, and the guard-and-test system the repository runs on itself.</p>
+        <span class="card-cta"><a href="internals/server-anatomy.html">Server anatomy</a> · <a href="internals/request-lifecycle.html">Request lifecycle</a> · <a href="internals/session-store.html">Session store</a> · <a href="internals/quality-system.html">Quality system</a></span>
+      </li>
+      <li class="card">
+        <h3>Design rationale</h3>
+        <p>Why the system is shaped the way it is: server-owned state, determinism over model judgment, progressive disclosure, detection over prevention — the forces behind each decision, and the costs accepted.</p>
+        <span class="card-cta"><a href="design/rationale.html">Design rationale</a></span>
       </li>
     </ul>
 
@@ -180,6 +190,9 @@
           <tr><td>What tools does the server expose, and with what signatures?</td><td><a href="https://github.com/m2ux/workflow-server/blob/main/docs/api-reference.md">API reference</a></td></tr>
           <tr><td>How do I author or validate a workflow definition?</td><td><a href="https://github.com/m2ux/workflow-server/blob/main/schemas/README.md">Schema guide</a></td></tr>
           <tr><td>How is the system designed?</td><td><a href="https://github.com/m2ux/workflow-server/blob/main/docs/architecture.md">Architecture overview</a>, which links each of the six model documents</td></tr>
+          <tr><td>Why is it designed this way?</td><td><a href="design/rationale.html">Design rationale</a> on this site, distilled from the project's decision records</td></tr>
+          <tr><td>How is the server implemented?</td><td>The <a href="internals/server-anatomy.html">server internals</a> section on this site, derived from the source</td></tr>
+          <tr><td>What do the server's errors and warnings mean in practice?</td><td><a href="api/protocol.html">The protocol in practice</a></td></tr>
           <tr><td>What keeps an agent faithful to a workflow?</td><td><a href="https://github.com/m2ux/workflow-server/blob/main/docs/workflow-fidelity.md">Workflow fidelity</a></td></tr>
           <tr><td>How do techniques declare their protocol and bindings?</td><td><a href="https://github.com/m2ux/workflow-server/blob/main/docs/technique-protocol-specification.md">Technique protocol specification</a></td></tr>
           <tr><td>How do I contribute to the server itself?</td><td><a href="https://github.com/m2ux/workflow-server/blob/main/docs/development.md">Development guide</a></td></tr>

--- a/site/internals/quality-system.html
+++ b/site/internals/quality-system.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Quality system — Workflow Server</title>
+<meta name="description" content="How the repository defends its invariants: the guard-script suite, baseline ratchets, the test architecture, and the generated-then-guarded documentation pipelines.">
+<link rel="stylesheet" href="../style.css">
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+
+<header class="site-header">
+  <div class="site-header__inner">
+    <a class="site-title" href="../">Workflow Server</a>
+    <nav class="site-nav" aria-label="Site">
+      <ul>
+        <li><a href="../">Home</a></li>
+        <li><a href="./server-anatomy.html">Server anatomy</a></li>
+        <li><a href="./request-lifecycle.html">Request lifecycle</a></li>
+        <li><a href="./session-store.html">Session store</a></li>
+        <li><a href="./quality-system.html" aria-current="page">Quality system</a></li>
+        <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
+<main id="main">
+  <h1>Quality system</h1>
+  <p class="lede">The server enforces workflow fidelity at runtime; the repository applies the same philosophy to itself. Every convention that matters — reference integrity, naming rules, schema truthfulness, even the geometry of this site's diagrams — is encoded as an executable guard, so a violation is a failing check, not a review comment.</p>
+  <p>The guards live in <a href="https://github.com/m2ux/workflow-server/tree/main/scripts"><code>scripts/</code></a> and run as <code>npm run check:*</code>; the tests live in <a href="https://github.com/m2ux/workflow-server/tree/main/tests"><code>tests/</code></a> under Vitest.</p>
+
+  <h2 id="guards">The guard suite</h2>
+  <p>Most guards audit the workflow corpus — the YAML and markdown definitions the server executes — because that content is data, not code, and the type checker cannot see into it:</p>
+  <div class="table-wrap">
+    <table>
+      <thead>
+        <tr><th scope="col">Guard</th><th scope="col">What it enforces</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><code>validate-workflow-yaml</code>, <code>validate-activities</code></td><td>Every workflow manifest and activity file parses and satisfies the schemas — a dry run of the server's own loaders.</td></tr>
+        <tr><td><code>check-all-refs</code></td><td>Every technique reference resolves to a real technique; no misspellings, no dangling paths.</td></tr>
+        <tr><td><code>check-binding-fidelity</code></td><td>Step bindings are coherent end to end: arguments conform to declared inputs, reads resolve to a producer, outputs are consumed, and inputs have a source.</td></tr>
+        <tr><td><code>check-identifier-qualification</code></td><td>Technique input and output ids are qualified noun phrases (<code>completion_summary</code>, never a bare <code>summary</code>).</td></tr>
+        <tr><td><code>check-technique-template</code></td><td>Technique markdown follows the normative structure of the <a href="https://github.com/m2ux/workflow-server/blob/main/docs/technique-protocol-specification.md">technique protocol</a>.</td></tr>
+        <tr><td><code>check-resource-anchors</code></td><td>Every <code>#section</code> anchor a technique uses to reference a resource exists in that resource.</td></tr>
+        <tr><td><code>check-activity-technique-overlap</code>, <code>check-self-provisioned-input</code>, <code>check-prism-lens-reachability</code></td><td>Namespace collisions between activities and techniques, inputs that circularly reference themselves, and unreachable review-lens paths.</td></tr>
+        <tr><td><code>check-site-links</code>, <code>check-svg-layout</code></td><td>This site: every internal link and anchor resolves, every GitHub link points at a real file, and no SVG diagram text collides with boxes, arrows, or sibling text.</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h2 id="baselines">Baselines: the ratchet</h2>
+  <p>Guards that arrived after the corpus grew would have failed on hundreds of pre-existing findings, so those guards carry a checked-in baseline (for example <a href="https://github.com/m2ux/workflow-server/blob/main/scripts/binding-fidelity-baseline.json"><code>binding-fidelity-baseline.json</code></a>): known findings are tolerated, <em>new</em> ones fail the check, and burning down the baseline is ordinary, visible work. A guard whose baseline is empty — identifier qualification is one — has been ratcheted all the way: the rule now holds everywhere. The pattern turns "we should clean this up eventually" into a number that can only go down.</p>
+
+  <h2 id="tests">The test architecture</h2>
+  <p>The Vitest suite (thirty-plus files) is organized around what could break:</p>
+  <ul>
+    <li><strong>Unit coverage of the machinery</strong> — schema validation and generation, every loader, and the session store's sharp edges: HMAC sealing, index derivation, collision handling, legacy-folder migration.</li>
+    <li><strong>Fidelity behaviour</strong> — the runtime validators, binding provenance, fetch observability, reference-not-repeat delivery, and trace-token signing, each tested as an observable contract rather than an implementation detail.</li>
+    <li><strong>End-to-end execution</strong> — <code>mcp-server.test.ts</code> drives real tool calls; a deterministic walker (<a href="https://github.com/m2ux/workflow-server/blob/main/tests/e2e/walker.ts"><code>tests/e2e/walker.ts</code></a>) enumerates every reachable path through every workflow definition and executes each one against the live server, so an unreachable activity or an impossible transition in <em>content</em> fails the <em>server's</em> test suite.</li>
+    <li><strong>Documentation</strong> — <code>site.test.ts</code> runs the two site guards and the drift check described below, making stale documentation a red build.</li>
+    <li><strong>Agent smoke runs</strong> — <a href="https://github.com/m2ux/workflow-server/blob/main/scripts/smoke/smoke-orchestrator.ts"><code>scripts/smoke/</code></a> drives a real agent through a workflow for the behaviour no deterministic walk can check: whether the instructions actually steer a model.</li>
+  </ul>
+
+  <h2 id="pipelines">Generated, then guarded</h2>
+  <p>Two artifacts are machine-derived from the source, and both are guarded against drift rather than trusted to stay fresh:</p>
+
+  <figure class="diagram">
+    <svg viewBox="0 0 960 240" role="img" aria-labelledby="qp-title qp-desc">
+      <title id="qp-title">The two generation pipelines</title>
+      <desc id="qp-desc">Top row: the Zod sources in src slash schema are compiled by npm run build colon schemas into the checked-in JSON schema files, which serve authoring validation and the schemas MCP resource. Bottom row: the server source is replayed by npm run build colon site into the generated regions of the site's API pages, and tests slash site.test.ts fails when the committed pages drift.</desc>
+      <defs>
+        <marker id="arrowqp" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--diagram-edge)"/>
+        </marker>
+      </defs>
+      <g font-size="14.5" font-weight="600" text-anchor="middle">
+        <rect x="15" y="40" width="210" height="52" rx="10" fill="var(--diagram-node-fill)" stroke="var(--diagram-node-stroke)" stroke-width="2"/>
+        <text x="120" y="62" fill="var(--diagram-label)" font-family="ui-monospace, Menlo, Consolas, monospace" font-size="14">src/schema (Zod)</text>
+        <text x="120" y="82" fill="var(--diagram-note)" font-size="12.5" font-weight="400">the source of truth</text>
+        <rect x="245" y="40" width="210" height="52" rx="10" fill="var(--diagram-node-fill)" stroke="var(--diagram-node-stroke)" stroke-width="2"/>
+        <text x="350" y="62" fill="var(--diagram-label)" font-family="ui-monospace, Menlo, Consolas, monospace" font-size="13.5">npm run build:schemas</text>
+        <text x="350" y="82" fill="var(--diagram-note)" font-size="12.5" font-weight="400">compile to JSON Schema</text>
+        <rect x="475" y="40" width="210" height="52" rx="10" fill="var(--diagram-node-fill)" stroke="var(--diagram-node-stroke)" stroke-width="2"/>
+        <text x="580" y="62" fill="var(--diagram-label)" font-family="ui-monospace, Menlo, Consolas, monospace" font-size="13.5">schemas/*.schema.json</text>
+        <text x="580" y="82" fill="var(--diagram-note)" font-size="12.5" font-weight="400">checked in, tested</text>
+        <rect x="705" y="40" width="240" height="52" rx="10" fill="var(--diagram-node-alt-fill)" stroke="var(--diagram-node-alt-stroke)" stroke-width="2"/>
+        <text x="825" y="62" fill="var(--diagram-label)">authoring + validation</text>
+        <text x="825" y="82" fill="var(--diagram-note)" font-size="12.5" font-weight="400">MCP resource + this site</text>
+        <rect x="15" y="150" width="210" height="52" rx="10" fill="var(--diagram-node-fill)" stroke="var(--diagram-node-stroke)" stroke-width="2"/>
+        <text x="120" y="172" fill="var(--diagram-label)">server source</text>
+        <text x="120" y="192" fill="var(--diagram-note)" font-size="12.5" font-weight="400">tool registrations</text>
+        <rect x="245" y="150" width="210" height="52" rx="10" fill="var(--diagram-node-fill)" stroke="var(--diagram-node-stroke)" stroke-width="2"/>
+        <text x="350" y="172" fill="var(--diagram-label)" font-family="ui-monospace, Menlo, Consolas, monospace" font-size="13.5">npm run build:site</text>
+        <text x="350" y="192" fill="var(--diagram-note)" font-size="12.5" font-weight="400">replayed on a recorder</text>
+        <rect x="475" y="150" width="210" height="52" rx="10" fill="var(--diagram-node-fill)" stroke="var(--diagram-node-stroke)" stroke-width="2"/>
+        <text x="580" y="172" fill="var(--diagram-label)" font-family="ui-monospace, Menlo, Consolas, monospace" font-size="14">site/api/*.html</text>
+        <text x="580" y="192" fill="var(--diagram-note)" font-size="12.5" font-weight="400">generated regions</text>
+        <rect x="705" y="150" width="240" height="52" rx="10" fill="var(--diagram-node-alt-fill)" stroke="var(--diagram-node-alt-stroke)" stroke-width="2"/>
+        <text x="825" y="172" fill="var(--diagram-label)" font-family="ui-monospace, Menlo, Consolas, monospace" font-size="14">tests/site.test.ts</text>
+        <text x="825" y="192" fill="var(--diagram-note)" font-size="12.5" font-weight="400">fails on drift</text>
+      </g>
+      <g stroke="var(--diagram-edge)" stroke-width="2" fill="none">
+        <line x1="225" y1="66" x2="241" y2="66" marker-end="url(#arrowqp)"/>
+        <line x1="455" y1="66" x2="471" y2="66" marker-end="url(#arrowqp)"/>
+        <line x1="685" y1="66" x2="701" y2="66" marker-end="url(#arrowqp)"/>
+        <line x1="225" y1="176" x2="241" y2="176" marker-end="url(#arrowqp)"/>
+        <line x1="455" y1="176" x2="471" y2="176" marker-end="url(#arrowqp)"/>
+        <line x1="685" y1="176" x2="701" y2="176" marker-end="url(#arrowqp)"/>
+      </g>
+    </svg>
+    <figcaption>The two generation pipelines. The JSON schemas are compiled from the Zod sources; the site's <a href="../api/tools.html">tool</a> and <a href="../api/schemas.html">schema</a> pages contain regions regenerated by replaying the real tool registrations against a recording stub. In both cases the generated artifact is committed, and a test fails when it no longer matches a fresh generation — documentation cannot silently lie about the code.</figcaption>
+  </figure>
+
+  <p>The same discipline extends to deployment: the GitHub Pages workflow re-runs the site guards before publishing, so the deployed site is exactly the checked, committed one.</p>
+
+  <h2 id="next">Next</h2>
+  <p>Why the project invests in mechanical guardrails rather than review vigilance is part of <a href="../design/rationale.html#guards">the design rationale</a>; the runtime half of the same philosophy is <a href="../specs/workflow-fidelity.html">workflow fidelity</a>.</p>
+</main>
+
+<footer class="site-footer">
+  <div class="site-footer__inner">
+    <span>Markdown in the <a href="https://github.com/m2ux/workflow-server">repository</a> is the canonical documentation source.</span>
+    <span><a href="https://github.com/m2ux/workflow-server/blob/main/LICENSE">MIT License</a></span>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/site/internals/request-lifecycle.html
+++ b/site/internals/request-lifecycle.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Request lifecycle — Workflow Server</title>
+<meta name="description" content="What happens inside one authenticated tool call: seal verification, definition loading, fidelity validation, deterministic state advance, atomic persistence, and trace signing.">
+<link rel="stylesheet" href="../style.css">
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+
+<header class="site-header">
+  <div class="site-header__inner">
+    <a class="site-title" href="../">Workflow Server</a>
+    <nav class="site-nav" aria-label="Site">
+      <ul>
+        <li><a href="../">Home</a></li>
+        <li><a href="./server-anatomy.html">Server anatomy</a></li>
+        <li><a href="./request-lifecycle.html" aria-current="page">Request lifecycle</a></li>
+        <li><a href="./session-store.html">Session store</a></li>
+        <li><a href="./quality-system.html">Quality system</a></li>
+        <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
+<main id="main">
+  <h1>Request lifecycle</h1>
+  <p class="lede">Every authenticated tool call follows the same skeleton: verify the session, load the definition, validate the claim the agent is making, advance the state, reseal it, and sign the trace. This page walks that skeleton using <a href="../api/tools.html#next_activity"><code>next_activity</code></a> — the most eventful call — as the example.</p>
+  <p>The handlers live in <a href="https://github.com/m2ux/workflow-server/blob/main/src/tools/workflow-tools.ts"><code>src/tools/workflow-tools.ts</code></a>; the shared machinery each stage uses is mapped in <a href="./server-anatomy.html">server anatomy</a>.</p>
+
+  <figure class="diagram">
+    <svg viewBox="0 0 960 290" role="img" aria-labelledby="rl-title rl-desc">
+      <title id="rl-title">The seven stages of an authenticated call</title>
+      <desc id="rl-desc">Seven boxes in sequence: validate parameters, load and verify the session, load the workflow, fidelity checks, advance the state, persist and reseal, sign trace and respond.</desc>
+      <defs>
+        <marker id="arrowrl" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--diagram-edge)"/>
+        </marker>
+      </defs>
+      <g font-size="15" font-weight="600" text-anchor="middle">
+        <rect x="15" y="55" width="210" height="56" rx="10" fill="var(--diagram-node-fill)" stroke="var(--diagram-node-stroke)" stroke-width="2"/>
+        <text x="120" y="79" fill="var(--diagram-label)">Validate parameters</text>
+        <text x="120" y="99" fill="var(--diagram-note)" font-size="12.5" font-weight="400">Zod schema on the call</text>
+        <rect x="245" y="55" width="210" height="56" rx="10" fill="var(--diagram-node-fill)" stroke="var(--diagram-node-stroke)" stroke-width="2"/>
+        <text x="350" y="79" fill="var(--diagram-label)" font-size="14.5">Load + verify session</text>
+        <text x="350" y="99" fill="var(--diagram-note)" font-size="12.5" font-weight="400">seal check, schema parse</text>
+        <rect x="475" y="55" width="210" height="56" rx="10" fill="var(--diagram-node-fill)" stroke="var(--diagram-node-stroke)" stroke-width="2"/>
+        <text x="580" y="79" fill="var(--diagram-label)">Load the workflow</text>
+        <text x="580" y="99" fill="var(--diagram-note)" font-size="12.5" font-weight="400">YAML to validated model</text>
+        <rect x="705" y="55" width="210" height="56" rx="10" fill="var(--diagram-node-fill)" stroke="var(--diagram-node-stroke)" stroke-width="2"/>
+        <text x="810" y="79" fill="var(--diagram-label)">Fidelity checks</text>
+        <text x="810" y="99" fill="var(--diagram-note)" font-size="12.5" font-weight="400">five validators</text>
+        <rect x="125" y="205" width="230" height="56" rx="10" fill="var(--diagram-node-fill)" stroke="var(--diagram-node-stroke)" stroke-width="2"/>
+        <text x="240" y="229" fill="var(--diagram-label)">Advance the state</text>
+        <text x="240" y="249" fill="var(--diagram-note)" font-size="12.5" font-weight="400">seq++, history events</text>
+        <rect x="425" y="205" width="230" height="56" rx="10" fill="var(--diagram-node-fill)" stroke="var(--diagram-node-stroke)" stroke-width="2"/>
+        <text x="540" y="229" fill="var(--diagram-label)">Persist and reseal</text>
+        <text x="540" y="249" fill="var(--diagram-note)" font-size="12.5" font-weight="400">atomic write + HMAC</text>
+        <rect x="705" y="205" width="230" height="56" rx="10" fill="var(--diagram-node-alt-fill)" stroke="var(--diagram-node-alt-stroke)" stroke-width="2"/>
+        <text x="820" y="229" fill="var(--diagram-label)">Sign trace, respond</text>
+        <text x="820" y="249" fill="var(--diagram-note)" font-size="12.5" font-weight="400">trace token in _meta</text>
+      </g>
+      <g stroke="var(--diagram-edge)" stroke-width="2" fill="none">
+        <line x1="225" y1="83" x2="241" y2="83" marker-end="url(#arrowrl)"/>
+        <line x1="455" y1="83" x2="471" y2="83" marker-end="url(#arrowrl)"/>
+        <line x1="685" y1="83" x2="701" y2="83" marker-end="url(#arrowrl)"/>
+        <path d="M 810 111 L 810 165 L 240 165 L 240 201" marker-end="url(#arrowrl)"/>
+        <line x1="355" y1="233" x2="421" y2="233" marker-end="url(#arrowrl)"/>
+        <line x1="655" y1="233" x2="701" y2="233" marker-end="url(#arrowrl)"/>
+      </g>
+    </svg>
+    <figcaption>The seven stages of an authenticated call. Stages one and two are identical for every tool; which validators run in stage four, and what stage five mutates, depend on the tool. Read-only tools such as <code>get_activity</code> skip stages five and six unless they record fetch or delivery events.</figcaption>
+  </figure>
+
+  <h2 id="entry">1–2. Entry, and proving the state is trustworthy</h2>
+  <p>Parameters are validated by the Zod schema attached at registration, so a handler never sees a malformed call. The handler runs inside <code>withAuditLog</code>, which times it and records a trace event whatever the outcome.</p>
+  <p><code>loadSessionForTool</code> then turns the six-character <code>session_index</code> into trusted state: it resolves the planning folder (<a href="./session-store.html#index">how the index maps to a folder</a>), recomputes the HMAC of <code>session.json</code>, and compares it with the stored <code>.session-token</code> digest using a timing-safe comparison. A mismatch raises <code>SessionStoreError(SEAL_MISMATCH)</code> and the call goes no further — the server refuses to act on state it cannot vouch for. The file is finally parsed against the session schema, so downstream code works with typed state, never raw JSON.</p>
+  <p>One more gate applies after loading: if <code>state.activeCheckpoint</code> is set, the session is paused — navigation and content reads alike are refused until the checkpoint is resolved (<a href="../specs/checkpoints.html">the checkpoint model</a>).</p>
+
+  <h2 id="definition">3. Loading the definition</h2>
+  <p>The workflow named in the session is loaded fresh from the workflow directory: the manifest is parsed and validated, each activity file is validated and gets its step ids populated, and the <code>artifactPrefix</code> is derived from the activity filename's numeric prefix. Nothing is cached across calls — the definition on disk is always the definition in force, which is what lets workflow hotfixes land mid-session (with a version-drift warning rather than a failure).</p>
+
+  <h2 id="validation">4. Fidelity checks</h2>
+  <p>With trusted state and a validated definition, the server checks the claim the call is making. For <code>next_activity</code> that means five validators from <a href="https://github.com/m2ux/workflow-server/blob/main/src/utils/validation.ts"><code>utils/validation.ts</code></a>:</p>
+  <div class="table-wrap">
+    <table>
+      <thead>
+        <tr><th scope="col">Validator</th><th scope="col">Checks</th><th scope="col">On failure</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><code>validateActivityTransition</code></td><td>The requested activity is a declared transition from the current one (the terminal sentinel is always valid).</td><td>Blocks</td></tr>
+        <tr><td><code>validateWorkflowVersion</code></td><td>The definition's version still matches the version captured at <code>start_session</code>.</td><td>Warns</td></tr>
+        <tr><td><code>validateStepManifest</code></td><td>The reported <code>step_manifest</code> covers the activity's declared steps — nothing missing, nothing invented, order preserved, no empty outputs.</td><td>Warns</td></tr>
+        <tr><td><code>validateTechniqueFetches</code></td><td>Every manifested technique step has a matching <code>technique_fetched</code> history event — the step was actually loaded, not summarized from memory.</td><td>Warns</td></tr>
+        <tr><td><code>validateTransitionCondition</code>, <code>validateActivityManifest</code></td><td>The stated transition condition exists in the definition, and the completed-activity trail is consistent with the workflow graph.</td><td>Warns</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p>The split is deliberate: only checks that are cheap and certain block the call; everything judgment-shaped becomes a warning in the response and the trace. <a href="../design/rationale.html#detection">Detection over prevention</a> explains why.</p>
+
+  <h2 id="advance">5. Advancing the state</h2>
+  <p><code>advanceSession</code> applies the mutation as a controlled update: the monotonic <code>seq</code> counter increments, the timestamp refreshes, and the handler's mutator appends history events — <code>activity_exited</code> for the activity being left, <code>activity_entered</code> for the new one, and <code>workflow_completed</code> when the transition is terminal. A child session reaching its terminal state also notifies its parent, flipping the child's entry in the parent's <code>triggeredWorkflows</code> to <code>completed</code> (best-effort — a moved parent is tolerated).</p>
+
+  <h2 id="persist">6. Persisting and resealing</h2>
+  <p>The updated state is written atomically — to a temporary file first, then renamed over <code>session.json</code>, with a copy-based fallback when the rename crosses filesystems. The HMAC is recomputed over the canonical JSON bytes and written to <code>.session-token</code>, and both files are kept at mode <code>0600</code>. There is no code path that writes state without resealing it.</p>
+
+  <h2 id="respond">7. Signing the trace and responding</h2>
+  <p>When tracing is enabled, the events accumulated since the last <code>next_activity</code> are packaged into a trace-token payload, HMAC-signed, and returned in <code>_meta.trace_token</code> — a tamper-evident receipt for that leg of the run, reconstructable later via <a href="../api/tools.html#get_trace"><code>get_trace</code></a>.</p>
+  <p>The response body itself stays minimal: <code>next_activity</code> returns just the new activity's id and name, because the full definition is the worker's to fetch via <code>get_activity</code>. Alongside it, <code>_meta.validation</code> carries the outcome of stage four — <code>{ status, warnings }</code> — so deviations are visible to the orchestrator on the very call that detected them. The warning taxonomy, error surfaces, and delivery markers an agent may encounter are catalogued in <a href="../api/protocol.html">the protocol in practice</a>.</p>
+
+  <h2 id="next">Next</h2>
+  <p>The state this lifecycle protects is described field-by-field in <a href="./session-store.html">the session store</a>; the checks that guard the definitions themselves are in <a href="./quality-system.html">the quality system</a>.</p>
+</main>
+
+<footer class="site-footer">
+  <div class="site-footer__inner">
+    <span>Markdown in the <a href="https://github.com/m2ux/workflow-server">repository</a> is the canonical documentation source.</span>
+    <span><a href="https://github.com/m2ux/workflow-server/blob/main/LICENSE">MIT License</a></span>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/site/internals/server-anatomy.html
+++ b/site/internals/server-anatomy.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Server anatomy — Workflow Server</title>
+<meta name="description" content="How the workflow-server codebase is organized: entry point, tool registrars, loaders, session store, and the cross-cutting layer every call passes through.">
+<link rel="stylesheet" href="../style.css">
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+
+<header class="site-header">
+  <div class="site-header__inner">
+    <a class="site-title" href="../">Workflow Server</a>
+    <nav class="site-nav" aria-label="Site">
+      <ul>
+        <li><a href="../">Home</a></li>
+        <li><a href="./server-anatomy.html" aria-current="page">Server anatomy</a></li>
+        <li><a href="./request-lifecycle.html">Request lifecycle</a></li>
+        <li><a href="./session-store.html">Session store</a></li>
+        <li><a href="./quality-system.html">Quality system</a></li>
+        <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
+<main id="main">
+  <h1>Server anatomy</h1>
+  <p class="lede">The <a href="../specs/architecture.html">architecture models</a> describe what the server guarantees; this page describes the code that delivers it — roughly 5,400 lines of TypeScript in <a href="https://github.com/m2ux/workflow-server/tree/main/src"><code>src/</code></a>, organized around two tool registrars, a family of loaders, and a session store. It is the map for reading the source.</p>
+  <p>This page and the rest of the internals section are derived from the server source itself; each section links to the files it describes. The contributor's build-and-test guide is <a href="https://github.com/m2ux/workflow-server/blob/main/docs/development.md">docs/development.md</a>.</p>
+
+  <h2 id="shape">The shape of the codebase</h2>
+  <p>Startup is a short, linear path: the entry point parses configuration, a factory builds the MCP server, and two registrar functions attach all sixteen tools as closures. There is no routing layer and no dependency-injection framework — the registrars close over the <code>ServerConfig</code> and call shared machinery directly.</p>
+
+  <figure class="diagram">
+    <svg viewBox="0 0 960 380" role="img" aria-labelledby="shape-title shape-desc">
+      <title id="shape-title">Startup and registration structure</title>
+      <desc id="shape-desc">The entry point src/index.ts calls createServer in src/server.ts, which invokes three registrars: registerWorkflowTools with twelve tools, registerResourceTools with four tools, and registerSchemaResources for the schemas MCP resource. The two tool registrars sit on shared machinery: loaders, schemas, the session store, validators, delivery, and trace.</desc>
+      <defs>
+        <marker id="arrowsa" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--diagram-edge)"/>
+        </marker>
+      </defs>
+      <g font-size="15" font-weight="600" text-anchor="middle">
+        <rect x="330" y="15" width="300" height="52" rx="10" fill="var(--diagram-node-alt-fill)" stroke="var(--diagram-node-alt-stroke)" stroke-width="2"/>
+        <text x="480" y="38" fill="var(--diagram-label)" font-family="ui-monospace, Menlo, Consolas, monospace">src/index.ts</text>
+        <text x="480" y="58" fill="var(--diagram-note)" font-size="13" font-weight="400">parses config, connects stdio</text>
+        <rect x="330" y="99" width="300" height="52" rx="10" fill="var(--diagram-node-fill)" stroke="var(--diagram-node-stroke)" stroke-width="2"/>
+        <text x="480" y="122" fill="var(--diagram-label)" font-family="ui-monospace, Menlo, Consolas, monospace">createServer()</text>
+        <text x="480" y="142" fill="var(--diagram-note)" font-size="13" font-weight="400">src/server.ts, wires the MCP surface</text>
+        <rect x="20" y="199" width="300" height="64" rx="10" fill="var(--diagram-node-fill)" stroke="var(--diagram-node-stroke)" stroke-width="2"/>
+        <text x="170" y="224" fill="var(--diagram-label)" font-family="ui-monospace, Menlo, Consolas, monospace" font-size="14.5">registerWorkflowTools</text>
+        <text x="170" y="246" fill="var(--diagram-note)" font-size="13" font-weight="400">12 tools: navigation, checkpoints</text>
+        <rect x="340" y="199" width="300" height="64" rx="10" fill="var(--diagram-node-fill)" stroke="var(--diagram-node-stroke)" stroke-width="2"/>
+        <text x="490" y="224" fill="var(--diagram-label)" font-family="ui-monospace, Menlo, Consolas, monospace" font-size="14.5">registerResourceTools</text>
+        <text x="490" y="246" fill="var(--diagram-note)" font-size="13" font-weight="400">4 tools: sessions, content</text>
+        <rect x="660" y="199" width="280" height="64" rx="10" fill="var(--diagram-node-fill)" stroke="var(--diagram-node-stroke)" stroke-width="2"/>
+        <text x="800" y="224" fill="var(--diagram-label)" font-family="ui-monospace, Menlo, Consolas, monospace" font-size="14">registerSchemaResources</text>
+        <text x="800" y="246" fill="var(--diagram-note)" font-size="13" font-weight="400">schemas as MCP resources</text>
+        <rect x="20" y="311" width="620" height="56" rx="10" fill="var(--diagram-node-alt-fill)" stroke="var(--diagram-node-alt-stroke)" stroke-width="2"/>
+        <text x="330" y="334" fill="var(--diagram-label)">Shared machinery</text>
+        <text x="330" y="354" fill="var(--diagram-note)" font-size="13" font-weight="400">loaders · schemas · session store · validators · delivery · trace</text>
+      </g>
+      <g stroke="var(--diagram-edge)" stroke-width="2" fill="none">
+        <line x1="480" y1="67" x2="480" y2="95" marker-end="url(#arrowsa)"/>
+        <path d="M 480 151 L 480 175 L 170 175 L 170 195" marker-end="url(#arrowsa)"/>
+        <path d="M 490 151 L 490 195" marker-end="url(#arrowsa)"/>
+        <path d="M 480 151 L 480 175 L 800 175 L 800 195" marker-end="url(#arrowsa)"/>
+        <line x1="170" y1="263" x2="170" y2="307" marker-end="url(#arrowsa)"/>
+        <line x1="490" y1="263" x2="490" y2="307" marker-end="url(#arrowsa)"/>
+      </g>
+    </svg>
+    <figcaption>Startup and registration. <code>main()</code> loads the configuration and connects the stdio transport; <code>createServer()</code> attaches every tool. Individual tools are closures inside the two registrars — <a href="https://github.com/m2ux/workflow-server/blob/main/src/tools/workflow-tools.ts"><code>workflow-tools.ts</code></a> registers the twelve navigation, checkpoint, and trace tools, and <a href="https://github.com/m2ux/workflow-server/blob/main/src/tools/resource-tools.ts"><code>resource-tools.ts</code></a> registers <code>start_session</code>, <code>dispatch_child</code>, <code>get_technique</code>, and <code>get_resource</code>.</figcaption>
+  </figure>
+
+  <h2 id="modules">Module map</h2>
+  <p>Each module owns one concern. The table lists them in the order a request touches them:</p>
+  <div class="table-wrap">
+    <table>
+      <thead>
+        <tr><th scope="col">Module</th><th scope="col">Responsibility</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/index.ts"><code>index.ts</code></a>, <a href="https://github.com/m2ux/workflow-server/blob/main/src/config.ts"><code>config.ts</code></a>, <a href="https://github.com/m2ux/workflow-server/blob/main/src/server.ts"><code>server.ts</code></a></td><td>Entry point, <code>ServerConfig</code> (workflow directory, schemas directory, workspace root from <code>--workspace</code> or <code>WORKFLOW_WORKSPACE</code>), and the server factory.</td></tr>
+        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/tools/workflow-tools.ts"><code>tools/</code></a></td><td>The sixteen tool handlers. Navigation, checkpoint, and trace tools live in <code>workflow-tools.ts</code>; session creation and content fetching live in <code>resource-tools.ts</code>.</td></tr>
+        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/loaders/workflow-loader.ts"><code>loaders/</code></a></td><td>Reading definitions: workflow and activity YAML (<code>workflow-loader.ts</code>), technique resolution and composition (<code>technique-loader.ts</code>), markdown technique parsing (<code>markdown-technique-loader.ts</code>), resources (<code>resource-loader.ts</code>), and the generated JSON schemas (<code>schema-loader.ts</code>).</td></tr>
+        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/schema/workflow.schema.ts"><code>schema/</code></a></td><td>Zod definitions for every file shape the server reads or writes — workflow, activity, condition, technique, resource, session — plus identifier rules. The JSON schemas in <a href="../api/schemas.html"><code>schemas/</code></a> are generated from these sources.</td></tr>
+        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/utils/session/store.ts"><code>utils/session/</code></a></td><td>The session store: planning-folder resolution, atomic <code>session.json</code> writes, HMAC sealing (<code>crypto.ts</code>), deterministic session-index derivation (<code>derivation.ts</code>), legacy-layout migration (<code>migration.ts</code>), and the load/save resolver every tool uses.</td></tr>
+        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/utils/validation.ts"><code>utils/validation.ts</code></a></td><td>The runtime fidelity validators: activity transitions, workflow version drift, step and activity manifests, transition conditions, and technique-fetch cross-checks.</td></tr>
+        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/utils/delivery.ts"><code>utils/delivery.ts</code></a>, <a href="https://github.com/m2ux/workflow-server/blob/main/src/utils/binding-provenance.ts"><code>utils/binding-provenance.ts</code></a></td><td>Reference-not-repeat delivery (content hashing, the per-agent delivered ledger, <code>unchanged</code> markers) and the static provenance annotations on technique inputs and outputs.</td></tr>
+        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/trace.ts"><code>trace.ts</code></a>, <a href="https://github.com/m2ux/workflow-server/blob/main/src/logging.ts"><code>logging.ts</code></a></td><td>The in-process <code>TraceStore</code> (per-session event buffers, evicting the oldest beyond 1,000 sessions), HMAC-signed trace tokens, and the <code>withAuditLog</code> wrapper around every handler.</td></tr>
+        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/result.ts"><code>result.ts</code></a>, <a href="https://github.com/m2ux/workflow-server/blob/main/src/errors.ts"><code>errors.ts</code></a></td><td>The <code>Result&lt;T, E&gt;</code> type loaders return, and the typed domain errors (<a href="#errors">below</a>).</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h2 id="cross-cutting">The layer every call passes through</h2>
+  <p>Three functions form a choke point that every authenticated tool call traverses, which is what makes the server's observability and integrity guarantees uniform rather than per-tool:</p>
+  <ol class="steps">
+    <li><strong><code>withAuditLog</code></strong> (<a href="https://github.com/m2ux/workflow-server/blob/main/src/logging.ts"><code>logging.ts</code></a>) wraps each handler — it times the call, emits a structured audit event to stderr, and appends a trace event to the session's <code>TraceStore</code> buffer.</li>
+    <li><strong><code>loadSessionForTool</code></strong> (<a href="https://github.com/m2ux/workflow-server/blob/main/src/utils/session/resolver.ts"><code>session/resolver.ts</code></a>) resolves the <code>session_index</code> to a planning folder, verifies the HMAC seal, and validates <code>session.json</code> against the session schema before the handler sees any state.</li>
+    <li><strong><code>saveSessionForTool</code></strong> persists the updated state atomically and recomputes the seal, so no code path can write state without resealing it.</li>
+  </ol>
+  <p>Everything cryptographic — session seals, session indexes, trace tokens — funnels to a single 32-byte server key created lazily at <code>~/.workflow-server/secret</code> (file mode <code>0600</code>) by <a href="https://github.com/m2ux/workflow-server/blob/main/src/utils/session/crypto.ts"><code>session/crypto.ts</code></a>. One key, three uses, one place to reason about it.</p>
+
+  <h2 id="errors">Error discipline</h2>
+  <p>Loaders return <code>Result&lt;T, E&gt;</code> values rather than throwing, and failures that must cross the tool boundary are typed so handlers can map them to user-facing responses without string matching:</p>
+  <div class="table-wrap">
+    <table>
+      <thead>
+        <tr><th scope="col">Error</th><th scope="col">Raised when</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><code>WorkflowNotFoundError</code>, <code>ActivityNotFoundError</code>, <code>TechniqueNotFoundError</code>, <code>ResourceNotFoundError</code></td><td>A definition referenced by id does not exist in the workflow directory.</td></tr>
+        <tr><td><code>WorkflowValidationError</code></td><td>A definition file parses but fails schema validation; the error carries the issue list.</td></tr>
+        <tr><td><code>SessionStoreError</code></td><td>Session state cannot be loaded or written. The <code>code</code> field distinguishes <code>NOT_FOUND</code>, <code>COLLISION</code>, <code>SEAL_MISMATCH</code>, <code>INVALID_INDEX</code>, and <code>WORKSPACE_INVALID</code>.</td></tr>
+        <tr><td><code>MarkdownTechniqueParseError</code>, <code>MigrationError</code>, <code>WorkspaceConfigError</code></td><td>A technique file violates the <a href="https://github.com/m2ux/workflow-server/blob/main/docs/technique-protocol-specification.md">technique protocol</a>, a legacy planning folder cannot be upgraded, or the workspace path is unusable at startup.</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p>How these surface to a calling agent — and how they differ from non-blocking validation warnings — is covered in <a href="../api/protocol.html">the protocol in practice</a>.</p>
+
+  <h2 id="disk">Where things live on disk</h2>
+  <ul>
+    <li><strong>Workflow definitions</strong> are read from the configured workflow directory — in this repository, the <code>workflows/</code> worktree of the orphan <code>workflows</code> branch (<a href="../design/rationale.html#orphan-branch">why an orphan branch</a>).</li>
+    <li><strong>Session state</strong> is written under <code>&lt;workspace&gt;/.engineering/artifacts/planning/&lt;slug&gt;/</code> — the <a href="./session-store.html">session store</a> page covers the folder's contents.</li>
+    <li><strong>The server key</strong> lives at <code>~/.workflow-server/secret</code>, per user, outside any repository.</li>
+  </ul>
+
+  <h2 id="next">Next</h2>
+  <p>Follow one request through this structure in <a href="./request-lifecycle.html">the request lifecycle</a>, or read how state is kept honest in <a href="./session-store.html">the session store</a>.</p>
+</main>
+
+<footer class="site-footer">
+  <div class="site-footer__inner">
+    <span>Markdown in the <a href="https://github.com/m2ux/workflow-server">repository</a> is the canonical documentation source.</span>
+    <span><a href="https://github.com/m2ux/workflow-server/blob/main/LICENSE">MIT License</a></span>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/site/internals/session-store.html
+++ b/site/internals/session-store.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Session store — Workflow Server</title>
+<meta name="description" content="How session state lives on disk: the planning folder, the sealed session.json, the deterministic session index, the append-only history, and embedded child sessions.">
+<link rel="stylesheet" href="../style.css">
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+
+<header class="site-header">
+  <div class="site-header__inner">
+    <a class="site-title" href="../">Workflow Server</a>
+    <nav class="site-nav" aria-label="Site">
+      <ul>
+        <li><a href="../">Home</a></li>
+        <li><a href="./server-anatomy.html">Server anatomy</a></li>
+        <li><a href="./request-lifecycle.html">Request lifecycle</a></li>
+        <li><a href="./session-store.html" aria-current="page">Session store</a></li>
+        <li><a href="./quality-system.html">Quality system</a></li>
+        <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
+<main id="main">
+  <h1>Session store</h1>
+  <p class="lede">A session is a folder. Everything the server knows about a run — position, variables, history, children — lives in one sealed <code>session.json</code> inside a planning folder in your workspace, and every piece of the design follows from making that file trustworthy, resumable, and inspectable.</p>
+  <p>The implementation is <a href="https://github.com/m2ux/workflow-server/blob/main/src/utils/session/store.ts"><code>src/utils/session/</code></a>; the file's exact shape is <a href="../api/schemas.html#session-file"><code>session-file.schema.json</code></a>, and the user-level view of the same folder is in <a href="../specs/artifact-management.html">artifact and workspace isolation</a>.</p>
+
+  <figure class="diagram">
+    <svg viewBox="0 0 960 320" role="img" aria-labelledby="ss-title ss-desc">
+      <title id="ss-title">The planning folder and the session tree</title>
+      <desc id="ss-desc">A planning folder contains session.json, a .session-token seal, a README, and artifacts. The session.json is expanded to show that it holds the parent session state and, embedded inside it under triggeredWorkflows, complete child sessions of the same shape, nesting recursively.</desc>
+      <defs>
+        <marker id="arrowss" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--diagram-edge)"/>
+        </marker>
+      </defs>
+      <g font-size="14.5" font-weight="600" text-anchor="middle">
+        <rect x="30" y="30" width="250" height="52" rx="10" fill="var(--diagram-node-fill)" stroke="var(--diagram-node-stroke)" stroke-width="2"/>
+        <text x="155" y="52" fill="var(--diagram-label)" font-family="ui-monospace, Menlo, Consolas, monospace">session.json</text>
+        <text x="155" y="72" fill="var(--diagram-note)" font-size="12.5" font-weight="400">canonical state</text>
+        <rect x="30" y="100" width="250" height="52" rx="10" fill="var(--diagram-node-fill)" stroke="var(--diagram-node-stroke)" stroke-width="2"/>
+        <text x="155" y="122" fill="var(--diagram-label)" font-family="ui-monospace, Menlo, Consolas, monospace">.session-token</text>
+        <text x="155" y="142" fill="var(--diagram-note)" font-size="12.5" font-weight="400">HMAC seal of the JSON</text>
+        <rect x="30" y="170" width="250" height="52" rx="10" fill="var(--diagram-node-fill)" stroke="var(--diagram-node-stroke)" stroke-width="2"/>
+        <text x="155" y="192" fill="var(--diagram-label)" font-family="ui-monospace, Menlo, Consolas, monospace">README.md</text>
+        <text x="155" y="212" fill="var(--diagram-note)" font-size="12.5" font-weight="400">human-readable progress</text>
+        <rect x="30" y="240" width="250" height="52" rx="10" fill="var(--diagram-node-fill)" stroke="var(--diagram-node-stroke)" stroke-width="2"/>
+        <text x="155" y="262" fill="var(--diagram-label)" font-family="ui-monospace, Menlo, Consolas, monospace">artifacts</text>
+        <text x="155" y="282" fill="var(--diagram-note)" font-size="12.5" font-weight="400">plans, reviews, close-out</text>
+        <rect x="330" y="30" width="600" height="270" rx="10" fill="var(--diagram-node-alt-fill)" stroke="var(--diagram-node-alt-stroke)" stroke-width="2"/>
+        <text x="630" y="58" fill="var(--diagram-label)" font-size="15">session.json, expanded</text>
+        <text x="630" y="82" fill="var(--diagram-note)" font-size="13" font-weight="400">seq · ts · variables · history · activeCheckpoint · status</text>
+        <rect x="370" y="110" width="520" height="80" rx="10" fill="var(--diagram-node-fill)" stroke="var(--diagram-node-stroke)" stroke-width="2"/>
+        <text x="630" y="138" fill="var(--diagram-label)" font-family="ui-monospace, Menlo, Consolas, monospace" font-size="14">triggeredWorkflows[0].state</text>
+        <text x="630" y="162" fill="var(--diagram-note)" font-size="13" font-weight="400">an embedded child session, same shape</text>
+        <text x="630" y="235" fill="var(--diagram-note)" font-size="13" font-weight="400">children nest recursively; the whole tree lives in this one file</text>
+        <text x="630" y="262" fill="var(--diagram-note)" font-size="13" font-weight="400">each child carries a parentSession back-reference</text>
+      </g>
+      <g stroke="var(--diagram-edge)" stroke-width="2" fill="none">
+        <line x1="280" y1="56" x2="326" y2="56" marker-end="url(#arrowss)"/>
+      </g>
+    </svg>
+    <figcaption>The planning folder and the session tree. Four files matter: <code>session.json</code> (canonical state), <code>.session-token</code> (its seal), the folder <code>README.md</code> (progress a human can read), and the artifacts the workflow produces. A work package that dispatches child workflows keeps their complete sessions embedded inside the parent file, so resuming the parent resumes the whole tree.</figcaption>
+  </figure>
+
+  <h2 id="index">The session index</h2>
+  <p>Tools identify a session with a six-character token like <code>K7KJTQ</code> rather than a path. The index is derived, not stored: the HMAC of the planning folder's resolved absolute path (keyed by the server key) is truncated to 30 bits and encoded as six RFC 4648 base32 characters (<a href="https://github.com/m2ux/workflow-server/blob/main/src/utils/session/derivation.ts"><code>derivation.ts</code></a>). That gives three properties:</p>
+  <ul>
+    <li><strong>Deterministic resume.</strong> The same folder always yields the same index, so "resume the work package" needs only the folder name — no registry to consult or corrupt.</li>
+    <li><strong>Cheap to type, hard to forge.</strong> Thirty bits is short enough for a human transcript, and because derivation is keyed, an index is only meaningful to the server that issued it. A malformed one fails <code>INVALID_INDEX</code>; two folders that collide fail loudly with <code>COLLISION</code> rather than silently sharing state.</li>
+    <li><strong>Children get indexes too.</strong> Embedded child sessions derive their index from the parent path plus their position, so a worker can address its own session while it remains physically inside the parent's file.</li>
+  </ul>
+
+  <h2 id="file">What the file records</h2>
+  <div class="table-wrap">
+    <table>
+      <thead>
+        <tr><th scope="col">Field group</th><th scope="col">Contents</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Identity</td><td><code>schemaVersion</code>, <code>sessionIndex</code>, <code>workflowId</code>, <code>workflowVersion</code> (captured at start, checked for drift on every call), <code>agentId</code>, <code>startedAt</code>.</td></tr>
+        <tr><td>Position</td><td><code>currentActivity</code>, <code>completedActivities</code>, <code>skippedActivities</code>, <code>status</code> (<code>running</code>, <code>completed</code>, <code>aborted</code>), and <code>activeCheckpoint</code> — the gate that pauses navigation while a decision is outstanding.</td></tr>
+        <tr><td>Data</td><td><code>variables</code>, the schema-validated bag mutated only through declared paths (checkpoint effects and recorded outputs — see <a href="../specs/state-management.html">state management</a>), plus <code>checkpointResponses</code>, which caches each resolved checkpoint so a replayed yield returns the earlier answer instead of asking twice.</td></tr>
+        <tr><td>Ordering</td><td><code>seq</code>, a monotonic counter bumped by every mutation, and <code>ts</code> — together they make "which write is newer" a comparison, not a guess.</td></tr>
+        <tr><td>Delivery</td><td><code>contextMode</code> (<code>persistent</code> or <code>fresh</code>) and <code>deliveredContent</code>, the per-agent ledger of content hashes behind <a href="../api/protocol.html#delivery">reference-not-repeat delivery</a>.</td></tr>
+        <tr><td>Structure</td><td><code>triggeredWorkflows</code> (embedded child sessions), <code>parentSession</code> (the back-reference), and <code>planningFolderPath</code>, re-stamped on resume so the file stays correct if the folder moves.</td></tr>
+        <tr><td>History</td><td>The append-only event log described next.</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h2 id="history">History: the append-only record</h2>
+  <p>Every consequential moment appends a typed event: workflow lifecycle (<code>workflow_started</code>, <code>workflow_completed</code>, <code>workflow_triggered</code>…), activity boundaries (<code>activity_entered</code>, <code>activity_exited</code>, <code>activity_skipped</code>), steps, checkpoints (<code>checkpoint_reached</code>, <code>checkpoint_response</code>, <code>checkpoint_replayed</code>), decisions and loops, <code>variable_set</code>, and <code>error</code> — twenty-three event types in all (<a href="https://github.com/m2ux/workflow-server/blob/main/src/schema/state.schema.ts"><code>state.schema.ts</code></a>).</p>
+  <p>Two of them do double duty as fidelity instruments: <code>get_technique</code> and <code>get_resource</code> append <code>technique_fetched</code> and <code>resource_fetched</code> events, and <code>next_activity</code> later cross-references those against the step manifest — a manifested step nobody actually fetched draws a warning. The history is how the server distinguishes "did the work" from "described the work".</p>
+
+  <h2 id="nesting">Nested and transient sessions</h2>
+  <p>When a workflow dispatches a child (<a href="../specs/dispatch.html">the dispatch model</a>), the child's complete session embeds under the parent's <code>triggeredWorkflows</code> — one file continues to hold the whole work package, which is what makes resume-by-folder-name total. A child reaching its terminal activity notifies the parent so the embedded entry flips to <code>completed</code>. Parent chains are walked, not trusted: nesting more than five levels deep draws a warning, since chains that long usually indicate a dispatch mistake rather than a real process.</p>
+  <p>Meta-orchestration sessions that exist only to choose a workflow start <em>transient</em> — created under the system temporary directory with a synthetic slug. The first <code>dispatch_child</code> that commits to real work promotes the session into the workspace planning root, taking its slug from the request (or a dated fallback), and the temporary folder is discarded. Nothing about a browse-only conversation ever lands in your repository.</p>
+
+  <h2 id="integrity">Integrity and migration</h2>
+  <p>The seal answers one question: <em>is this file exactly what the server last wrote?</em> Writes are atomic (temp file, then rename), the HMAC is computed over canonicalized JSON, and reads verify it with a timing-safe comparison before parsing. What it defends against is corruption, manual edits, restored backups, and racing writers — incoherence, not adversaries; the <a href="../design/rationale.html#integrity">threat model is spelled out in the rationale</a>.</p>
+  <p>Older planning folders that predate the current layout are upgraded in place by <a href="https://github.com/m2ux/workflow-server/blob/main/src/utils/session/migration.ts"><code>migration.ts</code></a> the first time they are touched; an upgrade that cannot complete raises <code>MigrationError</code> rather than leaving a half-converted folder.</p>
+
+  <h2 id="next">Next</h2>
+  <p>How a tool call reads and writes this state safely is <a href="./request-lifecycle.html">the request lifecycle</a>; the checkpoint pause encoded in <code>activeCheckpoint</code> is <a href="../specs/checkpoints.html">the checkpoint model</a>.</p>
+</main>
+
+<footer class="site-footer">
+  <div class="site-footer__inner">
+    <span>Markdown in the <a href="https://github.com/m2ux/workflow-server">repository</a> is the canonical documentation source.</span>
+    <span><a href="https://github.com/m2ux/workflow-server/blob/main/LICENSE">MIT License</a></span>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/site/specs/architecture.html
+++ b/site/specs/architecture.html
@@ -111,6 +111,13 @@
     <li><a href="https://github.com/m2ux/workflow-server/blob/main/docs/technique-protocol-specification.md"><strong>Technique protocol specification</strong></a> — the anatomy of a technique file (capability, inputs, outputs, protocol, rules), the <code>::</code> addressing grammar, contract inheritance, Initial/Final protocol composition, and delivery.</li>
     <li><a href="https://github.com/m2ux/workflow-server/blob/main/docs/orchestra-specification.md"><strong>Orchestra DSL specification</strong></a> — the workflow/activity definition language: step, decision, loop, and flow primitives, the EBNF grammar, and the semantic constraints.</li>
   </ul>
+
+  <h2 id="implementation">The implementation view</h2>
+  <p>The models above state the guarantees; two further sections of this site show the machinery and the reasoning behind them:</p>
+  <ul>
+    <li><a href="../internals/server-anatomy.html"><strong>Server internals</strong></a> — the code that delivers the guarantees: the <a href="../internals/server-anatomy.html">module map</a>, the <a href="../internals/request-lifecycle.html">lifecycle of one tool call</a>, the <a href="../internals/session-store.html">session store on disk</a>, and the <a href="../internals/quality-system.html">guard-and-test system</a>.</li>
+    <li><a href="../design/rationale.html"><strong>Design rationale</strong></a> — why the system is shaped this way: the forces behind each decision and the costs accepted.</li>
+  </ul>
 </main>
 
 <footer class="site-footer">


### PR DESCRIPTION
## Summary

Expands the documentation site beyond its markdown sources, adding the depth layer #132's site was scoped to grow into: how the server is implemented, why it is designed the way it is, and how the protocol behaves in practice. Content was derived from a full-codebase research pass (GitNexus graph survey over the 230 indexed execution flows, a source deep-read, ADR/engineering-history mining, and a coverage-gap analysis against the existing pages), with every behavioural claim verified against the source before writing.

## New pages

**Server internals** (`site/internals/`, new section)
- **Server anatomy** — module map, the two-registrar structure, the cross-cutting audit/seal layer, error discipline, where things live on disk
- **Request lifecycle** — the seven stages of an authenticated call, with the blocking-vs-advisory validator table
- **Session store** — the planning folder, sealed `session.json` field by field, index derivation, the append-only history, embedded child sessions, transient promotion
- **Quality system** — the guard suite, baseline ratchets, test architecture, and the generated-then-guarded pipelines

**Design rationale** (`site/design/rationale.html`, new section)
- Eleven standing decisions with their forces and accepted costs, distilled from the ADRs and engineering history. Decisions are cited inline, not linked — `.engineering` is a gitlink, so `blob/main` links would 404.

**The protocol in practice** (`site/api/protocol.html`)
- Call ordering and the checkpoint lock, error taxonomy with sensible agent reactions, the warning taxonomy behind `_meta.validation`, trace tokens, reference delivery, and dispatch in practice

## Wiring

- Landing page: five documentation cards and three new "finding a document" rows
- Architecture hub: new "implementation view" section
- API section nav gains Protocol; new sections follow the site's section-local nav convention
- `site/README.md` and `docs/documentation-system.md` codify placement: internals pages are canonical to the code they link to; rationale-on-site is the recorded exception to rationale-stays-in-engineering

## Verification

- `npm run check:site`, `npm run check:svg`, `npm run build:site` (no drift), `npm run typecheck` all pass — the same checks the Pages deploy workflow gates on
- Full suite: 478 passed, 14 skipped, 0 failures
- All five new SVG diagrams pass the collision guard (geometry computed against the guard's width model at authoring time)
- One research finding was corrected against source before publication: the checkpoint gate blocks content reads (`get_activity`, `get_technique`, `get_resource`, `get_trace`) as well as navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
