### PR TITLE
fix(review-mode): headless design-philosophy path checkpoint + converge create-mode E2E walks

### DIFF
--- a/scripts/binding-fidelity-baseline.json
+++ b/scripts/binding-fidelity-baseline.json
@@ -476,11 +476,6 @@
   },
   {
     "check": "dead-output",
-    "site": "work-package/techniques/research/synthesize.md",
-    "detail": "output 'synthesis_assumptions' is declared but nothing outside its own file consumes it (no read, condition, binding value, remap, or same-named input)"
-  },
-  {
-    "check": "dead-output",
     "site": "work-package/techniques/review-assumptions/interview.md",
     "detail": "output 'assumption_review_presentation' is declared but nothing outside its own file consumes it (no read, condition, binding value, remap, or same-named input)"
   },
@@ -1156,72 +1151,72 @@
   },
   {
     "check": "read-resolution",
-    "site": "substrate-node-security-audit/techniques/write-report.md:83",
+    "site": "substrate-node-security-audit/techniques/write-report.md:73",
     "detail": "{average} has no producer (declared id / $-local / workflow var / set-target)"
   },
   {
     "check": "read-resolution",
-    "site": "substrate-node-security-audit/techniques/write-report.md:85",
+    "site": "substrate-node-security-audit/techniques/write-report.md:75",
     "detail": "{category} has no producer (declared id / $-local / workflow var / set-target)"
   },
   {
     "check": "read-resolution",
-    "site": "substrate-node-security-audit/techniques/write-report.md:81",
+    "site": "substrate-node-security-audit/techniques/write-report.md:71",
     "detail": "{feasibility} has no producer (declared id / $-local / workflow var / set-target)"
   },
   {
     "check": "read-resolution",
-    "site": "substrate-node-security-audit/techniques/write-report.md:83",
+    "site": "substrate-node-security-audit/techniques/write-report.md:73",
     "detail": "{feasibility} has no producer (declared id / $-local / workflow var / set-target)"
   },
   {
     "check": "read-resolution",
-    "site": "substrate-node-security-audit/techniques/write-report.md:87",
+    "site": "substrate-node-security-audit/techniques/write-report.md:77",
     "detail": "{file} has no producer (declared id / $-local / workflow var / set-target)"
   },
   {
     "check": "read-resolution",
-    "site": "substrate-node-security-audit/techniques/write-report.md:87",
+    "site": "substrate-node-security-audit/techniques/write-report.md:77",
     "detail": "{file} has no producer (declared id / $-local / workflow var / set-target)"
   },
   {
     "check": "read-resolution",
-    "site": "substrate-node-security-audit/techniques/write-report.md:91",
+    "site": "substrate-node-security-audit/techniques/write-report.md:82",
     "detail": "{file} has no producer (declared id / $-local / workflow var / set-target)"
   },
   {
     "check": "read-resolution",
-    "site": "substrate-node-security-audit/techniques/write-report.md:79",
+    "site": "substrate-node-security-audit/techniques/write-report.md:69",
     "detail": "{impact} has no producer (declared id / $-local / workflow var / set-target)"
   },
   {
     "check": "read-resolution",
-    "site": "substrate-node-security-audit/techniques/write-report.md:83",
+    "site": "substrate-node-security-audit/techniques/write-report.md:73",
     "detail": "{impact} has no producer (declared id / $-local / workflow var / set-target)"
   },
   {
     "check": "read-resolution",
-    "site": "substrate-node-security-audit/techniques/write-report.md:79",
+    "site": "substrate-node-security-audit/techniques/write-report.md:69",
     "detail": "{justification} has no producer (declared id / $-local / workflow var / set-target)"
   },
   {
     "check": "read-resolution",
-    "site": "substrate-node-security-audit/techniques/write-report.md:81",
+    "site": "substrate-node-security-audit/techniques/write-report.md:71",
     "detail": "{justification} has no producer (declared id / $-local / workflow var / set-target)"
   },
   {
     "check": "read-resolution",
-    "site": "substrate-node-security-audit/techniques/write-report.md:83",
+    "site": "substrate-node-security-audit/techniques/write-report.md:73",
     "detail": "{level} has no producer (declared id / $-local / workflow var / set-target)"
   },
   {
     "check": "read-resolution",
-    "site": "work-package/techniques/create-issue.md:39",
+    "site": "work-package/techniques/create-issue.md:57",
     "detail": "{jira_cloud_id} has no producer (declared id / $-local / workflow var / set-target)"
   },
   {
     "check": "read-resolution",
-    "site": "work-package/techniques/create-issue.md:54",
+    "site": "work-package/techniques/create-issue.md:72",
     "detail": "{jira_cloud_id} has no producer (declared id / $-local / workflow var / set-target)"
   },
   {
@@ -1266,22 +1261,22 @@
   },
   {
     "check": "read-resolution",
-    "site": "work-package/techniques/manage-git/TECHNIQUE.md:30",
+    "site": "work-package/techniques/manage-git/TECHNIQUE.md:24",
     "detail": "{display_name} has no producer (declared id / $-local / workflow var / set-target)"
   },
   {
     "check": "read-resolution",
-    "site": "work-package/techniques/manage-git/TECHNIQUE.md:30",
+    "site": "work-package/techniques/manage-git/TECHNIQUE.md:24",
     "detail": "{display_name} has no producer (declared id / $-local / workflow var / set-target)"
   },
   {
     "check": "read-resolution",
-    "site": "work-package/techniques/manage-git/TECHNIQUE.md:30",
+    "site": "work-package/techniques/manage-git/TECHNIQUE.md:24",
     "detail": "{email} has no producer (declared id / $-local / workflow var / set-target)"
   },
   {
     "check": "read-resolution",
-    "site": "work-package/techniques/manage-git/TECHNIQUE.md:30",
+    "site": "work-package/techniques/manage-git/TECHNIQUE.md:24",
     "detail": "{email} has no producer (declared id / $-local / workflow var / set-target)"
   },
   {
@@ -1331,7 +1326,7 @@
   },
   {
     "check": "read-resolution",
-    "site": "workflow-design/techniques/audit-anti-patterns.md:23",
+    "site": "workflow-design/techniques/audit-anti-patterns.md:21",
     "detail": "{VAR} has no producer (declared id / $-local / workflow var / set-target)"
   }
 ]

