### PR TITLE
refactor(fragments): extract the duplicated rules and checkpoints into fragments (#166 B10)

### DIFF
--- a/cicd-pipeline-security-audit/workflow.yaml
+++ b/cicd-pipeline-security-audit/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: cicd-pipeline-security-audit
-version: 1.0.0
+version: 1.1.0
 title: CI/CD Pipeline Security Audit Workflow
 description: Fully automated multi-phase AI security audit for GitHub Actions CI/CD pipelines. Detects source-to-sink injection vulnerabilities exploited by autonomous attack agents (hackerbot-claw campaign, Feb 2026).
 author: m2ux
@@ -13,7 +13,7 @@ tags:
   - multi-phase
 rules:
   workflow:
-    - "PREREQUISITE: Agents MUST read and follow AGENTS.md before starting any work"
+    - ref: work-packages::agents-md-prerequisite
     - "PREREQUISITE: At least one target submodule MUST be specified before the workflow begins. If 'all' is specified, scan every submodule that contains .github/workflows/."
     - "FULLY AUTOMATED: This workflow executes without user checkpoints. Phase gates are set by each activity's completion step (a `set` flag on its final step)."
     - "CONCURRENT DISPATCH: All per-submodule scanner agents (S1-Sn) dispatch simultaneously in a single batch. Every assigned agent MUST be dispatched — skipping any agent is a HARD STOP."
@@ -27,7 +27,7 @@ rules:
     - "REMEDIATION GUIDANCE: Every finding in the final report MUST include a specific remediation recommendation referencing the playbook in resource 03."
     - "AI CONFIG FILES: Detection pattern P6 covers CLAUDE.md, AGENTS.md, .cursorrules, .cursor/rules/, and similar AI agent configuration files. These are high-value prompt injection targets when not protected by CODEOWNERS."
   universal:
-    - Artifacts in 'planning' location are gitignored — never reference them in PRs or issues
+    - ref: substrate-node-security-audit::planning-artifacts-gitignored
 techniques:
   activity:
     - variable-binding

--- a/prism-audit/workflow.yaml
+++ b/prism-audit/workflow.yaml
@@ -1,5 +1,5 @@
 id: prism-audit
-version: 1.1.0
+version: 1.2.0
 title: Security Audit Workflow
 description: Orchestrate security audits by generating tailored audit prompts from user descriptions and triggering prism workflow(s) for analysis. Audit-specific customisation is isolated here, keeping the prism workflow generic.
 author: m2ux
@@ -12,11 +12,14 @@ tags:
   - report-generation
 rules:
   workflow:
-    - "ORCHESTRATION MODEL: This workflow uses an orchestrator with disposable workers. The orchestrator manages transitions and triggers. Workers execute activities in fresh contexts. Prism workflows are triggered via the trigger-workflow mechanism, not called inline."
+    - ref: orchestration-model
     - "CONTRACT REUSE: prism owns analysis, per-unit iteration, blast-radius enrichment, methodology-stripping, finding-ID assignment, and consolidation within a run. This workflow adds only what prism does not: audit-prompt generation (security characteristics, trust boundaries, audit domains), cross-scope consolidation, and the audit deliverables. It sets analysis_focus to the generated audit prompt (naming the scope's security domains so prism assigns domain-prefixed finding IDs), reads prism's contract artifacts (`RUN-MANIFEST.md`, `REPORT.md`, `DEFINITIVE-FINDINGS.md`), and never re-reads prism's raw pass artifacts."
   activity:
-    - "WORKER PERMISSIONS: Sub-agents dispatched in this workflow have FULL READ/WRITE permissions. Workers MUST write all artifacts directly to target paths WITHOUT asking for permission."
-    - "ARTIFACT VERIFICATION: After writing each artifact, workers MUST report: (a) file path written, (b) file size (KB), (c) format validation status (OK or FAIL)."
+    - ref: prism::worker-permissions
+    - ref: prism::artifact-verification
+fragments:
+  rules:
+    orchestration-model: "ORCHESTRATION MODEL: This workflow uses an orchestrator with disposable workers. The orchestrator manages transitions and triggers. Workers execute activities in fresh contexts. Prism workflows are triggered via the trigger-workflow mechanism, not called inline."
 techniques:
   activity:
     - variable-binding

--- a/prism-evaluate/workflow.yaml
+++ b/prism-evaluate/workflow.yaml
@@ -1,5 +1,5 @@
 id: prism-evaluate
-version: 1.2.0
+version: 1.3.0
 title: Evaluation Workflow
 description: Orchestrate multi-dimensional evaluations by mapping user-defined evaluation dimensions to prism analytical lenses.
 author: m2ux
@@ -12,12 +12,12 @@ tags:
   - documents
 rules:
   workflow:
-    - "ORCHESTRATION MODEL: This workflow uses an orchestrator with disposable workers. The orchestrator manages transitions and triggers. Workers execute activities in fresh contexts. Prism workflows are triggered via the trigger-workflow mechanism, not called inline."
+    - ref: prism-audit::orchestration-model
     - Agents MUST NOT proceed past blocking checkpoints without user confirmation — auto-resolving a checkpoint is a protocol violation
     - "CONTRACT REUSE: prism owns analysis, per-unit iteration, blast-radius enrichment, methodology-stripping, finding-ID assignment, and consolidation within a run. This workflow adds only what prism does not: evaluation dimensions, cross-dimensional synthesis, and the resolution dialogue. It sets analysis_focus to the dimension-specific evaluation guidance (naming the dimension so prism assigns dimension-prefixed IDs), reads prism's contract artifacts (`RUN-MANIFEST.md`, `REPORT.md`, `DEFINITIVE-FINDINGS.md`), and never re-reads prism's raw pass artifacts."
   activity:
-    - "WORKER PERMISSIONS: Sub-agents dispatched in this workflow have FULL READ/WRITE permissions. Workers MUST write all artifacts directly to target paths WITHOUT asking for permission."
-    - "ARTIFACT VERIFICATION: After writing each artifact, workers MUST report: (a) file path written, (b) file size (KB), (c) format validation status (OK or FAIL)."
+    - ref: prism::worker-permissions
+    - ref: prism::artifact-verification
 techniques:
   activity:
     - variable-binding

--- a/prism/workflow.yaml
+++ b/prism/workflow.yaml
@@ -1,5 +1,5 @@
 id: prism
-version: 2.2.0
+version: 2.3.0
 title: Structural Analysis Prism Workflow
 description: Apply cognitive lenses to code or text through isolated sub-agent passes. Each pass runs in a fresh context window to guarantee analytical independence. For security audit use cases, use the prism-audit workflow which triggers prism and adds audit-specific post-processing.
 author: m2ux
@@ -20,10 +20,14 @@ rules:
     - "LENS HANDOFF: The orchestrator tells the worker which lens resource index to load; it does NOT load or forward the lens prompt itself."
   activity:
     - "LENS LOADING: Load the lens prompt for your pass from the prism workflow resources via get_technique (resources attached), using the resource index the orchestrator provides."
-    - "WORKER PERMISSIONS: Sub-agents dispatched in this workflow have FULL READ/WRITE permissions. Workers MUST write all artifacts directly to target paths WITHOUT asking for permission or deferring to the user."
+    - ref: worker-permissions
     - "NO PERMISSION QUESTIONS: Workers must NEVER ask 'Would you like me to save this?' or 'Can I write to this directory?' or similar permission-deferral questions. These questions create workflow stalls. Write artifacts immediately and report completion."
     - "BLOCKER SURFACING (Not Permission Deferrals): If a worker encounters a GENUINE BLOCKER (operational barrier, not permission question), it must surface immediately using format: '[BLOCKER]: [specific issue]. Requires: [resolution]. Blocking: [progress].' Genuine blockers: directory doesn't exist, file permissions system error, network unavailable. NOT genuine blockers: uncertainty about whether to write, asking permission, deferring to user."
-    - "ARTIFACT VERIFICATION: After writing each artifact, workers MUST report: (a) file path written, (b) file size (KB), (c) format validation status (OK or FAIL). This confirms successful completion and prevents silent write failures."
+    - ref: artifact-verification
+fragments:
+  rules:
+    worker-permissions: "WORKER PERMISSIONS: Sub-agents dispatched in this workflow have FULL READ/WRITE permissions. Workers MUST write all artifacts directly to target paths WITHOUT asking for permission or deferring to the user."
+    artifact-verification: "ARTIFACT VERIFICATION: After writing each artifact, workers MUST report: (a) file path written, (b) file size (KB), (c) format validation status (OK or FAIL). This confirms successful completion and prevents silent write failures."
 techniques:
   activity:
     - variable-binding

--- a/remediate-vuln/workflow.yaml
+++ b/remediate-vuln/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: remediate-vuln
-version: 1.0.1
+version: 1.1.0
 title: Security Vulnerability Remediation Workflow
 description: Remediate security vulnerabilities without public disclosure.
 author: m2ux
@@ -13,9 +13,7 @@ tags:
 rules:
   workflow:
     - "Agents MUST NOT skip or auto-resolve blocking checkpoints (blocking: true) — these require explicit user selection."
-    - Ask, don't assume - Clarify requirements before acting
-    - Summarize, then proceed - Provide brief status before asking to continue
-    - One task at a time - Complete current work before starting new work
+    - ref: work-package::interaction-discipline
     - Explicit approval - Get clear 'yes' or 'proceed' before major actions
     - "ORCHESTRATION MODEL: This workflow uses an orchestrator/worker pattern. The agent receiving the user request acts AS the orchestrator inline (technique: meta-orchestrator from meta/techniques) — it MUST NOT be spawned as a sub-agent. The orchestrator loads the workflow, manages transitions, tracks state, and presents checkpoints to the user. A worker sub-agent (technique: activity-worker from meta/techniques) executes activity steps and produces artifacts. When the worker reaches a blocking checkpoint, it yields a checkpoint_pending result. The orchestrator presents the checkpoint to the user, then resumes the worker with the response. CONSTRAINT: Only ONE level of sub-agent indirection (the worker)."
   activity:

--- a/substrate-node-security-audit/workflow.yaml
+++ b/substrate-node-security-audit/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: substrate-node-security-audit
-version: 4.18.0
+version: 4.19.0
 title: Security Audit Workflow
 description: Fully automated multi-phase AI security audit for Substrate-based blockchain node codebases.
 author: m2ux
@@ -33,7 +33,10 @@ rules:
     - "The node startup agent (A3) traces every genesis data parsing path — StorageInit construction, genesis extrinsics decoding, genesis header construction, and chain spec property parsing — verifying each independently for silent truncation, since iteration patterns that stop at the first invalid element (take_while, early-return on error, filter_map) truncate remaining data."
     - "The merge agent reviews all agent reconnaissance_leads and additional_observations, plus S-agent emergent_domains from s-architectural-analysis.json and R-agent leads from r-reconnaissance-data.json. Each emergent domain is dispositioned as captured, elevated, or not-applicable. Security-relevant observations (divergent code paths, missing validation, error-path persistence, silent errors, trust boundary amplification) are elevated to findings or explicitly mapped to existing findings."
   universal:
-    - Artifacts in 'planning' location are gitignored — never reference them in PRs or issues
+    - ref: planning-artifacts-gitignored
+fragments:
+  rules:
+    planning-artifacts-gitignored: Artifacts in 'planning' location are gitignored — never reference them in PRs or issues
 techniques:
   activity:
     - variable-binding

--- a/work-package/activities/04-research.yaml
+++ b/work-package/activities/04-research.yaml
@@ -1,5 +1,5 @@
 id: research
-version: 2.7.0
+version: 2.8.0
 name: Research
 description: Research the knowledge base and external sources to discover best practices, patterns, and resources to inform the plan-prepare activity.
 required: false
@@ -123,26 +123,7 @@ steps:
         technique: review-assumptions::interview
       - kind: checkpoint
         id: research-assumption-interview
-        condition:
-          type: simple
-          variable: has_open_assumptions
-          operator: ==
-          value: true
-        message: "Assumption {current_assumption.id}: {current_assumption.statement}. Can you resolve this, or defer to stakeholders?"
-        blocking: true
-        options:
-          - id: resolve-inline
-            label: Resolve now
-            description: Provide resolution for this assumption — it will be marked as resolved in the assumptions log
-            effect:
-              setVariable:
-                assumption_resolved_inline: true
-          - id: defer-to-stakeholder
-            label: Defer to stakeholder review
-            description: Queue this assumption for stakeholder review in the issue tracker
-            effect:
-              setVariable:
-                assumption_deferred: true
+        ref: assumption-interview
       - kind: technique
         id: record-response
         technique: review-assumptions::record

--- a/work-package/activities/05-implementation-analysis.yaml
+++ b/work-package/activities/05-implementation-analysis.yaml
@@ -1,5 +1,5 @@
 id: implementation-analysis
-version: 2.8.0
+version: 2.9.0
 name: Implementation Analysis
 description: Analyze the current implementation to understand effectiveness, establish baselines, and identify opportunities for improvement.
 required: false
@@ -83,26 +83,7 @@ steps:
         technique: review-assumptions::interview
       - kind: checkpoint
         id: analysis-assumption-interview
-        condition:
-          type: simple
-          variable: has_open_assumptions
-          operator: ==
-          value: true
-        message: "Assumption {current_assumption.id}: {current_assumption.statement}. Can you resolve this, or defer to stakeholders?"
-        blocking: true
-        options:
-          - id: resolve-inline
-            label: Resolve now
-            description: Provide resolution for this assumption — it will be marked as resolved in the assumptions log
-            effect:
-              setVariable:
-                assumption_resolved_inline: true
-          - id: defer-to-stakeholder
-            label: Defer to stakeholder review
-            description: Queue this assumption for stakeholder review in the issue tracker
-            effect:
-              setVariable:
-                assumption_deferred: true
+        ref: assumption-interview
       - kind: technique
         id: record-response
         technique: review-assumptions::record

--- a/work-package/activities/08-implement.yaml
+++ b/work-package/activities/08-implement.yaml
@@ -1,5 +1,5 @@
 id: implement
-version: 2.9.0
+version: 2.10.0
 name: Implement Tasks
 description: Execute the implementation plan task by task.
 required: true
@@ -112,26 +112,7 @@ steps:
         technique: review-assumptions::interview
       - kind: checkpoint
         id: implementation-assumption-interview
-        condition:
-          type: simple
-          variable: has_open_assumptions
-          operator: ==
-          value: true
-        message: "Assumption {current_assumption.id}: {current_assumption.statement}. Can you resolve this, or defer to stakeholders?"
-        blocking: true
-        options:
-          - id: resolve-inline
-            label: Resolve now
-            description: Provide resolution for this assumption — it will be marked as resolved in the assumptions log
-            effect:
-              setVariable:
-                assumption_resolved_inline: true
-          - id: defer-to-stakeholder
-            label: Defer to stakeholder review
-            description: Queue this assumption for stakeholder review in the issue tracker
-            effect:
-              setVariable:
-                assumption_deferred: true
+        ref: assumption-interview
       - kind: technique
         id: record-response
         technique: review-assumptions::record

--- a/work-package/workflow.yaml
+++ b/work-package/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: work-package
-version: 3.16.1
+version: 3.17.0
 title: Work Package Implementation Workflow
 description: Defines how to plan and implement ONE work package from inception to merged PR. A work package is a discrete unit of work such as a feature, bug-fix, enhancement, refactoring, or any other deliverable change. For multiple related work packages, use the work-packages workflow to create a roadmap first.
 author: m2ux
@@ -13,9 +13,7 @@ tags:
   - pr
 rules:
   workflow:
-    - Ask, don't assume - Clarify requirements before acting
-    - Summarize, then proceed - Provide brief status before asking to continue
-    - One task at a time - Complete current work before starting new work
+    - ref: interaction-discipline
     - Explicit approval - Get clear 'yes' or 'proceed' before major actions (within activity checkpoints only — NOT between activities)
     - Decision points require user choice - When issues are found, user decides whether to proceed or loop back
     - Git configuration is user-owned. Validate-action messages describe a misconfiguration but never prescribe config-changing commands; the user fixes their own environment at whatever scope (system, global, local) they prefer.
@@ -25,6 +23,34 @@ rules:
     - complementary-not-duplicative-with-strategic-review - The lean-coding audit applies the over-engineering and leanness lens; it does not re-adjudicate scope-vs-issue fit, which remains strategic-review's concern. The two stages stay complementary.
   activity:
     - On completing each activity, update the planning-folder README.md progress tracker — mark this activity's artifacts as ✅ Complete and set the work-package Status to reflect the current milestone.
+fragments:
+  rules:
+    interaction-discipline:
+      - Ask, don't assume - Clarify requirements before acting
+      - Summarize, then proceed - Provide brief status before asking to continue
+      - One task at a time - Complete current work before starting new work
+  checkpoints:
+    assumption-interview:
+      condition:
+        type: simple
+        variable: has_open_assumptions
+        operator: ==
+        value: true
+      message: "Assumption {current_assumption.id}: {current_assumption.statement}. Can you resolve this, or defer to stakeholders?"
+      blocking: true
+      options:
+        - id: resolve-inline
+          label: Resolve now
+          description: Provide resolution for this assumption — it will be marked as resolved in the assumptions log
+          effect:
+            setVariable:
+              assumption_resolved_inline: true
+        - id: defer-to-stakeholder
+          label: Defer to stakeholder review
+          description: Queue this assumption for stakeholder review in the issue tracker
+          effect:
+            setVariable:
+              assumption_deferred: true
 techniques:
   activity:
     - variable-binding

--- a/work-packages/workflow.yaml
+++ b/work-packages/workflow.yaml
@@ -1,5 +1,5 @@
 id: work-packages
-version: 3.0.0
+version: 3.1.0
 title: Work Packages Workflow
 description: Plan and coordinate multiple related work packages. Use when you have multiple related features, a roadmap spanning several weeks/months, or features with shared context. Execution triggers the work-package workflow for each package.
 author: m2ux
@@ -11,10 +11,13 @@ tags:
   - prioritization
 rules:
   workflow:
-    - "PREREQUISITE: Agents MUST read and follow AGENTS.md before starting any work"
+    - ref: agents-md-prerequisite
     - Agents must NOT proceed past checkpoints without user confirmation
     - Ask, don't assume - Clarify scope and priorities before planning
     - Explicit approval - Get clear 'yes' or 'proceed' before creating documents
+fragments:
+  rules:
+    agents-md-prerequisite: "PREREQUISITE: Agents MUST read and follow AGENTS.md before starting any work"
 techniques:
   activity:
     - variable-binding


### PR DESCRIPTION
Implements #166 B10 (content side): every exact cross-site duplicate the new `check:fragments` guard finds becomes a fragment declared once and imported by reference. The guard now holds the corpus at hard zero. Pairs with server PR #186.

## Rule fragments extracted

| Fragment | Declared in | Referenced by | Notes |
|---|---|---|---|
| `interaction-discipline` (Ask-don't-assume / Summarize-then-proceed / One-task-at-a-time trio) | work-package | remediate-vuln | previously verbatim in both |
| `worker-permissions`, `artifact-verification` | prism | prism-audit, prism-evaluate | the three drifted copies unified onto prism's fuller texts |
| `orchestration-model` (consumer-side contract) | prism-audit | prism-evaluate | prism's own ORCHESTRATION MODEL describes the inner pass pipeline and stays inline |
| `agents-md-prerequisite` | work-packages | cicd-pipeline-security-audit | |
| `planning-artifacts-gitignored` | substrate-node-security-audit | cicd-pipeline-security-audit | a duplicate the guard surfaced beyond the 2026-07-03 audit's catalogue |

## Checkpoint fragment

`work-package::assumption-interview` — the interview block previously pasted byte-identically in `research`, `implementation-analysis`, and `implement`; each site now carries only its `id` and the ref (the shared condition lives in the fragment).

## Deliberately NOT unified

Drifted apart *semantically*, not accidentally: the work-package 07 / workflow-design 03 `assumption-decision` pair (different effects and conditions), the implement model-switch pair (different messages), the CONTRACT REUSE pair, and the planning-folder progress rule pair. Forcing these together would add coupling, not remove drift.

## Verification

- Delivered content is unchanged: the server materializes refs at load, and the work-package e2e walk snapshot baselines pass unmodified.
- `check:fragments` hard-zero; `check:binding` 267 baselined / 0 new / 0 fixed; all other guards green.
- Versions bumped (minor) on all eight touched workflows and the three touched activities. Net −20 lines.

## Merge order

**Server PR #186 merges FIRST** — the `{ ref }` entries in this corpus do not validate against the pre-B10 schema (reversed from the usual content-first order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
