### PR TITLE
fix(site): widen the page shell and center the reading band

### DIFF
--- a/site/style.css
+++ b/site/style.css
@@ -30,7 +30,10 @@
   /* Type + spacing */
   --font-body: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
-  --measure: 72ch;
+  /* Prose measure in rem, not ch: every element in the centered reading band
+     must resolve to the same width regardless of its font size. */
+  --measure: 40rem;
+  --shell: 88rem;
   --radius: 10px;
   --space-1: 0.25rem;
   --space-2: 0.5rem;
@@ -83,17 +86,20 @@ body {
   line-height: 1.65;
 }
 
+/* Reading band: prose-width elements center within the wider shell, so
+   diagrams, tables, and card grids can break out to the shell's full width. */
 h1, h2, h3 {
   line-height: 1.25;
   letter-spacing: -0.01em;
-  margin: 0 0 var(--space-3);
+  margin: 0 auto var(--space-3);
+  max-width: var(--measure);
 }
 
 h1 { font-size: clamp(1.9rem, 4vw, 2.6rem); }
 h2 { font-size: clamp(1.4rem, 3vw, 1.75rem); margin-top: var(--space-5); }
 h3 { font-size: 1.15rem; margin-top: var(--space-4); }
 
-p, ul, ol { max-width: var(--measure); }
+p, ul, ol { max-width: var(--measure); margin-inline: auto; }
 
 a {
   color: var(--link);
@@ -124,6 +130,8 @@ pre {
   border-radius: var(--radius);
   padding: var(--space-3);
   overflow-x: auto;
+  max-width: var(--measure);
+  margin-inline: auto;
 }
 
 pre code { background: none; border: none; padding: 0; }
@@ -153,7 +161,7 @@ pre code { background: none; border: none; padding: 0; }
 .site-header__inner,
 main,
 .site-footer__inner {
-  max-width: 68rem;
+  max-width: var(--shell);
   margin: 0 auto;
   padding: 0 var(--space-3);
 }
@@ -202,7 +210,7 @@ main { padding-top: var(--space-4); padding-bottom: var(--space-5); }
   color: var(--text-muted);
 }
 
-.pill-row { display: flex; flex-wrap: wrap; gap: var(--space-2); margin: var(--space-3) 0; padding: 0; list-style: none; }
+.pill-row { display: flex; flex-wrap: wrap; gap: var(--space-2); margin: var(--space-3) auto; padding: 0; list-style: none; }
 
 .pill {
   font-size: 0.85rem;
@@ -231,6 +239,7 @@ figure.diagram figcaption {
   font-size: 0.9rem;
   color: var(--text-muted);
   max-width: var(--measure);
+  margin-inline: auto;
 }
 
 /* Card grid */
@@ -242,6 +251,7 @@ figure.diagram figcaption {
   padding: 0;
   margin: var(--space-3) 0 0;
   list-style: none;
+  max-width: none;
 }
 
 .card {
@@ -266,7 +276,7 @@ figure.diagram figcaption {
   counter-reset: step;
   list-style: none;
   padding: 0;
-  margin: var(--space-3) 0;
+  margin: var(--space-3) auto;
   display: grid;
   gap: var(--space-2);
   max-width: var(--measure);


### PR DESCRIPTION
## Problem

The docs site made poor use of wide displays: the entire shell (header, `main`, footer) was capped at `68rem` (~1090px), leaving more than half the viewport as empty margin on large monitors. The landing page's five documentation cards wrapped onto a ragged second row, and tables and SVG diagrams were squeezed into the same narrow column as body text.

## Change

CSS-only, in the one shared stylesheet (`site/style.css`); no HTML touched.

- **Wider shell** — header, `main`, and footer now cap at a new `--shell: 88rem` (~1400px) token.
- **Centered reading band** — prose-width elements (headings, paragraphs, lists, code blocks, steps, pill row, figure captions) keep a readable measure and center within the shell via `margin-inline: auto`.
- **Breakout display elements** — the card grid, tables, and diagrams span the shell's full width. The five landing-page cards now sit in a single row; diagrams render at ~1400px.
- **`--measure: 72ch` → `40rem`** — `ch` resolves against each element's own font size, so a centered `h2` would not share an edge with a centered paragraph. A rem measure (equivalent to the old 72ch at body size) gives every band element the same width, keeping the band's edges aligned.

Existing higher-specificity overrides (`.site-nav ul`, `.card p`, `.card h3`) are unaffected, so the header layout and card internals are unchanged.

## Verification

- `tests/site.test.ts` (link check, SVG layout, rendering) — 3/3 pass.
- Headless-Chrome screenshots at 2200px width of `index.html`, `guide/getting-started.html`, and `api/tools.html`: band stays aligned, cards single-row, tables/diagrams full-width, no horizontal overflow.

Known intentional consequences: the hero `h1` wraps to two lines (headings share the band measure), and `.tool` separator rules on the API tools page span the full shell as section dividers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
