### PR TITLE
fix(work-package): post the approved review summary verbatim to the PR (v3.24.0)

### DIFF
--- a/work-package/activities/13-submit-for-review.yaml
+++ b/work-package/activities/13-submit-for-review.yaml
@@ -1,5 +1,5 @@
 id: submit-for-review
-version: 1.8.0
+version: 1.9.0
 name: Submit for Review
 description: Submit the PR for review and handle reviewer feedback.
 required: true
@@ -59,7 +59,7 @@ steps:
             review_posted: false
   - kind: technique
     id: post-pr-review
-    technique: update-pr::render
+    technique: update-pr::post-review-comment
     condition:
       type: simple
       variable: is_review_mode

--- a/work-package/resources/review-mode.md
+++ b/work-package/resources/review-mode.md
@@ -2,7 +2,7 @@
 name: review-mode
 description: Guidelines for using the work-package workflow in review mode to conduct structured PR reviews. Covers detection, adapted workflow behavior, and output generation.
 metadata:
-  version: 1.3.0
+  version: 1.4.0
   order: 24
   legacy_id: 24
 ---
@@ -325,7 +325,13 @@ Disposition of every prior comment and review on the PR (human and bot), determi
 
 **Nice to Have (Optional)**:
 - [ ] Run `cargo clippy --fix` to clear warnings (VF-1)
