### PR TITLE
feat(research): auto-continuing research reconciliation loop

### DIFF
--- a/work-package/activities/04-research.yaml
+++ b/work-package/activities/04-research.yaml
@@ -1,5 +1,5 @@
 id: research
-version: 2.8.0
+version: 2.9.0
 name: Research
 description: Research the knowledge base and external sources to discover best practices, patterns, and resources to inform the plan-prepare activity.
 required: false
@@ -10,50 +10,49 @@ steps:
   - kind: technique
     id: synthesize
     technique: synthesize
-  - kind: checkpoint
-    id: research-findings
-    message: Here are the combined findings from knowledge base and web research. Proceeding in 30s unless you want changes.
-    blocking: false
-    defaultOption: sufficient
-    autoAdvanceMs: 30000
-    options:
-      - id: sufficient
-        label: Findings Sufficient
-        description: Research findings are relevant and sufficient (default — auto-proceeds after 30s)
-      - id: further-research
-        label: Need Further Research
-        description: Additional research is needed — specify focus area at next checkpoint
-        effect:
-          setVariable:
-            needs_further_research: true
+  - kind: technique
+    id: triage-research-candidates
+    technique: triage
+  - kind: loop
+    id: research-reconciliation
+    name: Research Reconciliation Loop
+    loopType: doWhile
+    condition:
+      type: simple
+      variable: has_reconcilable_research
+      operator: ==
+      value: true
+    maxIterations: 10
+    steps:
+      - kind: technique
+        id: reconcile-research-candidates
+        technique: reconcile
+        when: has_reconcilable_research == true
+      - kind: checkpoint
+        id: research-convergence
+        condition:
+          type: simple
+          variable: has_reconcilable_research
+          operator: ==
+          value: false
+        message: "Research has converged. Full candidate inventory (see kb-research.md → Open Research Candidates): {research_candidates}. Every research-reconcilable candidate was resolved; only irreconcilable items — or none — remain, each with its rationale and handoff target. Proceed to planning, or direct further research on a specific item?"
+        blocking: true
+        options:
+          - id: accept-research
+            label: Accept — proceed to planning
+            description: Research is complete; remaining open candidates are irreconcilable by research and are carried to their handoff targets (stakeholder interview, assumption reconciliation, or recorded out-of-scope).
+          - id: request-more
+            label: Direct further research
+            description: Reopen the loop to research a named candidate further — provide the focus in your response; the next pass incorporates it.
+            effect:
+              setVariable:
+                has_reconcilable_research: true
   - kind: technique
     id: collect-assumptions
     technique:
       name: review-assumptions::collect
       inputs:
         assumption_categories: Pattern Applicability, Source Relevance, Synthesis Decisions, Risk Assessment
-  - kind: checkpoint
-    id: research-focus
-    condition:
-      type: simple
-      variable: needs_further_research
-      operator: ==
-      value: true
-    message: What additional research is needed? Describe the focus area or questions to investigate.
-    blocking: true
-    options:
-      - id: focus-provided
-        label: Focus area provided
-        description: Proceed with the specified research focus
-        effect:
-          setVariable:
-            needs_further_research: true
-      - id: cancel-further
-        label: Cancel — findings are sufficient after all
-        description: Proceed without additional research
-        effect:
-          setVariable:
-            needs_further_research: false
   - kind: technique
     id: document
     technique: document

--- a/work-package/activities/README.md
+++ b/work-package/activities/README.md
@@ -157,10 +157,11 @@ Definition: [`04-research.yaml`](./04-research.yaml)
 graph TD
     entryNode(["Entry"]) --> kbResearch["Knowledge base and web research"]
     kbResearch --> synthesize["Synthesize findings"]
