### PR TITLE
fix(work-package): optimise review-mode path — remove spurious create-mode checkpoints

### DIFF
--- a/work-package/REVIEW-MODE.md
+++ b/work-package/REVIEW-MODE.md
@@ -123,14 +123,15 @@ graph TD
 
 | Activity | Mode Override |
 |----------|---------------|
-| `start-work-package` | Detect mode, capture PR reference, skip branch/PR creation |
+| `start-work-package` | Detect mode, capture PR reference; the `issue-verification` and `pr-creation` checkpoints and branch/PR-creation steps are gated `is_review_mode != true` so no issue/branch/PR is created |
 | `design-philosophy` | Assess ticket completeness, force skip elicitation |
+| `plan-prepare` | Plan the review approach; the `update-pr::render` (initial) step and `approach-confirmed` checkpoint are gated `is_review_mode != true` so the reviewed PR's body is never overwritten and no approach-confirmation is prompted |
 | `implementation-analysis` | Checkout base branch, document expected changes |
-| `implement` | **SKIPPED** — its steps and inbound transition are gated `when is_review_mode != true` |
+| `implement` | **SKIPPED** — `assumptions-review` carries a `is_review_mode == true → lean-coding-audit` transition that routes around the entire activity, so none of its steps or checkpoints (`switch-model-*`, assumption interview) are reached |
 | `lean-coding-audit` | Run the read-only over-engineering review, debt harvest, and gain report; the findings-confirmation checkpoint and simplification-apply-cycle are gated out so no code changes — findings become PR feedback |
 | `validate` | Document failures as findings, skip fix-failures |
 | `strategic-review` | Document recommendations, transition to submit-for-review |
-| `submit-for-review` | Generate review summary, post to PR, end workflow |
+| `submit-for-review` | Consolidate findings, generate the review summary, post it to the PR, then transition to `complete`; the create-mode tail (DCO attestation, PR-body render/verify, push, mark-ready, reviewer-feedback loop) is gated `is_review_mode != true` |
 | `post-impl-review` | Compare changes against expected |
 
 ---

--- a/work-package/activities/01-start-work-package.yaml
+++ b/work-package/activities/01-start-work-package.yaml
@@ -1,5 +1,5 @@
 id: start-work-package
-version: 3.11.0
+version: 3.12.0
 name: Start Work Package
 description: Initialize the work package with issue, branch, draft PR, dedicated worktree, and planning folder.
 required: true
@@ -113,9 +113,15 @@ steps:
   - kind: checkpoint
     id: issue-verification
     condition:
-      type: simple
-      variable: issue_number
-      operator: notExists
+      type: and
+      conditions:
+        - type: simple
+          variable: is_review_mode
+          operator: "!="
+          value: true
+        - type: simple
+          variable: issue_number
+          operator: notExists
     message: I didn't find a GitHub or Jira issue associated with this work package. Which option would you like?
     options:
       - id: provide-existing
@@ -524,6 +530,10 @@ steps:
     condition:
       type: and
       conditions:
+        - type: simple
+          variable: is_review_mode
+          operator: "!="
+          value: true
         - type: simple
           variable: issue_cancelled
           operator: "!="

--- a/work-package/activities/06-plan-prepare.yaml
+++ b/work-package/activities/06-plan-prepare.yaml
@@ -1,5 +1,5 @@
 id: plan-prepare
-version: 1.7.0
+version: 1.8.0
 name: Plan & Prepare
 description: Design the approach, create the work package plan, and prepare for implementation.
 required: true
@@ -77,8 +77,18 @@ steps:
       name: update-pr::render
       inputs:
         pr_template_variant: initial
+    condition:
+      type: simple
+      variable: is_review_mode
+      operator: "!="
+      value: true
   - kind: checkpoint
     id: approach-confirmed
+    condition:
+      type: simple
+      variable: is_review_mode
+      operator: "!="
+      value: true
     message: Approach presented above. Confirming in 30s unless you want to revise.
     blocking: false
     defaultOption: confirmed

--- a/work-package/activities/07-assumptions-review.yaml
+++ b/work-package/activities/07-assumptions-review.yaml
@@ -1,5 +1,5 @@
 id: assumptions-review
-version: 2.1.1
+version: 2.2.0
 name: Assumptions Review
 description: Review each open assumption with the user.
 required: true
@@ -155,6 +155,12 @@ transitions:
     condition:
       type: simple
       variable: needs_further_discussion
+      operator: ==
+      value: true
+  - to: lean-coding-audit
+    condition:
+      type: simple
+      variable: is_review_mode
       operator: ==
       value: true
   - to: implement

--- a/work-package/activities/13-submit-for-review.yaml
+++ b/work-package/activities/13-submit-for-review.yaml
@@ -1,5 +1,5 @@
 id: submit-for-review
-version: 1.7.0
+version: 1.8.0
 name: Submit for Review
 description: Submit the PR for review and handle reviewer feedback.
 required: true
@@ -75,6 +75,11 @@ steps:
       value: true
   - kind: checkpoint
     id: dco-sign-off-confirmation
