### PR TITLE
fix(work-package): scope review-mode findings to the PR's authored surface (v3.26.0)

### DIFF
--- a/work-package/resources/review-mode.md
+++ b/work-package/resources/review-mode.md
@@ -2,7 +2,7 @@
 name: review-mode
 description: Guidelines for using the work-package workflow in review mode to conduct structured PR reviews. Covers detection, adapted workflow behavior, and output generation.
 metadata:
-  version: 1.4.0
+  version: 1.5.0
   order: 24
   legacy_id: 24
 ---
@@ -10,99 +10,9 @@ metadata:
 
 # Review Mode Guide
 
-Review mode adapts the standard work-package workflow for reviewing existing implementations rather than creating new ones.
-
-## How Review Mode Is Driven
-
-Review mode is not a dedicated schema construct — it is plain workflow state.
-
-### Workflow-Level State
-
-A single boolean variable, `is_review_mode` (default `false`), drives the entire mode:
-
-```
-- name: is_review_mode
-  type: boolean
-  defaultValue: false
-```
-
-The `detect-review-mode` step in `start-work-package` recognizes review intent (from requests like "start review work package", "review pr", or "review existing implementation"), confirms with the user, and sets `is_review_mode = true`. There is no `skipActivities` list and no mode `defaults` block: requirements-elicitation and implement are skipped purely because their steps and inbound transitions are gated on `is_review_mode`, and mode-specific values such as `needs_elicitation = false` are set by an ordinary control step gated the same way.
-
-### Activity-Level Behavior
-
-Activities express review-mode behavior through standard conditions on steps, checkpoints, and transitions:
-
-- **Review-only steps** have `condition: is_review_mode == true` — they only execute in review mode
-- **Create-only steps** have `condition: is_review_mode != true` — they are skipped in review mode
-- **Review-only checkpoints** have `condition: is_review_mode == true`
-- **Review-mode transitions** are conditioned on `is_review_mode == true` and evaluated before default transitions
-
-## Per-Activity Review Guidance
-
-### start-work-package
-Capture PR reference and extract associated Jira ticket. Skip branch/PR creation — use existing PR from review target.
-
-### design-philosophy
-Assess ticket completeness and determine workflow path. Always skip elicitation — requirements come solely from the ticket. Assess the ticket using the [Jira Issue Creation Guide](jira-issue-creation.md) checklist. Research may still be needed based on complexity assessment.
-
-### implementation-analysis
-Analyze the pre-change baseline state from the base branch: checkout the base branch to analyze what existed BEFORE the PR, document what would need to change to fulfill requirements (the expected changes). This baseline becomes the reference for evaluating what the PR actually changed.
-
-### assumptions-review
-Skip the assumption interview and issue tracker posting. The review plan is for the reviewer's own use. Set `stakeholder_review_complete=true` and proceed directly to the next activity.
-
-### lean-coding-audit
-Run the read-only over-engineering review, debt harvest, and gain report so findings reach the artifacts. Skip the apply path — the findings-confirmation checkpoint and the simplification-apply-cycle are gated out so no code is changed; over-engineering and leanness findings become feedback for the PR author.
-
-### post-impl-review
-Compare PR changes against expected changes from implementation analysis. Identify deviations — missing changes, unexpected changes, alternative approaches. Document findings for the PR author.
-
-### validate
-Run validation checks and existing tests to verify they pass as claimed by the PR. Document failures as review findings — do NOT fix them (that's the PR author's job). Failures become critical findings in the review summary.
-
-### strategic-review
-Evaluate as though code were newly written. Document findings as review comments for the PR author; do not apply cleanup. Focus on identifying issues for feedback, not on rework transitions.
-
-### submit-for-review
-Generate and post consolidated PR review comments with findings from all review stages. Use structured format: Summary, Code Review, Test Review, Doc Review, Recommendations. Include severity ratings and actionable items for PR author.
-
-### complete
-Only conduct retrospective. Skip ADR creation and documentation finalization.
-
-## Workflow Adaptations
-
-### Phase Differences
-
-| Phase | Standard Mode | Review Mode |
-|-------|---------------|-------------|
-| **Issue Management** | Create/verify issue, create branch + PR | Extract ticket from existing PR |
-| **Design Philosophy** | Full problem classification | Assess ticket completeness, always skip elicitation |
-| **Elicitation** | Gather requirements interactively | **SKIPPED** - requirements from ticket only |
-| **Research** | As needed per complexity | As needed per complexity (unchanged) |
-| **Implementation Analysis** | Analyze current state | Analyze **pre-change** state (base branch) |
-| **Plan & Prepare** | Plan implementation tasks | Plan as reference (retrospective analysis) |
-| **Implement** | Execute implementation | **SKIPPED** - code already exists |
-| **Lean-Coding Audit** | Audit + apply simplifications | **Document** over-engineering findings (no apply) |
-| **Post-Impl Review** | Review own implementation | Compare PR to expected changes |
-| **Validate** | Fix failures | **Document** failures as findings |
-| **Strategic Review** | Apply cleanup | **Document** cleanup recommendations |
-| **Update PR** | Push and mark ready | **Generate and post review comments** |
-
-### Key Behavioral Changes
-
-1. **No Code Changes**: Review mode documents findings but does NOT modify the codebase
-2. **Findings as Feedback**: All issues become review comments, not fixes to apply
-3. **Baseline Comparison**: Implementation analysis captures what existed BEFORE the PR
-4. **Retrospective Planning**: Plan serves as reference for what SHOULD have been done
+Review mode adapts the work-package workflow for reviewing existing implementations. The workflow mechanism that drives it — the `is_review_mode` variable and the step, checkpoint, and transition conditions that branch on it — is documented in [REVIEW-MODE.md](../REVIEW-MODE.md), which also carries the per-activity behavior summary and the phase-difference table. This resource supplies the review-specific reference content the review techniques consume: the expected-changes template, the consolidated review-comment format, severity definitions, and the review-type mapping.
 
 ## Implementation Analysis in Review Mode
