### PR TITLE
chore(workflows): bump submodule to v3.27.0 + re-snapshot binding baseline

### DIFF
--- a/scripts/binding-fidelity-baseline.json
+++ b/scripts/binding-fidelity-baseline.json
@@ -836,11 +836,6 @@
   },
   {
     "check": "orphan-input",
-    "site": "work-package :: finalize-documentation::ensure-docs",
-    "detail": "own input 'changed_files' has no producer in workflow 'work-package' (no step-binding entry, workflow variable, step output, or default)"
-  },
-  {
-    "check": "orphan-input",
     "site": "work-package :: finalize-documentation::finalize-test-plan",
     "detail": "own input 'test_plan' has no producer in workflow 'work-package' (no step-binding entry, workflow variable, step output, or default)"
   },
@@ -996,11 +991,6 @@
   },
   {
     "check": "orphan-input",
-    "site": "work-package :: review-code",
-    "detail": "own input 'changed_files' has no producer in workflow 'work-package' (no step-binding entry, workflow variable, step output, or default)"
-  },
-  {
-    "check": "orphan-input",
     "site": "work-package :: review-mode-detection",
     "detail": "own input 'user_request' has no producer in workflow 'work-package' (no step-binding entry, workflow variable, step output, or default)"
   },
@@ -1021,11 +1011,6 @@
   },
   {
     "check": "orphan-input",
-    "site": "work-package :: review-test-suite",
-    "detail": "own input 'changed_files' has no producer in workflow 'work-package' (no step-binding entry, workflow variable, step output, or default)"
-  },
-  {
-    "check": "orphan-input",
     "site": "work-package :: stakeholder-overview",
     "detail": "own input 'source_material' has no producer in workflow 'work-package' (no step-binding entry, workflow variable, step output, or default)"
   },
@@ -1036,18 +1021,8 @@
   },
   {
     "check": "orphan-input",
-    "site": "work-package :: strategic-review::review-scope",
-    "detail": "own input 'changed_files' has no producer in workflow 'work-package' (no step-binding entry, workflow variable, step output, or default)"
-  },
-  {
-    "check": "orphan-input",
     "site": "work-package :: strategic-review::verify-fragment",
     "detail": "own input 'issue_url' has no producer in workflow 'work-package' (no step-binding entry, workflow variable, step output, or default)"
-  },
-  {
-    "check": "orphan-input",
-    "site": "work-package :: summarize-architecture",
-    "detail": "own input 'changed_files' has no producer in workflow 'work-package' (no step-binding entry, workflow variable, step output, or default)"
   },
   {
     "check": "orphan-input",
@@ -1281,12 +1256,12 @@
   },
   {
     "check": "read-resolution",
-    "site": "work-package/techniques/review-summary.md:45",
+    "site": "work-package/techniques/review-summary.md:51",
     "detail": "{sha} has no producer (declared id / $-local / workflow var / set-target)"
   },
   {
     "check": "read-resolution",
-    "site": "work-package/techniques/review-summary.md:45",
+    "site": "work-package/techniques/review-summary.md:51",
     "detail": "{user} has no producer (declared id / $-local / workflow var / set-target)"
   },
   {


### PR DESCRIPTION
## Summary

Advances the `workflows` submodule gitlink `b3da9c01 → e3bf9d2d`, catching `main` up across the content PRs merged to the `workflows` branch since the last pointer bump, and re-snapshots the binding-fidelity baseline against the new tip.

## Folded content

| Workflow | Version | PR | Change |
|---|---|---|---|
| work-package | v3.25.0 | #202 | Number the prior-feedback-triage review artifact |
| work-package | v3.26.0 | #204 | Scope review-mode findings to the PR's authored surface |
| workflow-design | v1.6.0 | #205 | Harden quality-review audit (documentation voice + resource-protocol) |
| work-package | v3.27.0 | #200 | Require all mandated PR-body sections in the `update-pr` conformance rubric |

## Binding baseline

Re-snapshots `scripts/binding-fidelity-baseline.json` (268 → 263): drops five pre-existing entries no longer present on the current tip. The folded content introduces **no new** binding drift — the delta is purely the shrink the guard had been flagging (`0 NEW`).

## Validation

- `npm run typecheck` — clean
- `npm test` — 529 passed / 14 skipped; **e2e walk snapshots unchanged** (the #200 change is rule-text only, no activity-graph change)
- `check:binding` — `263 total, 263 baselined, 0 NEW, 0 fixed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