--- a/scripts/review-mode-gating-baseline.json
+++ b/scripts/review-mode-gating-baseline.json
@@ -1,10 +1,8 @@
 [
   "work-package::codebase-comprehension::comprehension-sufficient",
-  "work-package::design-philosophy::classification-and-path-confirmed",
   "work-package::requirements-elicitation::elicitation-complete",
   "work-package::research::context-scope-declaration",
   "work-package::start-work-package::github-issue-missing",
   "work-package::start-work-package::issue-review",
-  "work-package::strategic-review::review-findings",
   "workflow-design::scope-and-draft::scope-and-structure-confirmed"
 ]

--- a/tests/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/tests/e2e/__snapshots__/snapshot.test.ts.snap
@@ -2055,6 +2055,7 @@ exports[`work-package walk snapshots (baseline) > [review-mode] matches committe
     "start-work-package",
     "design-philosophy",
     "codebase-comprehension",
+    "implementation-analysis",
     "plan-prepare",
     "assumptions-review",
     "lean-coding-audit",
@@ -2126,16 +2127,6 @@ exports[`work-package walk snapshots (baseline) > [review-mode] matches committe
       ],
       "checkpoints": [
         {
-          "id": "classification-and-path-confirmed",
-          "option": "skip-optional",
-          "setVariable": {
-            "needs_elicitation": false,
-            "needs_research": false,
-            "path_gating_complexity": "simple",
-            "skip_optional_activities": true,
-          },
-        },
-        {
           "id": "ticket-completeness",
           "option": "proceed-with-gaps",
           "setVariable": {
@@ -2173,8 +2164,8 @@ exports[`work-package walk snapshots (baseline) > [review-mode] matches committe
         "15-portfolio-synthesis.md",
       ],
       "checkpoints": [],
-      "manifestStatus": "warning",
-      "next": "plan-prepare",
+      "manifestStatus": "valid",
+      "next": "implementation-analysis",
       "orphanCheckpoints": [],
       "stepsExecuted": [
         "build-comprehension",
@@ -2191,6 +2182,38 @@ exports[`work-package walk snapshots (baseline) > [review-mode] matches committe
       "unresolved": [],
     },
     {
+      "activity": "implementation-analysis",
+      "artifacts": [
+        "implementation-analysis.md",
+        "assumptions-log.md",
+      ],
+      "artifactsWritten": [
+        "05-implementation-analysis.md",
+        "02-assumptions-log.md",
+      ],
+      "checkpoints": [
+        {
+          "id": "analysis-confirmed",
+          "option": "confirmed",
+          "setVariable": undefined,
+        },
+      ],
+      "manifestStatus": "valid",
+      "next": "plan-prepare",
+      "orphanCheckpoints": [],
+      "stepsExecuted": [
+        "review-baseline-state",
+        "analyze-implementation",
+        "collect-assumptions",
+        "document",
+        "update-assumptions-log",
+        "reconcile-assumptions",
+        "present-resolved-assumptions",
+        "interview-open-assumptions",
+      ],
+      "unresolved": [],
+    },
+    {
       "activity": "plan-prepare",
       "artifacts": [
         "work-package-plan.md",
@@ -2203,7 +2226,7 @@ exports[`work-package walk snapshots (baseline) > [review-mode] matches committe
         "02-assumptions-log.md",
       ],
       "checkpoints": [],
-      "manifestStatus": "valid",
+      "manifestStatus": "warning",
       "next": "assumptions-review",
       "orphanCheckpoints": [],
       "stepsExecuted": [

--- a/tests/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/tests/e2e/__snapshots__/snapshot.test.ts.snap
@@ -118,7 +118,7 @@ exports[`work-package walk snapshots (baseline) > [default] matches committed ba
         "15-portfolio-synthesis.md",
       ],
       "checkpoints": [],
-      "manifestStatus": "warning",
+      "manifestStatus": "valid",
       "next": "plan-prepare",
       "orphanCheckpoints": [],
       "stepsExecuted": [
@@ -188,7 +188,7 @@ exports[`work-package walk snapshots (baseline) > [default] matches committed ba
           },
         },
       ],
-      "manifestStatus": "warning",
+      "manifestStatus": "valid",
       "next": "implement",
       "orphanCheckpoints": [],
       "stepsExecuted": [
@@ -336,15 +336,7 @@ exports[`work-package walk snapshots (baseline) > [default] matches committed ba
         "12-strategic-review-n.md",
         "10-architecture-summary.md",
       ],
-      "checkpoints": [
-        {
-          "id": "review-findings",
-          "option": "acceptable",
-          "setVariable": {
-            "review_passed": true,
-          },
-        },
-      ],
+      "checkpoints": [],
       "manifestStatus": "warning",
       "next": "submit-for-review",
       "orphanCheckpoints": [],
@@ -395,7 +387,7 @@ exports[`work-package walk snapshots (baseline) > [default] matches committed ba
           },
         },
       ],
-      "manifestStatus": "warning",
+      "manifestStatus": "valid",
       "next": "complete",
       "orphanCheckpoints": [],
       "stepsExecuted": [
@@ -425,7 +417,7 @@ exports[`work-package walk snapshots (baseline) > [default] matches committed ba
         "14-COMPLETE.md",
       ],
       "checkpoints": [],
-      "manifestStatus": "warning",
+      "manifestStatus": "valid",
       "next": null,
       "orphanCheckpoints": [],
       "stepsExecuted": [
@@ -563,7 +555,7 @@ exports[`work-package walk snapshots (baseline) > [elicitation-only] matches com
         "15-portfolio-synthesis.md",
       ],
       "checkpoints": [],
-      "manifestStatus": "warning",
+      "manifestStatus": "valid",
       "next": "requirements-elicitation",
       "orphanCheckpoints": [],
       "stepsExecuted": [
@@ -706,7 +698,7 @@ exports[`work-package walk snapshots (baseline) > [elicitation-only] matches com
           },
         },
       ],
-      "manifestStatus": "warning",
+      "manifestStatus": "valid",
       "next": "implement",
       "orphanCheckpoints": [],
       "stepsExecuted": [
@@ -854,15 +846,7 @@ exports[`work-package walk snapshots (baseline) > [elicitation-only] matches com
         "12-strategic-review-n.md",
         "10-architecture-summary.md",
       ],
-      "checkpoints": [
-        {
-          "id": "review-findings",
-          "option": "acceptable",
-          "setVariable": {
-            "review_passed": true,
-          },
-        },
-      ],
+      "checkpoints": [],
       "manifestStatus": "warning",
       "next": "submit-for-review",
       "orphanCheckpoints": [],
@@ -913,7 +897,7 @@ exports[`work-package walk snapshots (baseline) > [elicitation-only] matches com
           },
         },
       ],
-      "manifestStatus": "warning",
+      "manifestStatus": "valid",
       "next": "complete",
       "orphanCheckpoints": [],
       "stepsExecuted": [
@@ -943,7 +927,7 @@ exports[`work-package walk snapshots (baseline) > [elicitation-only] matches com
         "14-COMPLETE.md",
       ],
       "checkpoints": [],
-      "manifestStatus": "warning",
+      "manifestStatus": "valid",
       "next": null,
       "orphanCheckpoints": [],
       "stepsExecuted": [
@@ -1084,7 +1068,7 @@ exports[`work-package walk snapshots (baseline) > [full-workflow] matches commit
         "15-portfolio-synthesis.md",
       ],
       "checkpoints": [],
-      "manifestStatus": "warning",
+      "manifestStatus": "valid",
       "next": "requirements-elicitation",
       "orphanCheckpoints": [],
       "stepsExecuted": [
@@ -1153,11 +1137,6 @@ exports[`work-package walk snapshots (baseline) > [full-workflow] matches commit
       ],
       "checkpoints": [
         {
-          "id": "research-findings",
-          "option": "sufficient",
-          "setVariable": undefined,
-        },
-        {
           "id": "context-scope-declaration",
           "option": "repo-only",
           "setVariable": {
@@ -1171,6 +1150,7 @@ exports[`work-package walk snapshots (baseline) > [full-workflow] matches commit
       "stepsExecuted": [
         "research-knowledge-base",
         "synthesize",
+        "triage-research-candidates",
         "collect-assumptions",
         "document",
         "update-assumptions-log",
@@ -1268,7 +1248,7 @@ exports[`work-package walk snapshots (baseline) > [full-workflow] matches commit
           },
         },
       ],
-      "manifestStatus": "warning",
+      "manifestStatus": "valid",
       "next": "implement",
       "orphanCheckpoints": [],
       "stepsExecuted": [
@@ -1416,15 +1396,7 @@ exports[`work-package walk snapshots (baseline) > [full-workflow] matches commit
         "12-strategic-review-n.md",
         "10-architecture-summary.md",
       ],
-      "checkpoints": [
-        {
-          "id": "review-findings",
-          "option": "acceptable",
-          "setVariable": {
-            "review_passed": true,
-          },
-        },
-      ],
+      "checkpoints": [],
       "manifestStatus": "warning",
       "next": "submit-for-review",
       "orphanCheckpoints": [],
@@ -1475,7 +1447,7 @@ exports[`work-package walk snapshots (baseline) > [full-workflow] matches commit
           },
         },
       ],
-      "manifestStatus": "warning",
+      "manifestStatus": "valid",
       "next": "complete",
       "orphanCheckpoints": [],
       "stepsExecuted": [
@@ -1505,7 +1477,7 @@ exports[`work-package walk snapshots (baseline) > [full-workflow] matches commit
         "14-COMPLETE.md",
       ],
       "checkpoints": [],
-      "manifestStatus": "warning",
+      "manifestStatus": "valid",
       "next": null,
       "orphanCheckpoints": [],
       "stepsExecuted": [
@@ -1645,7 +1617,7 @@ exports[`work-package walk snapshots (baseline) > [research-only] matches commit
         "15-portfolio-synthesis.md",
       ],
       "checkpoints": [],
-      "manifestStatus": "warning",
+      "manifestStatus": "valid",
       "next": "research",
       "orphanCheckpoints": [],
       "stepsExecuted": [
@@ -1674,11 +1646,6 @@ exports[`work-package walk snapshots (baseline) > [research-only] matches commit
       ],
       "checkpoints": [
         {
-          "id": "research-findings",
-          "option": "sufficient",
-          "setVariable": undefined,
-        },
-        {
           "id": "context-scope-declaration",
           "option": "repo-only",
           "setVariable": {
@@ -1692,6 +1659,7 @@ exports[`work-package walk snapshots (baseline) > [research-only] matches commit
       "stepsExecuted": [
         "research-knowledge-base",
         "synthesize",
+        "triage-research-candidates",
         "collect-assumptions",
         "document",
         "update-assumptions-log",
@@ -1789,7 +1757,7 @@ exports[`work-package walk snapshots (baseline) > [research-only] matches commit
           },
         },
       ],
-      "manifestStatus": "warning",
+      "manifestStatus": "valid",
       "next": "implement",
       "orphanCheckpoints": [],
       "stepsExecuted": [
@@ -1937,15 +1905,7 @@ exports[`work-package walk snapshots (baseline) > [research-only] matches commit
         "12-strategic-review-n.md",
         "10-architecture-summary.md",
       ],
-      "checkpoints": [
-        {
-          "id": "review-findings",
-          "option": "acceptable",
-          "setVariable": {
-            "review_passed": true,
-          },
-        },
-      ],
+      "checkpoints": [],
       "manifestStatus": "warning",
       "next": "submit-for-review",
       "orphanCheckpoints": [],
@@ -1996,7 +1956,7 @@ exports[`work-package walk snapshots (baseline) > [research-only] matches commit
           },
         },
       ],
-      "manifestStatus": "warning",
+      "manifestStatus": "valid",
       "next": "complete",
       "orphanCheckpoints": [],
       "stepsExecuted": [
@@ -2026,7 +1986,7 @@ exports[`work-package walk snapshots (baseline) > [research-only] matches commit
         "14-COMPLETE.md",
       ],
       "checkpoints": [],
-      "manifestStatus": "warning",
+      "manifestStatus": "valid",
       "next": null,
       "orphanCheckpoints": [],
       "stepsExecuted": [
@@ -2544,7 +2504,7 @@ exports[`work-package walk snapshots (baseline) > [skip-optional] matches commit
         "15-portfolio-synthesis.md",
       ],
       "checkpoints": [],
-      "manifestStatus": "warning",
+      "manifestStatus": "valid",
       "next": "plan-prepare",
       "orphanCheckpoints": [],
       "stepsExecuted": [
@@ -2614,7 +2574,7 @@ exports[`work-package walk snapshots (baseline) > [skip-optional] matches commit
           },
         },
       ],
-      "manifestStatus": "warning",
+      "manifestStatus": "valid",
       "next": "implement",
       "orphanCheckpoints": [],
       "stepsExecuted": [
@@ -2762,15 +2722,7 @@ exports[`work-package walk snapshots (baseline) > [skip-optional] matches commit
         "12-strategic-review-n.md",
         "10-architecture-summary.md",
       ],
-      "checkpoints": [
-        {
-          "id": "review-findings",
-          "option": "acceptable",
-          "setVariable": {
-            "review_passed": true,
-          },
-        },
-      ],
+      "checkpoints": [],
       "manifestStatus": "warning",
       "next": "submit-for-review",
       "orphanCheckpoints": [],
@@ -2821,7 +2773,7 @@ exports[`work-package walk snapshots (baseline) > [skip-optional] matches commit
           },
         },
       ],
-      "manifestStatus": "warning",
+      "manifestStatus": "valid",
       "next": "complete",
       "orphanCheckpoints": [],
       "stepsExecuted": [
@@ -2851,7 +2803,7 @@ exports[`work-package walk snapshots (baseline) > [skip-optional] matches commit
         "14-COMPLETE.md",
       ],
       "checkpoints": [],
-      "manifestStatus": "warning",
+      "manifestStatus": "valid",
       "next": null,
       "orphanCheckpoints": [],
       "stepsExecuted": [

--- a/tests/e2e/policies.ts
+++ b/tests/e2e/policies.ts
@@ -23,6 +23,11 @@ export const baseSimulation: Record<string, Record<string, unknown>> = {
   'codebase-comprehension': { needs_comprehension: false, has_open_questions: false },
   'requirements-elicitation': { elicitation_complete: true },
   'assumptions-review': { needs_plan_revision: false, needs_further_discussion: false, has_deferred_assumptions: false },
+  // strategic-findings-analysis emits review_passed on the finding-free / minor
+  // path (work-package #192): with no findings the review-findings checkpoint
+  // auto-dismisses (condition_not_met) and this signal drives the transition to
+  // submit-for-review. Without it the walk loops strategic-review → plan-prepare.
+  'strategic-review': { review_passed: true },
 };
 
 export interface PolicySpec {

--- a/tests/e2e/walker.ts
+++ b/tests/e2e/walker.ts
@@ -462,6 +462,20 @@ async function resolveCheckpoint(
 ): Promise<{ setVariable?: Record<string, unknown>; transitionTo?: string; skipActivities?: string[] }> {
   const y = await client.callTool({ name: 'yield_checkpoint', arguments: { session_index: sessionIndex, checkpoint_id: checkpointId } });
   if (isError(y)) throw new Error(`yield_checkpoint(${checkpointId}) failed`);
+  const yieldBody = parseToolResponse(y);
+
+  // Re-entering an activity replays its recorded checkpoint response: the server
+  // returns status:'replayed' and deliberately does NOT set an active checkpoint
+  // (the user is not prompted twice), so there is nothing to respond to. Apply
+  // the replayed effect and continue without respond/resume.
+  if (yieldBody.status === 'replayed') {
+    const effect = (yieldBody.effect ?? {}) as Record<string, unknown>;
+    return {
+      setVariable: (effect.setVariable ?? effect.variablesSet) as Record<string, unknown> | undefined,
+      transitionTo: (effect.transitionTo ?? effect.transitionedTo) as string | undefined,
+      skipActivities: (effect.skipActivities ?? effect.activitiesSkipped) as string[] | undefined,
+    };
+  }
 
   const r = await client.callTool({ name: 'respond_checkpoint', arguments: { session_index: sessionIndex, option_id: optionId } });
   if (isError(r)) throw new Error(`respond_checkpoint(${checkpointId}=${optionId}) failed`);

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1266,11 +1266,11 @@ describe('mcp-server integration', () => {
     it('respond_checkpoint with condition_not_met should reject unconditional checkpoint', async () => {
       const act = await client.callTool({
         name: 'next_activity',
-        arguments: { session_index: sessionToken, activity_id: 'design-philosophy' },
+        arguments: { session_index: sessionToken, activity_id: 'implementation-analysis' },
       });
       const actMeta = act._meta as Record<string, unknown>;
       const tokenWithAct = actMeta['session_index'] as string;
-      const unconditionalCpId = 'classification-and-path-confirmed';
+      const unconditionalCpId = 'analysis-confirmed';
 
       const yieldResult = await client.callTool({
         name: 'yield_checkpoint',


### PR DESCRIPTION
## Summary

Server-side landing of work-package **v3.22.0 + v3.23.0** (workflows submodule), plus fixes for the pre-existing create-mode E2E walk failures on this branch.

The workflow content is already on `origin/workflows` (commits 1879dc22, 0610f849); this PR advances the submodule gitlink to 0610f849 and carries the matching server/test changes.

## Workflow changes (via submodule bump)

- **design-philosophy** — the `classification-and-path-confirmed` checkpoint is gated `is_review_mode != true`, so headless review mode no longer prompts for the path. With the path variables at their defaults the run routes to `implementation-analysis` (running the review-only `review-baseline-state` step) instead of skipping it; a message records the classification. Fixes a case where the recommended `skip-optional` option silently skipped implementation-analysis in review mode. (v3.22.0)
- Added the `review-mode-headless-auto-advance` orchestrator rule: review-reachable auto-advance checkpoints resolve via `respond_checkpoint(auto_advance:true)` with a plain message, never an AskUserQuestion dialog.
- **research** — removed the dead `is_review_mode != true` gate on the assumption-interview loop; research is not on the headless review path, so the gate could only ever evaluate true. (v3.23.0)
- `REVIEW-MODE.md` / `README.md` updated to match.

## E2E harness fixes (pre-existing failures, unrelated to the above)

- **walker** `resolveCheckpoint` now handles the `yield_checkpoint` replay path: when an activity is re-entered (e.g. plan-prepare via the strategic-fix loop) the server replays the recorded response and sets no active checkpoint, so the walker must not call `respond_checkpoint`.
- **policies** `baseSimulation` gains `strategic-review: { review_passed: true }` — the converged-agent signal `strategic-findings-analysis` emits on the finding-free path (work-package #192). Without it the walk looped `strategic-review -> plan-prepare` until the loop guard tripped.
- `condition_not_met` "unconditional checkpoint" test switched to `analysis-confirmed` (`classification-and-path-confirmed` is now conditional).
- Regenerated all six work-package walk snapshots; refreshed the review-mode-gating and binding-fidelity baselines.

## Testing

- `npm test` — 529 passed, 0 failed, 14 skipped.
- `npm run typecheck` clean; definition guards green (`check:review-mode`, `check:variable-model`, `check:binding`, `check:fragments`, `check:identifiers`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