-
-### Baseline Capture
-
-1. **Checkout base branch** (PR target, typically `main` or `develop`)
-2. **Analyze pre-change state**: Architecture, interfaces, existing behavior
-3. **Document expected changes**: Based on ticket requirements, what changes should be made?
-4. **Return to PR branch** for subsequent review phases
 
 ### Expected Changes Document
 
@@ -133,6 +43,8 @@ Based on ticket [PM-XXXXX] requirements:
 
 The final review comment combines findings from all review stages.
 
+**Findings constraint:** every finding names a file within the authored surface (the PR's changed-files list). Findings on files in that set form the PR's findings; findings on other files form a separate "pre-existing" grouping.
+
 **Reports list:** The header includes a `Reports` field listing the engineering artifact reports with hyperlinks. Construct links using the engineering artifacts base URL:
 
 ```
@@ -147,20 +59,13 @@ https://github.com/{ENG_REPO_OWNER}/{ENG_REPO_NAME}/blob/main/.engineering/artif
 
 Section titles (e.g., `### Code Review Findings`) must NOT be hyperlinks — the report links live in the header instead.
 
-**Reviewers list:** The `Reviewers` field must list each agent role that contributed findings, with each name hyperlinked to the workflow `.yaml` file that defines that role. The workflow definitions live in a separate repository (submodule), so construct links using the workflow repo base URL — not the engineering repo's submodule path, which does not resolve on GitHub:
+**Reviewers list:** The `Reviewers` field lists each agent role that contributed findings, with each name hyperlinked to the workflow file that defines that role. The workflow definitions live in the workflows repository (a submodule), so reviewer links use the workflow repo base URL:
 
 ```
 https://github.com/{WORKFLOW_REPO_OWNER}/{WORKFLOW_REPO_NAME}/blob/{WORKFLOW_BRANCH}/work-package/
 ```
 
-Resolve `{WORKFLOW_REPO_OWNER}`, `{WORKFLOW_REPO_NAME}`, and `{WORKFLOW_BRANCH}` from the `.gitmodules` entry for the workflows submodule (typically `.engineering/workflows`).
-
-| Agent Role | YAML File |
-|------------|-----------|
-| Code Review Agent | `techniques/review-code.md` |
-| Test Suite Review Agent | `techniques/review-test-suite.md` |
-| Validation Agent | `activities/11-validate.yaml` |
-| Strategic Review Agent | `activities/12-strategic-review.yaml` |
+Resolve `{WORKFLOW_REPO_OWNER}`, `{WORKFLOW_REPO_NAME}`, and `{WORKFLOW_BRANCH}` from the `.gitmodules` entry for the workflows submodule (typically `.engineering/workflows`). The rendering step supplies the role-to-file mapping for the roles it links.
 
 **Table format:** All review tables only include non-passing findings — do not list passing or positive items. The `#` column value is a hyperlink to the pertinent artifact or symbol (file path and line for code review, test method for test review, document URL for documentation, CI run URL for validation, branch/commit for hygiene). Every table must include a `Severity` column. Every `#` link MUST be validated against the actual source at the referenced commit before inclusion — do not carry over line numbers from earlier analysis without verification.
 
@@ -181,7 +86,7 @@ Example: `(CR-1)` refers to Code Review finding 1, `(TR-3)` refers to Test Revie
 ## PR Review Summary
 
 **PR**: #XXX - Title  
-**Reviewers**: [Code Review Agent]({workflow_base}/techniques/review-code.md) · [Test Suite Review Agent]({workflow_base}/techniques/review-test-suite.md) · [Validation Agent]({workflow_base}/activities/11-validate.yaml) · [Strategic Review Agent]({workflow_base}/activities/12-strategic-review.yaml)  
+**Reviewers**: [each contributing agent role linked to its defining workflow file under `{workflow_base}`]  
 **Reports**: `Code Review` · `Test Suite Review`  
 **Date**: YYYY-MM-DD
 
@@ -354,30 +259,15 @@ Findings are classified on the classification scale (Critical / Major / Minor / 
 
 A correct-but-harmful finding (one classified Major or Critical on an impact axis such as unbounded state growth, economic/spam, liveness/halt, or migration/upgrade) therefore renders at High or Critical and reaches the Action Items as a blocking item — it is not downgraded to "safe" at the render boundary.
 
-## Posting Reviews
-
-### GitHub CLI Commands
-
-```bash
-# Post as a review comment
-gh pr review {pr_number} --comment --body-file review.md
-
-# Request changes (for blocking issues)
-gh pr review {pr_number} --request-changes --body-file review.md
-
-# Approve (when satisfied)
-gh pr review {pr_number} --approve --body-file review.md
-```
-
 ### Review Type Selection
 
-| Findings | Review Type |
-|----------|-------------|
-| Critical/High severity blockers | `--request-changes` |
-| Medium/Low findings only | `--comment` |
-| No significant issues | `--approve` with summary |
+The Overall Rating rendered in the summary maps to the posted review type:
 
-The Prior Feedback Triage caps the Overall Rating: when any prior blocker-class comment is dispositioned Confirmed (valid and unaddressed), the rating cannot exceed Request Changes — it cannot be Approve or Comment Only — regardless of how light the review's own findings are. An unaddressed external blocker is never rated away.
+| Overall Rating | Review Type |
+|----------------|-------------|
+| Request Changes | `request-changes` |
+| Comment Only | `comment` |
+| Approve | `approve` |
 
 ## Artifacts in Review Mode
 

--- a/work-package/techniques/review-baseline-state.md
+++ b/work-package/techniques/review-baseline-state.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -21,6 +21,10 @@ The ticket requirements used to derive what changes the PR is expected to make
 
 Path to the target checkout where the git operations run
 
+### pr_number
+
+PR identifier, used to read the authoritative changed-files list via `gh pr view`
+
 ## Outputs
 
 ### base_sha
@@ -31,9 +35,13 @@ Commit SHA of the base branch at the time of analysis
 
 Reference description of the changes that should be made to fulfil the requirements — the yardstick for evaluating the actual PR
 
+### changed_files
+
+The authored surface of the PR — GitHub's changed-files list. The canonical set every downstream review finding is scoped to.
+
 ### base_pr_diff
 
-The diff between the base branch and the PR branch, noted for later comparison
+The base↔PR diff (fresh three-dot `{base_branch}...HEAD`), noted for later comparison
 
 ## Protocol
 
@@ -47,16 +55,29 @@ The diff between the base branch and the PR branch, noted for later comparison
 - Based on `{requirements}` and the baseline analysis, document what changes SHOULD be made to fulfil the requirements.
 - Record this as `{expected_changes}` — it becomes the reference for evaluating whether the actual PR delivers what the requirements ask for.
 
-### 3. Return to PR Branch
+### 3. Capture Authored Surface
 
 - Check out the PR branch to continue the workflow.
-- Note the diff between the base branch and the PR branch and record it as `{base_pr_diff}`: `git -C {target_path} diff {base_sha}..HEAD`.
+- Record the authoritative changed-files list as `{changed_files}`: `gh pr view {pr_number} --json files --jq '.files[].path'`.
+- Note the base↔PR diff as `{base_pr_diff}` using a fresh three-dot range: `git -C {target_path} diff {base_branch}...HEAD`.
+
+### 4. Merge-In Guard
+
+- When HEAD is a merge commit or the branch contains merges of `{base_branch}`, recompute the three-dot set against a freshly resolved merge-base and **log** the merge-in.
 
 ## Rules
 
 ### review-mode-only
 
 This technique applies only when the work package is in review mode. In normal (authoring) mode there is no PR to baseline against, and the technique is skipped.
+
+### authoritative-authored-surface
+
+`{changed_files}` comes from GitHub's changed-files list (`gh pr view --json files`). This list is authoritative: it defines the PR's authored surface, and downstream scoping uses it as-is.
+
+### merge-in-guard
+
+When HEAD is a merge commit or the branch has merged `{base_branch}` in, recompute the diff with a fresh three-dot range against the merge-base and log that a merge-in was detected. The guard's sole action is to log.
 
 ### baseline-before-evaluation
 

--- a/work-package/techniques/review-code.md
+++ b/work-package/techniques/review-code.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 2.0.0
+  version: 2.1.0
 ---
 
 ## Capability
@@ -11,7 +11,7 @@ Perform comprehensive Rust/Substrate code review following established patterns,
 
 ### changed_files
 
-List of files changed in the work package (from `git diff`)
+The authored surface — the PR's changed-files set, produced canonically by `review-baseline-state`.
 
 ### project_type
 
@@ -37,8 +37,8 @@ Code review [report](../resources/rust-substrate-code-review.md#report-template)
 
 - Use attached [rust-substrate-code-review](../resources/rust-substrate-code-review.md) for full review criteria
   - If the code review resource is missing, check the resources folder for `16-rust-substrate-code-review.md`.
-- Establish the `{changed_files}` set by running `git diff` for all files changed since the work package started
-  - If no implementation changes are found, verify the correct branch and commit range.
+- Consume the canonical `{changed_files}` authored surface when it is established (review mode, produced by `review-baseline-state`). In create mode (no PR baseline), derive it from the local working-tree diff against the base branch.
+  - If `{changed_files}` is empty, verify the correct branch and commit range.
 
 ### 2. Bound Review Scope
 
@@ -79,3 +79,7 @@ Every finding must cite specific code with file path and line numbers
 ### severity-consistency
 
 Apply severity levels consistently — critical for security/data loss, high for correctness, medium for maintainability, low for style
+
+### findings-constraint
+
+Every finding names a file within the authored surface `{changed_files}`. Findings on files in `{changed_files}` form the PR's findings; findings on other files form a separate "pre-existing" grouping.

--- a/work-package/techniques/review-diff.md
+++ b/work-package/techniques/review-diff.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ Feature branch whose diff is reviewed (synced via `git pull`, parsed via `git di
 ### planning_folder_path
 
 Folder where the change block index and manual diff review report are written
+
+### pr_number
+
+PR identifier, used to resolve the authoritative base branch via `gh pr view`
 
 ## Outputs
 
@@ -57,7 +61,8 @@ True if any block marked as critical blocker
 
 - Run `git pull` on the `{branch_name}` feature branch to ensure it is up to date
 - Resolve merge conflicts before proceeding if any
-- Identify the base branch (`{$base_branch}`) — typically `main`/`master`, the branch the PR will merge into
+- Identify the base branch (`{$base_branch}`) as the PR's target branch: `gh pr view {pr_number} --json baseRefName --jq .baseRefName`
+- If HEAD is a merge commit or the branch has merged `{$base_branch}` in, the three-dot range against the merge-base already scopes to the authored diff; log that a merge-in was detected
 
 ### 2. Parse Diff
 

--- a/work-package/techniques/review-summary.md
+++ b/work-package/techniques/review-summary.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -25,6 +25,10 @@ The triage of prior PR feedback — each prior comment dispositioned Confirmed /
 
 The ceiling the Overall Rating may not exceed, derived from the prior-feedback triage. When set to the request-changes tier (an unaddressed external blocker), the rendered Overall Rating is held at or below Request Changes.
 
+### changed_files
+
+The authored surface — the PR's changed-files set. Used to enforce the findings-constraint at consolidation.
+
 ## Outputs
 
 ### review_summary
@@ -39,7 +43,9 @@ The structured consolidated review summary text, organized per the Consolidated 
 
 ### 2. Render the Summary
 
+- Enforce the findings-constraint: every rendered finding names a file within the authored surface `{changed_files}`. Findings on files in `{changed_files}` render as the PR's findings; findings on other files render under a separate "pre-existing" grouping.
 - Populate the template from `{consolidated_findings}`: executive summary, per-category findings (code, test, documentation, validation, branch hygiene), action items, and severity definitions.
+- Render the Reviewers field: hyperlink each contributing agent role to the workflow file that defines it, using the base URL from the Consolidated Review Format — Code Review Agent → `techniques/review-code.md`, Test Suite Review Agent → `techniques/review-test-suite.md`, Validation Agent → `activities/11-validate.yaml`, Strategic Review Agent → `activities/12-strategic-review.yaml`.
 - Render the Prior Feedback Triage section from `{prior_feedback_triage}`: one row per prior comment with its Confirmed / Refuted / Superseded disposition, and carry each Confirmed blocker-class entry into the Action Items as a blocking item.
 - Apply `{rating_cap}` to the Overall Rating: when the cap is the request-changes tier, the Overall Rating is held at or below Request Changes — never Approve or Comment Only — even if the review's own findings are light.
 - Render the attribution footer that closes the format template — resolving `{user}` and `{sha}` per the format's instruction — so `{review_summary}` carries it and the posted comment reaches the PR with it intact.

--- a/work-package/techniques/review-test-suite.md
+++ b/work-package/techniques/review-test-suite.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 2.0.0
+  version: 2.1.0
 ---
 
 ## Capability
@@ -91,3 +91,7 @@ Assess coverage relative to the changes made, not absolute project coverage
 ### actionable-recommendations
 
 Every finding must include a concrete improvement suggestion
+
+### findings-constraint
+
+Every finding names a file within the authored surface `{changed_files}`. Findings on files in `{changed_files}` form the PR's findings; findings on other files form a separate "pre-existing" grouping.

--- a/work-package/techniques/strategic-review/review-scope.md
+++ b/work-package/techniques/strategic-review/review-scope.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -36,14 +36,13 @@ The strategic review document this pass populates with categorized findings — 
 ### 1. Load Guidance
 
 - Use attached [architecture-review](../../resources/architecture-review.md) for architecture guidance; the rules below govern the review findings
-- Examine all changes on the feature branch `{branch_name}` against the base branch using `git diff` and `git log`:
+- Identify the base branch (`{$base_branch}`) as the PR's target branch: `gh pr view {pr_number} --json baseRefName --jq .baseRefName`
+- Examine the authored surface `{changed_files}` on the feature branch `{branch_name}` using three-dot diffs against the base branch (`{$base_branch}`, the PR's target branch):
+  - Consume the canonical `{changed_files}` when it is established (review mode, produced by `review-baseline-state`); otherwise (create mode, no PR baseline) derive it from the local working-tree diff against `{$base_branch}`.
 
   ```bash
-  # List all files changed in this branch
-  git diff --name-only <base-branch> HEAD
-
-  # For each file, ask: Is this change necessary for the solution?
-  git diff <base-branch> HEAD -- <file>
+  # For each file in {changed_files}, ask: Is this change necessary for the solution?
+  git diff {$base_branch}...HEAD -- <file>
   ```
 
 - Assess each changed file against [per-file-necessity](#per-file-necessity)
@@ -102,3 +101,7 @@ For each changed file, verify: the change directly supports the solution (not a 
 | Are all new dependencies required? | Remove unused dependencies |
 | Are all configuration changes required? | Revert unnecessary config changes |
 | Is the solution as simple as it could be? | Consider simplification |
+
+### findings-constraint
+
+Every finding names a file within the authored surface `{changed_files}`. Findings on files in `{changed_files}` form the PR's findings; findings on other files form a separate "pre-existing" grouping.

--- a/work-package/workflow.yaml
+++ b/work-package/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: work-package
-version: 3.25.0
+version: 3.26.0
 title: Work Package Implementation Workflow
 description: Defines how to plan and implement ONE work package from inception to merged PR. A work package is a discrete unit of work such as a feature, bug-fix, enhancement, refactoring, or any other deliverable change. For multiple related work packages, use the work-packages workflow to create a roadmap first.
 author: m2ux


### PR DESCRIPTION
## Summary

Fixes review-mode diff-scoping in the `work-package` workflow (**v3.25.0 → 3.26.0**), addressing #203.

Review mode scoped a PR's authored surface with a **two-dot** diff against a stored/stale base, sweeping in commits merged from the base branch and over-scoping reviews by an order of magnitude. This change makes GitHub's changed-files list the authoritative authored surface and constrains every downstream finding to it.

### What changes

- **Authoritative authored surface** — `changed_files` is produced canonically by `review-baseline-state` from GitHub's changed-files list (`gh pr view {pr_number} --json files`) using a fresh three-dot range, never a stored/stale two-dot base. A disagreeing (larger) local diff is treated as wrong; the list is never widened to match it.
- **Authoritative base branch** — resolved via `gh pr view {pr_number} --json baseRefName`, replacing the `main`/`develop` heuristic.
- **Merge-in guard** — when HEAD is a merge commit or the branch has merged the base in, the three-dot set is recomputed against the merge-base and the merge-in is **logged only** (no user gate — consistent with headless-after-activation review mode).
- **Findings-constraint** — a shared `## Rules` entry on every finding producer (`review-code`, `review-test-suite`, `review-scope`) plus enforcement at `review-summary` consolidation: every finding must name a file within the authored surface; a finding outside it is dropped or separated under a "pre-existing / not introduced by this PR" grouping.
- **Create-mode fallback** — `review-code` and `review-scope` keep a local working-tree-diff fallback so authoring mode (no PR baseline) still has a `changed_files` source.

## Scope manifest (8 files — all MODIFY; no create/remove; no activity-YAML)

| File (under `work-package/`) | Version | Change |
|------------------------------|---------|--------|
| `workflow.yaml` | 3.25.0 → 3.26.0 | Root version bump only |
| `techniques/review-baseline-state.md` | 1.0.0 → 1.1.0 | + `pr_number` input, `changed_files` output; step-3 two-dot → authoritative surface; +merge-in-guard step; +`authoritative-authored-surface` / `merge-in-guard` rules; `base_pr_diff` repurposed to three-dot (retained) |
| `techniques/review-code.md` | 2.0.0 → 2.1.0 | Consume canonical `{changed_files}` (review mode) with create-mode local-diff fallback; +`findings-constraint` rule |
| `techniques/review-test-suite.md` | 2.0.0 → 2.1.0 | +`findings-constraint` rule only |
| `techniques/strategic-review/review-scope.md` | 1.1.0 → 1.2.0 | Two-dot → three-dot `{$base_branch}...HEAD` scoped to `{changed_files}`, create-mode fallback; +`findings-constraint` rule |
| `techniques/review-diff.md` | 1.1.0 → 1.2.0 | + `pr_number` input; base derived from authoritative PR base; merge-in note |
| `techniques/review-summary.md` | 1.1.0 → 1.2.0 | + `changed_files` input; enforce findings-constraint at consolidation |
| `resources/review-mode.md` | 1.4.0 → 1.5.0 | Baseline Capture → authoritative surface + reconciliation rule; +findings-constraint narrative |

Non-destructive: every edit is correction-in-place or additive; nothing deleted.

## Validation

- `validate-workflow-yaml.ts` → all YAML valid (workflow.yaml v3.26.0, 15 activities, 99 techniques, no unanchored refs)
- `check-all-refs.ts` → 0 unresolved references across all workflows
- `check-binding-fidelity.ts` → **0 new binding drift** (5 baselined violations fixed by this change; a baseline shrink via `--update-baseline` is a post-merge follow-up)

## Planning artifacts

Design session: `.engineering/artifacts/planning/2026-07-09-review-mode-diff-scope/` (intake, requirements refinement, impact analysis, scope manifest, quality review — 4 passes clean + 1 High resolved).

Closes #203
