### PR TITLE
feat(work-package): headless review mode after activation (v3.21.0)

### DIFF
--- a/work-package/README.md
+++ b/work-package/README.md
@@ -187,6 +187,8 @@ This workflow supports **review mode** for reviewing existing PRs rather than im
 start-work-package → design-philosophy → [research →] implementation-analysis → plan-prepare → assumptions-review → lean-coding-audit → post-impl-review → validate → strategic-review → submit-for-review → END
 ```
 
+**Headless after activation:** Once review mode is confirmed, the run is headless — every review-reachable checkpoint auto-resolves to its recommended option, is gated out, or is bypassed by an unconditional transition. The only interactive gates a review-mode run actually stops at are the two activation prompts (`review-mode-detection`, `review-pr-reference`) and the single `review-summary-approval` confirmation before the review is posted to the PR.
+
 **See [REVIEW-MODE.md](./REVIEW-MODE.md) for complete documentation.**
 
 ---

--- a/work-package/REVIEW-MODE.md
+++ b/work-package/REVIEW-MODE.md
@@ -41,6 +41,25 @@ Activities express review-mode behavior through standard conditions on steps, ch
 
 Per-activity review guidance is in `resources/review-mode.md`.
 
+### Headless After Activation
+
+Once review mode is active, the run is **headless**: every review-reachable checkpoint either auto-resolves to its recommended option, is gated out, or is bypassed by an unconditional transition, so a review-mode run can be dispatched and left to complete without a human at each gate. Two classes of interaction remain:
+
+- **Activation prompts** — `review-mode-detection` and `review-pr-reference` (`start-work-package`) stay interactive. They run before review mode is confirmed and identify the PR under review.
+- **The single post-to-PR confirmation** — `review-summary-approval` (`submit-for-review`) stays interactive. It is the one review-mode checkpoint whose recommended option has an outward-facing side effect (posting the consolidated review as a comment on the GitHub PR), so it confirms with the user before that action.
+
+Every other review-reachable checkpoint is headless, by one of three mechanisms:
+
+| Mechanism | Behavior | Checkpoints |
+|-----------|----------|-------------|
+| **Auto-advance** (`defaultOption` + `autoAdvanceMs: 30000`) | The checkpoint occurs but auto-selects its recommended option after the timer; the option's effect is the always-correct call in review mode | `design-philosophy :: ticket-completeness` → `proceed-with-gaps` · `research :: research-convergence` → `accept-research` · `post-impl-review :: file-index-table` → `rationale-confirmed` · `post-impl-review :: block-interview` → `issue-recorded` |
+| **Gate-out** (`condition: is_review_mode != true` on the enclosing loop) | The assumption-interview `forEach` loop does not run in review mode; assumptions are still collected, recorded, and reconciled by the surrounding non-interview steps | `research` and `implementation-analysis` assumption-interview loops |
+| **Transition bypass** | The checkpoint stays interactive as authored, but the enclosing activity's unconditional review-mode transition routes to the next activity without the checkpoint's outcome affecting the review-mode path | `strategic-review :: review-findings` |
+
+The `strategic-review :: review-findings` checkpoint is **not** made to auto-advance. The `strategic-review → submit-for-review when is_review_mode == true` transition fires at the activity boundary regardless of any finding variable, so the review-mode path leaves `strategic-review` for `submit-for-review` without the checkpoint's option changing anything. It therefore stays interactive as originally authored — auto-advancing it would be inert in review mode, and because this checkpoint is not review-gated, adding an auto-advance would also change its behavior in normal (create) mode, where it is fully live.
+
+`jira-project-selection` (`start-work-package`) is gated `issue_platform == jira` inside the issue-creation branch and never fires in review mode (which references an existing PR/issue), so it needs no review-mode treatment.
+
 ---
 
 ## Activating Review Mode
@@ -124,15 +143,16 @@ graph TD
 | Activity | Mode Override |
 |----------|---------------|
 | `start-work-package` | Detect mode, capture PR reference; the `issue-verification` and `pr-creation` checkpoints and branch/PR-creation steps are gated `is_review_mode != true` so no issue/branch/PR is created |
-| `design-philosophy` | Assess ticket completeness, force skip elicitation |
+| `design-philosophy` | Assess ticket completeness, force skip elicitation; `ticket-completeness` auto-advances to `proceed-with-gaps` |
 | `plan-prepare` | Plan the review approach; the `update-pr::render` (initial) step and `approach-confirmed` checkpoint are gated `is_review_mode != true` so the reviewed PR's body is never overwritten and no approach-confirmation is prompted |
-| `implementation-analysis` | Checkout base branch, document expected changes |
+| `research` | `research-convergence` auto-advances to `accept-research`; the assumption-interview loop is gated out |
+| `implementation-analysis` | Checkout base branch, document expected changes; the assumption-interview loop is gated out |
 | `implement` | **SKIPPED** — `assumptions-review` carries a `is_review_mode == true → lean-coding-audit` transition that routes around the entire activity, so none of its steps or checkpoints (`switch-model-*`, assumption interview) are reached |
 | `lean-coding-audit` | Run the read-only over-engineering review, debt harvest, and gain report; the findings-confirmation checkpoint and simplification-apply-cycle are gated out so no code changes — findings become PR feedback |
 | `validate` | Document failures as findings, skip fix-failures |
-| `strategic-review` | Document recommendations, transition to submit-for-review |
-| `submit-for-review` | Consolidate findings, generate the review summary, post it to the PR, then transition to `complete`; the create-mode tail (DCO attestation, PR-body render/verify, push, mark-ready, reviewer-feedback loop) is gated `is_review_mode != true` |
-| `post-impl-review` | Compare changes against expected |
+| `strategic-review` | Document recommendations, transition to submit-for-review; `review-findings` stays interactive but is bypassed — the unconditional `is_review_mode == true → submit-for-review` transition routes past it before its outcome can affect the review-mode path |
+| `submit-for-review` | Consolidate findings, generate the review summary, post it to the PR, then transition to `complete`; the create-mode tail (DCO attestation, PR-body render/verify, push, mark-ready, reviewer-feedback loop) is gated `is_review_mode != true`. `review-summary-approval` stays interactive as the single confirmation before the review is posted to the PR |
+| `post-impl-review` | Compare changes against expected; `file-index-table` auto-advances to `rationale-confirmed` and `block-interview` to `issue-recorded` |
 
 ---
 

--- a/work-package/activities/02-design-philosophy.yaml
+++ b/work-package/activities/02-design-philosophy.yaml
@@ -1,5 +1,5 @@
 id: design-philosophy
-version: 1.9.0
+version: 1.10.0
 name: Design Philosophy
 description: Apply the design framework to classify the problem and decide the workflow path.
 required: true
@@ -111,6 +111,9 @@ steps:
       operator: ==
       value: true
     message: Would you like to refactor the ticket based on the gaps found?
+    blocking: false
+    defaultOption: proceed-with-gaps
+    autoAdvanceMs: 30000
     options:
       - id: refactor-ticket
         label: Refactor ticket

--- a/work-package/activities/04-research.yaml
+++ b/work-package/activities/04-research.yaml
@@ -1,5 +1,5 @@
 id: research
-version: 2.9.0
+version: 2.10.0
 name: Research
 description: Research the knowledge base and external sources to discover best practices, patterns, and resources to inform the plan-prepare activity.
 required: false
@@ -36,7 +36,9 @@ steps:
           operator: ==
           value: false
         message: "Research has converged. Full candidate inventory (see kb-research.md → Open Research Candidates): {research_candidates}. Every research-reconcilable candidate was resolved; only irreconcilable items — or none — remain, each with its rationale and handoff target. Proceed to planning, or direct further research on a specific item?"
-        blocking: true
+        blocking: false
+        defaultOption: accept-research
+        autoAdvanceMs: 30000
         options:
           - id: accept-research
             label: Accept — proceed to planning
@@ -116,6 +118,11 @@ steps:
     variable: current_assumption
     over: open_assumptions
     maxIterations: 20
+    condition:
+      type: simple
+      variable: is_review_mode
+      operator: "!="
+      value: true
     steps:
       - kind: technique
         id: present-assumption

--- a/work-package/activities/05-implementation-analysis.yaml
+++ b/work-package/activities/05-implementation-analysis.yaml
@@ -1,5 +1,5 @@
 id: implementation-analysis
-version: 2.9.0
+version: 2.10.0
 name: Implementation Analysis
 description: Analyze the current implementation to understand effectiveness, establish baselines, and identify opportunities for improvement.
 required: false
@@ -77,6 +77,11 @@ steps:
     variable: current_assumption
     over: open_assumptions
     maxIterations: 20
+    condition:
+      type: simple
+      variable: is_review_mode
+      operator: "!="
+      value: true
     steps:
       - kind: technique
         id: present-assumption

--- a/work-package/activities/10-post-impl-review.yaml
+++ b/work-package/activities/10-post-impl-review.yaml
@@ -1,5 +1,5 @@
 id: post-impl-review
-version: 1.15.0
+version: 1.16.0
 name: Post-Implementation Review
 description: Review implementation quality before validation.
 required: true
@@ -19,7 +19,9 @@ steps:
   - kind: checkpoint
     id: file-index-table
     message: "File index written to {change_block_index}. The index includes a rationale paragraph for each change block written by the agent. Please review the diff in your side-by-side app. Then: (1) confirm the rationale paragraphs are accurate — or include your corrections in your reply, which are recorded in manual-diff-review-report.md as your provenance statement — and (2) provide row numbers for any blocks with issues (e.g., '24, 31, 106') or 'none'. Your confirmation of the rationale serves as your provenance attestation for each change."
-    blocking: true
+    blocking: false
+    defaultOption: rationale-confirmed
+    autoAdvanceMs: 30000
     options:
       - id: rationale-confirmed
         label: Rationale confirmed — no issues
@@ -44,7 +46,9 @@ steps:
       operator: ==
       value: true
     message: "Reviewing block {current_block_index}: {block_path}:{block_line_range}. What's the issue with this change?"
-    blocking: true
+    blocking: false
+    defaultOption: issue-recorded
+    autoAdvanceMs: 30000
     options:
       - id: issue-recorded
         label: Issue recorded - continue

--- a/work-package/workflow.yaml
+++ b/work-package/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: work-package
-version: 3.20.0
+version: 3.21.0
 title: Work Package Implementation Workflow
 description: Defines how to plan and implement ONE work package from inception to merged PR. A work package is a discrete unit of work such as a feature, bug-fix, enhancement, refactoring, or any other deliverable change. For multiple related work packages, use the work-packages workflow to create a roadmap first.
 author: m2ux


### PR DESCRIPTION
## Summary

Makes the `work-package` workflow's **review mode headless after activation**: once review mode is activated, the walk proceeds without further interactive prompts, with the sole exception of the outward-facing review-summary approval.

## Feasibility answer

Yes — headless-after-activation is achievable purely through existing schema constructs, no engine changes. Three mechanisms cover every review-mode checkpoint:

- **Auto-advance** (`blocking: false`, `defaultOption`, `autoAdvanceMs: 30000`) on the informational gates: `ticket-completeness` (`proceed-with-gaps`), `research-convergence` (`accept-research`), `file-index-table` (`rationale-confirmed`), `block-interview` (`issue-recorded`).
- **Gate-out** in review mode: the two assumption-interview `forEach` loops in `04-research` and `05-implementation-analysis` are gated `is_review_mode != true`, so they are skipped entirely.
- **Transition-bypass / create-default checkpoints** (already present from prior work) skip the `implement` activity and default the submit-for-review gates when in review mode.

`review-summary-approval` (the `review-findings` checkpoint in `12-strategic-review`) stays **interactive** by design — it is material/outward-facing. `12-strategic-review.yaml` was reverted to a 0-diff.

## Quality review — Critical caught and fixed

The initial draft applied the auto-advance treatment to `review-findings` as well, which would have made the outward-facing review outcome auto-resolve without user input. The quality review flagged this as a Critical; it was fixed by reverting `12-strategic-review.yaml` to 0-diff so `review-findings` remains an interactive gate.

## Validation results

- **Schema validation:** PASS — `workflow.yaml` at v3.21.0, 15/15 activities, 98 technique files, no unanchored protocol refs.
- **check-all-refs:** 0 unresolved.
- **check-binding-fidelity:** 0 NEW drift (1 baselined violation now fixed).
- **E2E snapshots:** the `[review-mode]` walk snapshot was regenerated; the change contributes exactly one intended delta — `ticket-completeness` checkpoint `refactor-ticket` → `proceed-with-gaps` (`ticket_gaps_documented: true`, `ticket_refactor_needed: false`). Pre-existing create-mode snapshot drift (from prior merged PRs) is unrelated and out of scope for this change.

## Change set (7 files, v3.20.0 → v3.21.0)

- `work-package/workflow.yaml` — version bump.
- `work-package/activities/02-design-philosophy.yaml` — `ticket-completeness` auto-advance.
- `work-package/activities/04-research.yaml` — `research-convergence` auto-advance + assumption-interview loop gated out.
- `work-package/activities/05-implementation-analysis.yaml` — assumption-interview loop gated out.
- `work-package/activities/10-post-impl-review.yaml` — `file-index-table` + `block-interview` auto-advance.
- `work-package/REVIEW-MODE.md`, `work-package/README.md` — docs for the three mechanisms.
