### PR TITLE
feat(server): source-scoped borrowed-technique resolution + check:stealth leakage guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "check:technique-template": "tsx scripts/check-technique-template.ts",
     "check:variable-model": "tsx scripts/check-variable-model.ts",
     "check:fragments": "tsx scripts/check-fragments.ts",
-    "check:review-mode": "tsx scripts/check-review-mode-gating.ts"
+    "check:review-mode": "tsx scripts/check-review-mode-gating.ts",
+    "check:stealth": "tsx scripts/check-stealth-isolation.ts"
   },
   "license": "MIT",
   "devDependencies": {

--- a/scripts/binding-fidelity-baseline.json
+++ b/scripts/binding-fidelity-baseline.json
@@ -221,21 +221,6 @@
   },
   {
     "check": "dead-output",
-    "site": "remediate-vuln/techniques/secure-submit/push-secure-commits.md",
-    "detail": "output 'pushed_branch' is declared but nothing outside its own file consumes it (no read, condition, binding value, remap, or same-named input)"
-  },
-  {
-    "check": "dead-output",
-    "site": "remediate-vuln/techniques/secure-submit/verify-commit-signatures.md",
-    "detail": "output 'commits_signed' is declared but nothing outside its own file consumes it (no read, condition, binding value, remap, or same-named input)"
-  },
-  {
-    "check": "dead-output",
-    "site": "remediate-vuln/techniques/secure-submit/verify-security-remote.md",
-    "detail": "output 'security_remote_verified' is declared but nothing outside its own file consumes it (no read, condition, binding value, remap, or same-named input)"
-  },
-  {
-    "check": "dead-output",
     "site": "remediate-vuln/techniques/security-setup/configure-security-remote.md",
     "detail": "output 'security_remote_configured' is declared but nothing outside its own file consumes it (no read, condition, binding value, remap, or same-named input)"
   },
@@ -248,16 +233,6 @@
     "check": "dead-output",
     "site": "remediate-vuln/techniques/security-setup/verify-origin-untracked.md",
     "detail": "output 'origin_untracked' is declared but nothing outside its own file consumes it (no read, condition, binding value, remap, or same-named input)"
