### PR TITLE
feat(meta): headless target detection, exclude infra submodules (v5.3.0)

### DIFF
--- a/meta/activities/02-resolve-target.yaml
+++ b/meta/activities/02-resolve-target.yaml
@@ -1,10 +1,11 @@
 id: resolve-target
-version: 4.1.0
+version: 4.2.0
 name: Resolve Target
-description: Detect the target repository structure (regular directory vs. submodule monorepo) and resolve target_path.
+description: Detect the target repository structure (regular directory vs. submodule monorepo) and resolve target_path — headlessly, prompting only when a monorepo has more than one target-component submodule.
 required: true
 rules:
   - target_path MUST resolve to a directory containing a working git tree
+  - The workflows and .engineering infrastructure submodules are never a target component and never classify a repo as a monorepo on their own
 steps:
   - kind: action
     id: announce-start
@@ -14,39 +15,28 @@ steps:
   - kind: technique
     id: detect-monorepo
     technique: version-control::detect-repo-type
-  - kind: checkpoint
-    id: repo-type-confirmed
-    message: Is this a regular repository or a submodule monorepo?
-    options:
-      - id: regular
-        label: Regular repository
-        description: Single-repo project; target_path will be the repository root
-        effect:
-          setVariable:
-            is_monorepo: false
-            target_path: .
-      - id: monorepo
-        label: Submodule monorepo
-        description: Parent repo with submodules; the next step will list submodules for selection
-        effect:
-          setVariable:
-            is_monorepo: true
   - kind: technique
     id: list-submodules
     technique: version-control::list-submodules
     when: is_monorepo == true
-  - kind: action
-    id: capture-submodule-target
+  - kind: technique
+    id: select-component
+    technique: version-control::select-target-component
     when: is_monorepo == true
-    actions: []
   - kind: checkpoint
     id: submodule-selection
     condition:
-      type: simple
-      variable: is_monorepo
-      operator: ==
-      value: true
-    message: Select the target submodule from the enumerated entries. target_path is set to the chosen submodule path.
+      type: and
+      conditions:
+        - type: simple
+          variable: is_monorepo
+          operator: ==
+          value: true
+        - type: simple
+          variable: component_selection_needed
+          operator: ==
+          value: true
+    message: This monorepo has more than one component submodule. Select the target submodule; target_path is set to the chosen submodule path.
     options:
       - id: submodule-chosen
         label: Submodule selected
@@ -55,5 +45,5 @@ transitions:
   - to: dispatch-client-workflow
     isDefault: true
 outcome:
-  - The orchestrator knows whether it is operating on a single repo or a submodule monorepo, and which submodule the user intends as the target
+  - The orchestrator knows whether it is operating on a single repo or a submodule monorepo, and which submodule the user intends as the target — resolved without prompting except when a monorepo has multiple target components
   - Downstream git operations have a confirmed working git tree to act on, whether the repo root or a chosen submodule

--- a/meta/techniques/version-control/detect-repo-type.md
+++ b/meta/techniques/version-control/detect-repo-type.md
@@ -1,18 +1,24 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
 
-Determine whether the working directory is a regular repo or a submodule monorepo.
+Determine whether the working directory is a regular repo or a submodule monorepo, ignoring the `workflows` and `.engineering` infrastructure submodules that every project carries — they are never a target component and must not, on their own, classify a repo as a monorepo.
 
 ## Outputs
 
 ### is_monorepo
 
-true when `.gitmodules` exists at the repo root
+true when `.gitmodules` declares at least one submodule whose path is NOT an infrastructure submodule (`workflows`, `.engineering`); false otherwise.
+
+### target_path
+
+`.` when the repo is regular — set here so no confirmation step is needed. Left for submodule selection to resolve when `is_monorepo` is true.
 
 ## Protocol
 
-1. Run `test -f .gitmodules`; `{is_monorepo}` is true when the file exists, false otherwise.
+1. If `.gitmodules` does not exist at the repo root, set `{is_monorepo}` = false and `{target_path}` = `.` — a regular repo. Done.
+2. Parse `.gitmodules` and collect the `path` of every `[submodule "..."]` section. Discard any whose path is `workflows` or `.engineering` (the infrastructure submodules present in every project).
+3. If one or more submodule paths remain, set `{is_monorepo}` = true and leave `{target_path}` for submodule selection. Otherwise set `{is_monorepo}` = false and `{target_path}` = `.` — the `.gitmodules` file declared only infrastructure submodules, so this is effectively a regular repo.

--- a/meta/techniques/version-control/list-submodules.md
+++ b/meta/techniques/version-control/list-submodules.md
@@ -1,18 +1,19 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
 
-Read and parse `.gitmodules` to enumerate submodule paths.
+Read and parse `.gitmodules` to enumerate the target-component submodules, excluding the `workflows` and `.engineering` infrastructure submodules that every project carries.
 
 ## Outputs
 
 ### submodules
 