+
+---
+
+*Posted by an automated review agent on behalf of @{user}. The recommendation reflects an independent re-verification at head `{sha}`; the maintainers retain full discretion over disposition.*
 ```
+
+The attribution footer is the last block of the rendered summary and is posted verbatim as part of the review comment. Resolve `{user}` from the `gh` authenticated account (`gh api user --jq .login`) and `{sha}` from the PR head commit at review time (`gh pr view {pr_number} --json headRefOid --jq .headRefOid`, short form). It is part of the format so it renders into `{review_summary}` and reaches the PR unaltered.
 
 ### Severity Definitions
 

--- a/work-package/techniques/review-summary.md
+++ b/work-package/techniques/review-summary.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -42,5 +42,10 @@ The structured consolidated review summary text, organized per the Consolidated 
 - Populate the template from `{consolidated_findings}`: executive summary, per-category findings (code, test, documentation, validation, branch hygiene), action items, and severity definitions.
 - Render the Prior Feedback Triage section from `{prior_feedback_triage}`: one row per prior comment with its Confirmed / Refuted / Superseded disposition, and carry each Confirmed blocker-class entry into the Action Items as a blocking item.
 - Apply `{rating_cap}` to the Overall Rating: when the cap is the request-changes tier, the Overall Rating is held at or below Request Changes — never Approve or Comment Only — even if the review's own findings are light.
+- Render the attribution footer that closes the format template — resolving `{user}` and `{sha}` per the format's instruction — so `{review_summary}` carries it and the posted comment reaches the PR with it intact.
 - Produce `{review_summary}` as the rendered text.
-- Follow the loaded format exactly — do not invent a parallel structure; the review-mode resource is the authoritative owner of the format.
+- Follow the loaded format exactly — do not invent a parallel structure; the review-mode resource is the authoritative owner of the format. `{review_summary}` is the verbatim source the posting step (`update-pr::post-review-comment`) emits, so what is confirmed is exactly what reaches the PR.
+
+### 3. Present for Confirmation
+
+- Present the rendered `{review_summary}` verbatim (or a faithful excerpt when long) at the approval checkpoint — never a paraphrase or a re-described summary. The bytes shown are the bytes posted.

--- a/work-package/techniques/update-pr/TECHNIQUE.md
+++ b/work-package/techniques/update-pr/TECHNIQUE.md
@@ -1,11 +1,11 @@
 ---
 metadata:
-  version: 2.1.0
+  version: 2.2.0
 ---
 
 ## Capability
 
-Update a PR with final implementation details and mark it ready for review, or post consolidated review comments when operating in review mode. Operations cover rendering the body from a template, verifying body conformance, pushing commits, and marking ready.
+Update a PR with final implementation details and mark it ready for review, or post consolidated review comments when operating in review mode. Operations cover rendering the body from a template, verifying body conformance, pushing commits, marking ready, and posting the review summary as a `gh pr review` comment.
 
 ## Inputs
 
@@ -73,6 +73,10 @@ List of `{ rule_id, detail }` entries, one per failed conformance rule; empty wh
 ### draft-first
 
 Create PRs as drafts initially. Convert to ready-for-review only when a later step directs it.
+
+### posting
+
+- review-comment-verbatim: The `post-review-comment` op posts the confirmed `{review_summary}` to the PR byte-for-byte via `gh pr review` — never re-rendering, paraphrasing, or summarizing it. The summary is authored to [review-mode](../../resources/review-mode.md#consolidated-review-format); posting is a transport step, not a re-authoring one. This is distinct from `render`, which PATCHes the PR *description* body from a template.
 
 ### tool-usage
 

--- a/work-package/techniques/update-pr/post-review-comment.md
+++ b/work-package/techniques/update-pr/post-review-comment.md
@@ -1,0 +1,34 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Post the confirmed consolidated review summary to the PR **verbatim** as a `gh pr review` comment — the rendered `{review_summary}` reaches the PR byte-for-byte, unlike `render` which PATCHes the PR description body from a template.
+
+## Inputs
+
+### review_summary
+
+The rendered consolidated review summary text, authored to the [Consolidated Review Format](../../resources/review-mode.md#consolidated-review-format) and confirmed by the user at the `review-summary-approval` checkpoint. Posted verbatim — never re-rendered or paraphrased.
+
+### pr_number
+
+The PR number to post the review to.
+
+### review_type
+
+*(optional, enum: `approve` | `request-changes` | `comment`; default: derive from the summary's Overall Rating)* Which `gh pr review` flag to use. When not supplied, derive it from the Overall Rating already rendered in `{review_summary}` per the review-mode [Review Type Selection](../../resources/review-mode.md#review-type-selection) table: `Request Changes` → `request-changes`, `Comment Only` → `comment`, `Approve` → `approve`. Because the Overall Rating already honours the Prior Feedback Triage rating cap, the derived flag inherits that constraint with no separate variable.
+
+## Outputs
+
+### review_posted
+
+True once the review comment is posted to the `{pr_number}` PR; false when posting was skipped.
+
+## Protocol
+
+1. Write `{review_summary}` to a file **verbatim** — no re-rendering, no edits. The file content is exactly the confirmed summary bytes.
+2. Post it as a PR review via `gh pr review {pr_number} --{review_type} --body-file <file>`, mapping `{review_type}` to the flag: `approve` → `--approve`, `request-changes` → `--request-changes`, `comment` → `--comment`. Do NOT use `gh pr edit` or the `pulls PATCH` API — those update the PR description, not a review comment.
+3. Confirm the review posted and set `{review_posted}` true. If the PR cannot be found because `{pr_number}` does not exist, verify the PR number and check `gh` auth before retrying.

--- a/work-package/workflow.yaml
+++ b/work-package/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: work-package
-version: 3.23.0
+version: 3.24.0
 title: Work Package Implementation Workflow
 description: Defines how to plan and implement ONE work package from inception to merged PR. A work package is a discrete unit of work such as a feature, bug-fix, enhancement, refactoring, or any other deliverable change. For multiple related work packages, use the work-packages workflow to create a roadmap first.
 author: m2ux


### PR DESCRIPTION
## What

Fixes issue #197: in review mode, the `post-pr-review` step was mis-bound to
`update-pr::render`, which PATCHes the PR *description* body from a template
and ignores the consolidated review summary the user approves at
`review-summary-approval`. The approved content never reached the PR as a
review comment.

## Change (minimal, root-cause)

- **New op** `update-pr::post-review-comment` (v1.0.0) — writes `{review_summary}`
  to a file and posts it **verbatim** via
  `gh pr review {pr_number} --{review_type} --body-file <file>`.
- **Rebind** `post-pr-review` (`13-submit-for-review.yaml`) from
  `update-pr::render` to `update-pr::post-review-comment` — the root-cause fix.
- **Attribution footer** codified in the Consolidated Review Format
  (`review-mode.md`) so it renders into the summary and posts intact; the
  `review-summary` technique renders it and presents the artifact verbatim.
- **`update-pr` group**: op added to the Capability index + a light
  `posting.review-comment-verbatim` rule.

No conformance-verify loop, no new checkpoint, no new variables. One flagged
binding replacement; `update-pr::render` retains its 3 other live bindings.

## Versions

work-package 3.23.0 -> 3.24.0 · activity 1.8.0 -> 1.9.0 ·
update-pr group 2.1.0 -> 2.2.0 · review-mode.md 1.3.0 -> 1.4.0 ·
review-summary 1.0.0 -> 1.1.0.

## Validation

- `validate-workflow-yaml.ts workflows/work-package` — PASS (workflow + 15
  activities + 99 techniques).
- `check-all-refs.ts` — 0 unresolved.
- `check-binding-fidelity.ts` — clean after an intentional baseline re-snapshot
  (server-repo `scripts/binding-fidelity-baseline.json`, landed separately).

Closes #197.