-  },
-  {
-    "check": "dead-output",
-    "site": "remediate-vuln/techniques/strategic-review/apply-cleanup.md",
-    "detail": "output 'cleanup_commit' is declared but nothing outside its own file consumes it (no read, condition, binding value, remap, or same-named input)"
-  },
-  {
-    "check": "dead-output",
-    "site": "remediate-vuln/techniques/strategic-review/verify-fragment.md",
-    "detail": "output 'changes_fragment' is declared but nothing outside its own file consumes it (no read, condition, binding value, remap, or same-named input)"
   },
   {
     "check": "dead-output",
@@ -446,8 +421,18 @@
   },
   {
     "check": "dead-output",
+    "site": "work-package/techniques/manage-git/verify-commit-signatures.md",
+    "detail": "output 'commits_signed' is declared but nothing outside its own file consumes it (no read, condition, binding value, remap, or same-named input)"
+  },
+  {
+    "check": "dead-output",
     "site": "work-package/techniques/manage-git/verify-feature-branch.md",
     "detail": "output 'on_feature_branch' is declared but nothing outside its own file consumes it (no read, condition, binding value, remap, or same-named input)"
+  },
+  {
+    "check": "dead-output",
+    "site": "work-package/techniques/manage-git/verify-remote-private.md",
+    "detail": "output 'push_remote_verified' is declared but nothing outside its own file consumes it (no read, condition, binding value, remap, or same-named input)"
   },
   {
     "check": "dead-output",
@@ -501,8 +486,18 @@
   },
   {
     "check": "dead-output",
+    "site": "work-package/techniques/strategic-review/apply-cleanup.md",
+    "detail": "output 'cleanup_commit' is declared but nothing outside its own file consumes it (no read, condition, binding value, remap, or same-named input)"
+  },
+  {
+    "check": "dead-output",
     "site": "work-package/techniques/strategic-review/changes-folder.md",
     "detail": "output 'changes_fragment' is declared but nothing outside its own file consumes it (no read, condition, binding value, remap, or same-named input)"
+  },
+  {
+    "check": "dead-output",
+    "site": "work-package/techniques/strategic-review/TECHNIQUE.md",
+    "detail": "output 'architecture_summary_doc' is declared but nothing outside its own file consumes it (no read, condition, binding value, remap, or same-named input)"
   },
   {
     "check": "dead-output",

--- a/scripts/check-stealth-isolation.ts
+++ b/scripts/check-stealth-isolation.ts
@@ -1,0 +1,284 @@
+/**
+ * Stealth-isolation leakage guard.
+ *
+ * Verifies that a stealth-mode workflow (default: remediate-vuln) cannot leak data to public
+ * repositories or issue trackers. Two layers:
+ *
+ *   STATIC (always runs; CI-safe, no network):
+ *     (1) disclosure-gating — every step that binds a disclosure-capable operation (PR create/
+ *         render/mark-ready/review-comment, issue creation/commenting/assignment, tracker
+ *         transitions) must carry a gate that evaluates definitively FALSE under the workflow's
+ *         seeded variable defaults (stealth_mode: true et al.). An ungated or truthy-gated
+ *         disclosure step is a finding.
+ *     (2) push-target discipline — the workflow's seeded `push_remote` must not be `origin`,
+ *         and the private-remote verification step + isolation confirmation checkpoint must be
+ *         REACHABLE (gates evaluate TRUE) ahead of any reachable push step.
+ *     (3) reachable-text scan — the composed technique of every REACHABLE step must not invoke
+ *         public write endpoints (`gh pr create|comment|ready|review|merge`, `gh issue`,
+ *         `gh api` mutations, Jira comment/edit/transition tools) — catches a disclosure path
+ *         added to a technique body without a catalog entry.
+ *
+ *   RUNTIME (opt-in via --target <checkout-path>; requires git, optionally gh):
+ *     (4) private-target verification — for the checkout that a real remediation run would push
+ *         from, resolve the configured push remote's URL and verify the repository is actually
+ *         private: GitHub repos via `gh api repos/{owner}/{repo} --jq .private` (must be true);
+ *         all remotes additionally via an anonymous, credential-free `git ls-remote` probe
+ *         (anonymous readability == public == FAIL).
+ *
+ * Usage:
+ *   npx tsx scripts/check-stealth-isolation.ts [--workflow remediate-vuln] [--root <workflows-dir>]
+ *   npx tsx scripts/check-stealth-isolation.ts --target /path/to/private/checkout [--remote security]
+ *
+ * Exit code 0 = no leakage path found; 1 = findings (printed one per line).
+ */
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { existsSync } from 'node:fs';
+import { loadWorkflowWithDiagnostics } from '../src/loaders/workflow-loader.js';
+import { composeActivityTechnique } from '../src/loaders/technique-loader.js';
+import { stringifyForResponse } from '../src/utils/serialization.js';
+import type { Activity, Step, Condition } from '../src/schema/index.js';
+
+/* ----------------------------------- CLI ----------------------------------- */
+
+const args = process.argv.slice(2);
+const argOf = (flag: string): string | undefined => {
+  const i = args.indexOf(flag);
+  return i >= 0 ? args[i + 1] : undefined;
+};
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const workflowsRoot = argOf('--root') ?? process.env['WORKFLOWS_DIR'] ?? join(scriptDir, '..', 'workflows');
+const workflowId = argOf('--workflow') ?? 'remediate-vuln';
+const runtimeTarget = argOf('--target');
+const runtimeRemote = argOf('--remote');
+
+/* ------------------------- disclosure catalog (static) ------------------------ */
+
+/** Technique refs whose execution writes to a public surface. Matched on the authored ref
+ * (after `::`-normalization) — resolution scope does not matter for cataloging. */
+const DISCLOSURE_REFS: RegExp[] = [
+  /^update-pr::(create-pr|mark-ready|post-review-comment|render)$/,
+  /^(work-package::)?update-pr::(create-pr|mark-ready|post-review-comment|render)$/,
+  /^create-issue$/,
+  /^(work-package::)?create-issue$/,
+  /^github-cli-protocol::(comment-issue|assign-issue|create-issue|create-pr)$/,
+  /^atlassian-operations::(comment-jira-issue|edit-jira-issue|transition-jira-issue|create-jira-issue)$/,
+  /^respond-to-pr-review$/,
+  /^(work-package::)?respond-to-pr-review$/,
+];
+
+/** Public write invocations that must not appear in any REACHABLE step's composed technique. */
+const PUBLIC_WRITE_TEXT: RegExp[] = [
+  /\bgh pr (create|comment|ready|review|merge|edit)\b/,
+  /\bgh issue\b/,
+  /\bgh api\b[^\n]*(-X|--method)\s*(POST|PATCH|PUT|DELETE)/,
+  /\bcomment-jira-issue\b|\beditJiraIssue\b|\btransitionJiraIssue\b/,
+];
+
+/* ------------------------------ gate evaluation ------------------------------ */
+
+type Bag = Record<string, unknown>;
+
+function evalCondition(c: Condition | undefined, bag: Bag): boolean | undefined {
+  if (!c) return undefined;
+  const anyC = c as Record<string, unknown>;
+  const type = anyC['type'] as string;
+  if (type === 'simple') {
+    const name = anyC['variable'] as string;
+    const op = anyC['operator'] as string;
+    const value = anyC['value'];
+    const path = name.split('.');
+    let cur: unknown = bag;
+    for (const seg of path) {
+      if (cur !== null && typeof cur === 'object' && seg in (cur as Record<string, unknown>)) {
+        cur = (cur as Record<string, unknown>)[seg];
+      } else { cur = undefined; break; }
+    }
+    switch (op) {
+      case 'exists': return cur !== undefined && cur !== null;
+      case 'notExists': return cur === undefined || cur === null;
+      case '==': return cur === value;
+      case '!=': return cur !== value;
+      default: return undefined; // numeric comparators are not used on disclosure gates
+    }
+  }
+  if (type === 'and') return (anyC['conditions'] as Condition[]).every((x) => evalCondition(x, bag) === true);
+  if (type === 'or') return (anyC['conditions'] as Condition[]).some((x) => evalCondition(x, bag) === true);
+  if (type === 'not') { const inner = evalCondition(anyC['condition'] as Condition, bag); return inner === undefined ? undefined : !inner; }
+  return undefined;
+}
+
+/** Evaluate a `when` expression of the simple `a == b [&& c != d ...]` shape the corpus uses. */
+function evalWhen(expr: string | undefined, bag: Bag): boolean | undefined {
+  if (!expr) return undefined;
+  const clauses = expr.split('&&').map((s) => s.trim());
+  let result = true;
+  for (const clause of clauses) {
+    const m = /^([a-z_][a-z0-9_.]*)\s*(==|!=)\s*(.+)$/.exec(clause);
+    if (!m) return undefined;
+    const raw = m[3]!.trim().replace(/^['"]|['"]$/g, '');
+    const value: unknown = raw === 'true' ? true : raw === 'false' ? false : raw;
+    const got = evalCondition({ type: 'simple', variable: m[1]!, operator: m[2] as '==', value: value as never }, bag);
+    if (got === undefined) return undefined;
+    result &&= got;
+  }
+  return result;
+}
+
+/** A step is EXCLUDED (provably not executed) when any of its own or enclosing gates
+ * evaluates to false under the seeded bag. Undefined (unevaluable) gates count as reachable —
+ * the guard is conservative in the safe direction. */
+function stepReachable(step: Step, enclosingGates: Array<boolean | undefined>, bag: Bag): boolean {
+  const own = [evalWhen((step as { when?: string }).when, bag), evalCondition((step as { condition?: Condition }).condition, bag)];
+  return [...enclosingGates, ...own].every((g) => g !== false);
+}
+
+/* --------------------------------- static scan -------------------------------- */
+
+const findings: string[] = [];
+
+function refOf(step: Step): string | undefined {
+  if (step.kind !== 'technique') return undefined;
+  const t = (step as { technique: string | { name: string } }).technique;
+  return typeof t === 'string' ? t : t.name;
+}
+
+async function staticScan(): Promise<void> {
+  const loadResult = await loadWorkflowWithDiagnostics(workflowsRoot, workflowId);
+  if (!loadResult.success) {
+    findings.push(`workflow '${workflowId}' failed to load: ${loadResult.error.message}`);
+    return;
+  }
+  const { workflow, activitySourceWorkflow } = loadResult.value;
+
+  // Seed the bag exactly as the server seeds a fresh session: declared defaultValues only.
+  const bag: Bag = {};
+  for (const v of workflow.variables ?? []) {
+    if ('defaultValue' in v && v.defaultValue !== undefined) bag[v.name] = v.defaultValue;
+  }
+  if (bag['stealth_mode'] !== true) {
+    findings.push(`workflow '${workflowId}' does not seed stealth_mode: true — the disclosure gates have no driver`);
+  }
+  if (bag['push_remote'] === undefined || bag['push_remote'] === 'origin') {
+    findings.push(`workflow '${workflowId}' seeds push_remote='${String(bag['push_remote'])}' — must be a non-origin private remote`);
+  }
+
+  const reachableTechniqueSteps: Array<{ activity: Activity; step: Step; ref: string }> = [];
+
+  const walk = (activity: Activity, steps: Step[] | undefined, gates: Array<boolean | undefined>): void => {
+    for (const step of steps ?? []) {
+      const reachable = stepReachable(step, gates, bag);
+      const ref = refOf(step);
+      if (ref && DISCLOSURE_REFS.some((re) => re.test(ref))) {
+        if (reachable) {
+          findings.push(`disclosure step reachable under stealth defaults: ${activity.id}/${step.id ?? ref} (${ref})`);
+        }
+      } else if (ref && reachable) {
+        reachableTechniqueSteps.push({ activity, step, ref });
+      }
+      if (step.kind === 'loop') {
+        const loopGates = [...gates,
+          evalWhen((step as { when?: string }).when, bag),
+          evalCondition((step as { condition?: Condition }).condition, bag)];
+        walk(activity, (step as { steps?: Step[] }).steps, loopGates);
+      }
+    }
+  };
+  for (const activity of workflow.activities ?? []) walk(activity, activity.steps as Step[] | undefined, []);
+
+  // Push discipline: the private-remote verification and isolation confirmation must be
+  // reachable in the activity that carries a reachable push step.
+  for (const activity of workflow.activities ?? []) {
+    const steps = (activity.steps ?? []) as Step[];
+    const pushStep = steps.find((s) => refOf(s)?.endsWith('::push-commits') || refOf(s) === 'push-commits');
+    if (!pushStep || !stepReachable(pushStep, [], bag)) continue;
+    const verify = steps.find((s) => (refOf(s) ?? '').includes('verify-remote-private'));
+    const confirm = steps.find((s) => s.kind === 'checkpoint' && /private|isolation/i.test((s as { message?: string }).message ?? ''));
+    if (!verify || !stepReachable(verify, [], bag)) {
+      findings.push(`push step '${activity.id}/${pushStep.id ?? 'push-commits'}' is reachable but no reachable private-remote verification precedes it`);
+    }
+    if (!confirm || !stepReachable(confirm, [], bag)) {
+      findings.push(`push step '${activity.id}/${pushStep.id ?? 'push-commits'}' is reachable but no reachable isolation confirmation checkpoint precedes it`);
+    }
+  }
+
+  // Text scan of every reachable step's composed technique for public write invocations. Only
+  // the PROTOCOL carries invocations — rules and capability text legitimately NAME the
+  // prohibited commands (the isolation contracts say "gh pr create is prohibited"), so scanning
+  // them would flag the prohibition itself.
+  for (const { activity, step, ref } of reachableTechniqueSteps) {
+    const scope = activitySourceWorkflow.get(activity.id) ?? workflow.id;
+    const composed = await composeActivityTechnique(ref, workflowsRoot, scope, activity.id);
+    if (!composed.success) {
+      findings.push(`reachable step '${activity.id}/${step.id ?? ref}' binds unresolvable technique '${ref}' (scope ${scope})`);
+      continue;
+    }
+    const protocolText = stringifyForResponse(composed.value.technique.protocol ?? []);
+    for (const re of PUBLIC_WRITE_TEXT) {
+      const m = re.exec(protocolText);
+      if (m) findings.push(`reachable step '${activity.id}/${step.id ?? ref}' composed technique '${composed.value.techniqueId}' protocol contains public write invocation: ${m[0]}`);
+    }
+  }
+}
+
+/* -------------------------------- runtime probe ------------------------------- */
+
+function runtimeProbe(targetPath: string, remote: string): void {
+  if (!existsSync(targetPath)) {
+    findings.push(`--target path does not exist: ${targetPath}`);
+    return;
+  }
+  let url: string;
+  try {
+    url = execFileSync('git', ['-C', targetPath, 'remote', 'get-url', remote], { encoding: 'utf-8' }).trim();
+  } catch {
+    findings.push(`remote '${remote}' is not configured in ${targetPath}`);
+    return;
+  }
+  console.log(`runtime: remote '${remote}' -> ${url}`);
+
+  // GitHub visibility check (authoritative when the remote is a GitHub repo and gh is present).
+  const gh = /github\.com[:/]([^/]+)\/([^/.]+)(\.git)?$/.exec(url);
+  if (gh) {
+    try {
+      const priv = execFileSync('gh', ['api', `repos/${gh[1]}/${gh[2]}`, '--jq', '.private'], { encoding: 'utf-8' }).trim();
+      if (priv !== 'true') findings.push(`remote '${remote}' (${url}) is a PUBLIC GitHub repository`);
+      else console.log(`runtime: GitHub reports repository is private ✓`);
+    } catch {
+      console.log('runtime: gh unavailable or repo not visible to gh — falling back to anonymous probe only');
+    }
+  }
+
+  // Anonymous readability probe: a credential-free ls-remote succeeding means the repo is
+  // publicly readable — a leakage destination regardless of host.
+  try {
+    execFileSync('git', ['ls-remote', url, 'HEAD'], {
+      encoding: 'utf-8',
+      timeout: 20000,
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0', GIT_ASKPASS: 'true', GIT_CONFIG_NOSYSTEM: '1', HOME: '/nonexistent', XDG_CONFIG_HOME: '/nonexistent', GIT_SSH_COMMAND: 'ssh -o BatchMode=yes -o IdentitiesOnly=yes -o IdentityFile=/nonexistent' },
+    });
+    findings.push(`remote '${remote}' (${url}) is ANONYMOUSLY READABLE — public destination`);
+  } catch {
+    console.log('runtime: anonymous read probe rejected (repository not publicly readable) ✓');
+  }
+}
+
+/* ----------------------------------- main ------------------------------------ */
+
+async function main(): Promise<void> {
+  await staticScan();
+  if (runtimeTarget) runtimeProbe(runtimeTarget, runtimeRemote ?? 'security');
+
+  if (findings.length > 0) {
+    console.error(`stealth-isolation: ${findings.length} finding(s)`);
+    for (const f of findings) console.error(`  - ${f}`);
+    process.exit(1);
+  }
+  console.log(`stealth-isolation: OK — no leakage path found for '${workflowId}'${runtimeTarget ? ' (static + runtime)' : ' (static)'}`);
+}
+
+main().catch((error) => {
+  console.error('stealth-isolation: guard crashed:', error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/src/loaders/workflow-loader.ts
+++ b/src/loaders/workflow-loader.ts
@@ -29,7 +29,16 @@ export interface WorkflowManifestEntry { id: string; title: string; version: str
 export interface DefinitionLoadError { file: string; activity_id?: string | undefined; error: string; }
 
 /** A loaded workflow plus the per-file activity-load failures excluded from it. */
-export interface WorkflowWithDiagnostics { workflow: Workflow; activityLoadErrors: DefinitionLoadError[]; }
+export interface WorkflowWithDiagnostics {
+  workflow: Workflow;
+  activityLoadErrors: DefinitionLoadError[];
+  /**
+   * Activity id → the workflow the activity file was authored in. Differs from the loaded
+   * workflow's id only for borrowed cross-workflow activities; it scopes those activities'
+   * unqualified technique refs (and fragment refs) to their source workflow.
+   */
+  activitySourceWorkflow: Map<string, string>;
+}
 
 const formatZodIssues = (issues: Array<{ path: PropertyKey[]; message: string }>): string =>
   issues.map(i => `${i.path.join('.')}: ${i.message}`).join('; ');
@@ -347,7 +356,7 @@ export async function loadWorkflowWithDiagnostics(workflowDir: string, workflowI
     if (workflow.activities) workflow.activities = materialized;
 
     logInfo('Workflow loaded', { workflowId, version: workflow.version, activityCount: workflow.activities?.length ?? 0 });
-    return ok({ workflow, activityLoadErrors });
+    return ok({ workflow, activityLoadErrors, activitySourceWorkflow });
   } catch (error) {
     logError('Failed to load workflow', error instanceof Error ? error : undefined, { workflowId });
     return err(new WorkflowValidationError(workflowId, [error instanceof Error ? error.message : 'Unknown error']));

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -3,7 +3,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ServerConfig } from '../config.js';
 import { withAuditLog } from '../logging.js';
 
-import { loadWorkflow, getActivity } from '../loaders/workflow-loader.js';
+import { loadWorkflow, loadWorkflowWithDiagnostics, getActivity } from '../loaders/workflow-loader.js';
 import { readResourceStructured } from '../loaders/resource-loader.js';
 import { composeActivityTechnique, projectTechniqueToYaml } from '../loaders/technique-loader.js';
 import {
@@ -519,8 +519,13 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
 
       assertNoActiveCheckpoint(state);
 
-      const wfResult = await loadWorkflow(config.workflowDir, workflow_id);
-      if (!wfResult.success) throw wfResult.error;
+      const wfDiag = await loadWorkflowWithDiagnostics(config.workflowDir, workflow_id);
+      if (!wfDiag.success) throw wfDiag.error;
+      const wfResult = { success: true as const, value: wfDiag.value.workflow };
+      // A borrowed activity's technique refs resolve against the workflow the activity file was
+      // authored in (mirroring #166 B10 fragment scoping), not the borrowing session's workflow.
+      const techniqueScopeWorkflowId = (state.currentActivity
+        && wfDiag.value.activitySourceWorkflow.get(state.currentActivity)) || workflow_id;
 
       let techniqueId: string | undefined;
       let boundStep: Step | undefined;
@@ -564,9 +569,10 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
       }
 
       // Activity-group convention (see composeActivityTechnique): a bare op id resolves first
-      // against the group named after the current activity, falling back to as-authored.
+      // against the group named after the current activity, falling back to as-authored — both
+      // within the activity's source-workflow scope.
       const composed = await composeActivityTechnique(
-        techniqueId, config.workflowDir, workflow_id, state.currentActivity || undefined,
+        techniqueId, config.workflowDir, techniqueScopeWorkflowId, state.currentActivity || undefined,
       );
       if (!composed.success) throw composed.error;
       techniqueId = composed.value.techniqueId;
@@ -585,6 +591,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
           workflowDir: config.workflowDir,
           currentActivityId: state.currentActivity,
           currentStepId: boundStep.id,
+          activitySourceWorkflow: wfDiag.value.activitySourceWorkflow,
         });
         if (ctx) {
           const binding = boundStep.kind === 'technique' && typeof boundStep.technique === 'object'

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -386,7 +386,13 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       }
 
       const view = sessionView(state);
-      const result = await loadWorkflow(config.workflowDir, workflow_id);
+      const diagResult = await loadWorkflowWithDiagnostics(config.workflowDir, workflow_id);
+      const result = diagResult.success
+        ? { success: true as const, value: diagResult.value.workflow }
+        : diagResult;
+      const activitySourceWorkflow = diagResult.success
+        ? diagResult.value.activitySourceWorkflow
+        : new Map<string, string>();
 
       // Reference-not-repeat delivery: active via per-call opt-in or the session's declared
       // context mode. Full delivery stays the default — in disposable-worker topologies each
@@ -482,7 +488,9 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
         for (const step of eligible) {
           const ref = techniqueName(step.technique);
           if (!ref) continue;
-          const composedStep = await composeActivityTechnique(ref, config.workflowDir, workflow_id, activity_id);
+          // Borrowed activities resolve their step techniques against the source workflow the
+          // activity file was authored in (mirroring #166 B10 fragment scoping).
+          const composedStep = await composeActivityTechnique(ref, config.workflowDir, sourceWorkflowId, activity_id);
           // An unresolvable ref is the binding guard's business; delivery skips it (the step's
           // own get_technique fetch will surface the error to the worker).
           if (!composedStep.success) continue;
@@ -494,6 +502,7 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
             workflowDir: config.workflowDir,
             currentActivityId: activity_id,
             currentStepId: step.id!,
+            activitySourceWorkflow,
           });
           if (ctx) {
             const binding = typeof step.technique === 'object' ? step.technique : undefined;

--- a/src/utils/binding-provenance.ts
+++ b/src/utils/binding-provenance.ts
@@ -85,8 +85,14 @@ export async function buildProvenanceContext(args: {
   workflowDir: string;
   currentActivityId: string;
   currentStepId: string;
+  /**
+   * Per-activity technique-resolution scope: activity id → the workflow the activity file was
+   * authored in. A borrowed cross-workflow activity resolves its bound ops against its source
+   * workflow (mirroring fragment scoping); absent entries fall back to the session workflow.
+   */
+  activitySourceWorkflow?: ReadonlyMap<string, string>;
 }): Promise<ProvenanceContext | null> {
-  const { workflow, workflowDir, currentActivityId, currentStepId } = args;
+  const { workflow, workflowDir, currentActivityId, currentStepId, activitySourceWorkflow } = args;
   const declaredVariables = new Set((workflow.variables ?? []).map((v) => v.name));
   const producers: ProducerSite[] = [];
   let position = -1;
@@ -98,17 +104,19 @@ export async function buildProvenanceContext(args: {
     const hit = ownOutputsCache.get(key);
     if (hit) return hit;
     let ids: string[] = [];
+    // A borrowed activity's bound ops resolve against the workflow the file was authored in.
+    const scopeWorkflowId = activitySourceWorkflow?.get(activityId) ?? workflow.id;
     try {
       // Mirror get_technique's activity-group shorthand: a bare op resolves first against the
       // group named after its activity, then as-authored.
       let result = (!ref.includes('::') && !ref.includes('/'))
-        ? await readTechnique(`${activityId}::${ref}`, workflowDir, workflow.id)
+        ? await readTechnique(`${activityId}::${ref}`, workflowDir, scopeWorkflowId)
         : null;
-      if (!result?.success) result = await readTechnique(ref, workflowDir, workflow.id);
+      if (!result?.success) result = await readTechnique(ref, workflowDir, scopeWorkflowId);
       if (result.success) ids = (result.value.outputs ?? []).map((o) => o.id);
     } catch (error) {
       logWarn('Provenance producer scan skipped an unreadable bound op', {
-        ref, activityId, workflowId: workflow.id,
+        ref, activityId, workflowId: scopeWorkflowId,
         error: error instanceof Error ? error.message : String(error),
       });
     }

--- a/tests/borrowed-technique-resolution.test.ts
+++ b/tests/borrowed-technique-resolution.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { loadWorkflowWithDiagnostics } from '../src/loaders/workflow-loader.js';
+import { composeActivityTechnique } from '../src/loaders/technique-loader.js';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const WORKFLOW_DIR = resolve(import.meta.dirname, '../workflows');
+
+/**
+ * Borrowed cross-workflow activities resolve their technique refs against the workflow the
+ * activity file was authored in — the technique-side counterpart of #166 B10 fragment scoping.
+ * Before this fix, a borrowed activity's unqualified refs resolved [borrower → meta] and failed.
+ */
+describe('borrowed-activity technique resolution', () => {
+  let fixtureDir: string;
+
+  beforeAll(() => {
+    fixtureDir = mkdtempSync(join(tmpdir(), 'borrowed-technique-resolution-'));
+
+    // Source workflow: owns an activity file and the techniques it binds — a group named after
+    // the activity (exercising activity-group shorthand) and a standalone op.
+    const sourceDir = join(fixtureDir, 'source-wf');
+    mkdirSync(join(sourceDir, 'activities'), { recursive: true });
+    mkdirSync(join(sourceDir, 'techniques', 'shared-work'), { recursive: true });
+    writeFileSync(join(sourceDir, 'workflow.yaml'), [
+      'id: source-wf',
+      'version: 1.0.0',
+      'title: Source Workflow',
+      'initialActivity: shared-work',
+    ].join('\n'));
+    writeFileSync(join(sourceDir, 'activities', '01-shared-work.yaml'), [
+      'id: shared-work',
+      'version: 1.0.0',
+      'name: Shared Work',
+      'steps:',
+      '  - kind: technique',
+      '    id: do-thing',
+      '    technique: do-thing',
+      '  - kind: technique',
+      '    id: standalone-step',
+      '    technique: standalone-op',
+    ].join('\n'));
+    writeFileSync(join(sourceDir, 'techniques', 'shared-work', 'TECHNIQUE.md'), [
+      '---', 'metadata:', '  version: 1.0.0', '---', '',
+      '## Capability', '', 'Group contract for shared-work ops.',
+    ].join('\n'));
+    writeFileSync(join(sourceDir, 'techniques', 'shared-work', 'do-thing.md'), [
+      '---', 'metadata:', '  version: 1.0.0', '---', '',
+      '## Capability', '', 'Does the thing.', '', '## Protocol', '', '1. Do it.',
+    ].join('\n'));
+    writeFileSync(join(sourceDir, 'techniques', 'standalone-op.md'), [
+      '---', 'metadata:', '  version: 1.0.0', '---', '',
+      '## Capability', '', 'Standalone operation.', '', '## Protocol', '', '1. Operate.',
+    ].join('\n'));
+
+    // Borrower: no techniques of its own; borrows the source workflow's activity by string ref.
+    const borrowerDir = join(fixtureDir, 'borrower-wf');
+    mkdirSync(join(borrowerDir, 'activities'), { recursive: true });
+    writeFileSync(join(borrowerDir, 'workflow.yaml'), [
+      'id: borrower-wf',
+      'version: 1.0.0',
+      'title: Borrower Workflow',
+      'initialActivity: own-start',
+      'activities:',
+      '  - 01-own-start.yaml',
+      '  - source-wf/01-shared-work.yaml',
+    ].join('\n'));
+    writeFileSync(join(borrowerDir, 'activities', '01-own-start.yaml'), [
+      'id: own-start',
+      'version: 1.0.0',
+      'name: Own Start',
+    ].join('\n'));
+  });
+
+  afterAll(() => {
+    rmSync(fixtureDir, { recursive: true, force: true });
+  });
+
+  it('loadWorkflowWithDiagnostics maps each activity to its source workflow', async () => {
+    const result = await loadWorkflowWithDiagnostics(fixtureDir, 'borrower-wf');
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const sources = result.value.activitySourceWorkflow;
+    expect(sources.get('own-start')).toBe('borrower-wf');
+    expect(sources.get('shared-work')).toBe('source-wf');
+  });
+
+  it('resolves a borrowed activity-group shorthand ref under the source-workflow scope', async () => {
+    const composed = await composeActivityTechnique('do-thing', fixtureDir, 'source-wf', 'shared-work');
+    expect(composed.success).toBe(true);
+    if (composed.success) expect(composed.value.techniqueId).toBe('shared-work::do-thing');
+
+    // The pre-fix behavior: resolving under the borrower's scope fails — this is exactly the
+    // gap the source-workflow threading closes.
+    const underBorrower = await composeActivityTechnique('do-thing', fixtureDir, 'borrower-wf', 'shared-work');
+    expect(underBorrower.success).toBe(false);
+  });
+
+  it('resolves a borrowed standalone ref under the source-workflow scope', async () => {
+    const composed = await composeActivityTechnique('standalone-op', fixtureDir, 'source-wf', 'shared-work');
+    expect(composed.success).toBe(true);
+  });
+
+  it('maps the real corpus: remediate-vuln borrows work-package activities', async () => {
+    const result = await loadWorkflowWithDiagnostics(WORKFLOW_DIR, 'remediate-vuln');
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const sources = result.value.activitySourceWorkflow;
+    expect(sources.get('start')).toBe('remediate-vuln');
+    expect(sources.get('design-philosophy')).toBe('work-package');
+    expect(sources.get('implement')).toBe('work-package');
+    expect(sources.get('submit-for-review')).toBe('work-package');
+  });
+});

--- a/tests/e2e/walker.ts
+++ b/tests/e2e/walker.ts
@@ -301,8 +301,12 @@ function getVar(path: string, vars: Record<string, unknown>): unknown {
   return cur;
 }
 
-/** Evaluate a step's inline `when` expression. Unparseable expressions don't gate (execute). */
+/** Evaluate a step's inline `when` expression. Compound `a == x && b != y` expressions
+ * evaluate clause-by-clause (all must pass). Unparseable expressions don't gate (execute). */
 function evaluateWhen(expr: string, vars: Record<string, unknown>): boolean {
+  if (expr.includes('&&')) {
+    return expr.split('&&').every((clause) => evaluateWhen(clause.trim(), vars));
+  }
   const m = expr.match(/^\s*([\w.]+)\s*(==|!=)\s*(.+?)\s*$/);
   if (!m) {
     // Bare variable → truthiness.


### PR DESCRIPTION
## Summary

Server-side half of the remediate-vuln ↔ work-package alignment (content PR: #211 — merge that **first**).

### Borrowed-activity technique resolution (F1)
A cross-workflow borrowed activity's unqualified technique refs previously resolved against the borrowing session's workflow (then meta), so every work-package-local ref inside remediate-vuln's 14 borrowed activities failed with `TechniqueNotFoundError` (~65 of ~80 step bindings — verified empirically). The per-activity source workflow (already computed at load for #166 B10 fragment scoping) is now exposed on `WorkflowWithDiagnostics` and used as the resolution scope in `get_technique`, `get_activity` eager bundling, and binding-provenance producer scans. Non-borrowed activities are unaffected (`sourceWorkflowId == workflowId`).

### check:stealth — leakage smoke test
`scripts/check-stealth-isolation.ts` (`npm run check:stealth`) verifies a stealth workflow cannot leak to public repos/trackers:
- **static:** every disclosure-capable step must be provably gated out under the workflow's seeded defaults; private-remote verification + isolation confirmation must be reachable ahead of any reachable push; reachable steps' composed protocols are scanned for public write invocations.
- **runtime** (`--target <checkout> [--remote security]`): the configured push remote must be an actually-private repository — GitHub visibility via `gh api` AND an anonymous credential-free `ls-remote` probe that must fail.

Negative test: the guard fails (3 findings) against the pre-alignment corpus.

### Also
- e2e walker `when` evaluator: compound `&&` clause support (corpus already uses compound gates).
- 4 regression tests (`tests/borrowed-technique-resolution.test.ts`): synthetic borrower/source fixture + real-corpus source mapping.
- binding-fidelity baseline regenerated (263 → 262): known-benign dead-output entries migrated with the ops moved from remediate-vuln's forks into work-package; zero new drift.

## Dependencies / CI note

Depends on #211: the regenerated baseline, snapshots, and the real-corpus regression test expect the aligned corpus. After #211 merges, bump the `workflows` submodule pointer before (or with) merging this PR.

## Testing
- `npm run typecheck` clean; full suite **544 passed / 14 skipped**.
- All corpus guards green against the aligned corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
