### PR TITLE
fix(work-package): explicit, finding-aware strategic-review disposition

### DIFF
--- a/work-package/activities/12-strategic-review.yaml
+++ b/work-package/activities/12-strategic-review.yaml
@@ -1,5 +1,5 @@
 id: strategic-review
-version: 2.6.0
+version: 2.7.0
 name: Strategic Review
 description: Review the implementation to ensure changes are minimal and focused.
 required: true
@@ -47,20 +47,23 @@ steps:
     technique: strategic-findings-analysis
   - kind: checkpoint
     id: review-findings
+    condition:
+      type: simple
+      variable: strategic_findings_summary
+      operator: "!="
+      value: ""
     message: |-
       Strategic review complete.
 
       Findings:
       {strategic_findings_summary}
 
-      Recommended action: {recommended_strategic_option}. Auto-advancing in 30s.
-    blocking: false
-    defaultOption: acceptable
-    autoAdvanceMs: 30000
+      Recommended action: {recommended_strategic_option}.
+    blocking: true
     options:
       - id: acceptable
         label: All acceptable
-        description: Findings noted but no changes needed (default — auto-accepts after 30s)
+        description: Findings noted but no changes needed
         effect:
           setVariable:
             review_passed: true
@@ -70,12 +73,20 @@ steps:
         effect:
           setVariable:
             needs_strategic_fixes: true
+      - id: selective-fixes
+        label: Fix selected findings
+        description: Choose which findings to fix, by priority
+        effect:
+          setVariable:
+            needs_strategic_fixes: true
+            strategic_fixes_selective: true
       - id: defer-findings
         label: Defer findings
         description: Note findings for future but proceed now
         effect:
           setVariable:
             review_passed: true
+            strategic_findings_deferred: true
       - id: more-review
         label: Need more review
         description: Additional areas need examination

--- a/work-package/activities/README.md
+++ b/work-package/activities/README.md
@@ -395,8 +395,8 @@ graph TD
     applyCleanup --> createArchSummary["Architecture summary"]
     createArchSummary --> analyze["Analyze strategic findings"]
     analyze --> cpFindings{"review-findings checkpoint"}
-    cpFindings -->|"review mode or passed"| exitSubmit(["submit-for-review"])
-    cpFindings -->|"fix / more review"| exitPlan(["plan-prepare"])
+    cpFindings -->|"review mode / passed / accept / defer"| exitSubmit(["submit-for-review"])
+    cpFindings -->|"fix / selective / more review"| exitPlan(["plan-prepare"])
 ```
 
 ---

--- a/work-package/techniques/strategic-findings-analysis.md
+++ b/work-package/techniques/strategic-findings-analysis.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -27,6 +27,10 @@ The recommended outcome based on the severity assessment: `fix-findings` when si
 
 A concise multi-line summary of the strategic-review findings — one line per finding, each a severity tag plus a one-line description. Empty string when there are no findings.
 
+### review_passed
+
+*(boolean)* Set to `true` on the finding-free / minor path — the value that signals the review may proceed. Left unset when significant findings exist, so the outcome is decided by explicit user choice rather than this recommendation.
+
 ## Protocol
 
 ### 1. Assess Severity
@@ -44,6 +48,11 @@ A concise multi-line summary of the strategic-review findings — one line per f
 - Build `{strategic_findings_summary}` as a multi-line block — a severity tag and a one-line description per finding.
 - Use an empty string when there are no findings.
 
+### 4. Signal the Finding-Free Path
+
+- Set `{review_passed}` to `true` when the review is finding-free or minor — `{strategic_findings_summary}` is empty (`""`) or `{recommended_strategic_option}` is `acceptable`.
+- Leave `{review_passed}` unset when significant findings are present, so the outcome rests on explicit user choice rather than this recommendation.
+
 ## Rules
 
 ### significant-findings-route-to-fix
@@ -53,3 +62,7 @@ Only significant scope, over-engineering, or investigation-artifact findings rec
 ### summary-stays-concise
 
 Keep `{strategic_findings_summary}` concise — one severity-tagged line per finding.
+
+### finding-free-path-signals-passed
+
+On the finding-free / minor path, emit `{review_passed}: true`. Never emit `{review_passed}: true` when significant findings are present — that outcome is an explicit user decision, not this technique's to assert.

--- a/work-package/workflow.yaml
+++ b/work-package/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: work-package
-version: 3.19.0
+version: 3.20.0
 title: Work Package Implementation Workflow
 description: Defines how to plan and implement ONE work package from inception to merged PR. A work package is a discrete unit of work such as a feature, bug-fix, enhancement, refactoring, or any other deliverable change. For multiple related work packages, use the work-packages workflow to create a roadmap first.
 author: m2ux
@@ -258,6 +258,14 @@ variables:
   - name: needs_strategic_fixes
     type: boolean
     description: Whether strategic review findings require fixes
+    defaultValue: false
+  - name: strategic_fixes_selective
+    type: boolean
+    description: Whether the user chose to fix only selected strategic-review findings (by priority) rather than all of them. Set by the strategic-review review-findings checkpoint's selective-fixes option alongside needs_strategic_fixes; a structural record of the selective-fix intent for the plan-prepare re-loop.
+    defaultValue: false
+  - name: strategic_findings_deferred
+    type: boolean
+    description: Whether the user chose to defer strategic-review findings (note them for later but proceed to submission now). Set by the strategic-review review-findings checkpoint's defer-findings option alongside review_passed; differentiates a deliberate defer from a clean accept.
     defaultValue: false
   - name: needs_cleanup
     type: boolean


### PR DESCRIPTION
## Summary

Fixes four findings in the work-package workflow's strategic-review activity
(review-findings checkpoint) raised by a scoped compliance review.

- WP-SR-01 (High) — checkpoint now gates on `strategic_findings_summary != ""`,
  so a finding-free review auto-dismisses instead of asking the user to dispose
  of nothing.
- WP-SR-02 (Medium) — new `selective-fixes` option for priority-based partial
  disposition, mirroring workflow-design's `review-disposition`.
- WP-SR-03 (Medium) — findings-present checkpoint is now `blocking: true` with
  no auto-advance; a real decision can no longer silently auto-accept.
- WP-SR-04 (Low) — `defer-findings` differentiated from `acceptable` via
  `strategic_findings_deferred: true`.

The `strategic-findings-analysis` technique now emits `review_passed: true` on
the finding-free / minor path, which is what routes the auto-dismissal to
submit-for-review.

## Files

| File | Change |
|------|--------|
| `work-package/activities/12-strategic-review.yaml` | checkpoint condition + blocking + options; v2.6.0 -> 2.7.0 |
| `work-package/techniques/strategic-findings-analysis.md` | `review_passed` output; v1.0.0 -> 1.1.0 |
| `work-package/workflow.yaml` | 2 new boolean vars; v3.18.0 -> 3.19.0 |
| `work-package/activities/README.md` | mermaid edge labels |

## Validation

Schema validation, check-all-refs, binding-fidelity, fragments,
variable-model, resource-anchors, identifier-qualification and
activity-technique-overlap all pass. The change additionally clears one
pre-existing review-mode-gating violation (corpus 10 -> 9).