+    condition:
+      type: simple
+      variable: is_review_mode
+      operator: "!="
+      value: true
     message: |-
       Before pushing: please certify the Developer Certificate of Origin for this work package.
 
@@ -119,6 +124,7 @@ steps:
     id: verify-pr-body-rerender
     name: PR Body Verification Re-render Loop
     loopType: while
+    when: is_review_mode != true
     condition:
       type: simple
       variable: body_conforms
@@ -138,10 +144,16 @@ steps:
   - kind: checkpoint
     id: body-non-conformant
     condition:
-      type: simple
-      variable: body_conforms
-      operator: ==
-      value: false
+      type: and
+      conditions:
+        - type: simple
+          variable: is_review_mode
+          operator: "!="
+          value: true
+        - type: simple
+          variable: body_conforms
+          operator: ==
+          value: false
     message: |-
       The PR body still fails update-pr::rules.pr-body-conformance after the verify-pr-body-rerender loop's two iterations.
 
@@ -183,10 +195,16 @@ steps:
   - kind: action
     id: merge-strategy-guidance
     condition:
-      type: simple
-      variable: squash_merge_supported
-      operator: ==
-      value: true
+      type: and
+      conditions:
+        - type: simple
+          variable: is_review_mode
+          operator: "!="
+          value: true
+        - type: simple
+          variable: squash_merge_supported
+          operator: ==
+          value: true
     actions:
       - action: message
         message: |-
@@ -216,6 +234,11 @@ steps:
     actions: []
   - kind: checkpoint
     id: review-received
+    condition:
+      type: simple
+      variable: is_review_mode
+      operator: "!="
+      value: true
     message: Has the PR received manual review feedback?
     options:
       - id: yes-review
@@ -227,11 +250,26 @@ steps:
   - kind: technique
     id: process-review-comments
     technique: respond-to-pr-review
+    condition:
+      type: simple
+      variable: is_review_mode
+      operator: "!="
+      value: true
   - kind: technique
     id: analyze-review-outcome
     technique: review-outcome-analysis
+    condition:
+      type: simple
+      variable: is_review_mode
+      operator: "!="
+      value: true
   - kind: checkpoint
     id: review-outcome
+    condition:
+      type: simple
+      variable: is_review_mode
+      operator: "!="
+      value: true
     message: |-
       Review outcome analysis complete.
 

--- a/work-package/workflow.yaml
+++ b/work-package/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: work-package
-version: 3.18.0
+version: 3.19.0
 title: Work Package Implementation Workflow
 description: Defines how to plan and implement ONE work package from inception to merged PR. A work package is a discrete unit of work such as a feature, bug-fix, enhancement, refactoring, or any other deliverable change. For multiple related work packages, use the work-packages workflow to create a roadmap first.
 author: m2ux


### PR DESCRIPTION
## Summary

Optimises the `work-package` review-mode path so it stops presenting checkpoints whose outcome the mode already determines. Bumps work-package to **v3.19.0**. Definition-layer only — no server source changes.

Review mode was implemented as a per-step `is_review_mode` retrofit onto a create-oriented workflow, with two systematic gaps:
1. **No activity-level skip** — create-only activities were entered via ungated default transitions, so all their ungated steps/checkpoints ran before the review-mode exit transition was even consulted.
2. **Un-gated proceed/skip checkpoints defaulting to the create action** — so the user had to hand-decline them, and auto-advance did the *wrong* thing.

## Findings fixed

| # | Finding | Fix |
|---|---------|-----|
| F1 (High) | `implement` never skipped in review; fired `switch-model-*` + assumption interview | `07-assumptions-review`: `is_review_mode == true → lean-coding-audit` transition routes around the whole activity |
| F2 (High) | `submit-for-review` create tail ran in review (DCO cert, PR-body verify, reviewer-feedback loop) | `13`: gated the entire create tail on `is_review_mode != true`; review path ends after posting the summary |
| F3 (High/Med) | `pr-creation` fired with default "Create branch and PR" | `01`: added `is_review_mode != true` to its condition |
| F5 (Low/Med) | `issue-verification` prompted in review | `01`: gated on `is_review_mode != true` |
| F4 (Med) | `plan-prepare` overwrote the reviewed PR body + prompted `approach-confirmed` | `06`: gated `update-pr::render (initial)` and `approach-confirmed` |
| F6 (Doc) | `REVIEW-MODE.md` documented gating that didn't exist | Reconciled with the real mechanism |

## Validation

Guards run against this worktree (`--root`): schema PASS (15/15 activities), binding-fidelity **0 new** (incidentally fixed 1 baselined), variable-model / identifiers / fragments / all-refs / self-input / activity-tech all OK.

## Follow-ups (not in this PR)

- **R5**: a definition guard flagging un-gated create-default checkpoints reachable in review mode (regression prevention).
- **R6**: a review-mode E2E walk asserting only mode-relevant checkpoints fire.
- Server-repo `binding-fidelity-baseline.json` can be shrunk by 1 (non-blocking).

Full review report: `.engineering/artifacts/planning/2026-07-08-work-package-review-mode-optimisation/08-review-mode-optimisation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