-    synthesize --> cpFindings{"research-findings checkpoint"}
-    cpFindings -->|"sufficient"| collectAssumptions["Collect assumptions"]
-    cpFindings -->|"further research"| cpFocus{"research-focus checkpoint"}
-    cpFocus --> collectAssumptions
+    synthesize --> triageRes["Triage research candidates (reconcilable | irreconcilable)"]
+    triageRes --> reconcileRes["Reconcile candidates (autonomous research pass)"]
+    reconcileRes --> cpConverge{"research-convergence checkpoint (fires only when converged)"}
+    cpConverge -->|"not converged / request-more"| reconcileRes
+    cpConverge -->|"accept"| collectAssumptions["Collect assumptions"]
 
     collectAssumptions --> createDoc["Create research document"]
     createDoc --> updateLog["Update assumptions log"]

--- a/work-package/resources/README.md
+++ b/work-package/resources/README.md
@@ -2,7 +2,7 @@
 
 > Part of the [Work Package Implementation Workflow](../README.md)
 
-The workflow includes 26 resources that provide templates, guidance, and reference material for techniques and activities. Each resource lives as `resources/<id>.md` and is loaded by id (e.g. `get_resource({ resource_id: "pr-description" })`). The numbering system is deprecated — resources are obtained by id only.
+The workflow includes 27 resources that provide templates, guidance, and reference material for techniques and activities. Each resource lives as `resources/<id>.md` and is loaded by id (e.g. `get_resource({ resource_id: "pr-description" })`). The numbering system is deprecated — resources are obtained by id only.
 
 | Resource ID | Title | Purpose |
 |-------------|-------|---------|
@@ -31,4 +31,5 @@ The workflow includes 26 resources that provide templates, guidance, and referen
 | `review-mode` | Review Mode | Complete guide for review mode behavior and PR review formats |
 | `codebase-comprehension` | Codebase Comprehension | Comprehension techniques, artifact template, and deep-dive guidance from reverse engineering and code forensics literature |
 | `assumption-reconciliation` | Assumption Reconciliation | Assumptions-log integration and scorecard formats (classification and convergence rules live on review-assumptions::reconcile) |
+| `research-reconciliation` | Research Reconciliation | Research-candidate inventory shape, reconcilability statuses, and scorecard format (enumerate/classify/converge rules live on research::triage and research::reconcile) |
 | `pr-review-response` | PR Review Response | Response-format and review-document templates (protocol and rules live on respond-to-pr-review) |

