### PR TITLE
fix(work-package): number the prior-feedback-triage review artifact (v3.25.0)

### DIFF
--- a/work-package/techniques/review-existing-feedback.md
+++ b/work-package/techniques/review-existing-feedback.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -49,9 +49,9 @@ The ceiling the Overall Rating may not exceed, derived from the triage. When any
 - Set `{rating_cap}` to the request-changes tier when any blocker-class concern is dispositioned Confirmed (valid and unaddressed); leave it unset when every blocker-class concern is Refuted or Superseded.
 - An unaddressed external blocker therefore prevents an "approve" or "comment only" verdict regardless of the review's own findings.
 
-### 4. Write the Triage
+### 4. Create the Triage
 
-- Write `{prior_feedback_triage}` to `{planning_folder_path}` so the consolidated summary renders the triage section and applies the cap.
+- Create the `{prior_feedback_triage}` artifact in `{planning_folder_path}` so the consolidated summary renders the triage section and applies the cap.
 
 ## Rules
 

--- a/work-package/workflow.yaml
+++ b/work-package/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: work-package
-version: 3.24.0
+version: 3.25.0
 title: Work Package Implementation Workflow
 description: Defines how to plan and implement ONE work package from inception to merged PR. A work package is a discrete unit of work such as a feature, bug-fix, enhancement, refactoring, or any other deliverable change. For multiple related work packages, use the work-packages workflow to create a roadmap first.
 author: m2ux


### PR DESCRIPTION
## Problem

In review mode, the work-package workflow produced `prior-feedback-triage.md` with **no numeric prefix**, while every sibling planning artifact is numbered (`02-design-philosophy.md`, `09-code-review.md`, etc.).

## Root cause

The number prefix is the server-computed `artifactPrefix` (the activity's filename index), applied at write time per the manage-artifacts `artifact-prefix` rule. Techniques declare **bare** names; the prefix is applied when the declared artifact is created.

`review-existing-feedback` step 4 diverged from its two sibling review techniques:

| Technique | Phrasing | Result |
|---|---|---|
| `review-code` | "Create the `{code_review_report}` in `{planning_folder_path}`" | numbered ✅ |
| `review-test-suite` | "Create the `{test_suite_review_report}` in `{planning_folder_path}`" | numbered ✅ |
| `review-existing-feedback` | "**Write** `{prior_feedback_triage}` **to** `{planning_folder_path}`" | unnumbered ❌ |

"Write X to path" reads as a literal filesystem write and bypasses the prefix rule; "Create the `{artifact}` in `{path}`" materializes the declared artifact so the rule applies.

## Fix

Align `review-existing-feedback` step 4 with the sibling phrasing. The artifact will now be written as `01-prior-feedback-triage.md` (activity 01's prefix). No new step, no `write-artifact` route, no binding change — the minimal, corpus-consistent fix.

- `review-existing-feedback` technique `version` 1.0.0 → 1.1.0
- `work-package/workflow.yaml` `version` 3.24.0 → 3.25.0

## Verification

All 9 workflow guards pass against this worktree (`--root`): technique-template, binding-fidelity (0 new drift), identifiers, self-input, activity-tech, anchors, variable-model, fragments, review-mode.

The `review-mode.md` reports table intentionally keeps the **bare** name (matching `code-review.md`/`test-suite-review.md` there) — no change needed. Downstream consumers reference the artifact via the `{prior_feedback_triage}` variable, so they are prefix-agnostic.

## Follow-up (server → main, post-merge)

Server-side e2e snapshots and the submodule pointer regenerate after this merges, per the two-repo flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
