### PR TITLE
chore(scripts): re-snapshot binding-fidelity baseline for work-package #197

### DIFF
--- a/scripts/binding-fidelity-baseline.json
+++ b/scripts/binding-fidelity-baseline.json
@@ -136,11 +136,6 @@
   },
   {
     "check": "dead-output",
-    "site": "meta/techniques/version-control/list-submodules.md",
-    "detail": "output 'submodules' is declared but nothing outside its own file consumes it (no read, condition, binding value, remap, or same-named input)"
-  },
-  {
-    "check": "dead-output",
     "site": "meta/techniques/workflow-engine/dispatch-activity.md",
     "detail": "output 'trace_token' is declared but nothing outside its own file consumes it (no read, condition, binding value, remap, or same-named input)"
   },
@@ -501,11 +496,6 @@
   },
   {
     "check": "dead-output",
-    "site": "work-package/techniques/review-summary.md",
-    "detail": "output 'review_summary' is declared but nothing outside its own file consumes it (no read, condition, binding value, remap, or same-named input)"
-  },
-  {
-    "check": "dead-output",
     "site": "work-package/techniques/stakeholder-overview.md",
     "detail": "output 'stakeholder_overview' is declared but nothing outside its own file consumes it (no read, condition, binding value, remap, or same-named input)"
   },
@@ -523,6 +513,11 @@
     "check": "dead-output",
     "site": "work-package/techniques/update-pr/mark-ready.md",
     "detail": "output 'updated_pr' is declared but nothing outside its own file consumes it (no read, condition, binding value, remap, or same-named input)"
+  },
+  {
+    "check": "dead-output",
+    "site": "work-package/techniques/update-pr/post-review-comment.md",
+    "detail": "output 'review_posted' is declared but nothing outside its own file consumes it (no read, condition, binding value, remap, or same-named input)"
   },
   {
     "check": "dead-output",
@@ -1056,6 +1051,11 @@
   },
   {
     "check": "orphan-input",
+    "site": "work-package :: update-pr::post-review-comment",
+    "detail": "own input 'review_type' has no producer in workflow 'work-package' (no step-binding entry, workflow variable, step output, or default)"
+  },
+  {
+    "check": "orphan-input",
     "site": "work-package :: update-pr::render",
     "detail": "own input 'pr_template_variant' has no producer in workflow 'work-package' (no step-binding entry, workflow variable, step output, or default)"
   },
@@ -1278,6 +1278,16 @@
     "check": "read-resolution",
     "site": "work-package/techniques/manage-git/TECHNIQUE.md:24",
     "detail": "{email} has no producer (declared id / $-local / workflow var / set-target)"
+  },
+  {
+    "check": "read-resolution",
+    "site": "work-package/techniques/review-summary.md:45",
+    "detail": "{sha} has no producer (declared id / $-local / workflow var / set-target)"
+  },
+  {
+    "check": "read-resolution",
+    "site": "work-package/techniques/review-summary.md:45",
+    "detail": "{user} has no producer (declared id / $-local / workflow var / set-target)"
   },
   {
     "check": "read-resolution",


### PR DESCRIPTION
## What

Re-snapshots `scripts/binding-fidelity-baseline.json` to accept the intentional
binding-fidelity entries introduced by the review-mode review-comment fix
(work-package v3.24.0), and drops two entries that are now stale.

This is the **server-side follow-up** to workflows PR #199 (issue #197), kept
separate from that content PR per the two-repo flow.

## Baseline delta (+20 / −10)

**Added (intentional, by design):**
- `dead-output` `review_posted` — `update-pr/post-review-comment.md`. The real
  producer is the `review-summary-approval` checkpoint's `setVariable`; the op's
  declared output is redundant-but-honest.
- `orphan-input` `review_type` — `work-package :: update-pr::post-review-comment`.
  Optional input with a prose-derived default (no bag producer by design).
- `read-resolution` `{sha}` and `{user}` — `review-summary.md:45`. Prose tokens
  in the attribution-footer sentence, resolved at authoring time.

**Removed (no longer applicable):**
- `dead-output` `submodules` — `meta version-control/list-submodules.md` (stale).
- `dead-output` `review_summary` — `work-package review-summary.md`. Now consumed
  verbatim by `update-pr::post-review-comment`.

## Validation

Regenerated via `npx tsx scripts/check-binding-fidelity.ts --update-baseline`;
re-run reports `0 NEW, 0 fixed — OK`.

## Depends on

Workflows PR #199 (merged into `workflows`).
