### PR TITLE
test(review-mode): guard + E2E walk against review-mode checkpoint friction (R5+R6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "check:anchors": "tsx scripts/check-resource-anchors.ts",
     "check:technique-template": "tsx scripts/check-technique-template.ts",
     "check:variable-model": "tsx scripts/check-variable-model.ts",
-    "check:fragments": "tsx scripts/check-fragments.ts"
+    "check:fragments": "tsx scripts/check-fragments.ts",
+    "check:review-mode": "tsx scripts/check-review-mode-gating.ts"
   },
   "license": "MIT",
   "devDependencies": {

--- a/scripts/check-review-mode-gating.ts
+++ b/scripts/check-review-mode-gating.ts
@@ -1,0 +1,216 @@
+/**
+ * check-review-mode-gating — review-mode checkpoint-friction guard (work-package review-mode
+ * optimisation follow-up, R5).
+ *
+ * Review mode in a workflow (e.g. work-package) is driven by an `is_review_mode` boolean: activities,
+ * steps, and checkpoints branch on it. The failure this guards against is the class the review-mode
+ * optimisation fixed: a checkpoint that is REACHABLE while `is_review_mode == true`, is NOT itself
+ * mode-aware (its own gate never mentions `is_review_mode`), and auto-advances to a CONSEQUENTIAL
+ * default — a `defaultOption` whose option carries an `effect` (setVariable / transitionTo /
+ * skipActivities). In review mode that default is applied silently on the autoAdvance timer even
+ * though the mode may make it the wrong (create/mutating) action — exactly the spurious "skip this
+ * create step" prompt the optimisation removed (pr-creation defaulting to "Create branch and PR",
+ * review-outcome defaulting to "approved", etc.).
+ *
+ * Reachability respects transition ORDER: a transition provably-true under `is_review_mode == true`
+ * (e.g. `is_review_mode == true`) fires first, so later default edges behind it (assumptions-review's
+ * default edge into `implement`) are correctly treated as unreachable in review mode.
+ *
+ * The current corpus carries benign instances (checkpoints whose consequential default is harmless in
+ * review because the review-mode transition ignores the variable they set — e.g. strategic-review's
+ * review-findings). Those are snapshotted in scripts/review-mode-gating-baseline.json; the guard fails
+ * ONLY on violations absent from that baseline (NEW friction, or a reverted gate). Regenerate the
+ * baseline after an intentional, reviewed change with:
+ *   npx tsx scripts/check-review-mode-gating.ts --root <workflows-dir> --update-baseline
+ *
+ * Run: npx tsx scripts/check-review-mode-gating.ts [--root <workflows-dir>]
+ */
+import { readFileSync, readdirSync, existsSync, statSync, writeFileSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { parse } from 'yaml';
+import { evaluateCondition, type Condition } from '../src/schema/condition.schema.js';
+import { resolveWorkflowsRoot } from './workflows-root.js';
+
+const DIR = fileURLToPath(new URL('.', import.meta.url));
+const ROOT = resolveWorkflowsRoot(resolve(join(DIR, '..', 'workflows')));
+const BASELINE = join(DIR, 'review-mode-gating-baseline.json');
+const REVIEW_BAG = { is_review_mode: true } as const;
+
+export interface ReviewGatingViolation {
+  /** `<workflow>::<activity>::<checkpoint>` — stable key for the baseline. */
+  key: string;
+  detail: string;
+}
+
+interface CheckpointOption {
+  id: string;
+  effect?: { setVariable?: Record<string, unknown>; transitionTo?: string; skipActivities?: string[] };
+}
+interface StepDef {
+  kind?: string;
+  id?: string;
+  when?: string;
+  condition?: Condition;
+  // checkpoint fields
+  options?: CheckpointOption[];
+  defaultOption?: string;
+  // loop body
+  steps?: StepDef[];
+}
+interface ActivityDef { id: string; steps?: StepDef[]; transitions?: Array<{ to: string; condition?: Condition; isDefault?: boolean }>; }
+
+/** A condition provably FALSE under is_review_mode == true, whatever the other variables are. */
+function reviewExcluded(cond?: Condition): boolean {
+  if (!cond) return false;
+  const c = cond as { type?: string; variable?: string; conditions?: Condition[]; condition?: Condition };
+  if (c.type === 'simple') return c.variable === 'is_review_mode' && !evaluateCondition(cond, REVIEW_BAG);
+  if (c.type === 'and') return (c.conditions ?? []).some(reviewExcluded);
+  if (c.type === 'or') return (c.conditions ?? []).length > 0 && (c.conditions ?? []).every(reviewExcluded);
+  if (c.type === 'not') return reviewProvablyTrue(c.condition);
+  return false;
+}
+
+/** A condition provably TRUE under is_review_mode == true, whatever the other variables are. */
+function reviewProvablyTrue(cond?: Condition): boolean {
+  if (!cond) return true; // an unconditional transition always fires
+  const c = cond as { type?: string; variable?: string; conditions?: Condition[]; condition?: Condition };
+  if (c.type === 'simple') return c.variable === 'is_review_mode' && evaluateCondition(cond, REVIEW_BAG);
+  if (c.type === 'and') return (c.conditions ?? []).length > 0 && (c.conditions ?? []).every(reviewProvablyTrue);
+  if (c.type === 'or') return (c.conditions ?? []).some(reviewProvablyTrue);
+  if (c.type === 'not') return reviewExcluded(c.condition);
+  return false;
+}
+
+/** Parse `is_review_mode (==|!=) (true|false)` in a step `when`; true iff provably false in review. */
+function whenExcludesReview(when?: string): boolean {
+  if (!when) return false;
+  const m = when.match(/\bis_review_mode\s*(==|!=)\s*(true|false)\b/);
+  if (!m) return false;
+  const truth = m[2] === 'true';
+  return m[1] === '==' ? !truth : truth; // is_review_mode==false / !=true → excluded in review
+}
+
+function mentionsReview(step: StepDef): boolean {
+  if (step.when && /\bis_review_mode\b/.test(step.when)) return true;
+  return step.condition ? JSON.stringify(step.condition).includes('is_review_mode') : false;
+}
+
+/** Successor activities reachable in review mode, honouring first-provably-true-transition-wins order. */
+function reviewSuccessors(act: ActivityDef): string[] {
+  const out: string[] = [];
+  for (const t of act.transitions ?? []) {
+    if (reviewExcluded(t.condition)) continue; // cannot be taken in review
+    out.push(t.to);
+    if (reviewProvablyTrue(t.condition)) break; // definitely taken → later edges unreachable in review
+  }
+  return out;
+}
+
+function reachableInReview(initial: string, activities: Map<string, ActivityDef>): Set<string> {
+  const seen = new Set<string>();
+  const queue = [initial];
+  while (queue.length) {
+    const id = queue.shift()!;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const act = activities.get(id);
+    if (act) for (const s of reviewSuccessors(act)) if (!seen.has(s)) queue.push(s);
+  }
+  return seen;
+}
+
+/** Walk an activity's steps (recursing loop bodies); yield checkpoints reachable in review mode. */
+function reviewReachableCheckpoints(act: ActivityDef): StepDef[] {
+  const out: StepDef[] = [];
+  const walk = (steps: StepDef[] | undefined, gatedOut: boolean): void => {
+    for (const s of steps ?? []) {
+      const excluded = gatedOut || reviewExcluded(s.condition) || whenExcludesReview(s.when);
+      if (s.kind === 'checkpoint' && !excluded) out.push(s);
+      if (s.steps) walk(s.steps, excluded);
+    }
+  };
+  walk(act.steps, false);
+  return out;
+}
+
+/** A checkpoint auto-advances to a consequential default: its defaultOption carries an effect. */
+function hasConsequentialDefault(cp: StepDef): boolean {
+  if (!cp.defaultOption) return false;
+  const opt = (cp.options ?? []).find(o => o.id === cp.defaultOption);
+  const e = opt?.effect;
+  return Boolean(e && (e.setVariable || e.transitionTo || e.skipActivities));
+}
+
+export function collectReviewGatingViolations(root: string = ROOT): ReviewGatingViolation[] {
+  const out: ReviewGatingViolation[] = [];
+  for (const workflow of readdirSync(root).sort()) {
+    const workflowYamlPath = join(root, workflow, 'workflow.yaml');
+    if (!existsSync(workflowYamlPath)) continue;
+    const wf = parse(readFileSync(workflowYamlPath, 'utf-8')) as { variables?: Array<{ name?: string }>; initialActivity?: string };
+    const declaresReview = (wf.variables ?? []).some(v => v?.name === 'is_review_mode');
+    if (!declaresReview) continue; // guard applies only to workflows with a review mode
+
+    const activitiesDir = join(root, workflow, 'activities');
+    if (!existsSync(activitiesDir) || !statSync(activitiesDir).isDirectory()) continue;
+    const activities = new Map<string, ActivityDef>();
+    for (const entry of readdirSync(activitiesDir).sort()) {
+      if (!entry.endsWith('.yaml') && !entry.endsWith('.yml')) continue;
+      const def = parse(readFileSync(join(activitiesDir, entry), 'utf-8')) as ActivityDef;
+      if (def?.id) activities.set(def.id, def);
+    }
+    const initial = wf.initialActivity ?? [...activities.keys()][0];
+    if (!initial) continue;
+    const reachable = reachableInReview(initial, activities);
+
+    for (const actId of reachable) {
+      const act = activities.get(actId);
+      if (!act) continue;
+      for (const cp of reviewReachableCheckpoints(act)) {
+        if (mentionsReview(cp)) continue; // mode-aware: intentionally review-conditioned
+        if (!hasConsequentialDefault(cp)) continue; // no silent stateful auto-advance
+        out.push({
+          key: `${workflow}::${actId}::${cp.id ?? '?'}`,
+          detail: `checkpoint reachable while is_review_mode == true is not mode-aware and auto-advances to default option '${cp.defaultOption}', which applies an effect the user did not choose — gate it on is_review_mode or drop the consequential default`,
+        });
+      }
+    }
+  }
+  return out.sort((a, b) => a.key.localeCompare(b.key));
+}
+
+function loadBaseline(): Set<string> {
+  if (!existsSync(BASELINE)) return new Set();
+  try { return new Set(JSON.parse(readFileSync(BASELINE, 'utf-8')) as string[]); } catch { return new Set(); }
+}
+
+/** Violations not in the committed baseline (`added`) and baselined keys no longer present (`fixed`). */
+export function diffBaseline(root: string = ROOT): { added: ReviewGatingViolation[]; fixed: string[] } {
+  const all = collectReviewGatingViolations(root);
+  const baseline = loadBaseline();
+  return {
+    added: all.filter(v => !baseline.has(v.key)),
+    fixed: [...baseline].filter(k => !all.some(v => v.key === k)),
+  };
+}
+
+const isMain = !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  const all = collectReviewGatingViolations();
+  if (process.argv.includes('--update-baseline')) {
+    writeFileSync(BASELINE, JSON.stringify(all.map(v => v.key), null, 2) + '\n');
+    process.stdout.write(`review-mode-gating: baseline updated with ${all.length} entr(ies) at ${relative(process.cwd(), BASELINE)}\n`);
+    process.exit(0);
+  }
+  const baseline = loadBaseline();
+  const fresh = all.filter(v => !baseline.has(v.key));
+  const fixed = [...baseline].filter(k => !all.some(v => v.key === k));
+  if (fresh.length === 0) {
+    process.stdout.write(`review-mode-gating: OK — ${all.length} total, ${baseline.size} baselined, 0 NEW${fixed.length ? `, ${fixed.length} fixed` : ''}\n`);
+    if (fixed.length) process.stdout.write(`  ${fixed.length} baselined entr(ies) no longer present — run --update-baseline to shrink the baseline\n`);
+    process.exit(0);
+  }
+  process.stdout.write(`review-mode-gating: ${fresh.length} NEW violation(s) — a review-reachable checkpoint gained a silent create-mode default:\n`);
+  for (const v of fresh) process.stdout.write(`  ${v.key} — ${v.detail}\n`);
+  process.exit(1);
+}

--- a/scripts/review-mode-gating-baseline.json
+++ b/scripts/review-mode-gating-baseline.json
@@ -1,0 +1,10 @@
+[
+  "work-package::codebase-comprehension::comprehension-sufficient",
+  "work-package::design-philosophy::classification-and-path-confirmed",
+  "work-package::requirements-elicitation::elicitation-complete",
+  "work-package::research::context-scope-declaration",
+  "work-package::start-work-package::github-issue-missing",
+  "work-package::start-work-package::issue-review",
+  "work-package::strategic-review::review-findings",
+  "workflow-design::scope-and-draft::scope-and-structure-confirmed"
+]

--- a/tests/e2e/harness.ts
+++ b/tests/e2e/harness.ts
@@ -29,8 +29,14 @@ export interface HarnessOptions {
 /** Create a connected client + server pair backed by a workspace (fresh temp by default). */
 export async function createHarness(opts: HarnessOptions = {}): Promise<Harness> {
   const workspaceDir = opts.workspaceDir ?? mkdtempSync(join(tmpdir(), 'wf-e2e-'));
+  // Default to the repo's own `../../workflows` checkout; allow WORKFLOWS_DIR to point the harness
+  // at a dedicated worktree's workflows directory (parity with the guard scripts' resolveWorkflowsRoot),
+  // so a change under review in a worktree can be walked before it lands in the submodule checkout.
+  const workflowDir = process.env.WORKFLOWS_DIR
+    ? resolve(process.env.WORKFLOWS_DIR)
+    : resolve(import.meta.dirname, '../../workflows');
   const config = {
-    workflowDir: resolve(import.meta.dirname, '../../workflows'),
+    workflowDir,
     schemasDir: resolve(import.meta.dirname, '../../schemas'),
     workspaceDir,
     serverName: 'e2e-workflow-server',

--- a/tests/e2e/workflow-e2e.test.ts
+++ b/tests/e2e/workflow-e2e.test.ts
@@ -30,7 +30,9 @@ describe('work-package E2E walk (Layer 1: machinery)', () => {
     // B1 fix: elicitation-only (needs_research=false) now skips the research
     // activity — requirements-elicitation routes straight to implementation-analysis.
     { policy: elicitationOnlyPolicy, mustInclude: ['requirements-elicitation', 'implementation-analysis'], mustExclude: ['research'] },
-    { policy: reviewModePolicy },
+    // Review mode routes around the create-only implement activity entirely (work-package v3.19.0):
+    // assumptions-review carries an is_review_mode transition to lean-coding-audit.
+    { policy: reviewModePolicy, mustExclude: ['implement'] },
   ];
 
   for (const { policy, mustInclude, mustExclude } of cases) {
@@ -47,4 +49,24 @@ describe('work-package E2E walk (Layer 1: machinery)', () => {
       for (const a of mustExclude ?? []) expect(result.path).not.toContain(a);
     });
   }
+
+  // R6: review mode must present ONLY the checkpoints whose outcome the mode does not already
+  // determine. Every create-mode checkpoint below is either in an activity review mode skips
+  // (implement) or is gated is_review_mode != true (work-package v3.19.0); if any surfaces in a
+  // review walk, a spurious "skip this create step" prompt has regressed back into the review path.
+  it('[review-mode] presents no create-mode checkpoints', async () => {
+    const result = await walk(h, 'work-package', reviewModePolicy);
+    const fired = new Set(result.steps.flatMap(s => s.checkpoints.map(c => c.checkpointId)));
+
+    const forbidden = [
+      'switch-model-pre-impl', 'switch-model-post-impl', 'symbol-provenance-confirmed',
+      'implementation-assumption-interview', 'pr-creation', 'issue-verification',
+      'approach-confirmed', 'dco-sign-off-confirmation', 'body-non-conformant',
+      'review-received', 'review-outcome',
+    ];
+    for (const cp of forbidden) expect(Array.from(fired)).not.toContain(cp);
+
+    // Sanity: the review path IS actually being exercised (not excluding everything by dying early).
+    expect(Array.from(fired)).toContain('review-summary-approval');
+  });
 });

--- a/tests/review-mode-gating.test.ts
+++ b/tests/review-mode-gating.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { diffBaseline } from '../scripts/check-review-mode-gating.js';
+
+/**
+ * Review-mode friction guard: a workflow with a review mode must introduce no NEW checkpoint that
+ * is reachable while is_review_mode == true, is not mode-aware, and auto-advances to a consequential
+ * (effect-bearing) default — the spurious "silently take the create action" prompt the work-package
+ * review-mode optimisation removed. Beyond the committed baseline
+ * (scripts/review-mode-gating-baseline.json) the set must be empty. If a change is intentional and
+ * reviewed, re-snapshot with `npx tsx scripts/check-review-mode-gating.ts --update-baseline`.
+ */
+describe('review-mode-gating drift guard', () => {
+  const { added } = diffBaseline();
+
+  it('introduces no NEW review-reachable create-default checkpoints beyond the baseline', () => {
+    expect(added.map((v) => `${v.key} — ${v.detail}`)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Regression protection for the `work-package` review-mode optimisation (follow-ups **R5** and **R6** from the review). Guards against the class of defect that optimisation fixed: a checkpoint reachable while `is_review_mode == true` that silently takes a create-mode action.

## R5 — definition guard (`scripts/check-review-mode-gating.ts`, npm `check:review-mode`)

Flags a checkpoint that is **reachable while `is_review_mode == true`**, is **not mode-aware** (its own gate never mentions `is_review_mode`), and **auto-advances to a consequential default** (a `defaultOption` whose option carries an `effect`). Reachability respects transition **order** — a transition provably-true under review mode fires first, so edges behind it (e.g. `assumptions-review`'s default edge into `implement`) are correctly unreachable.

- Baselined (`scripts/review-mode-gating-baseline.json`, 8 benign entries where the consequential default is harmless in review); fails only on **NEW** drift. Re-snapshot with `--update-baseline`.
- Paired test: `tests/review-mode-gating.test.ts`.
- **Bite check:** against the pre-#190 corpus it flags exactly `start-work-package::pr-creation` and `submit-for-review::review-outcome` — the two silent-create-default checkpoints #190 gates — as NEW.

## R6 — review-mode E2E walk (`tests/e2e/workflow-e2e.test.ts`)

The review-mode walk now asserts the path **never enters `implement`** and presents **none** of the create-mode checkpoints (`switch-model-*`, `pr-creation`, `issue-verification`, `approach-confirmed`, `dco-sign-off-confirmation`, `body-non-conformant`, `review-received`, `review-outcome`), while still exercising the real review path (asserts `review-summary-approval` fires).

`tests/e2e/harness.ts` gains a `WORKFLOWS_DIR` override (parity with the guards' `resolveWorkflowsRoot`) so a change in a dedicated worktree can be walked before it lands in the submodule checkout.

## ⚠️ Merge ordering — depends on PR #190

Both the guard and the walk assert the **post-#190** gating (work-package v3.19.0). They are **red against the pre-#190 corpus** (that's the bite check above). **Merge this only after #190 has landed in the `workflows` submodule and the submodule pointer is bumped**, otherwise CI on `main` fails. Validated green against the #190 worktree via `WORKFLOWS_DIR` / `--root`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