-Array of `{ path, name, url }` entries
+Array of `{ path, name, url }` entries, one per target-component submodule. The `workflows` and `.engineering` infrastructure submodules are omitted.
 
 ## Protocol
 
-1. Read `.gitmodules`; parse each `[submodule "name"]` section to extract `path` and `url`, collecting one entry per section into `{submodules}`.
+1. Read `.gitmodules`; parse each `[submodule "name"]` section to extract `path` and `url`.
+2. Omit any section whose `path` is `workflows` or `.engineering` (infrastructure submodules, never a target component). Collect one entry per remaining section into `{submodules}`.

--- a/meta/techniques/version-control/select-target-component.md
+++ b/meta/techniques/version-control/select-target-component.md
@@ -1,0 +1,33 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Resolve the target component of a submodule monorepo without user input when the choice is unambiguous, and flag when it is not.
+
+## Inputs
+
+### submodules
+
+The enumerated target-component submodules (infrastructure submodules already excluded).
+
+### identifying_context
+
+Optional request context that may name the intended target component (used to pre-select when more than one component exists).
+
+## Outputs
+
+### target_path
+
+Set to the single component's `path` when exactly one component exists. Left for the submodule-selection checkpoint to resolve when more than one exists.
+
+### component_selection_needed
+
+true when two or more target-component submodules exist (the submodule-selection checkpoint then prompts); false when the target was auto-resolved.
+
+## Protocol
+
+1. If `{submodules}` has exactly one entry, set `{target_path}` to that entry's `path` and `{component_selection_needed}` = false — the target is unambiguous, no prompt.
+2. If `{submodules}` has more than one entry, set `{component_selection_needed}` = true and leave `{target_path}` for the submodule-selection checkpoint. When `{identifying_context}` clearly names one of the components, pre-select it as the recommended option.

--- a/meta/workflow.yaml
+++ b/meta/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: meta
-version: 5.2.0
+version: 5.3.0
 title: Meta Workflow
 description: Top-level lifecycle workflow that orchestrates client workflow sessions. Excluded from list_workflows — bootstrap navigates here directly.
 author: m2ux
@@ -71,6 +71,10 @@ variables:
     type: string
     description: Resolved target directory for git operations — '.' for regular repos, a submodule path for monorepos
     defaultValue: .
+  - name: component_selection_needed
+    type: boolean
+    description: Whether the monorepo has more than one target-component submodule (after excluding the workflows and .engineering infrastructure submodules), requiring the user to pick. Set by resolve-target's select-target-component step; gates the submodule-selection checkpoint so a single-component monorepo resolves headlessly.
+    defaultValue: false
   - name: client_workflow_completed
     type: boolean
     description: Whether the dispatched client workflow has reached workflow_complete


### PR DESCRIPTION
## Summary

Makes the meta workflow's `resolve-target` activity run **headlessly** and fixes a false-positive monorepo classification.

**Root cause:** every project carries the `workflows` and `.engineering` infrastructure submodules, so `resolve-target`'s bare `test -f .gitmodules` classified *every* repo — including `workflow-server` itself — as a submodule monorepo and prompted the user to pick a submodule.

## Changes (meta v5.2.0 → v5.3.0)

- **`detect-repo-type`** — parse `.gitmodules` and exclude the `workflows` and `.engineering` infrastructure submodules; `is_monorepo` is true only when a real target-component submodule remains. Sets `target_path='.'` for a regular repo so no confirmation is needed.
- **`list-submodules`** — omit the two infrastructure submodules from the enumerated components.
- **`select-target-component`** *(new technique)* — auto-resolve `target_path` when exactly one component exists; set `component_selection_needed` when 2+.
- **`resolve-target`** — remove the `repo-type-confirmed` prompt (detection is now authoritative); gate `submodule-selection` to fire only when the repo is a monorepo **and** has more than one component. Adds the `component_selection_needed` variable.

## Behavior after this change

- `workflow-server` (only `workflows` + `.engineering`) → both excluded → 0 real components → **regular repo, zero prompts**.
- Monorepo with exactly one real component → auto-selected, **headless**.
- Monorepo with 2+ real components → the single remaining prompt (prompt-only-when-ambiguous).

## Validation

Against the branch worktree: schema PASS (meta v5.3.0, 5/5 activities, 103 techniques); `check-all-refs` 0 unresolved; `check-variable-model` coherent; `check-binding-fidelity` 0 new (the 2 "fixed" are the removed `repo-type-confirmed` checkpoint's baseline entries). No meta E2E snapshot exists, so nothing to regenerate.

Companion to #194 (work-package review-mode headless): together they make a review work package headless from bootstrap through the post-activation checkpoints.