--- a/work-package/resources/research-reconciliation.md
+++ b/work-package/resources/research-reconciliation.md
@@ -1,0 +1,55 @@
+---
+name: research-reconciliation
+description: Research-candidate inventory shape, reconcilability statuses, and scorecard format for research reconciliation; the enumerate-classify-converge protocol and classification rules live on the research triage and reconcile techniques.
+metadata:
+  version: 1.0.0
+  order: 27
+---
+
+
+# Research Reconciliation
+
+The research activity surfaces research candidates — open gaps between what the findings establish and what the requirements need. Research reconciliation closes the research-reconcilable candidates autonomously so the user reviews only the irreducible set, and it decides when research is objectively done: research continues while a reconcilable candidate remains and ends when none — or only irreconcilable candidates — remain. The enumerate-classify-converge procedure, classification criteria, and convergence definition live on [triage](../techniques/research/triage.md#rules) and [reconcile](../techniques/research/reconcile.md#rules); this resource carries the inventory shape and scorecard format that protocol consumes.
+
+## Integration with Research Artifact
+
+The candidate inventory lives in an **Open Research Candidates** section of the research [artifact](knowledge-base-research.md#planning-artifact) (`kb-research.md`), one table row per candidate, updated in place across passes.
+
+### Reconcilability statuses
+
+| Status | Meaning |
+|--------|---------|
+| Reconcilable | Open — further knowledge-base or web research could close it; a research pass is warranted |
+| Resolved | Research closed it; the finding and its citations are recorded |
+| Partially Resolved | Research narrowed it; residual uncertainty and what remains are noted |
+| Irreconcilable | Research cannot close it — carries the non-reconcilability rationale and a handoff target |
+
+### Handoff targets
+
+Every irreconcilable candidate records where it goes when research ends, so no gap is lost:
+
+| Target | Meaning |
+|--------|---------|
+| stakeholder | A decision or operational fact — carried into the downstream assumption interview |
+| code-analysis | A claim about this codebase — answerable by the assumption-reconciliation loop |
+| out-of-scope | Outside this work package — recorded only, no further action |
+
+### Section structure
+
+- A **Resolved** or **Partially Resolved** candidate's row records the finding and its citations in the Resolution column and the status in the Outcome column.
+- An **Irreconcilable** candidate keeps its row (Outcome `Irreconcilable (<target>)`) plus a bold-label entry carrying the rationale (why research cannot resolve it) and the handoff target. The entry is removed only if a later pass or a `request-more` reopens and resolves it.
+
+### Markdown formatting rule
+
+Bold-label entries follow the [markdown-line-breaks](../techniques/manage-artifacts/TECHNIQUE.md#markdown-line-breaks) rule: every bold-label line except the last in its group ends with two trailing spaces, or consecutive lines collapse into one rendered paragraph. No bullet prefixes as a substitute.
+
+## Scorecard
+
+After each reconciliation pass, present a summary scorecard:
+
+```
+Total: N | Resolved: N | Partially Resolved: N | Reconcilable (open): N | Irreconcilable: N
+Passes: N | Newly surfaced: N
+```
+
+This gives an at-a-glance view of how the candidate set converged. When the Reconcilable (open) count reaches zero, research has converged and the convergence checkpoint presents the full inventory. If the Irreconcilable count is also zero, research resolved every candidate.

--- a/work-package/techniques/research/reconcile.md
+++ b/work-package/techniques/research/reconcile.md
@@ -1,0 +1,80 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Iteratively close research-reconcilable candidates through targeted knowledge-base and web research until only irreconcilable candidates remain, re-triaging after each pass so the loop gate reflects the current inventory. Runs autonomously — the user is presented only the converged result, at the convergence checkpoint.
+
+## Inputs
+
+### research_candidates
+
+The running [inventory](../../resources/research-reconciliation.md#integration-with-research-artifact) of open and resolved candidates to reconcile. On the first pass this is the triaged set; on later passes it also carries any candidates a `request-more` reopened.
+
+### requirements
+
+Work package requirements that scope the targeted research and to which resolved candidates are mapped back.
+
+### problem_statement
+
+The work package problem statement, read alongside `{requirements}` to keep the targeted research in scope.
+
+## Outputs
+
+### research_candidates
+
+The candidate [inventory](../../resources/research-reconciliation.md#integration-with-research-artifact) with every candidate closable by research this pass resolved (finding + citations recorded) and only irreconcilable candidates left open — the same inventory written back in place.
+
+### has_reconcilable_research
+
+Boolean gate driving the loop — true while open research-reconcilable candidates remain (another pass is warranted), false once convergence is reached (only irreconcilable candidates, or none, remain).
+
+### research_document
+
+The research [artifact](../../resources/knowledge-base-research.md#planning-artifact) augmented with the findings gathered while closing candidates this pass, each carrying its source per the group's `url-per-finding` rule.
+
+## Protocol
+
+### 1. Select Reconcilable Candidates
+
+- Read `{research_candidates}`; take the candidates classified reconcilable-by-research
+- If none are reconcilable, there is nothing to research — set `{has_reconcilable_research}` false and return; convergence is already reached
+
+### 2. Targeted Research
+
+- For each reconcilable candidate, perform focused research scoped to that candidate: match it to a `concept-rag://activities` entry and follow that technique's tool sequence for institutional knowledge, and use `WebSearch` for current external knowledge where the gap needs it — the same mechanisms as the [research](./research.md) operation, narrowed to the single candidate
+- Validate every web finding on the [research](./research.md#source-validation) axes before it informs a resolution
+- Determine the outcome: Resolved (research answers the candidate, with citations), Partially Resolved (research narrows it but leaves residual uncertainty), or — when targeted research surfaces that the answer is not published knowledge after all — reclassify the candidate as irreconcilable with its handoff target
+
+### 3. Update the Inventory
+
+- Write each resolution and its citations into the candidate's row in `{research_candidates}` per the [integration shape](../../resources/research-reconciliation.md#integration-with-research-artifact); remove resolved candidates from the open set
+- Append the gathered findings to `{research_document}`
+- Add any research gap newly surfaced during this pass as a new candidate, classified per [triage](./triage.md#rules)
+
+### 4. Check Convergence
+
+- Re-classify all open candidates after the pass
+- If any open candidate is research-reconcilable (including newly surfaced ones), signal another pass is needed — set `{has_reconcilable_research}` true
+- If no open candidate is research-reconcilable, convergence is reached per the [convergence-definition](#convergence-definition) — set `{has_reconcilable_research}` false; the remaining open set is irreducible through research
+- Present the [scorecard](../../resources/research-reconciliation.md#scorecard) in the session after each pass; do not persist count tables in the artifact — the candidate rows are the record
+
+## Rules
+
+### no-user-interaction
+
+Reconciliation runs autonomously, without user interaction. Successive passes continue automatically while reconcilable candidates remain; the user sees only the converged inventory at the convergence checkpoint.
+
+### convergence-definition
+
+Convergence is reached when no open candidate in the inventory — including candidates surfaced during a pass — is classified research-reconcilable. Convergence does NOT mean every candidate is resolved: the remaining open set is irreducible through research and requires stakeholder input, operational verification, code analysis, or is out of scope. Each remaining open candidate carries an explicit non-reconcilability rationale and a handoff target.
+
+### classification-transparency
+
+When the converged result is presented, include the classification rationale for every remaining irreconcilable candidate — explain why research cannot resolve it and which handoff target owns it.
+
+### bounded-passes
+
+Each pass must make progress — resolve at least one candidate or reclassify one as irreconcilable. A pass that resolves nothing and surfaces nothing new is treated as converged rather than repeating; this backstops the loop's `maxIterations` bound.

--- a/work-package/techniques/research/triage.md
+++ b/work-package/techniques/research/triage.md
@@ -1,0 +1,87 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Enumerate the open research candidates left after synthesis and classify each as reconcilable-by-research or irreconcilable, seeding the candidate inventory and the loop gate before reconciliation begins. Runs autonomously — the user is not consulted during triage.
+
+## Inputs
+
+### findings_synthesis
+
+The synthesized findings connected to requirements; read to detect where a requirement is only partially answered or unsupported by the findings gathered so far.
+
+### applicable_patterns
+
+Patterns mapped to needs during synthesis; read to detect needs that no validated pattern yet covers.
+
+### synthesis_assumptions
+
+Assumptions about pattern applicability recorded during synthesis; each inferred-rather-than-established fit is a candidate research gap.
+
+### requirements
+
+Work package requirements the candidate set is triaged against, so every requirement with an unresolved research question surfaces as a candidate.
+
+### problem_statement
+
+The work package problem statement, read alongside `{requirements}` to scope which gaps are in-scope research candidates.
+
+## Outputs
+
+### research_candidates
+
+The candidate [inventory](../../resources/research-reconciliation.md#integration-with-research-artifact) — one entry per open research gap, each carrying its statement, its classification (reconcilable-by-research or irreconcilable), the classification rationale, and, for irreconcilable candidates, the handoff target. Empty when synthesis left no open gaps.
+
+### has_reconcilable_research
+
+Boolean gate driving the reconciliation loop — true when at least one candidate is classified reconcilable-by-research (another research pass is warranted), false when none are (only irreconcilable candidates, or none, remain).
+
+## Protocol
+
+### 1. Enumerate Candidates
+
+- Read `{findings_synthesis}`, `{applicable_patterns}`, and `{synthesis_assumptions}` against `{requirements}` and `{problem_statement}`
+- Surface every open research gap: a requirement the findings only partially answer, a need no validated pattern covers, a contradiction between sources left unresolved, an inferred pattern fit that evidence has not established, a best-practice or library-behaviour question research has not yet settled
+- If no open gaps remain, record none — set `{research_candidates}` empty and `{has_reconcilable_research}` false; the convergence checkpoint then presents an empty inventory and the flow proceeds
+
+### 2. Classify Reconcilability
+
+- For each candidate, determine whether further knowledge-base or web research could close it, per the [research-reconcilable](#research-reconcilable) and [research-irreconcilable](#research-irreconcilable) rules
+- Record the classification rationale for every candidate; for an irreconcilable candidate, record its handoff target per [handoff-targets](#handoff-targets)
+
+### 3. Seed the Inventory
+
+- Write the candidates to `{research_candidates}` and into the research artifact's Open Research Candidates section per the [integration shape](../../resources/research-reconciliation.md#integration-with-research-artifact)
+- Set `{has_reconcilable_research}` true if any candidate is reconcilable-by-research, false otherwise
+
+## Rules
+
+### no-user-interaction
+
+Triage runs autonomously, without user interaction. Candidates and their classifications are surfaced to the user only at the convergence checkpoint, after reconciliation.
+
+### research-reconcilable
+
+A candidate is reconcilable-by-research if further knowledge-base or web research could plausibly close it — the answer exists in documentation, precedent, or published practice and has simply not been gathered yet. Examples:
+
+- "The recommended retry policy for library X is unclear" — official docs or established practice can settle it
+- "Sources disagree on whether pattern P applies to async contexts" — more authoritative sources can resolve the contradiction
+- "It is unknown whether API A deprecated method M" — changelogs and release notes are researchable
+- "No validated pattern yet covers requirement R" — the knowledge base or web may hold one
+
+### research-irreconcilable
+
+A candidate is irreconcilable-by-research if no amount of knowledge-base or web research could close it — it depends on information outside published knowledge. Examples:
+
+- "Stakeholders must choose between approach A and B" — a human decision, not a researchable fact
+- "The production data volume for network N is unknown" — a project-specific/operational fact
+- "Whether the staging environment already runs version V" — a runtime/environment unknown
+- "Which trade-off the team prefers for this module" — a design judgement
+- "Behaviour of the internal service S" — not documented in any researchable source
+
+### handoff-targets
+
+Every irreconcilable candidate records where it goes next: `stakeholder` (a decision or operational fact for the downstream assumption interview), `code-analysis` (a claim about this codebase, answerable by the assumption-reconciliation loop), or `out-of-scope` (recorded only, no further action). This keeps irreconcilable research gaps from being lost when research ends.

--- a/work-package/workflow.yaml
+++ b/work-package/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: work-package
-version: 3.17.0
+version: 3.18.0
 title: Work Package Implementation Workflow
 description: Defines how to plan and implement ONE work package from inception to merged PR. A work package is a discrete unit of work such as a feature, bug-fix, enhancement, refactoring, or any other deliverable change. For multiple related work packages, use the work-packages workflow to create a roadmap first.
 author: m2ux
@@ -228,6 +228,13 @@ variables:
     type: boolean
     description: Whether code-resolvable assumptions exist that can be validated through targeted analysis. Drives the assumption reconciliation loop.
     defaultValue: false
+  - name: research_candidates
+    type: array
+    description: "Inventory of open research gaps surfaced after synthesis, each triaged as reconcilable-by-research or irreconcilable, with rationale and (for irreconcilable candidates) a handoff target. Drives the research reconciliation loop and the full-picture presentation at the research-convergence checkpoint. Sub-shape per entry: { id, statement, status (Reconcilable|Resolved|Partially Resolved|Irreconcilable), rationale, handoff (stakeholder|code-analysis|out-of-scope, irreconcilable only) }."
+  - name: has_reconcilable_research
+    type: boolean
+    description: "Whether open research-reconcilable candidates remain — gaps further knowledge-base or web research could close. Drives the research reconciliation loop: true while another research pass is warranted, false once research converges (only irreconcilable candidates, or none, remain)."
+    defaultValue: false
   - name: has_open_questions
     type: boolean
     description: Whether unresolved open questions remain after the codebase comprehension deep-dive. When false, comprehension is objectively sufficient and the sufficiency checkpoint is skipped.
@@ -285,10 +292,6 @@ variables:
   - name: prism_artifact_paths
     type: array
     description: Paths to prism structural analysis artifacts produced during post-impl-review. Single-pass produces one path; full-prism produces paths to structural, adversarial, and synthesis artifacts.
-  - name: needs_further_research
-    type: boolean
-    description: Whether additional research focus areas were identified during research activity
-    defaultValue: false
   - name: has_deferred_assumptions
     type: boolean
     description: Whether any assumptions were deferred during review (triggers issue tracker posting)


### PR DESCRIPTION
## Summary

Replaces the sub-optimal "further research required" mechanism in the work-package research activity with a **triage → autonomous reconcile-loop → converged full-picture checkpoint**, modelled on the `assumption-reconciliation` pattern already in the same activity.

### Problem

The old `research-findings` / `research-focus` checkpoints had three defects:

1. **No full picture** — neither checkpoint enumerated *which* items were candidates for further research, nor whether a candidate was *reconcilable*.
2. **"Further research" did not loop** — selecting it set `needs_further_research: true`, but no loop consumed the flag; the `research` technique was never re-run. A dead toggle.
3. **No termination logic** — just a manual boolean.

### Design

```
synthesize
  → triage-research-candidates       classify each open gap: reconcilable-by-research | irreconcilable (+ rationale, + handoff target)
  → doWhile (has_reconcilable_research == true, max 10):
        reconcile-research-candidates   autonomous kb/web research on reconcilable ones, re-triage   [when reconcilable remain]
        research-convergence CHECKPOINT (condition: has_reconcilable_research == false)
  → collect-assumptions → document → …
```

The checkpoint sits inside the loop but is gated `== false`, so it is **auto-dismissed on every non-converged pass** — research continues automatically while reconcilable candidates remain, and the checkpoint fires **only at convergence**, presenting the full triaged inventory. `accept` exits; `request-more` re-opens the loop for a user-directed item. Irreconcilable candidates carry a handoff target (stakeholder interview / assumption-reconciliation / out-of-scope) so nothing is lost.

This satisfies: **full picture whenever asked**, **auto-continue while reconcilable candidates remain**, **end only when none / only irreconcilable remain**.

## Changes (7 files, +275/−49)

- `workflow.yaml` — `+research_candidates`, `+has_reconcilable_research`; remove dead `needs_further_research`; **v3.17.0 → v3.18.0**
- `activities/04-research.yaml` — remove 2 checkpoints; add triage + `doWhile` loop + convergence checkpoint; **v2.8.0 → v2.9.0**
- `techniques/research/triage.md`, `techniques/research/reconcile.md` — new autonomous ops (modelled on `review-assumptions`)
- `resources/research-reconciliation.md` — candidate-inventory shape, statuses, scorecard
- `activities/README.md`, `resources/README.md` — reflect the new flow

## Validation

All guard checks pass against the branch: `variable-model`, `binding` (0 new drift; **1 pre-existing baseline entry now fixed** by removing the dead toggle), `identifiers`, `self-input`, `activity-tech`, `anchors`, `technique-template`, `fragments`; workflow loads cleanly with **0 unresolved refs**.

**Follow-up:** the binding-fidelity baseline lives in the server repo and can be shrunk by 1 as a separate server-side commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
