### PR TITLE
Improve documentation site readability and navigation

### DIFF
--- a/docs/documentation-system.md
+++ b/docs/documentation-system.md
@@ -6,7 +6,9 @@ How this repository's documentation is organized: what each source is for, who i
 
 **Markdown is canonical.** Every fact about the system lives in a markdown file in this repository, and those files are the source of truth.
 
-**The HTML site renders it.** [`site/`](../site/) is a hand-authored static documentation site — semantic HTML, one shared stylesheet, inline SVG diagrams, no site-generator toolchain — that presents the same material as a navigable, illustrated view. Site pages link back to their canonical markdown sources. Two site pages contain machine-generated regions derived from the server source and the JSON schemas (`npm run build:site` regenerates them); `tests/site.test.ts` fails when those regions drift from the code, and `npm run check:site` verifies every internal link and anchor.
+**The HTML site renders it.** [`site/`](../site/) is a hand-authored static documentation site — semantic HTML, one shared stylesheet, inline SVG diagrams, no client-side JavaScript — that presents the same material as a navigable, illustrated view. **Prefer on-site HTML links for reading**; link to markdown on GitHub for editing or for documents with no HTML mirror.
+
+[`scripts/generate-site-data.ts`](../scripts/generate-site-data.ts) maintains a route registry (`SITE_ROUTES`) and regenerates global navigation, breadcrumbs, pagination, and the API reference bodies (`npm run build:site`). `tests/site.test.ts` fails when generated regions drift; `npm run check:site` verifies internal links and anchors.
 
 Two site sections have no markdown counterpart because their canonical source is not markdown: `site/internals/` documents the server implementation (canonical source: the code in `src/`, `scripts/`, and `tests/`, which every page links to), and `site/design/` records design rationale distilled from the decision records on the engineering branch. When the implementation or a recorded decision changes, those pages are updated in the same change.
 
@@ -45,4 +47,4 @@ Workflow definitions themselves (the `workflows` branch, checked out as a worktr
 
 - **Describe the system as it is.** Documentation states current behaviour in plain present tense; evolution narratives belong in `.engineering/` planning artifacts. Rationale is the one exception: the standing reasons behind current decisions are product documentation, kept on the site's design-rationale page — still present tense, never a changelog.
 - **Filenames are stable.** Documents are heavily cross-linked (from this repository and beyond), so structure changes are expressed through linking and navigation, never by renaming or moving existing files.
-- **Everything is reachable.** Every document is linked from an entry point — the README's navigation strip, the [`docs/architecture.md`](architecture.md) hub, or the site's landing page — so no document depends on full-text search to be found.
+- **Everything is reachable.** Every HTML page is listed in `SITE_ROUTES` and linked from the generated global navigation. The home page "Where to start" table and section hubs provide additional entry points. No document should depend on full-text search alone.

--- a/scripts/generate-site-data.ts
+++ b/scripts/generate-site-data.ts
@@ -1,19 +1,16 @@
 #!/usr/bin/env npx tsx
 /**
- * Regenerates the machine-derived regions of the documentation site
- * (site/api/tools.html, site/api/schemas.html) from the server source:
- * tool names, descriptions, and parameter schemas are captured by replaying
- * the MCP tool registrations against a recording stub, and the schema
- * reference is rendered from the checked-in schemas/*.schema.json files.
+ * Regenerates machine-derived regions of the documentation site:
+ * - Global navigation, breadcrumbs, and pagination on every HTML page
+ * - Tool and schema reference bodies on api/tools.html and api/schemas.html
  *
- * Only the content between the BEGIN/END GENERATED markers is rewritten;
- * everything outside the markers is hand-authored. tests/site.test.ts fails
- * when the committed pages drift from a fresh regeneration.
+ * Hand-authored content outside the BEGIN/END GENERATED markers is preserved.
+ * tests/site.test.ts fails when committed pages drift from a fresh regeneration.
  */
 import { z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { join, resolve, relative, dirname } from 'node:path';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ServerConfig } from '../src/config.js';
 import { registerWorkflowTools } from '../src/tools/workflow-tools.js';
@@ -22,6 +19,201 @@ import { registerResourceTools } from '../src/tools/resource-tools.js';
 const ROOT = resolve(import.meta.dirname, '..');
 const SITE_DIR = join(ROOT, 'site');
 const GITHUB_BLOB = 'https://github.com/m2ux/workflow-server/blob/main';
+
+// ---------------------------------------------------------------------------
+// Site route registry
+
+export type SiteSection = 'home' | 'guide' | 'specs' | 'api' | 'internals' | 'design';
+
+export interface SiteRoute {
+  relPath: string;
+  section: SiteSection;
+  title: string;
+  navLabel: string;
+  /** Order within section for prev/next links. Omit on hubs without sequence. */
+  sequence?: number;
+  /** Parent route relPath for breadcrumbs (e.g. specs/architecture.html). */
+  parent?: string;
+  breadcrumbLabel?: string;
+}
+
+export const SITE_ROUTES: SiteRoute[] = [
+  { relPath: 'index.html', section: 'home', title: 'Home', navLabel: 'Home' },
+  { relPath: 'guide/getting-started.html', section: 'guide', title: 'Getting started', navLabel: 'Getting started', sequence: 1 },
+  { relPath: 'guide/ide-setup.html', section: 'guide', title: 'IDE setup', navLabel: 'IDE setup', sequence: 2 },
+  { relPath: 'guide/concepts.html', section: 'guide', title: 'Concepts', navLabel: 'Concepts', sequence: 3 },
+  { relPath: 'guide/running-workflows.html', section: 'guide', title: 'Running workflows', navLabel: 'Running workflows', sequence: 4 },
+  { relPath: 'specs/architecture.html', section: 'specs', title: 'Architecture overview', navLabel: 'Overview', sequence: 0, breadcrumbLabel: 'Architecture' },
+  { relPath: 'specs/dispatch.html', section: 'specs', title: 'Hierarchical dispatch', navLabel: 'Dispatch', sequence: 1, parent: 'specs/architecture.html', breadcrumbLabel: 'Dispatch' },
+  { relPath: 'specs/checkpoints.html', section: 'specs', title: 'Just-in-time checkpoints', navLabel: 'Checkpoints', sequence: 2, parent: 'specs/architecture.html', breadcrumbLabel: 'Checkpoints' },
+  { relPath: 'specs/state-management.html', section: 'specs', title: 'State management', navLabel: 'State', sequence: 3, parent: 'specs/architecture.html', breadcrumbLabel: 'State' },
+  { relPath: 'specs/artifact-management.html', section: 'specs', title: 'Artifact management', navLabel: 'Artifacts', sequence: 4, parent: 'specs/architecture.html', breadcrumbLabel: 'Artifacts' },
+  { relPath: 'specs/resource-resolution.html', section: 'specs', title: 'Resource resolution', navLabel: 'Resolution', sequence: 5, parent: 'specs/architecture.html', breadcrumbLabel: 'Resolution' },
+  { relPath: 'specs/workflow-fidelity.html', section: 'specs', title: 'Workflow fidelity', navLabel: 'Fidelity', sequence: 6, parent: 'specs/architecture.html', breadcrumbLabel: 'Fidelity' },
+  { relPath: 'api/tools.html', section: 'api', title: 'MCP tool reference', navLabel: 'Tools', sequence: 1 },
+  { relPath: 'api/schemas.html', section: 'api', title: 'Schema reference', navLabel: 'Schemas', sequence: 2 },
+  { relPath: 'api/protocol.html', section: 'api', title: 'Protocol in practice', navLabel: 'Protocol guide', sequence: 3 },
+  { relPath: 'internals/server-anatomy.html', section: 'internals', title: 'Server anatomy', navLabel: 'Server anatomy', sequence: 1 },
+  { relPath: 'internals/request-lifecycle.html', section: 'internals', title: 'Request lifecycle', navLabel: 'Request lifecycle', sequence: 2 },
+  { relPath: 'internals/session-store.html', section: 'internals', title: 'Session store', navLabel: 'Session store', sequence: 3 },
+  { relPath: 'internals/quality-system.html', section: 'internals', title: 'Quality system', navLabel: 'Quality system', sequence: 4 },
+  { relPath: 'design/rationale.html', section: 'design', title: 'Design rationale', navLabel: 'Design rationale', sequence: 1 },
+];
+
+const ROUTE_BY_PATH = new Map(SITE_ROUTES.map(r => [r.relPath, r]));
+
+const NAV_SECTIONS: Array<{ id: SiteSection; label: string }> = [
+  { id: 'guide', label: 'Guide' },
+  { id: 'specs', label: 'Architecture' },
+  { id: 'api', label: 'API' },
+  { id: 'internals', label: 'Internals' },
+  { id: 'design', label: 'Design' },
+];
+
+function routePrefix(relPath: string): string {
+  const depth = relPath.split('/').length - 1;
+  return depth === 0 ? '' : '../'.repeat(depth);
+}
+
+function hrefFrom(pageRelPath: string, targetRelPath: string): string {
+  if (targetRelPath === 'index.html') {
+    const depth = pageRelPath.split('/').length - 1;
+    return depth === 0 ? './' : '../'.repeat(depth);
+  }
+  const fromDir = dirname(join(SITE_DIR, pageRelPath));
+  const target = join(SITE_DIR, targetRelPath);
+  let href = relative(fromDir, target).replace(/\\/g, '/');
+  if (!href.startsWith('.') && !href.startsWith('/')) href = `./${href}`;
+  return href;
+}
+
+function routesInSection(section: SiteSection): SiteRoute[] {
+  return SITE_ROUTES.filter(r => r.section === section && r.relPath !== 'index.html')
+    .sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0));
+}
+
+export function renderSiteNav(pageRelPath: string): string {
+  const current = ROUTE_BY_PATH.get(pageRelPath);
+  const homeHref = hrefFrom(pageRelPath, 'index.html');
+  const lines: string[] = [];
+  lines.push('    <nav class="site-nav" aria-label="Documentation">');
+  lines.push('      <ul class="site-nav__primary">');
+  lines.push(`        <li><a href="${homeHref}"${current?.section === 'home' ? ' aria-current="page"' : ''}>Home</a></li>`);
+
+  for (const { id, label } of NAV_SECTIONS) {
+    const items = routesInSection(id);
+    const inSection = current?.section === id;
+    lines.push('        <li>');
+    lines.push(`          <details class="site-nav__group"${inSection ? ' open' : ''}>`);
+    lines.push(`            <summary>${escapeHtml(label)}</summary>`);
+    lines.push('            <ul>');
+    for (const item of items) {
+      const href = hrefFrom(pageRelPath, item.relPath);
+      const isCurrent = pageRelPath === item.relPath;
+      lines.push(`              <li><a href="${href}"${isCurrent ? ' aria-current="page"' : ''}>${escapeHtml(item.navLabel)}</a></li>`);
+    }
+    lines.push('            </ul>');
+    lines.push('          </details>');
+    lines.push('        </li>');
+  }
+
+  lines.push('        <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>');
+  lines.push('      </ul>');
+  lines.push('    </nav>');
+  return lines.join('\n');
+}
+
+export function renderBreadcrumb(pageRelPath: string): string {
+  const route = ROUTE_BY_PATH.get(pageRelPath);
+  if (!route || route.section === 'home') return '';
+
+  const crumbs: Array<{ label: string; href?: string }> = [];
+  const sectionLabel = NAV_SECTIONS.find(s => s.id === route.section)?.label ?? route.section;
+  const hub = routesInSection(route.section).find(r => r.sequence === 0);
+
+  if (route.section === 'design') {
+    crumbs.push({ label: 'Design' });
+    crumbs.push({ label: route.navLabel });
+  } else if (hub && route.parent === hub.relPath) {
+    crumbs.push({ label: sectionLabel, href: hrefFrom(pageRelPath, hub.relPath) });
+    crumbs.push({ label: route.breadcrumbLabel ?? route.navLabel });
+  } else if (hub && route.relPath === hub.relPath) {
+    crumbs.push({ label: sectionLabel });
+    crumbs.push({ label: route.navLabel });
+  } else {
+    crumbs.push({ label: sectionLabel });
+    if (hub) crumbs.push({ label: hub.navLabel, href: hrefFrom(pageRelPath, hub.relPath) });
+    crumbs.push({ label: route.navLabel });
+  }
+
+  const items = crumbs.map((c, i) => {
+    const isLast = i === crumbs.length - 1;
+    if (c.href && !isLast) {
+      return `      <li><a href="${c.href}">${escapeHtml(c.label)}</a></li>`;
+    }
+    return `      <li${isLast ? ' aria-current="page"' : ''}>${escapeHtml(c.label)}</li>`;
+  });
+
+  return [
+    '  <nav class="breadcrumb" aria-label="Breadcrumb">',
+    '    <ol>',
+    ...items,
+    '    </ol>',
+    '  </nav>',
+  ].join('\n');
+}
+
+export function renderPagination(pageRelPath: string): string {
+  const route = ROUTE_BY_PATH.get(pageRelPath);
+  if (!route || route.section === 'home' || route.sequence === undefined) return '';
+
+  const sectionRoutes = routesInSection(route.section).filter(r => r.sequence !== undefined && r.sequence > 0);
+  const idx = sectionRoutes.findIndex(r => r.relPath === pageRelPath);
+  if (idx === -1) return '';
+
+  const prev = idx > 0 ? sectionRoutes[idx - 1] : undefined;
+  const next = idx < sectionRoutes.length - 1 ? sectionRoutes[idx + 1] : undefined;
+  if (!prev && !next) return '';
+
+  const parts: string[] = ['  <nav class="page-pagination" aria-label="Page sequence">'];
+  if (prev) {
+    parts.push(`    <a class="page-pagination__prev" href="${hrefFrom(pageRelPath, prev.relPath)}">← ${escapeHtml(prev.navLabel)}</a>`);
+  } else {
+    parts.push('    <span></span>');
+  }
+  if (next) {
+    parts.push(`    <a class="page-pagination__next" href="${hrefFrom(pageRelPath, next.relPath)}">${escapeHtml(next.navLabel)} →</a>`);
+  }
+  parts.push('  </nav>');
+  return parts.join('\n');
+}
+
+/** Every registered page except home must appear in generated global nav. */
+export function checkSiteNavigation(): string[] {
+  const errors: string[] = [];
+  const navHtml = renderSiteNav('index.html');
+  for (const route of SITE_ROUTES) {
+    if (route.relPath === 'index.html') continue;
+    const href = hrefFrom('index.html', route.relPath);
+    if (!navHtml.includes(`href="${href}"`)) {
+      errors.push(`Global nav from index.html missing link to ${route.relPath}`);
+    }
+  }
+
+  for (const route of SITE_ROUTES) {
+    const pagePath = join(SITE_DIR, route.relPath);
+    const html = readFileSync(pagePath, 'utf-8');
+    if (!html.includes('BEGIN GENERATED NAV')) {
+      errors.push(`site/${route.relPath}: missing GENERATED NAV markers`);
+    }
+    const expectedNav = renderSiteNav(route.relPath);
+    const actualNav = extractRegion(html, 'NAV');
+    if (actualNav !== expectedNav) {
+      errors.push(`site/${route.relPath}: stale navigation — run npm run build:site`);
+    }
+  }
+  return errors;
+}
 
 // ---------------------------------------------------------------------------
 // Tool capture
@@ -59,7 +251,6 @@ function toParamsSchema(shape: unknown): JsonSchemaNode | null {
   return json;
 }
 
-/** Replay the tool registrations against a recorder instead of a live server. */
 export function captureTools(): CapturedTool[] {
   const tools: CapturedTool[] = [];
   const recorder = {
@@ -83,9 +274,6 @@ export function captureTools(): CapturedTool[] {
   return tools;
 }
 
-// The six concerns mirror the README's tools-at-a-glance table. Membership is
-// asserted below so a new or renamed tool fails generation instead of being
-// silently omitted from the site.
 const TOOL_GROUPS: Array<{ title: string; note: string; tools: string[] }> = [
   { title: 'Bootstrap', note: 'Callable without a session_index.', tools: ['discover', 'list_workflows', 'health_check'] },
   { title: 'Session', note: 'Create, inspect, and extend workflow sessions.', tools: ['start_session', 'get_workflow_status', 'dispatch_child'] },
@@ -102,9 +290,15 @@ function escapeHtml(text: string): string {
   return text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;');
 }
 
-/** Escape, then promote `backtick` spans to <code>. */
 function richText(text: string): string {
   return escapeHtml(text).replace(/`([^`]+)`/g, '<code>$1</code>');
+}
+
+function firstSentence(text: string): string {
+  const trimmed = text.trim();
+  const match = trimmed.match(/^[^.!?]+[.!?]/);
+  if (match) return match[0];
+  return trimmed.length > 160 ? `${trimmed.slice(0, 157)}…` : trimmed;
 }
 
 function typeLabel(prop: JsonSchemaNode): string {
@@ -120,46 +314,78 @@ function typeLabel(prop: JsonSchemaNode): string {
   return prop.type ?? 'any';
 }
 
-/** Discriminated-union variants read better by their tag (`kind`/`type` const) than as `object`. */
 function variantLabel(variant: JsonSchemaNode): string {
   const tag = variant.properties?.['kind']?.const ?? variant.properties?.['type']?.const;
   return tag !== undefined ? String(tag) : typeLabel(variant);
 }
 
-function paramRows(schema: JsonSchemaNode, prefix = ''): string[] {
+function paramRows(schema: JsonSchemaNode, prefix = '', topLevelOnly = false): string[] {
   const rows: string[] = [];
   const required = new Set(schema.required ?? []);
   for (const [name, prop] of Object.entries(schema.properties ?? {})) {
     const label = `${prefix}${name}`;
+    if (topLevelOnly && prefix !== '') continue;
     const notes: string[] = [];
     if (prop.description) notes.push(richText(prop.description));
     if (prop.default !== undefined) notes.push(`Default: <code>${escapeHtml(JSON.stringify(prop.default))}</code>`);
     rows.push(
       `          <tr><td><code>${escapeHtml(label)}</code></td><td><code>${escapeHtml(typeLabel(prop))}</code></td>` +
-      `<td>${required.has(name) ? 'yes' : 'no'}</td><td>${notes.join(' ') || '—'}</td></tr>`,
+      `<td>${required.has(name) ? 'yes' : 'no'}</td><td>${notes.join(' ') || '-'}</td></tr>`,
     );
-    // Array-of-object parameters (e.g. step_manifest) get one row per item field.
     if (prop.type === 'array' && prop.items?.properties) {
-      rows.push(...paramRows(prop.items, `${label}[].`));
+      rows.push(...paramRows(prop.items, `${label}[].`, topLevelOnly));
     }
   }
   return rows;
 }
 
+function renderParamTable(schema: JsonSchemaNode, topLevelOnly: boolean): string {
+  const rows = paramRows(schema, '', topLevelOnly);
+  if (rows.length === 0) return '';
+  return [
+    '        <div class="table-wrap">',
+    '        <table>',
+    '          <thead><tr><th scope="col">Parameter</th><th scope="col">Type</th><th scope="col">Required</th><th scope="col">Description</th></tr></thead>',
+    '          <tbody>',
+    ...rows,
+    '          </tbody>',
+    '        </table>',
+    '        </div>',
+  ].join('\n');
+}
+
 function renderTool(tool: CapturedTool): string {
   const lines: string[] = [];
+  const summary = firstSentence(tool.description);
+  const hasLongDescription = tool.description.length > summary.length + 20;
+
   lines.push(`      <section class="tool" id="${escapeHtml(tool.name)}">`);
   lines.push(`        <h3><code>${escapeHtml(tool.name)}</code></h3>`);
-  lines.push(`        <p>${richText(tool.description)}</p>`);
+  lines.push(`        <p class="tool-summary">${richText(summary)}</p>`);
+  if (hasLongDescription) {
+    lines.push('        <details class="tool-details">');
+    lines.push('          <summary>Full description</summary>');
+    lines.push(`          <p>${richText(tool.description)}</p>`);
+    lines.push('        </details>');
+  } else if (tool.description !== summary) {
+    lines.push(`        <p>${richText(tool.description)}</p>`);
+  }
+
   if (tool.params) {
-    lines.push('        <div class="table-wrap">');
-    lines.push('        <table>');
-    lines.push('          <thead><tr><th scope="col">Parameter</th><th scope="col">Type</th><th scope="col">Required</th><th scope="col">Description</th></tr></thead>');
-    lines.push('          <tbody>');
-    lines.push(...paramRows(tool.params));
-    lines.push('          </tbody>');
-    lines.push('        </table>');
-    lines.push('        </div>');
+    const allRows = paramRows(tool.params);
+    const topRows = paramRows(tool.params, '', true);
+    const hasNested = allRows.length > topRows.length;
+    if (topRows.length > 0) {
+      lines.push(renderParamTable(tool.params, true).replace('Parameter', 'Parameter').replace(/^        /gm, '        '));
+    }
+    if (hasNested || allRows.length > 6) {
+      lines.push('        <details class="tool-details">');
+      lines.push('          <summary>All parameters</summary>');
+      lines.push(renderParamTable(tool.params, false));
+      lines.push('        </details>');
+    } else if (topRows.length === 0) {
+      lines.push(renderParamTable(tool.params, false));
+    }
   } else {
     lines.push('        <p class="no-params">No parameters.</p>');
   }
@@ -191,8 +417,8 @@ export function renderToolsRegion(): string {
   });
 
   return [
-    `      <p>The server registers ${tools.length} MCP tools.</p>`,
-    '      <nav aria-label="Tools">',
+    `      <p>The server registers ${tools.length} MCP tools. Each entry shows a short summary; expand for the full description and advanced parameters.</p>`,
+    '      <nav aria-label="Tools on this page">',
     '      <ul>',
     ...toc,
     '      </ul>',
@@ -201,15 +427,28 @@ export function renderToolsRegion(): string {
   ].join('\n');
 }
 
-// ---------------------------------------------------------------------------
-// Schema reference
-
 function schemaRoot(json: JsonSchemaNode & { title?: string }): JsonSchemaNode {
   if (json.$ref && json.definitions) {
     const name = json.$ref.split('/').pop()!;
     return json.definitions[name] ?? json;
   }
   return json;
+}
+
+function renderFieldTable(schema: JsonSchemaNode, caption: string): string {
+  const rows = paramRows(schema);
+  if (rows.length === 0) return '';
+  return [
+    `        <p class="table-caption">${escapeHtml(caption)}</p>`,
+    '        <div class="table-wrap">',
+    '        <table>',
+    '          <thead><tr><th scope="col">Field</th><th scope="col">Type</th><th scope="col">Required</th><th scope="col">Description</th></tr></thead>',
+    '          <tbody>',
+    ...rows,
+    '          </tbody>',
+    '        </table>',
+    '        </div>',
+  ].join('\n');
 }
 
 export function renderSchemasRegion(): string {
@@ -222,17 +461,28 @@ export function renderSchemasRegion(): string {
     const lines: string[] = [];
     lines.push(`      <section class="schema" id="${escapeHtml(anchor)}">`);
     lines.push(`        <h2><code>${escapeHtml(file)}</code></h2>`);
-    if (json.description) lines.push(`        <p>${richText(json.description)}</p>`);
-    lines.push(`        <p><a href="${GITHUB_BLOB}/schemas/${file}">Full schema on GitHub</a></p>`);
+    if (json.description) lines.push(`        <p class="schema-summary">${richText(firstSentence(json.description))}</p>`);
+    if (json.description && json.description.length > 120) {
+      lines.push('        <details class="schema-details">');
+      lines.push('          <summary>Full schema description</summary>');
+      lines.push(`          <p>${richText(json.description)}</p>`);
+      lines.push('        </details>');
+    }
+    lines.push(`        <p><a href="${GITHUB_BLOB}/schemas/${file}">Edit source on GitHub</a></p>`);
     if (root.properties) {
-      lines.push('        <div class="table-wrap">');
-      lines.push('        <table>');
-      lines.push('          <thead><tr><th scope="col">Field</th><th scope="col">Type</th><th scope="col">Required</th><th scope="col">Description</th></tr></thead>');
-      lines.push('          <tbody>');
-      lines.push(...paramRows(root));
-      lines.push('          </tbody>');
-      lines.push('        </table>');
-      lines.push('        </div>');
+      const topLevel: JsonSchemaNode = { properties: {}, required: root.required };
+      for (const [name, prop] of Object.entries(root.properties)) {
+        topLevel.properties![name] = prop;
+      }
+      lines.push(renderFieldTable(topLevel, 'Top-level fields'));
+      const allRows = paramRows(root);
+      const topRows = paramRows(topLevel);
+      if (allRows.length > topRows.length) {
+        lines.push('        <details class="schema-details">');
+        lines.push('          <summary>All fields (including nested)</summary>');
+        lines.push(renderFieldTable(root, 'Complete field list'));
+        lines.push('        </details>');
+      }
     } else if (root.anyOf) {
       const variants = root.anyOf.map(v => {
         const typeProp = v.properties?.['type'];
@@ -249,30 +499,72 @@ export function renderSchemasRegion(): string {
 // ---------------------------------------------------------------------------
 // Marker injection
 
-const PAGES: Array<{ relPath: string; render: () => string }> = [
-  { relPath: 'api/tools.html', render: renderToolsRegion },
-  { relPath: 'api/schemas.html', render: renderSchemasRegion },
-];
+const BEGIN = '<!-- BEGIN GENERATED';
+const END = '<!-- END GENERATED';
 
-const BEGIN = '<!-- BEGIN GENERATED — edit scripts/generate-site-data.ts, then run npm run build:site -->';
-const END = '<!-- END GENERATED -->';
+type GeneratedRegion = 'NAV' | 'BREADCRUMB' | 'PAGINATION' | 'CONTENT';
 
-export function injectRegion(page: string, generated: string, relPath: string): string {
-  const start = page.indexOf(BEGIN);
-  const end = page.indexOf(END);
-  if (start === -1 || end === -1 || end < start) {
-    throw new Error(`Missing or malformed GENERATED markers in site/${relPath}`);
+function markerPair(region: GeneratedRegion): { begin: string; end: string } {
+  if (region === 'CONTENT') {
+    return {
+      begin: `${BEGIN} — edit scripts/generate-site-data.ts, then run npm run build:site -->`,
+      end: `${END} -->`,
+    };
   }
-  return page.slice(0, start + BEGIN.length) + '\n' + generated + '\n      ' + page.slice(end);
+  return { begin: `${BEGIN} ${region} -->`, end: `${END} ${region} -->` };
 }
 
-/** Compute the post-injection content of every generated page. */
+export function extractRegion(page: string, region: GeneratedRegion): string {
+  const { begin, end } = markerPair(region);
+  const start = page.indexOf(begin);
+  const endIdx = page.indexOf(end);
+  if (start === -1 || endIdx === -1 || endIdx < start) return '';
+  return page.slice(start + begin.length, endIdx).replace(/^\n/, '').replace(/\n\s*$/, '');
+}
+
+export function injectRegion(page: string, generated: string, region: GeneratedRegion): string {
+  const { begin, end } = markerPair(region);
+  const start = page.indexOf(begin);
+  const endIdx = page.indexOf(end);
+  if (start === -1 || endIdx === -1 || endIdx < start) {
+    throw new Error(`Missing or malformed GENERATED ${region} markers`);
+  }
+  const pad = region === 'CONTENT' ? '\n' : '\n';
+  const suffix = region === 'CONTENT' ? '\n      ' : '\n';
+  return page.slice(0, start + begin.length) + pad + generated + suffix + page.slice(endIdx);
+}
+
+function renderContentRegion(relPath: string): string | null {
+  if (relPath === 'api/tools.html') return renderToolsRegion();
+  if (relPath === 'api/schemas.html') return renderSchemasRegion();
+  return null;
+}
+
+function allHtmlRelPaths(): string[] {
+  return readdirSync(SITE_DIR, { recursive: true, encoding: 'utf-8' })
+    .filter(f => f.endsWith('.html'))
+    .map(f => f.replace(/\\/g, '/'));
+}
+
+/** Compute post-regeneration content for every site page that has generated markers. */
 export function renderSitePages(): Array<{ relPath: string; content: string }> {
-  return PAGES.map(({ relPath, render }) => {
+  const results: Array<{ relPath: string; content: string }> = [];
+  for (const relPath of allHtmlRelPaths()) {
     const pagePath = join(SITE_DIR, relPath);
-    const current = readFileSync(pagePath, 'utf-8');
-    return { relPath, content: injectRegion(current, render(), relPath) };
-  });
+    let content = readFileSync(pagePath, 'utf-8');
+    if (!content.includes('BEGIN GENERATED NAV')) continue;
+
+    content = injectRegion(content, renderSiteNav(relPath), 'NAV');
+    content = injectRegion(content, renderBreadcrumb(relPath), 'BREADCRUMB');
+    content = injectRegion(content, renderPagination(relPath), 'PAGINATION');
+
+    const body = renderContentRegion(relPath);
+    if (body !== null) {
+      content = injectRegion(content, body, 'CONTENT');
+    }
+    results.push({ relPath, content });
+  }
+  return results;
 }
 
 const isMain = process.argv[1] !== undefined && resolve(process.argv[1]) === resolve(import.meta.filename);

--- a/site/README.md
+++ b/site/README.md
@@ -1,7 +1,35 @@
 # Documentation site
 
-Hand-authored static HTML documentation for the workflow-server: semantic HTML pages, one shared stylesheet ([style.css](style.css)), and inline SVG diagrams. No site-generator toolchain.
+Hand-authored static HTML documentation for the workflow-server: semantic HTML pages, one shared stylesheet ([style.css](style.css)), and inline SVG diagrams. No client-side JavaScript.
 
-The markdown files in the repository (`README.md`, `SETUP.md`, `docs/`, `schemas/README.md`) are the **canonical documentation source**; the pages under `guide/`, `specs/`, and `api/` are the navigable, illustrated view over them and link back to their sources. Two sections go beyond the markdown: `internals/` documents the server implementation (its canonical source is the code in `src/`, which every page links to), and `design/` records design rationale distilled from the engineering branch's decision records. Open [index.html](index.html) directly in a browser to preview.
+The markdown files in the repository (`README.md`, `SETUP.md`, `docs/`, `schemas/README.md`) are the **canonical documentation source** for editing. The HTML site is the **browsable view** for reading: shorter prose, diagrams, and direct links to every page.
 
-How the whole documentation system fits together — every source's purpose and audience, and where new documentation belongs — is described in [docs/documentation-system.md](../docs/documentation-system.md).
+## Navigation
+
+Every page includes **generated global navigation** (Guide, Architecture, API, Internals, Design) produced by [`scripts/generate-site-data.ts`](../scripts/generate-site-data.ts). The route registry lives in that script as `SITE_ROUTES`. Run `npm run build:site` after adding a page or changing nav structure.
+
+Hand-authored regions sit outside `<!-- BEGIN GENERATED … -->` / `<!-- END GENERATED … -->` markers. Generated regions include:
+
+| Marker | Content |
+|--------|---------|
+| `GENERATED NAV` | Global documentation nav in the header |
+| `GENERATED BREADCRUMB` | Section breadcrumb below the header |
+| `GENERATED PAGINATION` | Previous/next links for sequenced pages |
+| `GENERATED` (content) | Tool and schema reference bodies on `api/tools.html` and `api/schemas.html` |
+
+`tests/site.test.ts` fails when generated regions drift. `npm run check:site` verifies internal links and anchors.
+
+## Linking policy
+
+- **Prefer on-site HTML** when a mirror page exists (`guide/`, `specs/`, `api/`, `internals/`, `design/`).
+- **Link to GitHub markdown** for editing source or for documents with no HTML mirror (for example `docs/development.md`, normative specifications).
+- Label GitHub targets as "(source)" or "edit source" where it helps readers choose the right destination.
+
+## Readability conventions
+
+- User-facing pages use short paragraphs (`.prose`, max ~65 characters per line).
+- Contributor-only pages use `.contributor-note` at the top.
+- Dense API and schema material uses native `<details>` for full descriptions and nested fields.
+- Tables and diagrams may use the full layout width.
+
+Open [index.html](index.html) directly in a browser to preview. How the whole documentation system fits together is described in [docs/documentation-system.md](../docs/documentation-system.md).

--- a/site/api/protocol.html
+++ b/site/api/protocol.html
@@ -13,17 +13,80 @@
 <header class="site-header">
   <div class="site-header__inner">
     <a class="site-title" href="../">Workflow Server</a>
-    <nav class="site-nav" aria-label="Site">
-      <ul>
+    <!-- BEGIN GENERATED NAV -->
+    <nav class="site-nav" aria-label="Documentation">
+      <ul class="site-nav__primary">
         <li><a href="../">Home</a></li>
-        <li><a href="./tools.html">Tools</a></li>
-        <li><a href="./schemas.html">Schemas</a></li>
-        <li><a href="./protocol.html" aria-current="page">Protocol</a></li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Guide</summary>
+            <ul>
+              <li><a href="../guide/getting-started.html">Getting started</a></li>
+              <li><a href="../guide/ide-setup.html">IDE setup</a></li>
+              <li><a href="../guide/concepts.html">Concepts</a></li>
+              <li><a href="../guide/running-workflows.html">Running workflows</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Architecture</summary>
+            <ul>
+              <li><a href="../specs/architecture.html">Overview</a></li>
+              <li><a href="../specs/dispatch.html">Dispatch</a></li>
+              <li><a href="../specs/checkpoints.html">Checkpoints</a></li>
+              <li><a href="../specs/state-management.html">State</a></li>
+              <li><a href="../specs/artifact-management.html">Artifacts</a></li>
+              <li><a href="../specs/resource-resolution.html">Resolution</a></li>
+              <li><a href="../specs/workflow-fidelity.html">Fidelity</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group" open>
+            <summary>API</summary>
+            <ul>
+              <li><a href="./tools.html">Tools</a></li>
+              <li><a href="./schemas.html">Schemas</a></li>
+              <li><a href="./protocol.html" aria-current="page">Protocol guide</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Internals</summary>
+            <ul>
+              <li><a href="../internals/server-anatomy.html">Server anatomy</a></li>
+              <li><a href="../internals/request-lifecycle.html">Request lifecycle</a></li>
+              <li><a href="../internals/session-store.html">Session store</a></li>
+              <li><a href="../internals/quality-system.html">Quality system</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Design</summary>
+            <ul>
+              <li><a href="../design/rationale.html">Design rationale</a></li>
+            </ul>
+          </details>
+        </li>
         <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
       </ul>
     </nav>
+<!-- END GENERATED NAV -->
   </div>
 </header>
+
+
+<!-- BEGIN GENERATED BREADCRUMB -->
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li>API</li>
+      <li aria-current="page">Protocol guide</li>
+    </ol>
+  </nav>
+<!-- END GENERATED BREADCRUMB -->
 
 <main id="main">
   <h1>The protocol in practice</h1>
@@ -130,6 +193,13 @@
   <h2 id="next">Next</h2>
   <p>Signatures for every tool are on the <a href="./tools.html">tool reference</a>; the server-side mechanics of a call are in <a href="../internals/request-lifecycle.html">the request lifecycle</a>.</p>
 </main>
+
+
+<!-- BEGIN GENERATED PAGINATION -->
+  <nav class="page-pagination" aria-label="Page sequence">
+    <a class="page-pagination__prev" href="./schemas.html">← Schemas</a>
+  </nav>
+<!-- END GENERATED PAGINATION -->
 
 <footer class="site-footer">
   <div class="site-footer__inner">

--- a/site/api/schemas.html
+++ b/site/api/schemas.html
@@ -13,17 +13,80 @@
 <header class="site-header">
   <div class="site-header__inner">
     <a class="site-title" href="../">Workflow Server</a>
-    <nav class="site-nav" aria-label="Site">
-      <ul>
+    <!-- BEGIN GENERATED NAV -->
+    <nav class="site-nav" aria-label="Documentation">
+      <ul class="site-nav__primary">
         <li><a href="../">Home</a></li>
-        <li><a href="./tools.html">Tools</a></li>
-        <li><a href="./schemas.html" aria-current="page">Schemas</a></li>
-        <li><a href="./protocol.html">Protocol</a></li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Guide</summary>
+            <ul>
+              <li><a href="../guide/getting-started.html">Getting started</a></li>
+              <li><a href="../guide/ide-setup.html">IDE setup</a></li>
+              <li><a href="../guide/concepts.html">Concepts</a></li>
+              <li><a href="../guide/running-workflows.html">Running workflows</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Architecture</summary>
+            <ul>
+              <li><a href="../specs/architecture.html">Overview</a></li>
+              <li><a href="../specs/dispatch.html">Dispatch</a></li>
+              <li><a href="../specs/checkpoints.html">Checkpoints</a></li>
+              <li><a href="../specs/state-management.html">State</a></li>
+              <li><a href="../specs/artifact-management.html">Artifacts</a></li>
+              <li><a href="../specs/resource-resolution.html">Resolution</a></li>
+              <li><a href="../specs/workflow-fidelity.html">Fidelity</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group" open>
+            <summary>API</summary>
+            <ul>
+              <li><a href="./tools.html">Tools</a></li>
+              <li><a href="./schemas.html" aria-current="page">Schemas</a></li>
+              <li><a href="./protocol.html">Protocol guide</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Internals</summary>
+            <ul>
+              <li><a href="../internals/server-anatomy.html">Server anatomy</a></li>
+              <li><a href="../internals/request-lifecycle.html">Request lifecycle</a></li>
+              <li><a href="../internals/session-store.html">Session store</a></li>
+              <li><a href="../internals/quality-system.html">Quality system</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Design</summary>
+            <ul>
+              <li><a href="../design/rationale.html">Design rationale</a></li>
+            </ul>
+          </details>
+        </li>
         <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
       </ul>
     </nav>
+<!-- END GENERATED NAV -->
   </div>
 </header>
+
+
+<!-- BEGIN GENERATED BREADCRUMB -->
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li>API</li>
+      <li aria-current="page">Schemas</li>
+    </ol>
+  </nav>
+<!-- END GENERATED BREADCRUMB -->
 
 <main id="main">
   <h1>Schema reference</h1>
@@ -33,8 +96,9 @@
       <!-- BEGIN GENERATED — edit scripts/generate-site-data.ts, then run npm run build:site -->
       <section class="schema" id="activity">
         <h2><code>activity.schema.json</code></h2>
-        <p>Activity definition schema — unified ordered, kind-tagged steps[] (technique | action | checkpoint | loop).</p>
-        <p><a href="https://github.com/m2ux/workflow-server/blob/main/schemas/activity.schema.json">Full schema on GitHub</a></p>
+        <p class="schema-summary">Activity definition schema — unified ordered, kind-tagged steps[] (technique | action | checkpoint | loop).</p>
+        <p><a href="https://github.com/m2ux/workflow-server/blob/main/schemas/activity.schema.json">Edit source on GitHub</a></p>
+        <p class="table-caption">Top-level fields</p>
         <div class="table-wrap">
         <table>
           <thead><tr><th scope="col">Field</th><th scope="col">Type</th><th scope="col">Required</th><th scope="col">Description</th></tr></thead>
@@ -47,18 +111,18 @@
           <tr><td><code>bundleTechniques</code></td><td><code>object</code></td><td>no</td><td>Opt-in hybrid bundling: get_activity inlines each ungated step technique whose composed wire form is at most maxChars; larger and gated ones remain lazy-fetched via get_technique. Bundled deliveries are recorded as technique_bundled history events and satisfy the manifest fidelity check.</td></tr>
           <tr><td><code>steps</code></td><td><code>(technique | action | checkpoint | loop)[]</code></td><td>no</td><td>Ordered, kind-tagged execution steps for this activity</td></tr>
           <tr><td><code>decisions</code></td><td><code>object[]</code></td><td>no</td><td>Conditional branching points; branch conditions are evaluated by the orchestrator, not the server.</td></tr>
-          <tr><td><code>decisions[].id</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>decisions[].name</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>decisions[].description</code></td><td><code>string</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>decisions[].branches</code></td><td><code>object[]</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>decisions[].branches[].id</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>decisions[].branches[].label</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>decisions[].branches[].condition</code></td><td><code>condition</code></td><td>no</td><td>—</td></tr>
+          <tr><td><code>decisions[].id</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>decisions[].name</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>decisions[].description</code></td><td><code>string</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>decisions[].branches</code></td><td><code>object[]</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>decisions[].branches[].id</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>decisions[].branches[].label</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>decisions[].branches[].condition</code></td><td><code>condition</code></td><td>no</td><td>-</td></tr>
           <tr><td><code>decisions[].branches[].transitionTo</code></td><td><code>string</code></td><td>no</td><td>Activity ID to transition to. Omit for terminal branches (workflow ends)</td></tr>
           <tr><td><code>decisions[].branches[].isDefault</code></td><td><code>boolean</code></td><td>no</td><td>Default: <code>false</code></td></tr>
           <tr><td><code>transitions</code></td><td><code>object[]</code></td><td>no</td><td>Navigation to other activities. Legality is validated warn-only at next_activity — an out-of-graph transition warns in _meta.validation but is not blocked.</td></tr>
           <tr><td><code>transitions[].to</code></td><td><code>string</code></td><td>yes</td><td>Activity ID to transition to</td></tr>
-          <tr><td><code>transitions[].condition</code></td><td><code>condition</code></td><td>no</td><td>—</td></tr>
+          <tr><td><code>transitions[].condition</code></td><td><code>condition</code></td><td>no</td><td>-</td></tr>
           <tr><td><code>transitions[].isDefault</code></td><td><code>boolean</code></td><td>no</td><td>Default: <code>false</code></td></tr>
           <tr><td><code>triggers</code></td><td><code>object[]</code></td><td>no</td><td>Workflows the orchestrator dispatches from this activity (via dispatch_child with an explicit workflow_id); the server does not act on trigger declarations.</td></tr>
           <tr><td><code>triggers[].workflow</code></td><td><code>string</code></td><td>yes</td><td>ID of the workflow to trigger</td></tr>
@@ -74,121 +138,124 @@
       </section>
       <section class="schema" id="condition">
         <h2><code>condition.schema.json</code></h2>
-        <p>Condition expression schema</p>
-        <p><a href="https://github.com/m2ux/workflow-server/blob/main/schemas/condition.schema.json">Full schema on GitHub</a></p>
+        <p class="schema-summary">Condition expression schema</p>
+        <p><a href="https://github.com/m2ux/workflow-server/blob/main/schemas/condition.schema.json">Edit source on GitHub</a></p>
         <p>One of 4 variants: <code>simple</code>, <code>and</code>, <code>or</code>, <code>not</code>.</p>
       </section>
       <section class="schema" id="session-file">
         <h2><code>session-file.schema.json</code></h2>
-        <p>Server-managed session file (session.json) — canonical session state owned by the workflow server.</p>
-        <p><a href="https://github.com/m2ux/workflow-server/blob/main/schemas/session-file.schema.json">Full schema on GitHub</a></p>
+        <p class="schema-summary">Server-managed session file (session.</p>
+        <p><a href="https://github.com/m2ux/workflow-server/blob/main/schemas/session-file.schema.json">Edit source on GitHub</a></p>
+        <p class="table-caption">Top-level fields</p>
         <div class="table-wrap">
         <table>
           <thead><tr><th scope="col">Field</th><th scope="col">Type</th><th scope="col">Required</th><th scope="col">Description</th></tr></thead>
           <tbody>
-          <tr><td><code>schemaVersion</code></td><td><code>1</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>sessionIndex</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>workflowId</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>workflowVersion</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>agentId</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>seq</code></td><td><code>integer</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>ts</code></td><td><code>integer</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>startedAt</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
+          <tr><td><code>schemaVersion</code></td><td><code>1</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>sessionIndex</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>workflowId</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>workflowVersion</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>agentId</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>seq</code></td><td><code>integer</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>ts</code></td><td><code>integer</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>startedAt</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
           <tr><td><code>currentActivity</code></td><td><code>string</code></td><td>no</td><td>Default: <code>&quot;&quot;</code></td></tr>
           <tr><td><code>currentTechnique</code></td><td><code>string</code></td><td>no</td><td>Default: <code>&quot;&quot;</code></td></tr>
           <tr><td><code>condition</code></td><td><code>string</code></td><td>no</td><td>Default: <code>&quot;&quot;</code></td></tr>
-          <tr><td><code>activeCheckpoint</code></td><td><code>object</code></td><td>no</td><td>—</td></tr>
+          <tr><td><code>activeCheckpoint</code></td><td><code>object</code></td><td>no</td><td>-</td></tr>
           <tr><td><code>variables</code></td><td><code>object</code></td><td>no</td><td>Default: <code>{}</code></td></tr>
           <tr><td><code>completedActivities</code></td><td><code>string[]</code></td><td>no</td><td>Default: <code>[]</code></td></tr>
           <tr><td><code>skippedActivities</code></td><td><code>string[]</code></td><td>no</td><td>Default: <code>[]</code></td></tr>
           <tr><td><code>checkpointResponses</code></td><td><code>object</code></td><td>no</td><td>Default: <code>{}</code></td></tr>
           <tr><td><code>history</code></td><td><code>object[]</code></td><td>no</td><td>Default: <code>[]</code></td></tr>
-          <tr><td><code>history[].timestamp</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>history[].type</code></td><td><code>&quot;workflow_started&quot; | &quot;workflow_completed&quot; | &quot;workflow_aborted&quot; | &quot;workflow_triggered&quot; | &quot;workflow_returned&quot; | &quot;workflow_suspended&quot; | &quot;activity_entered&quot; | &quot;activity_exited&quot; | &quot;activity_skipped&quot; | &quot;step_started&quot; | &quot;step_completed&quot; | &quot;checkpoint_reached&quot; | &quot;checkpoint_response&quot; | &quot;checkpoint_replayed&quot; | &quot;decision_reached&quot; | &quot;decision_branch_taken&quot; | &quot;loop_started&quot; | &quot;loop_iteration&quot; | &quot;loop_completed&quot; | &quot;loop_break&quot; | &quot;variable_set&quot; | &quot;error&quot; | &quot;technique_fetched&quot; | &quot;resource_fetched&quot; | &quot;technique_bundled&quot; | &quot;variables_seeded&quot;</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>history[].activity</code></td><td><code>string</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>history[].step</code></td><td><code>integer</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>history[].checkpoint</code></td><td><code>string</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>history[].decision</code></td><td><code>string</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>history[].loop</code></td><td><code>string</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>history[].data</code></td><td><code>object</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>history[].error</code></td><td><code>object</code></td><td>no</td><td>—</td></tr>
+          <tr><td><code>history[].timestamp</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>history[].type</code></td><td><code>&quot;workflow_started&quot; | &quot;workflow_completed&quot; | &quot;workflow_aborted&quot; | &quot;workflow_triggered&quot; | &quot;workflow_returned&quot; | &quot;workflow_suspended&quot; | &quot;activity_entered&quot; | &quot;activity_exited&quot; | &quot;activity_skipped&quot; | &quot;step_started&quot; | &quot;step_completed&quot; | &quot;checkpoint_reached&quot; | &quot;checkpoint_response&quot; | &quot;checkpoint_replayed&quot; | &quot;decision_reached&quot; | &quot;decision_branch_taken&quot; | &quot;loop_started&quot; | &quot;loop_iteration&quot; | &quot;loop_completed&quot; | &quot;loop_break&quot; | &quot;variable_set&quot; | &quot;error&quot; | &quot;technique_fetched&quot; | &quot;resource_fetched&quot; | &quot;technique_bundled&quot; | &quot;variables_seeded&quot;</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>history[].activity</code></td><td><code>string</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>history[].step</code></td><td><code>integer</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>history[].checkpoint</code></td><td><code>string</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>history[].decision</code></td><td><code>string</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>history[].loop</code></td><td><code>string</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>history[].data</code></td><td><code>object</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>history[].error</code></td><td><code>object</code></td><td>no</td><td>-</td></tr>
           <tr><td><code>status</code></td><td><code>&quot;running&quot; | &quot;completed&quot; | &quot;aborted&quot;</code></td><td>no</td><td>Default: <code>&quot;running&quot;</code></td></tr>
           <tr><td><code>triggeredWorkflows</code></td><td><code>object[]</code></td><td>no</td><td>Default: <code>[]</code></td></tr>
-          <tr><td><code>triggeredWorkflows[].workflowId</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>triggeredWorkflows[].sessionIndex</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>triggeredWorkflows[].triggeredAt</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>triggeredWorkflows[].triggeredFrom</code></td><td><code>object</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>triggeredWorkflows[].status</code></td><td><code>&quot;running&quot; | &quot;completed&quot; | &quot;aborted&quot; | &quot;error&quot;</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>triggeredWorkflows[].completedAt</code></td><td><code>string</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>triggeredWorkflows[].returnedContext</code></td><td><code>object</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>triggeredWorkflows[].state</code></td><td><code>session-file</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>planningFolderPath</code></td><td><code>string</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>contextMode</code></td><td><code>&quot;persistent&quot; | &quot;fresh&quot;</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>deliveredContent</code></td><td><code>object</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>parentSession</code></td><td><code>session-file</code></td><td>no</td><td>—</td></tr>
+          <tr><td><code>triggeredWorkflows[].workflowId</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>triggeredWorkflows[].sessionIndex</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>triggeredWorkflows[].triggeredAt</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>triggeredWorkflows[].triggeredFrom</code></td><td><code>object</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>triggeredWorkflows[].status</code></td><td><code>&quot;running&quot; | &quot;completed&quot; | &quot;aborted&quot; | &quot;error&quot;</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>triggeredWorkflows[].completedAt</code></td><td><code>string</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>triggeredWorkflows[].returnedContext</code></td><td><code>object</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>triggeredWorkflows[].state</code></td><td><code>session-file</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>planningFolderPath</code></td><td><code>string</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>contextMode</code></td><td><code>&quot;persistent&quot; | &quot;fresh&quot;</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>deliveredContent</code></td><td><code>object</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>parentSession</code></td><td><code>session-file</code></td><td>no</td><td>-</td></tr>
           </tbody>
         </table>
         </div>
       </section>
       <section class="schema" id="state">
         <h2><code>state.schema.json</code></h2>
-        <p>Workflow state schema</p>
-        <p><a href="https://github.com/m2ux/workflow-server/blob/main/schemas/state.schema.json">Full schema on GitHub</a></p>
+        <p class="schema-summary">Workflow state schema</p>
+        <p><a href="https://github.com/m2ux/workflow-server/blob/main/schemas/state.schema.json">Edit source on GitHub</a></p>
+        <p class="table-caption">Top-level fields</p>
         <div class="table-wrap">
         <table>
           <thead><tr><th scope="col">Field</th><th scope="col">Type</th><th scope="col">Required</th><th scope="col">Description</th></tr></thead>
           <tbody>
-          <tr><td><code>workflowId</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>workflowVersion</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
+          <tr><td><code>workflowId</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>workflowVersion</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
           <tr><td><code>stateVersion</code></td><td><code>integer</code></td><td>no</td><td>Default: <code>1</code></td></tr>
-          <tr><td><code>startedAt</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>updatedAt</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>completedAt</code></td><td><code>string</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>currentActivity</code></td><td><code>string</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>currentStep</code></td><td><code>integer</code></td><td>no</td><td>—</td></tr>
+          <tr><td><code>startedAt</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>updatedAt</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>completedAt</code></td><td><code>string</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>currentActivity</code></td><td><code>string</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>currentStep</code></td><td><code>integer</code></td><td>no</td><td>-</td></tr>
           <tr><td><code>completedActivities</code></td><td><code>string[]</code></td><td>no</td><td>Default: <code>[]</code></td></tr>
           <tr><td><code>skippedActivities</code></td><td><code>string[]</code></td><td>no</td><td>Default: <code>[]</code></td></tr>
           <tr><td><code>completedSteps</code></td><td><code>object</code></td><td>no</td><td>Default: <code>{}</code></td></tr>
           <tr><td><code>checkpointResponses</code></td><td><code>object</code></td><td>no</td><td>Default: <code>{}</code></td></tr>
           <tr><td><code>decisionOutcomes</code></td><td><code>object</code></td><td>no</td><td>Default: <code>{}</code></td></tr>
           <tr><td><code>activeLoops</code></td><td><code>object[]</code></td><td>no</td><td>Default: <code>[]</code></td></tr>
-          <tr><td><code>activeLoops[].activityId</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>activeLoops[].loopId</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>activeLoops[].currentIteration</code></td><td><code>integer</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>activeLoops[].totalItems</code></td><td><code>integer</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>activeLoops[].currentItem</code></td><td><code>any</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>activeLoops[].startedAt</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
+          <tr><td><code>activeLoops[].activityId</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>activeLoops[].loopId</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>activeLoops[].currentIteration</code></td><td><code>integer</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>activeLoops[].totalItems</code></td><td><code>integer</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>activeLoops[].currentItem</code></td><td><code>any</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>activeLoops[].startedAt</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
           <tr><td><code>variables</code></td><td><code>object</code></td><td>no</td><td>Default: <code>{}</code></td></tr>
           <tr><td><code>history</code></td><td><code>object[]</code></td><td>no</td><td>Default: <code>[]</code></td></tr>
-          <tr><td><code>history[].timestamp</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>history[].type</code></td><td><code>&quot;workflow_started&quot; | &quot;workflow_completed&quot; | &quot;workflow_aborted&quot; | &quot;workflow_triggered&quot; | &quot;workflow_returned&quot; | &quot;workflow_suspended&quot; | &quot;activity_entered&quot; | &quot;activity_exited&quot; | &quot;activity_skipped&quot; | &quot;step_started&quot; | &quot;step_completed&quot; | &quot;checkpoint_reached&quot; | &quot;checkpoint_response&quot; | &quot;checkpoint_replayed&quot; | &quot;decision_reached&quot; | &quot;decision_branch_taken&quot; | &quot;loop_started&quot; | &quot;loop_iteration&quot; | &quot;loop_completed&quot; | &quot;loop_break&quot; | &quot;variable_set&quot; | &quot;error&quot; | &quot;technique_fetched&quot; | &quot;resource_fetched&quot; | &quot;technique_bundled&quot; | &quot;variables_seeded&quot;</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>history[].activity</code></td><td><code>string</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>history[].step</code></td><td><code>integer</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>history[].checkpoint</code></td><td><code>string</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>history[].decision</code></td><td><code>string</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>history[].loop</code></td><td><code>string</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>history[].data</code></td><td><code>object</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>history[].error</code></td><td><code>object</code></td><td>no</td><td>—</td></tr>
+          <tr><td><code>history[].timestamp</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>history[].type</code></td><td><code>&quot;workflow_started&quot; | &quot;workflow_completed&quot; | &quot;workflow_aborted&quot; | &quot;workflow_triggered&quot; | &quot;workflow_returned&quot; | &quot;workflow_suspended&quot; | &quot;activity_entered&quot; | &quot;activity_exited&quot; | &quot;activity_skipped&quot; | &quot;step_started&quot; | &quot;step_completed&quot; | &quot;checkpoint_reached&quot; | &quot;checkpoint_response&quot; | &quot;checkpoint_replayed&quot; | &quot;decision_reached&quot; | &quot;decision_branch_taken&quot; | &quot;loop_started&quot; | &quot;loop_iteration&quot; | &quot;loop_completed&quot; | &quot;loop_break&quot; | &quot;variable_set&quot; | &quot;error&quot; | &quot;technique_fetched&quot; | &quot;resource_fetched&quot; | &quot;technique_bundled&quot; | &quot;variables_seeded&quot;</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>history[].activity</code></td><td><code>string</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>history[].step</code></td><td><code>integer</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>history[].checkpoint</code></td><td><code>string</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>history[].decision</code></td><td><code>string</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>history[].loop</code></td><td><code>string</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>history[].data</code></td><td><code>object</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>history[].error</code></td><td><code>object</code></td><td>no</td><td>-</td></tr>
           <tr><td><code>status</code></td><td><code>&quot;running&quot; | &quot;paused&quot; | &quot;suspended&quot; | &quot;completed&quot; | &quot;aborted&quot; | &quot;error&quot;</code></td><td>no</td><td>Default: <code>&quot;running&quot;</code></td></tr>
-          <tr><td><code>parentWorkflow</code></td><td><code>object</code></td><td>no</td><td>—</td></tr>
+          <tr><td><code>parentWorkflow</code></td><td><code>object</code></td><td>no</td><td>-</td></tr>
           <tr><td><code>triggeredWorkflows</code></td><td><code>object[]</code></td><td>no</td><td>Default: <code>[]</code></td></tr>
-          <tr><td><code>triggeredWorkflows[].workflowId</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>triggeredWorkflows[].planningSlug</code></td><td><code>string</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>triggeredWorkflows[].sessionIndex</code></td><td><code>string</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>triggeredWorkflows[].triggeredAt</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>triggeredWorkflows[].triggeredFrom</code></td><td><code>object</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>triggeredWorkflows[].status</code></td><td><code>&quot;running&quot; | &quot;completed&quot; | &quot;aborted&quot; | &quot;error&quot;</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>triggeredWorkflows[].completedAt</code></td><td><code>string</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>triggeredWorkflows[].returnedContext</code></td><td><code>object</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>lastError</code></td><td><code>object</code></td><td>no</td><td>—</td></tr>
+          <tr><td><code>triggeredWorkflows[].workflowId</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>triggeredWorkflows[].planningSlug</code></td><td><code>string</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>triggeredWorkflows[].sessionIndex</code></td><td><code>string</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>triggeredWorkflows[].triggeredAt</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>triggeredWorkflows[].triggeredFrom</code></td><td><code>object</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>triggeredWorkflows[].status</code></td><td><code>&quot;running&quot; | &quot;completed&quot; | &quot;aborted&quot; | &quot;error&quot;</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>triggeredWorkflows[].completedAt</code></td><td><code>string</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>triggeredWorkflows[].returnedContext</code></td><td><code>object</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>lastError</code></td><td><code>object</code></td><td>no</td><td>-</td></tr>
           </tbody>
         </table>
         </div>
       </section>
       <section class="schema" id="technique">
         <h2><code>technique.schema.json</code></h2>
-        <p>Technique definition schema for workflow-server</p>
-        <p><a href="https://github.com/m2ux/workflow-server/blob/main/schemas/technique.schema.json">Full schema on GitHub</a></p>
+        <p class="schema-summary">Technique definition schema for workflow-server</p>
+        <p><a href="https://github.com/m2ux/workflow-server/blob/main/schemas/technique.schema.json">Edit source on GitHub</a></p>
+        <p class="table-caption">Top-level fields</p>
         <div class="table-wrap">
         <table>
           <thead><tr><th scope="col">Field</th><th scope="col">Type</th><th scope="col">Required</th><th scope="col">Description</th></tr></thead>
@@ -197,37 +264,38 @@
           <tr><td><code>version</code></td><td><code>string</code></td><td>yes</td><td>Semantic version of the technique</td></tr>
           <tr><td><code>capability</code></td><td><code>string</code></td><td>yes</td><td>What this technique enables agents to do</td></tr>
           <tr><td><code>provenance_note</code></td><td><code>string</code></td><td>no</td><td>Delivery-only, server-populated on a step-bound get_technique: states the output delivery mechanics that the <code>source:</code>/<code>destination:</code> annotations rely on. Never authored in technique markdown.</td></tr>
-          <tr><td><code>rules</code></td><td><code>rulesDefinition</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>inputs</code></td><td><code>inputsDefinition</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>inherited_inputs</code></td><td><code>inheritedInputs</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>protocol</code></td><td><code>protocolDefinition</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>outputs</code></td><td><code>outputsDefinition</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>inherited_outputs</code></td><td><code>inheritedOutputs</code></td><td>no</td><td>—</td></tr>
+          <tr><td><code>rules</code></td><td><code>rulesDefinition</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>inputs</code></td><td><code>inputsDefinition</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>inherited_inputs</code></td><td><code>inheritedInputs</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>protocol</code></td><td><code>protocolDefinition</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>outputs</code></td><td><code>outputsDefinition</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>inherited_outputs</code></td><td><code>inheritedOutputs</code></td><td>no</td><td>-</td></tr>
           </tbody>
         </table>
         </div>
       </section>
       <section class="schema" id="workflow">
         <h2><code>workflow.schema.json</code></h2>
-        <p>Workflow definition schema</p>
-        <p><a href="https://github.com/m2ux/workflow-server/blob/main/schemas/workflow.schema.json">Full schema on GitHub</a></p>
+        <p class="schema-summary">Workflow definition schema</p>
+        <p><a href="https://github.com/m2ux/workflow-server/blob/main/schemas/workflow.schema.json">Edit source on GitHub</a></p>
+        <p class="table-caption">Top-level fields</p>
         <div class="table-wrap">
         <table>
           <thead><tr><th scope="col">Field</th><th scope="col">Type</th><th scope="col">Required</th><th scope="col">Description</th></tr></thead>
           <tbody>
-          <tr><td><code>$schema</code></td><td><code>string</code></td><td>no</td><td>—</td></tr>
+          <tr><td><code>$schema</code></td><td><code>string</code></td><td>no</td><td>-</td></tr>
           <tr><td><code>id</code></td><td><code>string</code></td><td>yes</td><td>Unique workflow identifier</td></tr>
           <tr><td><code>version</code></td><td><code>string</code></td><td>yes</td><td>Semantic version</td></tr>
           <tr><td><code>title</code></td><td><code>string</code></td><td>yes</td><td>Human-readable workflow title</td></tr>
           <tr><td><code>description</code></td><td><code>string</code></td><td>no</td><td>Detailed workflow description</td></tr>
           <tr><td><code>author</code></td><td><code>string</code></td><td>no</td><td>Author metadata; not read by the server.</td></tr>
-          <tr><td><code>tags</code></td><td><code>string[]</code></td><td>no</td><td>—</td></tr>
+          <tr><td><code>tags</code></td><td><code>string[]</code></td><td>no</td><td>-</td></tr>
           <tr><td><code>rules</code></td><td><code>object</code></td><td>no</td><td>Workflow rules partitioned by audience: <code>workflow</code> (orchestrator-only) and <code>activity</code> (inherited by every activity, injected into get_activity). Entries are rule strings or <code>{ ref }</code> references into <code>fragments.rules</code>.</td></tr>
           <tr><td><code>fragments</code></td><td><code>object</code></td><td>no</td><td>Shared rule texts and checkpoint bodies, declared once and imported by reference (<code>[workflow::]name</code>) from rules slots and kind:checkpoint steps — this workflow's or another's. Resolved at load; agents always receive materialized content.</td></tr>
           <tr><td><code>variables</code></td><td><code>object[]</code></td><td>no</td><td>Workflow-level variable declarations, rendered in get_workflow for agents. The session variable bag is seeded from each declaration's defaultValue at session creation; thereafter the server writes it only through checkpoint setVariable effects.</td></tr>
           <tr><td><code>variables[].name</code></td><td><code>string | &quot;requirements&quot; | &quot;features&quot; | &quot;exclusions&quot; | &quot;dimensions&quot; | &quot;tasks&quot; | &quot;results&quot; | &quot;submodules&quot; | &quot;paths&quot; | &quot;fields&quot; | &quot;filters&quot; | &quot;stats&quot; | &quot;effects&quot; | &quot;substitutions&quot; | &quot;findings&quot; | &quot;assumptions&quot; | &quot;subsystems&quot; | &quot;transitions&quot; | &quot;options&quot; | &quot;branches&quot; | &quot;agents&quot; | &quot;changes&quot; | &quot;failures&quot; | &quot;items&quot; | &quot;files&quot; | &quot;gaps&quot; | &quot;outcomes&quot; | &quot;body&quot; | &quot;query&quot; | &quot;repo&quot; | &quot;owner&quot; | &quot;number&quot; | &quot;title&quot; | &quot;branch&quot; | &quot;diff&quot; | &quot;limit&quot; | &quot;name&quot; | &quot;sha&quot; | &quot;url&quot; | &quot;head&quot; | &quot;base&quot; | &quot;ref&quot; | &quot;labels&quot; | &quot;path&quot; | &quot;cursor&quot; | &quot;cql&quot; | &quot;jql&quot; | &quot;description&quot; | &quot;assignee&quot; | &quot;depth&quot; | &quot;direction&quot; | &quot;summary&quot; | &quot;state&quot; | &quot;target&quot; | &quot;adr&quot; | &quot;type&quot; | &quot;mode&quot; | &quot;kind&quot;</code></td><td>yes</td><td>Qualified snake_case noun phrase (&gt;=2 words, AP-60), or an enumerated bare-word exemption.</td></tr>
           <tr><td><code>variables[].type</code></td><td><code>&quot;string&quot; | &quot;number&quot; | &quot;boolean&quot; | &quot;array&quot; | &quot;object&quot;</code></td><td>yes</td><td>Declared type. The server validates checkpoint setVariable values against it, warn-only: a mismatch is stored as written and surfaced in _meta.validation and on the variable_set history event. Agents honor it for their own writes.</td></tr>
-          <tr><td><code>variables[].description</code></td><td><code>string</code></td><td>no</td><td>—</td></tr>
+          <tr><td><code>variables[].description</code></td><td><code>string</code></td><td>no</td><td>-</td></tr>
           <tr><td><code>variables[].defaultValue</code></td><td><code>any</code></td><td>no</td><td>Initial value the server seeds into the session variable bag at session creation (start_session fresh sessions and dispatch_child children), recorded as one variables_seeded history event. Do not gate a defaulted variable with exists/notExists — seeding makes the gate constant (check:variable-model enforces this).</td></tr>
           <tr><td><code>variables[].required</code></td><td><code>boolean</code></td><td>no</td><td>Authoring metadata; the server does not check that the variable is ever set. Default: <code>false</code></td></tr>
           <tr><td><code>techniques</code></td><td><code>object</code></td><td>no</td><td>Workflow techniques partitioned by audience: <code>workflow</code> (orchestrator, bundled into get_workflow) and <code>activity</code> (inherited by every activity, injected into get_activity).</td></tr>
@@ -241,18 +309,18 @@
           <tr><td><code>activities[].bundleTechniques</code></td><td><code>object</code></td><td>no</td><td>Opt-in hybrid bundling: get_activity inlines each ungated step technique whose composed wire form is at most maxChars; larger and gated ones remain lazy-fetched via get_technique. Bundled deliveries are recorded as technique_bundled history events and satisfy the manifest fidelity check.</td></tr>
           <tr><td><code>activities[].steps</code></td><td><code>(technique | action | checkpoint | loop)[]</code></td><td>no</td><td>Ordered, kind-tagged execution steps for this activity</td></tr>
           <tr><td><code>activities[].decisions</code></td><td><code>object[]</code></td><td>no</td><td>Conditional branching points; branch conditions are evaluated by the orchestrator, not the server.</td></tr>
-          <tr><td><code>activities[].decisions[].id</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>activities[].decisions[].name</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>activities[].decisions[].description</code></td><td><code>string</code></td><td>no</td><td>—</td></tr>
-          <tr><td><code>activities[].decisions[].branches</code></td><td><code>object[]</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>activities[].decisions[].branches[].id</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>activities[].decisions[].branches[].label</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>activities[].decisions[].branches[].condition</code></td><td><code>condition</code></td><td>no</td><td>—</td></tr>
+          <tr><td><code>activities[].decisions[].id</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>activities[].decisions[].name</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>activities[].decisions[].description</code></td><td><code>string</code></td><td>no</td><td>-</td></tr>
+          <tr><td><code>activities[].decisions[].branches</code></td><td><code>object[]</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>activities[].decisions[].branches[].id</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>activities[].decisions[].branches[].label</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>activities[].decisions[].branches[].condition</code></td><td><code>condition</code></td><td>no</td><td>-</td></tr>
           <tr><td><code>activities[].decisions[].branches[].transitionTo</code></td><td><code>string</code></td><td>no</td><td>Activity ID to transition to. Omit for terminal branches (workflow ends)</td></tr>
           <tr><td><code>activities[].decisions[].branches[].isDefault</code></td><td><code>boolean</code></td><td>no</td><td>Default: <code>false</code></td></tr>
           <tr><td><code>activities[].transitions</code></td><td><code>object[]</code></td><td>no</td><td>Navigation to other activities. Legality is validated warn-only at next_activity — an out-of-graph transition warns in _meta.validation but is not blocked.</td></tr>
           <tr><td><code>activities[].transitions[].to</code></td><td><code>string</code></td><td>yes</td><td>Activity ID to transition to</td></tr>
-          <tr><td><code>activities[].transitions[].condition</code></td><td><code>condition</code></td><td>no</td><td>—</td></tr>
+          <tr><td><code>activities[].transitions[].condition</code></td><td><code>condition</code></td><td>no</td><td>-</td></tr>
           <tr><td><code>activities[].transitions[].isDefault</code></td><td><code>boolean</code></td><td>no</td><td>Default: <code>false</code></td></tr>
           <tr><td><code>activities[].triggers</code></td><td><code>object[]</code></td><td>no</td><td>Workflows the orchestrator dispatches from this activity (via dispatch_child with an explicit workflow_id); the server does not act on trigger declarations.</td></tr>
           <tr><td><code>activities[].triggers[].workflow</code></td><td><code>string</code></td><td>yes</td><td>ID of the workflow to trigger</td></tr>
@@ -268,6 +336,14 @@
       </section>
       <!-- END GENERATED -->
 </main>
+
+
+<!-- BEGIN GENERATED PAGINATION -->
+  <nav class="page-pagination" aria-label="Page sequence">
+    <a class="page-pagination__prev" href="./tools.html">← Tools</a>
+    <a class="page-pagination__next" href="./protocol.html">Protocol guide →</a>
+  </nav>
+<!-- END GENERATED PAGINATION -->
 
 <footer class="site-footer">
   <div class="site-footer__inner">

--- a/site/api/tools.html
+++ b/site/api/tools.html
@@ -13,17 +13,80 @@
 <header class="site-header">
   <div class="site-header__inner">
     <a class="site-title" href="../">Workflow Server</a>
-    <nav class="site-nav" aria-label="Site">
-      <ul>
+    <!-- BEGIN GENERATED NAV -->
+    <nav class="site-nav" aria-label="Documentation">
+      <ul class="site-nav__primary">
         <li><a href="../">Home</a></li>
-        <li><a href="./tools.html" aria-current="page">Tools</a></li>
-        <li><a href="./schemas.html">Schemas</a></li>
-        <li><a href="./protocol.html">Protocol</a></li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Guide</summary>
+            <ul>
+              <li><a href="../guide/getting-started.html">Getting started</a></li>
+              <li><a href="../guide/ide-setup.html">IDE setup</a></li>
+              <li><a href="../guide/concepts.html">Concepts</a></li>
+              <li><a href="../guide/running-workflows.html">Running workflows</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Architecture</summary>
+            <ul>
+              <li><a href="../specs/architecture.html">Overview</a></li>
+              <li><a href="../specs/dispatch.html">Dispatch</a></li>
+              <li><a href="../specs/checkpoints.html">Checkpoints</a></li>
+              <li><a href="../specs/state-management.html">State</a></li>
+              <li><a href="../specs/artifact-management.html">Artifacts</a></li>
+              <li><a href="../specs/resource-resolution.html">Resolution</a></li>
+              <li><a href="../specs/workflow-fidelity.html">Fidelity</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group" open>
+            <summary>API</summary>
+            <ul>
+              <li><a href="./tools.html" aria-current="page">Tools</a></li>
+              <li><a href="./schemas.html">Schemas</a></li>
+              <li><a href="./protocol.html">Protocol guide</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Internals</summary>
+            <ul>
+              <li><a href="../internals/server-anatomy.html">Server anatomy</a></li>
+              <li><a href="../internals/request-lifecycle.html">Request lifecycle</a></li>
+              <li><a href="../internals/session-store.html">Session store</a></li>
+              <li><a href="../internals/quality-system.html">Quality system</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Design</summary>
+            <ul>
+              <li><a href="../design/rationale.html">Design rationale</a></li>
+            </ul>
+          </details>
+        </li>
         <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
       </ul>
     </nav>
+<!-- END GENERATED NAV -->
   </div>
 </header>
+
+
+<!-- BEGIN GENERATED BREADCRUMB -->
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li>API</li>
+      <li aria-current="page">Tools</li>
+    </ol>
+  </nav>
+<!-- END GENERATED BREADCRUMB -->
 
 <main id="main">
   <h1>MCP tool reference</h1>
@@ -31,8 +94,8 @@
   <p>Conventions: most tools identify their session with a <code>session_index</code> — the 6-character token returned by <code>start_session</code>. Tools in the Bootstrap group work without one. The prose reference with usage guidance lives in <a href="https://github.com/m2ux/workflow-server/blob/main/docs/api-reference.md">docs/api-reference.md</a>.</p>
 
       <!-- BEGIN GENERATED — edit scripts/generate-site-data.ts, then run npm run build:site -->
-      <p>The server registers 16 MCP tools.</p>
-      <nav aria-label="Tools">
+      <p>The server registers 16 MCP tools. Each entry shows a short summary; expand for the full description and advanced parameters.</p>
+      <nav aria-label="Tools on this page">
       <ul>
         <li>Bootstrap: <a href="#discover"><code>discover</code></a>, <a href="#list_workflows"><code>list_workflows</code></a>, <a href="#health_check"><code>health_check</code></a></li>
         <li>Session: <a href="#start_session"><code>start_session</code></a>, <a href="#get_workflow_status"><code>get_workflow_status</code></a>, <a href="#dispatch_child"><code>dispatch_child</code></a></li>
@@ -46,24 +109,40 @@
       <p>Callable without a session_index.</p>
       <section class="tool" id="discover">
         <h3><code>discover</code></h3>
-        <p>Entry point for this server. Call this before any other tool to learn the bootstrap procedure for starting a session. Returns the server name, version, and the bootstrap guide explaining the full tool-calling sequence. Use list_workflows to discover available workflows. No parameters required and no session_index needed.</p>
+        <p class="tool-summary">Entry point for this server.</p>
+        <details class="tool-details">
+          <summary>Full description</summary>
+          <p>Entry point for this server. Call this before any other tool to learn the bootstrap procedure for starting a session. Returns the server name, version, and the bootstrap guide explaining the full tool-calling sequence. Use list_workflows to discover available workflows. No parameters required and no session_index needed.</p>
+        </details>
         <p class="no-params">No parameters.</p>
       </section>
       <section class="tool" id="list_workflows">
         <h3><code>list_workflows</code></h3>
-        <p>List all available workflow definitions with their ID, title, version, and tags. Use this when you need to discover or filter available workflows. Returns an array of workflow summaries with tag-based categorization. If any workflow definition fails to load (unreadable file or manifest missing id/title/version), the response is instead an object with <code>workflows</code> (the loadable entries) and <code>load_errors</code> (one entry per failed file). Does not require a session_index.</p>
+        <p class="tool-summary">List all available workflow definitions with their ID, title, version, and tags.</p>
+        <details class="tool-details">
+          <summary>Full description</summary>
+          <p>List all available workflow definitions with their ID, title, version, and tags. Use this when you need to discover or filter available workflows. Returns an array of workflow summaries with tag-based categorization. If any workflow definition fails to load (unreadable file or manifest missing id/title/version), the response is instead an object with <code>workflows</code> (the loadable entries) and <code>load_errors</code> (one entry per failed file). Does not require a session_index.</p>
+        </details>
         <p class="no-params">No parameters.</p>
       </section>
       <section class="tool" id="health_check">
         <h3><code>health_check</code></h3>
-        <p>Check server health and availability. Returns server status, name, version, number of available workflows, and uptime in seconds. Does not require a session_index. Use this to verify the server is running before starting a workflow.</p>
+        <p class="tool-summary">Check server health and availability.</p>
+        <details class="tool-details">
+          <summary>Full description</summary>
+          <p>Check server health and availability. Returns server status, name, version, number of available workflows, and uptime in seconds. Does not require a session_index. Use this to verify the server is running before starting a workflow.</p>
+        </details>
         <p class="no-params">No parameters.</p>
       </section>
       <h2>Session</h2>
       <p>Create, inspect, and extend workflow sessions.</p>
       <section class="tool" id="start_session">
         <h3><code>start_session</code></h3>
-        <p>Start or resume the TOP-LEVEL workflow session. Identifies the planning folder via <code>planning_folder</code> — an absolute path whose basename is the slug (e.g., <code>/home/user/repo/.engineering/artifacts/planning/2026-05-28-my-slug</code> → slug <code>2026-05-28-my-slug</code>). Only the basename is consumed; the path part is a hint and is otherwise ignored, so a stale or off-workspace path passed by the agent is harmless. The server always resolves the slug against its own workspace planning root. Returns a 6-character base32 <code>session_index</code> for the root session, plus basic workflow metadata, plus the canonical server-side <code>planning_folder_path</code> (the absolute path of the folder under THIS server's workspace) — the agent can pick up the current location from this response without doing any path math. Behaviour: if a folder for that slug already exists under the server's workspace planning root with <code>session.json</code>, the server resumes it (workflow_id taken from state — caller cannot rebrand a live session). Otherwise the folder is created (for non-meta workflows) or a transient tmp folder is used (for meta-bootstrap), and a fresh session is written with its variable bag seeded from the workflow's declared <code>defaultValue</code>s (recorded as a <code>variables_seeded</code> history event; resumes never re-seed). When <code>planning_folder</code> is omitted entirely, a fresh meta-bootstrap session is created in <code>os.tmpdir()</code> and a synthetic UUID slug is registered so subsequent <code>dispatch_child</code> calls can promote it. The full resolved absolute path is persisted as <code>planningFolderPath</code> inside session.json; on resume, if the folder has been renamed or moved within the planning root, the recorded value is silently overwritten with its current location. Other tools identify the session by <code>session_index</code> (returned here) — they do not need the path, because session.json carries it. Child workflows are not created through start_session — call <code>dispatch_child({ session_index, workflow_id })</code> from inside the parent session to append a child under <code>triggeredWorkflows[]</code> (embedded inline; the whole work-package tree lives in the top-level session.json). If the resolved folder contains legacy <code>workflow-state.json</code> + <code>.session-token</code> artefacts, the server migrates them in place. The agent_id parameter is stored on <code>session.json#agentId</code>, distinguishing orchestrator from worker calls in the trace.</p>
+        <p class="tool-summary">Start or resume the TOP-LEVEL workflow session.</p>
+        <details class="tool-details">
+          <summary>Full description</summary>
+          <p>Start or resume the TOP-LEVEL workflow session. Identifies the planning folder via <code>planning_folder</code> — an absolute path whose basename is the slug (e.g., <code>/home/user/repo/.engineering/artifacts/planning/2026-05-28-my-slug</code> → slug <code>2026-05-28-my-slug</code>). Only the basename is consumed; the path part is a hint and is otherwise ignored, so a stale or off-workspace path passed by the agent is harmless. The server always resolves the slug against its own workspace planning root. Returns a 6-character base32 <code>session_index</code> for the root session, plus basic workflow metadata, plus the canonical server-side <code>planning_folder_path</code> (the absolute path of the folder under THIS server's workspace) — the agent can pick up the current location from this response without doing any path math. Behaviour: if a folder for that slug already exists under the server's workspace planning root with <code>session.json</code>, the server resumes it (workflow_id taken from state — caller cannot rebrand a live session). Otherwise the folder is created (for non-meta workflows) or a transient tmp folder is used (for meta-bootstrap), and a fresh session is written with its variable bag seeded from the workflow's declared <code>defaultValue</code>s (recorded as a <code>variables_seeded</code> history event; resumes never re-seed). When <code>planning_folder</code> is omitted entirely, a fresh meta-bootstrap session is created in <code>os.tmpdir()</code> and a synthetic UUID slug is registered so subsequent <code>dispatch_child</code> calls can promote it. The full resolved absolute path is persisted as <code>planningFolderPath</code> inside session.json; on resume, if the folder has been renamed or moved within the planning root, the recorded value is silently overwritten with its current location. Other tools identify the session by <code>session_index</code> (returned here) — they do not need the path, because session.json carries it. Child workflows are not created through start_session — call <code>dispatch_child({ session_index, workflow_id })</code> from inside the parent session to append a child under <code>triggeredWorkflows[]</code> (embedded inline; the whole work-package tree lives in the top-level session.json). If the resolved folder contains legacy <code>workflow-state.json</code> + <code>.session-token</code> artefacts, the server migrates them in place. The agent_id parameter is stored on <code>session.json#agentId</code>, distinguishing orchestrator from worker calls in the trace.</p>
+        </details>
         <div class="table-wrap">
         <table>
           <thead><tr><th scope="col">Parameter</th><th scope="col">Type</th><th scope="col">Required</th><th scope="col">Description</th></tr></thead>
@@ -78,7 +157,11 @@
       </section>
       <section class="tool" id="get_workflow_status">
         <h3><code>get_workflow_status</code></h3>
-        <p>Check the status of a workflow session. Returns the session status (active/blocked/completed), current activity, completed activities trace, last checkpoint info, and parent context if nested. Requires a session_index.</p>
+        <p class="tool-summary">Check the status of a workflow session.</p>
+        <details class="tool-details">
+          <summary>Full description</summary>
+          <p>Check the status of a workflow session. Returns the session status (active/blocked/completed), current activity, completed activities trace, last checkpoint info, and parent context if nested. Requires a session_index.</p>
+        </details>
         <div class="table-wrap">
         <table>
           <thead><tr><th scope="col">Parameter</th><th scope="col">Type</th><th scope="col">Required</th><th scope="col">Description</th></tr></thead>
@@ -90,7 +173,11 @@
       </section>
       <section class="tool" id="dispatch_child">
         <h3><code>dispatch_child</code></h3>
-        <p>Dispatch a child workflow from the current session. Pass <code>session_index</code> of the parent (any depth) and <code>workflow_id</code> of the child workflow. The server appends a child entry under the parent's <code>triggeredWorkflows[]</code> with the child's full SessionFile embedded inline (the entire work-package tree lives in the top-level session.json). The child's variable bag is seeded from the CHILD workflow's own declared <code>defaultValue</code>s; the parent's bag is untouched. Returns the child's <code>session_index</code>, which the agent threads to subsequent authenticated tool calls operating on the child, plus the canonical <code>planning_folder_path</code> — the absolute path of the planning folder under THIS server's workspace (the <code>.engineering</code> root supplied at init). All work-package artifacts are written under that absolute path; the agent never composes the location relative to its CWD or the target component repo. Special case: when the parent is a transient orchestrator-bootstrap session (e.g. meta), the parent's state is promoted onto disk under a stable workspace planning folder before the child is embedded. The slug is taken from (in order): the optional <code>planning_slug</code> argument; the slug registered at start_session; a <code>YYYY-MM-DD-&lt;workflow-id&gt;</code> fallback. The parent's tmp folder is discarded post-promotion, but the parent's session_index is retained — the orchestrator can keep using its original index to authenticate subsequent calls (it resolves to the promoted folder for the lifetime of this server process). The on-disk shape matches the persistent-parent case — parent at the top of the file, child under <code>triggeredWorkflows[0].state</code>.</p>
+        <p class="tool-summary">Dispatch a child workflow from the current session.</p>
+        <details class="tool-details">
+          <summary>Full description</summary>
+          <p>Dispatch a child workflow from the current session. Pass <code>session_index</code> of the parent (any depth) and <code>workflow_id</code> of the child workflow. The server appends a child entry under the parent's <code>triggeredWorkflows[]</code> with the child's full SessionFile embedded inline (the entire work-package tree lives in the top-level session.json). The child's variable bag is seeded from the CHILD workflow's own declared <code>defaultValue</code>s; the parent's bag is untouched. Returns the child's <code>session_index</code>, which the agent threads to subsequent authenticated tool calls operating on the child, plus the canonical <code>planning_folder_path</code> — the absolute path of the planning folder under THIS server's workspace (the <code>.engineering</code> root supplied at init). All work-package artifacts are written under that absolute path; the agent never composes the location relative to its CWD or the target component repo. Special case: when the parent is a transient orchestrator-bootstrap session (e.g. meta), the parent's state is promoted onto disk under a stable workspace planning folder before the child is embedded. The slug is taken from (in order): the optional <code>planning_slug</code> argument; the slug registered at start_session; a <code>YYYY-MM-DD-&lt;workflow-id&gt;</code> fallback. The parent's tmp folder is discarded post-promotion, but the parent's session_index is retained — the orchestrator can keep using its original index to authenticate subsequent calls (it resolves to the promoted folder for the lifetime of this server process). The on-disk shape matches the persistent-parent case — parent at the top of the file, child under <code>triggeredWorkflows[0].state</code>.</p>
+        </details>
         <div class="table-wrap">
         <table>
           <thead><tr><th scope="col">Parameter</th><th scope="col">Type</th><th scope="col">Required</th><th scope="col">Description</th></tr></thead>
@@ -108,7 +195,11 @@
       <p>Load workflow structure and advance through activities.</p>
       <section class="tool" id="get_workflow">
         <h3><code>get_workflow</code></h3>
-        <p>Load the workflow definition for the current session. The response begins with the resolved orchestrator technique bundle, then a <code>---</code> separator, then lightweight workflow metadata: rules, variables, the initialActivity field (which activity to load first), and a stub list of all activities with their IDs and names. If any activity file failed to load (invalid or unparsable YAML), the response includes <code>activity_load_errors</code> listing each failed file with its error — those activities are absent from the activity list. Call this after start_session to learn the workflow structure — the initialActivity field in the response tells you which activity_id to pass to your first next_activity call. This is the only tool that provides initialActivity. The response also carries <code>planning_folder_path</code>: the canonical absolute planning folder for this session under THIS server's workspace <code>.engineering</code> root — bind it as the single artifact location and never recompose it relative to your CWD or the target component repo.</p>
+        <p class="tool-summary">Load the workflow definition for the current session.</p>
+        <details class="tool-details">
+          <summary>Full description</summary>
+          <p>Load the workflow definition for the current session. The response begins with the resolved orchestrator technique bundle, then a <code>---</code> separator, then lightweight workflow metadata: rules, variables, the initialActivity field (which activity to load first), and a stub list of all activities with their IDs and names. If any activity file failed to load (invalid or unparsable YAML), the response includes <code>activity_load_errors</code> listing each failed file with its error — those activities are absent from the activity list. Call this after start_session to learn the workflow structure — the initialActivity field in the response tells you which activity_id to pass to your first next_activity call. This is the only tool that provides initialActivity. The response also carries <code>planning_folder_path</code>: the canonical absolute planning folder for this session under THIS server's workspace <code>.engineering</code> root — bind it as the single artifact location and never recompose it relative to your CWD or the target component repo.</p>
+        </details>
         <div class="table-wrap">
         <table>
           <thead><tr><th scope="col">Parameter</th><th scope="col">Type</th><th scope="col">Required</th><th scope="col">Description</th></tr></thead>
@@ -120,7 +211,11 @@
       </section>
       <section class="tool" id="next_activity">
         <h3><code>next_activity</code></h3>
-        <p>Transition to the specified activity. This is the orchestrator's tool for advancing the workflow — it validates the transition, advances the session state on disk, and records the trace, but does NOT return the activity definition. After calling next_activity, the worker should call get_activity to load the complete activity definition including steps, checkpoints, transitions, and technique references. For the first call, use the initialActivity value from get_workflow. For subsequent calls, use the activity IDs from the transitions field of the current activity's response. Optionally include a step_manifest summarizing completed steps and a transition_condition to enable server-side validation. Manifest validation also cross-checks fidelity (warn-only): a manifested technique step with no technique_fetched event recorded during the activity (see get_technique) — and no technique_bundled event from a bundling activity's get_activity — draws a warning.</p>
+        <p class="tool-summary">Transition to the specified activity.</p>
+        <details class="tool-details">
+          <summary>Full description</summary>
+          <p>Transition to the specified activity. This is the orchestrator's tool for advancing the workflow — it validates the transition, advances the session state on disk, and records the trace, but does NOT return the activity definition. After calling next_activity, the worker should call get_activity to load the complete activity definition including steps, checkpoints, transitions, and technique references. For the first call, use the initialActivity value from get_workflow. For subsequent calls, use the activity IDs from the transitions field of the current activity's response. Optionally include a step_manifest summarizing completed steps and a transition_condition to enable server-side validation. Manifest validation also cross-checks fidelity (warn-only): a manifested technique step with no technique_fetched event recorded during the activity (see get_technique) — and no technique_bundled event from a bundling activity's get_activity — draws a warning.</p>
+        </details>
         <div class="table-wrap">
         <table>
           <thead><tr><th scope="col">Parameter</th><th scope="col">Type</th><th scope="col">Required</th><th scope="col">Description</th></tr></thead>
@@ -129,19 +224,38 @@
           <tr><td><code>activity_id</code></td><td><code>string</code></td><td>yes</td><td>Activity ID to transition to. For the first call, use initialActivity from get_workflow. For subsequent calls, use an activity ID from the transitions field of the current activity.</td></tr>
           <tr><td><code>transition_condition</code></td><td><code>string</code></td><td>no</td><td>The transition condition that led to this activity (from the transitions field of the previous activity). Enables server-side validation of condition-activity consistency.</td></tr>
           <tr><td><code>step_manifest</code></td><td><code>object[]</code></td><td>no</td><td>Array of completed-step entries from the previous activity, e.g. [{&quot;step_id&quot;:&quot;detect-review-mode&quot;,&quot;output&quot;:&quot;is_review_mode=false&quot;}]. Each entry has two string fields: step_id (the literal id from the activity's steps[] — note the field is step_id, not id) and output. output is a short summary of what the step produced; for a step with more than one declared output, report a JSON object keyed by output id, e.g. {&quot;step_id&quot;:&quot;resolve-reference&quot;,&quot;output&quot;:&quot;{\&quot;reference_path\&quot;:\&quot;lib/x\&quot;,\&quot;component_name\&quot;:\&quot;x\&quot;}&quot;}. Omit the parameter entirely when no steps ran; do not pass an empty array or empty string.</td></tr>
-          <tr><td><code>step_manifest[].step_id</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>step_manifest[].output</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
           <tr><td><code>activity_manifest</code></td><td><code>object[]</code></td><td>no</td><td>Activity completion manifest from the orchestrator. Reports the sequence of activities completed so far with outcomes and transition conditions.</td></tr>
-          <tr><td><code>activity_manifest[].activity_id</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>activity_manifest[].outcome</code></td><td><code>string</code></td><td>yes</td><td>—</td></tr>
-          <tr><td><code>activity_manifest[].transition_condition</code></td><td><code>string</code></td><td>no</td><td>—</td></tr>
           </tbody>
         </table>
         </div>
+        <details class="tool-details">
+          <summary>All parameters</summary>
+        <div class="table-wrap">
+        <table>
+          <thead><tr><th scope="col">Parameter</th><th scope="col">Type</th><th scope="col">Required</th><th scope="col">Description</th></tr></thead>
+          <tbody>
+          <tr><td><code>session_index</code></td><td><code>string</code></td><td>yes</td><td>REQUIRED. The 6-character session_index returned by start_session. The server resolves this index to a planning folder under .engineering/artifacts/planning/ and reads/writes session.json there. The index is stable across all tool calls in the session — there is no rotation discipline.</td></tr>
+          <tr><td><code>activity_id</code></td><td><code>string</code></td><td>yes</td><td>Activity ID to transition to. For the first call, use initialActivity from get_workflow. For subsequent calls, use an activity ID from the transitions field of the current activity.</td></tr>
+          <tr><td><code>transition_condition</code></td><td><code>string</code></td><td>no</td><td>The transition condition that led to this activity (from the transitions field of the previous activity). Enables server-side validation of condition-activity consistency.</td></tr>
+          <tr><td><code>step_manifest</code></td><td><code>object[]</code></td><td>no</td><td>Array of completed-step entries from the previous activity, e.g. [{&quot;step_id&quot;:&quot;detect-review-mode&quot;,&quot;output&quot;:&quot;is_review_mode=false&quot;}]. Each entry has two string fields: step_id (the literal id from the activity's steps[] — note the field is step_id, not id) and output. output is a short summary of what the step produced; for a step with more than one declared output, report a JSON object keyed by output id, e.g. {&quot;step_id&quot;:&quot;resolve-reference&quot;,&quot;output&quot;:&quot;{\&quot;reference_path\&quot;:\&quot;lib/x\&quot;,\&quot;component_name\&quot;:\&quot;x\&quot;}&quot;}. Omit the parameter entirely when no steps ran; do not pass an empty array or empty string.</td></tr>
+          <tr><td><code>step_manifest[].step_id</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>step_manifest[].output</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>activity_manifest</code></td><td><code>object[]</code></td><td>no</td><td>Activity completion manifest from the orchestrator. Reports the sequence of activities completed so far with outcomes and transition conditions.</td></tr>
+          <tr><td><code>activity_manifest[].activity_id</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>activity_manifest[].outcome</code></td><td><code>string</code></td><td>yes</td><td>-</td></tr>
+          <tr><td><code>activity_manifest[].transition_condition</code></td><td><code>string</code></td><td>no</td><td>-</td></tr>
+          </tbody>
+        </table>
+        </div>
+        </details>
       </section>
       <section class="tool" id="get_activity">
         <h3><code>get_activity</code></h3>
-        <p>Load the complete activity definition for the current activity in the session. This is the worker's tool for retrieving the full activity details after the orchestrator has called next_activity to transition. Returns the complete activity definition including all steps, checkpoints, transitions to subsequent activities, rules, and technique references — everything needed to execute the activity. The activity is determined from the session state on disk, so no activity_id parameter is needed. context_tokens is REQUIRED — the worker declares its own context window; the server derives an eager step-technique bundling budget from it (availability headroom × a token→char factor, both server config) and inlines the activity's ungated step-bound techniques that fit, in document order, under that budget. When reference delivery is active (session context_mode &quot;persistent&quot; or bundle: &quot;reference&quot;), inherited techniques/rules content already delivered to this session+agent arrives as short { delivery: &quot;unchanged&quot;, content_hash } markers instead of being repeated; bundle: &quot;full&quot; forces full delivery. Eligible ungated step-bound techniques are inlined corpus-wide under a step_techniques map (keyed by step id, each entry a discrete ▼ STEP block identical to a get_technique { step_id } fetch — engage those steps in order without refetching); gated steps and any technique that would overflow the derived budget (or a per-activity bundleTechniques.maxChars size cap; maxChars 0 opts the activity out) stay lazy and still require get_technique. Bundled deliveries are recorded as technique_bundled history events and count as fetch coverage for next_activity's manifest fidelity check.</p>
+        <p class="tool-summary">Load the complete activity definition for the current activity in the session.</p>
+        <details class="tool-details">
+          <summary>Full description</summary>
+          <p>Load the complete activity definition for the current activity in the session. This is the worker's tool for retrieving the full activity details after the orchestrator has called next_activity to transition. Returns the complete activity definition including all steps, checkpoints, transitions to subsequent activities, rules, and technique references — everything needed to execute the activity. The activity is determined from the session state on disk, so no activity_id parameter is needed. context_tokens is REQUIRED — the worker declares its own context window; the server derives an eager step-technique bundling budget from it (availability headroom × a token→char factor, both server config) and inlines the activity's ungated step-bound techniques that fit, in document order, under that budget. When reference delivery is active (session context_mode &quot;persistent&quot; or bundle: &quot;reference&quot;), inherited techniques/rules content already delivered to this session+agent arrives as short { delivery: &quot;unchanged&quot;, content_hash } markers instead of being repeated; bundle: &quot;full&quot; forces full delivery. Eligible ungated step-bound techniques are inlined corpus-wide under a step_techniques map (keyed by step id, each entry a discrete ▼ STEP block identical to a get_technique { step_id } fetch — engage those steps in order without refetching); gated steps and any technique that would overflow the derived budget (or a per-activity bundleTechniques.maxChars size cap; maxChars 0 opts the activity out) stay lazy and still require get_technique. Bundled deliveries are recorded as technique_bundled history events and count as fetch coverage for next_activity's manifest fidelity check.</p>
+        </details>
         <div class="table-wrap">
         <table>
           <thead><tr><th scope="col">Parameter</th><th scope="col">Type</th><th scope="col">Required</th><th scope="col">Description</th></tr></thead>
@@ -157,7 +271,11 @@
       <p>Yield to the orchestrator, present decisions to the user, and resume.</p>
       <section class="tool" id="yield_checkpoint">
         <h3><code>yield_checkpoint</code></h3>
-        <p>Yield execution to the orchestrator at a checkpoint. Call this tool when you encounter a checkpoint step during activity execution. It records the checkpoint as active in the session state and returns the session_index, which the worker yields back to the orchestrator via a &lt;checkpoint_yield&gt; block.</p>
+        <p class="tool-summary">Yield execution to the orchestrator at a checkpoint.</p>
+        <details class="tool-details">
+          <summary>Full description</summary>
+          <p>Yield execution to the orchestrator at a checkpoint. Call this tool when you encounter a checkpoint step during activity execution. It records the checkpoint as active in the session state and returns the session_index, which the worker yields back to the orchestrator via a &lt;checkpoint_yield&gt; block.</p>
+        </details>
         <div class="table-wrap">
         <table>
           <thead><tr><th scope="col">Parameter</th><th scope="col">Type</th><th scope="col">Required</th><th scope="col">Description</th></tr></thead>
@@ -170,7 +288,11 @@
       </section>
       <section class="tool" id="resume_checkpoint">
         <h3><code>resume_checkpoint</code></h3>
-        <p>Resume execution after the orchestrator resolves a checkpoint. Call this tool when the orchestrator resumes you with a checkpoint response. It verifies the checkpoint was resolved (no activeCheckpoint in state) and returns any variable updates you need to apply to your state.</p>
+        <p class="tool-summary">Resume execution after the orchestrator resolves a checkpoint.</p>
+        <details class="tool-details">
+          <summary>Full description</summary>
+          <p>Resume execution after the orchestrator resolves a checkpoint. Call this tool when the orchestrator resumes you with a checkpoint response. It verifies the checkpoint was resolved (no activeCheckpoint in state) and returns any variable updates you need to apply to your state.</p>
+        </details>
         <div class="table-wrap">
         <table>
           <thead><tr><th scope="col">Parameter</th><th scope="col">Type</th><th scope="col">Required</th><th scope="col">Description</th></tr></thead>
@@ -182,7 +304,11 @@
       </section>
       <section class="tool" id="present_checkpoint">
         <h3><code>present_checkpoint</code></h3>
-        <p>Load the full details of the currently-active checkpoint for the session. Returns the checkpoint definition including its message, user-facing options (with labels, descriptions, and effects like variable assignments), and any auto-advance configuration. Use this when you need to present a checkpoint interaction to the user based on a worker's yield. Reads the active checkpoint from state.activeCheckpoint — no separate checkpoint handle is needed.</p>
+        <p class="tool-summary">Load the full details of the currently-active checkpoint for the session.</p>
+        <details class="tool-details">
+          <summary>Full description</summary>
+          <p>Load the full details of the currently-active checkpoint for the session. Returns the checkpoint definition including its message, user-facing options (with labels, descriptions, and effects like variable assignments), and any auto-advance configuration. Use this when you need to present a checkpoint interaction to the user based on a worker's yield. Reads the active checkpoint from state.activeCheckpoint — no separate checkpoint handle is needed.</p>
+        </details>
         <div class="table-wrap">
         <table>
           <thead><tr><th scope="col">Parameter</th><th scope="col">Type</th><th scope="col">Required</th><th scope="col">Description</th></tr></thead>
@@ -194,7 +320,11 @@
       </section>
       <section class="tool" id="respond_checkpoint">
         <h3><code>respond_checkpoint</code></h3>
-        <p>Submit a checkpoint response to clear the active-checkpoint gate. *MUST* present the checkpoint to the user and wait for their input. Exactly one of option_id, auto_advance, or condition_not_met must be provided. option_id: the user's selected option (works for all checkpoint types, enforces minimum response time). auto_advance: use the checkpoint's defaultOption (only for checkpoints with autoAdvanceMs; the server enforces the full timer). condition_not_met: dismiss a conditional checkpoint whose condition evaluated to false (only valid when the checkpoint has a condition field). setVariable effects are validated against the declared variable type, warn-only: mismatches are stored as written and surfaced in _meta.validation. Reads the active checkpoint from state.activeCheckpoint — no separate checkpoint handle is needed.</p>
+        <p class="tool-summary">Submit a checkpoint response to clear the active-checkpoint gate.</p>
+        <details class="tool-details">
+          <summary>Full description</summary>
+          <p>Submit a checkpoint response to clear the active-checkpoint gate. *MUST* present the checkpoint to the user and wait for their input. Exactly one of option_id, auto_advance, or condition_not_met must be provided. option_id: the user's selected option (works for all checkpoint types, enforces minimum response time). auto_advance: use the checkpoint's defaultOption (only for checkpoints with autoAdvanceMs; the server enforces the full timer). condition_not_met: dismiss a conditional checkpoint whose condition evaluated to false (only valid when the checkpoint has a condition field). setVariable effects are validated against the declared variable type, warn-only: mismatches are stored as written and surfaced in _meta.validation. Reads the active checkpoint from state.activeCheckpoint — no separate checkpoint handle is needed.</p>
+        </details>
         <div class="table-wrap">
         <table>
           <thead><tr><th scope="col">Parameter</th><th scope="col">Type</th><th scope="col">Required</th><th scope="col">Description</th></tr></thead>
@@ -211,7 +341,11 @@
       <p>Fetch technique definitions and lazy-loaded reference material.</p>
       <section class="tool" id="get_technique">
         <h3><code>get_technique</code></h3>
-        <p>Load a single composed technique within the current workflow or activity. If called before next_activity (no current activity), it loads the workflow's first declared technique. During an activity, it resolves the technique reference from the activity definition; with step_id, it loads the technique assigned to that step; without step_id, the activity's first declared technique. The returned technique is fully COMPOSED: it inherits its workflow-root <code>techniques/TECHNIQUE.md</code> base contract recursively — never the meta root for a non-meta workflow. Contract-inherited inputs/outputs are delivered under marked <code>inherited_inputs</code>/<code>inherited_outputs</code> blocks (each with a scope note) distinct from the technique's own <code>inputs</code>/<code>outputs</code>; rules are merged; ancestor Initial/Final protocol blocks wrap the descendant protocol and the server renumbers. A step-bound fetch also annotates the binding seam: each of the technique's own inputs carries a <code>source:</code> (step-binding value, workflow variable, prior step output, declared default, or UNRESOLVED — the latter also a warn-only validation warning), inherited entries carry one only where it adds to their scope note (step-binding override or a producer positioned later in the workflow), each remapped output carries a <code>destination:</code>, and a <code>provenance_note</code> states the output delivery mechanics. Annotations are static — resolved from declarations and document order — so payloads are deterministic per corpus and step. Techniques are loaded one at a time. In a session with context_mode &quot;persistent&quot;, a refetch whose composed content is byte-identical to what this session+agent already received returns a short unchanged-reference ({ delivery: unchanged, content_hash }) instead of the full payload; pass full: true to force full content. Every fetch (either delivery path) is recorded in the session history as a technique_fetched event (resolved technique id, bound step_id when supplied, agent); next_activity's manifest validation reads these events and warns — advisory only — when a manifested technique step had no fetch during the activity.</p>
+        <p class="tool-summary">Load a single composed technique within the current workflow or activity.</p>
+        <details class="tool-details">
+          <summary>Full description</summary>
+          <p>Load a single composed technique within the current workflow or activity. If called before next_activity (no current activity), it loads the workflow's first declared technique. During an activity, it resolves the technique reference from the activity definition; with step_id, it loads the technique assigned to that step; without step_id, the activity's first declared technique. The returned technique is fully COMPOSED: it inherits its workflow-root <code>techniques/TECHNIQUE.md</code> base contract recursively — never the meta root for a non-meta workflow. Contract-inherited inputs/outputs are delivered under marked <code>inherited_inputs</code>/<code>inherited_outputs</code> blocks (each with a scope note) distinct from the technique's own <code>inputs</code>/<code>outputs</code>; rules are merged; ancestor Initial/Final protocol blocks wrap the descendant protocol and the server renumbers. A step-bound fetch also annotates the binding seam: each of the technique's own inputs carries a <code>source:</code> (step-binding value, workflow variable, prior step output, declared default, or UNRESOLVED — the latter also a warn-only validation warning), inherited entries carry one only where it adds to their scope note (step-binding override or a producer positioned later in the workflow), each remapped output carries a <code>destination:</code>, and a <code>provenance_note</code> states the output delivery mechanics. Annotations are static — resolved from declarations and document order — so payloads are deterministic per corpus and step. Techniques are loaded one at a time. In a session with context_mode &quot;persistent&quot;, a refetch whose composed content is byte-identical to what this session+agent already received returns a short unchanged-reference ({ delivery: unchanged, content_hash }) instead of the full payload; pass full: true to force full content. Every fetch (either delivery path) is recorded in the session history as a technique_fetched event (resolved technique id, bound step_id when supplied, agent); next_activity's manifest validation reads these events and warns — advisory only — when a manifested technique step had no fetch during the activity.</p>
+        </details>
         <div class="table-wrap">
         <table>
           <thead><tr><th scope="col">Parameter</th><th scope="col">Type</th><th scope="col">Required</th><th scope="col">Description</th></tr></thead>
@@ -225,7 +359,11 @@
       </section>
       <section class="tool" id="get_resource">
         <h3><code>get_resource</code></h3>
-        <p>Load a resource by its id, optionally narrowed to a single section. Use this to fetch resources referenced in technique content (e.g. a template hyperlinked from an Input/Output). The resource_id is a text-only slug — bare (e.g., &quot;review-mode&quot;) resolves within the session's workflow, or prefixed cross-workflow (e.g., &quot;meta/bootstrap-protocol&quot;) resolves from the named workflow. Append a <code>#section</code> anchor (GitHub-style heading slug, e.g. &quot;assumption-reconciliation#integration-with-assumptions-log&quot;) to return only that section and its body — used to fetch just the template a technique references without the whole file. Returns the resource content, id, and version. Each fetch is recorded in the session history as a resource_fetched event (observability only — no validation reads it).</p>
+        <p class="tool-summary">Load a resource by its id, optionally narrowed to a single section.</p>
+        <details class="tool-details">
+          <summary>Full description</summary>
+          <p>Load a resource by its id, optionally narrowed to a single section. Use this to fetch resources referenced in technique content (e.g. a template hyperlinked from an Input/Output). The resource_id is a text-only slug — bare (e.g., &quot;review-mode&quot;) resolves within the session's workflow, or prefixed cross-workflow (e.g., &quot;meta/bootstrap-protocol&quot;) resolves from the named workflow. Append a <code>#section</code> anchor (GitHub-style heading slug, e.g. &quot;assumption-reconciliation#integration-with-assumptions-log&quot;) to return only that section and its body — used to fetch just the template a technique references without the whole file. Returns the resource content, id, and version. Each fetch is recorded in the session history as a resource_fetched event (observability only — no validation reads it).</p>
+        </details>
         <div class="table-wrap">
         <table>
           <thead><tr><th scope="col">Parameter</th><th scope="col">Type</th><th scope="col">Required</th><th scope="col">Description</th></tr></thead>
@@ -240,7 +378,11 @@
       <p>Execution history for debugging and audit.</p>
       <section class="tool" id="get_trace">
         <h3><code>get_trace</code></h3>
-        <p>Retrieve the execution trace for the current workflow session. Accepts an optional array of trace_tokens accumulated from next_activity _meta.trace_token responses to reconstruct a specific trace segment. If no trace_tokens are provided, returns the full in-memory trace for the current session (requires server-side tracing to be enabled). Use this for debugging, auditing, or reviewing the sequence of tool calls made during the session.</p>
+        <p class="tool-summary">Retrieve the execution trace for the current workflow session.</p>
+        <details class="tool-details">
+          <summary>Full description</summary>
+          <p>Retrieve the execution trace for the current workflow session. Accepts an optional array of trace_tokens accumulated from next_activity _meta.trace_token responses to reconstruct a specific trace segment. If no trace_tokens are provided, returns the full in-memory trace for the current session (requires server-side tracing to be enabled). Use this for debugging, auditing, or reviewing the sequence of tool calls made during the session.</p>
+        </details>
         <div class="table-wrap">
         <table>
           <thead><tr><th scope="col">Parameter</th><th scope="col">Type</th><th scope="col">Required</th><th scope="col">Description</th></tr></thead>
@@ -253,6 +395,14 @@
       </section>
       <!-- END GENERATED -->
 </main>
+
+
+<!-- BEGIN GENERATED PAGINATION -->
+  <nav class="page-pagination" aria-label="Page sequence">
+    <span></span>
+    <a class="page-pagination__next" href="./schemas.html">Schemas →</a>
+  </nav>
+<!-- END GENERATED PAGINATION -->
 
 <footer class="site-footer">
   <div class="site-footer__inner">

--- a/site/design/rationale.html
+++ b/site/design/rationale.html
@@ -13,33 +13,99 @@
 <header class="site-header">
   <div class="site-header__inner">
     <a class="site-title" href="../">Workflow Server</a>
-    <nav class="site-nav" aria-label="Site">
-      <ul>
+    <!-- BEGIN GENERATED NAV -->
+    <nav class="site-nav" aria-label="Documentation">
+      <ul class="site-nav__primary">
         <li><a href="../">Home</a></li>
-        <li><a href="./rationale.html" aria-current="page">Design rationale</a></li>
-        <li><a href="../specs/architecture.html">Architecture</a></li>
-        <li><a href="../internals/server-anatomy.html">Internals</a></li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Guide</summary>
+            <ul>
+              <li><a href="../guide/getting-started.html">Getting started</a></li>
+              <li><a href="../guide/ide-setup.html">IDE setup</a></li>
+              <li><a href="../guide/concepts.html">Concepts</a></li>
+              <li><a href="../guide/running-workflows.html">Running workflows</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Architecture</summary>
+            <ul>
+              <li><a href="../specs/architecture.html">Overview</a></li>
+              <li><a href="../specs/dispatch.html">Dispatch</a></li>
+              <li><a href="../specs/checkpoints.html">Checkpoints</a></li>
+              <li><a href="../specs/state-management.html">State</a></li>
+              <li><a href="../specs/artifact-management.html">Artifacts</a></li>
+              <li><a href="../specs/resource-resolution.html">Resolution</a></li>
+              <li><a href="../specs/workflow-fidelity.html">Fidelity</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>API</summary>
+            <ul>
+              <li><a href="../api/tools.html">Tools</a></li>
+              <li><a href="../api/schemas.html">Schemas</a></li>
+              <li><a href="../api/protocol.html">Protocol guide</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Internals</summary>
+            <ul>
+              <li><a href="../internals/server-anatomy.html">Server anatomy</a></li>
+              <li><a href="../internals/request-lifecycle.html">Request lifecycle</a></li>
+              <li><a href="../internals/session-store.html">Session store</a></li>
+              <li><a href="../internals/quality-system.html">Quality system</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group" open>
+            <summary>Design</summary>
+            <ul>
+              <li><a href="./rationale.html" aria-current="page">Design rationale</a></li>
+            </ul>
+          </details>
+        </li>
         <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
       </ul>
     </nav>
+<!-- END GENERATED NAV -->
   </div>
 </header>
 
+
+<!-- BEGIN GENERATED BREADCRUMB -->
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li>Design</li>
+      <li aria-current="page">Design rationale</li>
+    </ol>
+  </nav>
+<!-- END GENERATED BREADCRUMB -->
+
 <main id="main">
   <h1>Design rationale</h1>
-  <p class="lede">The <a href="../specs/architecture.html">specifications</a> describe the system as it is; this page records <em>why</em> it is that way. Every position here traces to a real force — usually a failure mode observed while running agents against earlier versions — and most accept a visible cost in exchange.</p>
-  <p>The material is distilled from the project's architecture decision records and engineering history, which live on the engineering branch alongside the code. Where a decision is implemented, the internals pages show the mechanism.</p>
+  <p class="lede prose">The <a href="../specs/architecture.html">specifications</a> describe what the system does. This page explains why it is shaped that way.</p>
+  <p class="prose contributor-note">For contributors and architects. If you only need to run workflows, start with the <a href="../guide/concepts.html">user guide</a>.</p>
 
   <h2 id="state-ownership">Who holds the truth</h2>
 
   <h3 id="state">The server owns the state, not the agent</h3>
-  <p>Early designs had agents carry session state in opaque tokens and transcribe them between calls. That failed in the mundane way everything agent-transcribed eventually fails: tokens drifted, got truncated, or were reconstructed from memory. The recorded decision (ADR-0003, server-managed session state) moves the whole record into a <a href="../internals/session-store.html">sealed <code>session.json</code></a> the server alone writes, with agents holding only a six-character index. Authority and write capability now sit in the same place as the HMAC secret; a server restart is invisible because the disk, not the process, is the memory. The accepted costs: the server must be told its workspace at launch, and every authenticated call pays filesystem I/O.</p>
+  <p class="takeaway">Session truth lives in a sealed <code>session.json</code> on disk; agents hold only a short index.</p>
+  <p class="prose">Earlier designs had agents transcribe opaque tokens between calls. Tokens drifted, truncated, or were reconstructed from memory. ADR-0003 moved the record to <a href="../internals/session-store.html">server-managed session state</a>. Cost: the server needs a workspace at launch, and every authenticated call reads or writes disk.</p>
 
   <h3 id="integrity">Integrity, not security</h3>
-  <p>The cryptography invites overreading, so the threat model is worth stating plainly: the HMAC seals exist to detect <em>incoherence</em> — a corrupted file, a hand-edit, a restored backup, two writers racing — not to resist an adversary, who could simply delete the folder. Framing it honestly keeps the mechanism proportionate: one server key, cheap digests, hard failure on mismatch, and no pretence that a workspace file is a security boundary.</p>
+  <p class="takeaway">HMAC seals detect corruption and incoherence; they are not an adversary-proof security boundary.</p>
+  <p class="prose">The seals catch corrupted files, hand-edits, restored backups, and racing writers. One server key, cheap digests, hard failure on mismatch.</p>
 
   <h3 id="determinism">Determinism over model judgment</h3>
-  <p>Wherever a choice can be resolved from the definition and the state, the system resolves it mechanically: transitions evaluate first-matching-condition, artifact contracts are synthesized from technique outputs rather than restated, binding provenance is computed statically, and identical inputs produce byte-identical payloads. The reasoning is that model judgment is the scarce, expensive, variable ingredient — spending it on plumbing wastes it and makes runs unreproducible. Given the same definition and state, any conforming agent follows the same path; creativity is confined to the work itself.</p>
+  <p class="takeaway">Resolve plumbing mechanically; reserve model judgment for the actual work.</p>
+  <p class="prose">Transitions, artifact contracts, binding provenance, and delivery payloads are computed from definitions and state. Same inputs, same path.</p>
 
   <h2 id="agent-experience">How agents experience the system</h2>
 
@@ -77,6 +143,11 @@
   <h2 id="next">Next</h2>
   <p>See these decisions as running code in the <a href="../internals/server-anatomy.html">internals section</a>, or as guarantees in the <a href="../specs/architecture.html">architecture models</a>.</p>
 </main>
+
+
+<!-- BEGIN GENERATED PAGINATION -->
+
+<!-- END GENERATED PAGINATION -->
 
 <footer class="site-footer">
   <div class="site-footer__inner">

--- a/site/guide/concepts.html
+++ b/site/guide/concepts.html
@@ -13,22 +13,98 @@
 <header class="site-header">
   <div class="site-header__inner">
     <a class="site-title" href="../">Workflow Server</a>
-    <nav class="site-nav" aria-label="Site">
-      <ul>
+    <!-- BEGIN GENERATED NAV -->
+    <nav class="site-nav" aria-label="Documentation">
+      <ul class="site-nav__primary">
         <li><a href="../">Home</a></li>
-        <li><a href="./getting-started.html">Getting started</a></li>
-        <li><a href="./concepts.html" aria-current="page">Concepts</a></li>
-        <li><a href="./running-workflows.html">Running workflows</a></li>
-        <li><a href="./ide-setup.html">IDE setup</a></li>
+        <li>
+          <details class="site-nav__group" open>
+            <summary>Guide</summary>
+            <ul>
+              <li><a href="./getting-started.html">Getting started</a></li>
+              <li><a href="./ide-setup.html">IDE setup</a></li>
+              <li><a href="./concepts.html" aria-current="page">Concepts</a></li>
+              <li><a href="./running-workflows.html">Running workflows</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Architecture</summary>
+            <ul>
+              <li><a href="../specs/architecture.html">Overview</a></li>
+              <li><a href="../specs/dispatch.html">Dispatch</a></li>
+              <li><a href="../specs/checkpoints.html">Checkpoints</a></li>
+              <li><a href="../specs/state-management.html">State</a></li>
+              <li><a href="../specs/artifact-management.html">Artifacts</a></li>
+              <li><a href="../specs/resource-resolution.html">Resolution</a></li>
+              <li><a href="../specs/workflow-fidelity.html">Fidelity</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>API</summary>
+            <ul>
+              <li><a href="../api/tools.html">Tools</a></li>
+              <li><a href="../api/schemas.html">Schemas</a></li>
+              <li><a href="../api/protocol.html">Protocol guide</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Internals</summary>
+            <ul>
+              <li><a href="../internals/server-anatomy.html">Server anatomy</a></li>
+              <li><a href="../internals/request-lifecycle.html">Request lifecycle</a></li>
+              <li><a href="../internals/session-store.html">Session store</a></li>
+              <li><a href="../internals/quality-system.html">Quality system</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Design</summary>
+            <ul>
+              <li><a href="../design/rationale.html">Design rationale</a></li>
+            </ul>
+          </details>
+        </li>
         <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
       </ul>
     </nav>
+<!-- END GENERATED NAV -->
   </div>
 </header>
 
+
+<!-- BEGIN GENERATED BREADCRUMB -->
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li>Guide</li>
+      <li aria-current="page">Concepts</li>
+    </ol>
+  </nav>
+<!-- END GENERATED BREADCRUMB -->
+
 <main id="main">
   <h1>Concepts</h1>
-  <p class="lede">Five ideas explain the whole system: <strong>workflows</strong> define a process, <strong>activities</strong> are its phases, <strong>techniques</strong> describe how to do each piece of work, <strong>sessions</strong> track where you are, and <strong>checkpoints</strong> pause for your decisions. This page walks through each in plain language — the <a href="../#model">model diagram on the home page</a> shows how they chain from a user goal down to tool calls.</p>
+  <p class="lede prose">Five ideas explain the system: <strong>workflows</strong>, <strong>activities</strong>, <strong>techniques</strong>, <strong>sessions</strong>, and <strong>checkpoints</strong>. The <a href="../#model">model diagram on the home page</a> shows how they chain from a user goal down to tool calls.</p>
+
+  <h2 id="glossary">Terms at a glance</h2>
+  <div class="table-wrap">
+    <table>
+      <thead><tr><th scope="col">Term</th><th scope="col">Plain meaning</th></tr></thead>
+      <tbody>
+        <tr><td><strong>Work package</strong></td><td>A bundled workflow for planning and implementing one unit of work (for example a feature or issue). You start or resume it in natural language.</td></tr>
+        <tr><td><strong>MCP</strong></td><td>Model Context Protocol. How your IDE talks to the workflow-server process.</td></tr>
+        <tr><td><strong>Session</strong></td><td>One run of a workflow. State lives in your project's <code>.engineering/artifacts/planning/</code> folder.</td></tr>
+        <tr><td><strong>Checkpoint</strong></td><td>A deliberate pause where you approve, choose, or confirm before work continues.</td></tr>
+        <tr><td><strong>Technique</strong></td><td>A markdown document describing how to perform one capability.</td></tr>
+      </tbody>
+    </table>
+  </div>
 
   <h2 id="workflow-anatomy">What a workflow is made of</h2>
   <p>A workflow is a directory of declarative files, not code. The manifest names the workflow and its variables; each activity file defines one phase as an ordered list of steps; techniques are markdown documents describing a capability; and resources are reference material a technique can pull in when needed.</p>
@@ -127,17 +203,25 @@
   <h2 id="techniques">Techniques and resources</h2>
   <p>A technique is a markdown document that tells the agent how to perform one capability — its inputs, its protocol, its outputs. Steps bind techniques by reference, and the agent fetches each one just-in-time with <a href="../api/tools.html#get_technique"><code>get_technique</code></a> as it reaches the step, rather than receiving everything up front. When a technique points at longer reference material, the agent pulls it with <a href="../api/tools.html#get_resource"><code>get_resource</code></a> only if it actually needs it. This progressive disclosure keeps the agent's context small and focused on the current step.</p>
 
-  <h2 id="fidelity">Fidelity — why agents stay on script</h2>
-  <p>The server enforces the workflow rather than trusting the agent to follow it: transitions are validated against the definition, checkpoints gate advancement, and session state on disk is the single source of truth. What each layer protects against is described in <a href="https://github.com/m2ux/workflow-server/blob/main/docs/workflow-fidelity.md">workflow fidelity</a>; the six architecture models behind all of this are indexed from the <a href="https://github.com/m2ux/workflow-server/blob/main/docs/architecture.md">architecture overview</a>.</p>
+  <h2 id="fidelity">Fidelity: why agents stay on script</h2>
+  <p class="prose">The server enforces the workflow instead of trusting the agent to follow it. Transitions are validated, checkpoints gate advancement, and session state on disk is the single source of truth.</p>
+  <p class="prose">Read <a href="../specs/workflow-fidelity.html">workflow fidelity</a> for what each layer protects against, and <a href="../specs/architecture.html">architecture overview</a> for the six models behind it.</p>
 
   <h2 id="next">Next</h2>
-  <p><a href="./running-workflows.html">Run your first workflow</a> — what to say to the agent and what happens underneath.</p>
+  <p class="prose"><a href="./running-workflows.html">Run your first workflow</a> - what to say to the agent and what happens underneath.</p>
 </main>
+
+
+<!-- BEGIN GENERATED PAGINATION -->
+  <nav class="page-pagination" aria-label="Page sequence">
+    <a class="page-pagination__prev" href="./ide-setup.html">← IDE setup</a>
+    <a class="page-pagination__next" href="./running-workflows.html">Running workflows →</a>
+  </nav>
+<!-- END GENERATED PAGINATION -->
 
 <footer class="site-footer">
   <div class="site-footer__inner">
-    <span>Markdown in the <a href="https://github.com/m2ux/workflow-server">repository</a> is the canonical documentation source.</span>
-    <span><a href="https://github.com/m2ux/workflow-server/blob/main/LICENSE">MIT License</a></span>
+    <span>Source on <a href="https://github.com/m2ux/workflow-server">GitHub</a> · <a href="https://github.com/m2ux/workflow-server/blob/main/LICENSE">MIT License</a></span>
   </div>
 </footer>
 

--- a/site/guide/getting-started.html
+++ b/site/guide/getting-started.html
@@ -13,25 +13,87 @@
 <header class="site-header">
   <div class="site-header__inner">
     <a class="site-title" href="../">Workflow Server</a>
-    <nav class="site-nav" aria-label="Site">
-      <ul>
+    <!-- BEGIN GENERATED NAV -->
+    <nav class="site-nav" aria-label="Documentation">
+      <ul class="site-nav__primary">
         <li><a href="../">Home</a></li>
-        <li><a href="./getting-started.html" aria-current="page">Getting started</a></li>
-        <li><a href="./concepts.html">Concepts</a></li>
-        <li><a href="./running-workflows.html">Running workflows</a></li>
-        <li><a href="./ide-setup.html">IDE setup</a></li>
+        <li>
+          <details class="site-nav__group" open>
+            <summary>Guide</summary>
+            <ul>
+              <li><a href="./getting-started.html" aria-current="page">Getting started</a></li>
+              <li><a href="./ide-setup.html">IDE setup</a></li>
+              <li><a href="./concepts.html">Concepts</a></li>
+              <li><a href="./running-workflows.html">Running workflows</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Architecture</summary>
+            <ul>
+              <li><a href="../specs/architecture.html">Overview</a></li>
+              <li><a href="../specs/dispatch.html">Dispatch</a></li>
+              <li><a href="../specs/checkpoints.html">Checkpoints</a></li>
+              <li><a href="../specs/state-management.html">State</a></li>
+              <li><a href="../specs/artifact-management.html">Artifacts</a></li>
+              <li><a href="../specs/resource-resolution.html">Resolution</a></li>
+              <li><a href="../specs/workflow-fidelity.html">Fidelity</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>API</summary>
+            <ul>
+              <li><a href="../api/tools.html">Tools</a></li>
+              <li><a href="../api/schemas.html">Schemas</a></li>
+              <li><a href="../api/protocol.html">Protocol guide</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Internals</summary>
+            <ul>
+              <li><a href="../internals/server-anatomy.html">Server anatomy</a></li>
+              <li><a href="../internals/request-lifecycle.html">Request lifecycle</a></li>
+              <li><a href="../internals/session-store.html">Session store</a></li>
+              <li><a href="../internals/quality-system.html">Quality system</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Design</summary>
+            <ul>
+              <li><a href="../design/rationale.html">Design rationale</a></li>
+            </ul>
+          </details>
+        </li>
         <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
       </ul>
     </nav>
+<!-- END GENERATED NAV -->
   </div>
 </header>
 
+
+<!-- BEGIN GENERATED BREADCRUMB -->
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li>Guide</li>
+      <li aria-current="page">Getting started</li>
+    </ol>
+  </nav>
+<!-- END GENERATED BREADCRUMB -->
+
 <main id="main">
   <h1>Getting started</h1>
-  <p class="lede">This page takes you from a fresh clone to a working setup: the server built, your MCP client talking to it, and the agent able to list workflows. You need <strong>Node.js 18+</strong> and an MCP client (Cursor, Claude Desktop, Claude Code, or any compatible client).</p>
+  <p class="lede prose">Install the server, connect your MCP client, and verify the agent can list workflows. You need <strong>Node.js 18+</strong> and an MCP client (Cursor, Claude Desktop, Claude Code, or similar).</p>
 
   <h2 id="pieces">The pieces</h2>
-  <p>Three things work together. Your MCP client runs the server as a local process and talks to it over the Model Context Protocol. The server reads workflow definitions from a data directory, and it reads and writes session state inside the project you are working on.</p>
+  <p class="prose">Three parts work together: your MCP client, the workflow-server process, and your project's planning workspace.</p>
 
   <figure class="diagram">
     <svg viewBox="0 0 960 250" role="img" aria-labelledby="topo-title topo-desc">
@@ -81,7 +143,16 @@ git worktree add ./workflows workflows
 
 # Build the server
 npm run build</code></pre>
-  <p>The workflow definitions live on a separate <code>workflows</code> branch of the same repository, checked out as a worktree — server code and workflow data evolve independently.</p>
+  <p class="prose">The workflow definitions live on a separate <code>workflows</code> branch, checked out as a <strong>worktree</strong> (a second folder from the same repo). Server code and workflow data can evolve independently.</p>
+
+  <aside class="note prose" id="layout">
+    <strong>Repository layout (quick primer).</strong>
+    <ul>
+      <li><strong>Product repo</strong> - server code, docs, and schemas (what you cloned).</li>
+      <li><strong><code>workflows/</code> worktree</strong> - workflow definitions the server reads (<code>WORKFLOW_DIR</code>).</li>
+      <li><strong><code>.engineering/</code> in your project</strong> - planning folders and <code>session.json</code> for active runs.</li>
+    </ul>
+  </aside>
 
   <h2 id="configure">2. Configure your MCP client</h2>
   <p>Register the server in your client's MCP configuration. For Cursor this is <code>~/.cursor/mcp.json</code>; for Claude Desktop it is <code>claude_desktop_config.json</code> (macOS: <code>~/Library/Application Support/Claude/</code>, Windows: <code>%APPDATA%\Claude\</code>).</p>
@@ -118,17 +189,25 @@ npm run build</code></pre>
   <p>The agent should call <a href="../api/tools.html#list_workflows"><code>list_workflows</code></a> and return the workflow inventory. If it does, the connection works.</p>
 
   <h2 id="next">Next steps</h2>
-  <ul>
-    <li><a href="./ide-setup.html">Set up the IDE bootstrap rule</a> so natural-language workflow requests reach the server reliably.</li>
-    <li><a href="./concepts.html">Learn the concepts</a> — workflows, activities, techniques, sessions, and checkpoints.</li>
-    <li>Deploying the engineering-branch pattern into your own project (the <code>.engineering/</code> folder) is covered in <a href="https://github.com/m2ux/workflow-server/blob/main/SETUP.md">SETUP.md</a>.</li>
+  <ul class="prose">
+    <li><a href="./ide-setup.html">Set up the IDE bootstrap rule</a> so workflow requests reach the server reliably.</li>
+    <li><a href="./concepts.html">Learn the concepts</a>: workflows, activities, techniques, sessions, and checkpoints.</li>
+    <li><a href="./running-workflows.html">Run your first workflow</a> with natural-language requests.</li>
+    <li>Deploying the <code>.engineering/</code> pattern into your own project is covered in <a href="https://github.com/m2ux/workflow-server/blob/main/SETUP.md">SETUP.md (source)</a>.</li>
   </ul>
 </main>
 
+
+<!-- BEGIN GENERATED PAGINATION -->
+  <nav class="page-pagination" aria-label="Page sequence">
+    <span></span>
+    <a class="page-pagination__next" href="./ide-setup.html">IDE setup →</a>
+  </nav>
+<!-- END GENERATED PAGINATION -->
+
 <footer class="site-footer">
   <div class="site-footer__inner">
-    <span>Markdown in the <a href="https://github.com/m2ux/workflow-server">repository</a> is the canonical documentation source.</span>
-    <span><a href="https://github.com/m2ux/workflow-server/blob/main/LICENSE">MIT License</a></span>
+    <span>Source on <a href="https://github.com/m2ux/workflow-server">GitHub</a> · <a href="https://github.com/m2ux/workflow-server/blob/main/LICENSE">MIT License</a></span>
   </div>
 </footer>
 

--- a/site/guide/ide-setup.html
+++ b/site/guide/ide-setup.html
@@ -13,29 +13,91 @@
 <header class="site-header">
   <div class="site-header__inner">
     <a class="site-title" href="../">Workflow Server</a>
-    <nav class="site-nav" aria-label="Site">
-      <ul>
+    <!-- BEGIN GENERATED NAV -->
+    <nav class="site-nav" aria-label="Documentation">
+      <ul class="site-nav__primary">
         <li><a href="../">Home</a></li>
-        <li><a href="./getting-started.html">Getting started</a></li>
-        <li><a href="./concepts.html">Concepts</a></li>
-        <li><a href="./running-workflows.html">Running workflows</a></li>
-        <li><a href="./ide-setup.html" aria-current="page">IDE setup</a></li>
+        <li>
+          <details class="site-nav__group" open>
+            <summary>Guide</summary>
+            <ul>
+              <li><a href="./getting-started.html">Getting started</a></li>
+              <li><a href="./ide-setup.html" aria-current="page">IDE setup</a></li>
+              <li><a href="./concepts.html">Concepts</a></li>
+              <li><a href="./running-workflows.html">Running workflows</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Architecture</summary>
+            <ul>
+              <li><a href="../specs/architecture.html">Overview</a></li>
+              <li><a href="../specs/dispatch.html">Dispatch</a></li>
+              <li><a href="../specs/checkpoints.html">Checkpoints</a></li>
+              <li><a href="../specs/state-management.html">State</a></li>
+              <li><a href="../specs/artifact-management.html">Artifacts</a></li>
+              <li><a href="../specs/resource-resolution.html">Resolution</a></li>
+              <li><a href="../specs/workflow-fidelity.html">Fidelity</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>API</summary>
+            <ul>
+              <li><a href="../api/tools.html">Tools</a></li>
+              <li><a href="../api/schemas.html">Schemas</a></li>
+              <li><a href="../api/protocol.html">Protocol guide</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Internals</summary>
+            <ul>
+              <li><a href="../internals/server-anatomy.html">Server anatomy</a></li>
+              <li><a href="../internals/request-lifecycle.html">Request lifecycle</a></li>
+              <li><a href="../internals/session-store.html">Session store</a></li>
+              <li><a href="../internals/quality-system.html">Quality system</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Design</summary>
+            <ul>
+              <li><a href="../design/rationale.html">Design rationale</a></li>
+            </ul>
+          </details>
+        </li>
         <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
       </ul>
     </nav>
+<!-- END GENERATED NAV -->
   </div>
 </header>
 
+
+<!-- BEGIN GENERATED BREADCRUMB -->
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li>Guide</li>
+      <li aria-current="page">IDE setup</li>
+    </ol>
+  </nav>
+<!-- END GENERATED BREADCRUMB -->
+
 <main id="main">
   <h1>IDE setup</h1>
-  <p class="lede">One always-applied rule connects your IDE's agent to the server. It doesn't encode any protocol — it just makes the agent call <code>discover</code> first, and the server takes it from there.</p>
+  <p class="lede prose">One always-applied rule connects your IDE agent to the server. It does not encode the full protocol; it makes the agent call <code>discover</code> first, and the server returns the current bootstrap procedure.</p>
 
   <h2 id="rule">The bootstrap rule</h2>
   <p>Add this to your IDE's "always-applied" rule set (a Cursor rule, a Claude Code project rule, or the equivalent in your client):</p>
   <pre><code>For any start workflow, create work package, or resume work package request, call the `discover` tool on the workflow-server MCP server to learn the bootstrap procedure. Complete the procedure before any other action.
 
 If the user provides a `session_token`, pass it to subsequent workflow-server calls per their instructions.</code></pre>
-  <p>The rule wires natural-language requests — "start a work package", "resume the workflow" — into the server's bootstrap procedure. Because the agent always asks the server first, the procedure stays in sync with whatever server version is running; there is no protocol copy in your IDE rules to go stale.</p>
+  <p class="prose">The rule wires natural-language requests ("start a work package", "resume the workflow") into the server's bootstrap procedure. Because the agent always asks the server first, the procedure stays in sync with the running server version.</p>
 
   <h2 id="discover">What <code>discover</code> returns</h2>
   <ul>
@@ -56,10 +118,17 @@ If the user provides a `session_token`, pass it to subsequent workflow-server ca
   <p>If the agent skips <code>discover</code>, the rule has not been picked up — re-check your IDE's rule configuration.</p>
 </main>
 
+
+<!-- BEGIN GENERATED PAGINATION -->
+  <nav class="page-pagination" aria-label="Page sequence">
+    <a class="page-pagination__prev" href="./getting-started.html">← Getting started</a>
+    <a class="page-pagination__next" href="./concepts.html">Concepts →</a>
+  </nav>
+<!-- END GENERATED PAGINATION -->
+
 <footer class="site-footer">
   <div class="site-footer__inner">
-    <span>Markdown in the <a href="https://github.com/m2ux/workflow-server">repository</a> is the canonical documentation source.</span>
-    <span><a href="https://github.com/m2ux/workflow-server/blob/main/LICENSE">MIT License</a></span>
+    <span>Source on <a href="https://github.com/m2ux/workflow-server">GitHub</a> · <a href="https://github.com/m2ux/workflow-server/blob/main/LICENSE">MIT License</a></span>
   </div>
 </footer>
 

--- a/site/guide/running-workflows.html
+++ b/site/guide/running-workflows.html
@@ -13,22 +13,85 @@
 <header class="site-header">
   <div class="site-header__inner">
     <a class="site-title" href="../">Workflow Server</a>
-    <nav class="site-nav" aria-label="Site">
-      <ul>
+    <!-- BEGIN GENERATED NAV -->
+    <nav class="site-nav" aria-label="Documentation">
+      <ul class="site-nav__primary">
         <li><a href="../">Home</a></li>
-        <li><a href="./getting-started.html">Getting started</a></li>
-        <li><a href="./concepts.html">Concepts</a></li>
-        <li><a href="./running-workflows.html" aria-current="page">Running workflows</a></li>
-        <li><a href="./ide-setup.html">IDE setup</a></li>
+        <li>
+          <details class="site-nav__group" open>
+            <summary>Guide</summary>
+            <ul>
+              <li><a href="./getting-started.html">Getting started</a></li>
+              <li><a href="./ide-setup.html">IDE setup</a></li>
+              <li><a href="./concepts.html">Concepts</a></li>
+              <li><a href="./running-workflows.html" aria-current="page">Running workflows</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Architecture</summary>
+            <ul>
+              <li><a href="../specs/architecture.html">Overview</a></li>
+              <li><a href="../specs/dispatch.html">Dispatch</a></li>
+              <li><a href="../specs/checkpoints.html">Checkpoints</a></li>
+              <li><a href="../specs/state-management.html">State</a></li>
+              <li><a href="../specs/artifact-management.html">Artifacts</a></li>
+              <li><a href="../specs/resource-resolution.html">Resolution</a></li>
+              <li><a href="../specs/workflow-fidelity.html">Fidelity</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>API</summary>
+            <ul>
+              <li><a href="../api/tools.html">Tools</a></li>
+              <li><a href="../api/schemas.html">Schemas</a></li>
+              <li><a href="../api/protocol.html">Protocol guide</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Internals</summary>
+            <ul>
+              <li><a href="../internals/server-anatomy.html">Server anatomy</a></li>
+              <li><a href="../internals/request-lifecycle.html">Request lifecycle</a></li>
+              <li><a href="../internals/session-store.html">Session store</a></li>
+              <li><a href="../internals/quality-system.html">Quality system</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Design</summary>
+            <ul>
+              <li><a href="../design/rationale.html">Design rationale</a></li>
+            </ul>
+          </details>
+        </li>
         <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
       </ul>
     </nav>
+<!-- END GENERATED NAV -->
   </div>
 </header>
 
+
+<!-- BEGIN GENERATED BREADCRUMB -->
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li>Guide</li>
+      <li aria-current="page">Running workflows</li>
+    </ol>
+  </nav>
+<!-- END GENERATED BREADCRUMB -->
+
 <main id="main">
   <h1>Running workflows</h1>
-  <p class="lede">You drive workflows in natural language — no tool names, no tokens to copy. Describe what you want; the agent matches your request to a workflow, runs it phase by phase, and comes back to you at every checkpoint.</p>
+  <p class="lede prose">Drive workflows in natural language. No tool names, no tokens to copy. Describe what you want; the agent matches your request, runs phases, and returns at every checkpoint.</p>
+  <p class="prose note">A <strong>work package</strong> is the bundled workflow for planning and implementing one unit of work (for example a feature or issue).</p>
 
   <h2 id="requests">What to say</h2>
   <p><strong>Start</strong> a workflow by naming the goal:</p>
@@ -78,7 +141,7 @@
     <figcaption>A session timeline. Activities run in sequence; checkpoints (rounded) pause the run for your decision, and your choice can change which activities follow. Real workflows have more activities and more checkpoints than this sketch.</figcaption>
   </figure>
 
-  <p>Underneath, the agent follows the server's bootstrap procedure — <code>discover</code>, then <a href="../api/tools.html#start_session"><code>start_session</code></a>, <a href="../api/tools.html#get_workflow"><code>get_workflow</code></a>, and the <a href="../api/tools.html#next_activity"><code>next_activity</code></a> → <a href="../api/tools.html#get_activity"><code>get_activity</code></a> loop shown on the <a href="../#how-it-works">home page</a>. You never manage this sequence yourself; the <a href="./ide-setup.html">IDE bootstrap rule</a> makes sure it happens.</p>
+  <p class="prose">Underneath, the agent follows the server's bootstrap procedure. You never manage this sequence; the <a href="./ide-setup.html">IDE bootstrap rule</a> routes workflow requests to the server. Tool-level detail: <a href="../api/tools.html">MCP tool reference</a> and the <a href="../#how-it-works">home page overview</a>.</p>
 
   <h2 id="checkpoint-etiquette">At a checkpoint</h2>
   <p>When the run reaches a checkpoint, the agent presents the decision with its options and waits. Answer it like any question — pick an option, or give the custom input it asks for. The server enforces the pause: the workflow cannot advance until a response is recorded, and checkpoints with an auto-advance default still respect the server-enforced timer before proceeding.</p>
@@ -87,13 +150,19 @@
   <p>Each session owns a planning folder under your project's <code>.engineering/artifacts/planning/&lt;date-slug&gt;/</code>. Workflow artifacts — plans, analyses, review notes — are written there, alongside the <code>session.json</code> the server uses to track state. The folder name is the handle for resuming: "resume the authentication work package" finds the matching slug and continues that session.</p>
 
   <h2 id="next">Next</h2>
-  <p>If the agent isn't picking these requests up, work through <a href="./ide-setup.html">IDE setup</a> — the always-applied rule is what routes workflow requests to the server.</p>
+  <p class="prose">If the agent is not picking up workflow requests, work through <a href="./ide-setup.html">IDE setup</a> first.</p>
 </main>
+
+
+<!-- BEGIN GENERATED PAGINATION -->
+  <nav class="page-pagination" aria-label="Page sequence">
+    <a class="page-pagination__prev" href="./concepts.html">← Concepts</a>
+  </nav>
+<!-- END GENERATED PAGINATION -->
 
 <footer class="site-footer">
   <div class="site-footer__inner">
-    <span>Markdown in the <a href="https://github.com/m2ux/workflow-server">repository</a> is the canonical documentation source.</span>
-    <span><a href="https://github.com/m2ux/workflow-server/blob/main/LICENSE">MIT License</a></span>
+    <span>Source on <a href="https://github.com/m2ux/workflow-server">GitHub</a> · <a href="https://github.com/m2ux/workflow-server/blob/main/LICENSE">MIT License</a></span>
   </div>
 </footer>
 

--- a/site/index.html
+++ b/site/index.html
@@ -13,22 +13,81 @@
 <header class="site-header">
   <div class="site-header__inner">
     <a class="site-title" href="./">Workflow Server</a>
-    <nav class="site-nav" aria-label="Site">
-      <ul>
-        <li><a href="#how-it-works">How it works</a></li>
-        <li><a href="#documentation">Documentation</a></li>
-        <li><a href="#docs-map">Finding a document</a></li>
+    <!-- BEGIN GENERATED NAV -->
+    <nav class="site-nav" aria-label="Documentation">
+      <ul class="site-nav__primary">
+        <li><a href="./" aria-current="page">Home</a></li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Guide</summary>
+            <ul>
+              <li><a href="./guide/getting-started.html">Getting started</a></li>
+              <li><a href="./guide/ide-setup.html">IDE setup</a></li>
+              <li><a href="./guide/concepts.html">Concepts</a></li>
+              <li><a href="./guide/running-workflows.html">Running workflows</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Architecture</summary>
+            <ul>
+              <li><a href="./specs/architecture.html">Overview</a></li>
+              <li><a href="./specs/dispatch.html">Dispatch</a></li>
+              <li><a href="./specs/checkpoints.html">Checkpoints</a></li>
+              <li><a href="./specs/state-management.html">State</a></li>
+              <li><a href="./specs/artifact-management.html">Artifacts</a></li>
+              <li><a href="./specs/resource-resolution.html">Resolution</a></li>
+              <li><a href="./specs/workflow-fidelity.html">Fidelity</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>API</summary>
+            <ul>
+              <li><a href="./api/tools.html">Tools</a></li>
+              <li><a href="./api/schemas.html">Schemas</a></li>
+              <li><a href="./api/protocol.html">Protocol guide</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Internals</summary>
+            <ul>
+              <li><a href="./internals/server-anatomy.html">Server anatomy</a></li>
+              <li><a href="./internals/request-lifecycle.html">Request lifecycle</a></li>
+              <li><a href="./internals/session-store.html">Session store</a></li>
+              <li><a href="./internals/quality-system.html">Quality system</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Design</summary>
+            <ul>
+              <li><a href="./design/rationale.html">Design rationale</a></li>
+            </ul>
+          </details>
+        </li>
         <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
       </ul>
     </nav>
+<!-- END GENERATED NAV -->
   </div>
 </header>
+
+
+<!-- BEGIN GENERATED BREADCRUMB -->
+
+<!-- END GENERATED BREADCRUMB -->
 
 <main id="main">
 
   <section class="hero">
     <h1>Structured workflows for AI agents</h1>
-    <p class="lede">Workflow Server is a <a href="https://modelcontextprotocol.io/">Model Context Protocol (MCP)</a> server that guides AI agents through structured, multi-step workflows. You describe a goal in natural language; the server gives the agent a defined process to follow — with checkpoints where you stay in control of the decisions that matter.</p>
+    <p class="lede">Workflow Server is an <a href="https://modelcontextprotocol.io/">MCP</a> server that guides agents through multi-step workflows. You describe a goal in plain language; the agent follows a defined process and pauses at checkpoints when your decision matters.</p>
     <ul class="pill-row" aria-label="Project facts">
       <li class="pill">MCP compatible</li>
       <li class="pill">TypeScript · Node.js 18+</li>
@@ -78,15 +137,55 @@
     </figure>
   </section>
 
+  <section id="start-here" aria-labelledby="start-here-h">
+    <h2 id="start-here-h">Start here</h2>
+    <p class="prose">Pick the path that matches what you need. Every link below goes to a page on this site.</p>
+    <ul class="card-grid card-grid--personas">
+      <li class="card">
+        <p class="audience-badge">Use workflows</p>
+        <h3>Run work in your IDE</h3>
+        <p>Install the server, wire up your MCP client, and drive workflows in natural language.</p>
+        <span class="card-cta"><a href="guide/getting-started.html">Getting started</a> · <a href="guide/ide-setup.html">IDE setup</a> · <a href="guide/running-workflows.html">Running workflows</a></span>
+      </li>
+      <li class="card">
+        <p class="audience-badge">Understand the system</p>
+        <h3>Learn how it works</h3>
+        <p>Core concepts, architecture models, API reference, and design rationale.</p>
+        <span class="card-cta"><a href="guide/concepts.html">Concepts</a> · <a href="specs/architecture.html">Architecture</a> · <a href="api/tools.html">Tools</a></span>
+      </li>
+      <li class="card">
+        <p class="audience-badge">Contribute</p>
+        <h3>Work on the server</h3>
+        <p>Module map, request lifecycle, session store, and the guard-and-test system.</p>
+        <span class="card-cta"><a href="internals/server-anatomy.html">Server anatomy</a> · <a href="internals/quality-system.html">Quality system</a> · <a href="https://github.com/m2ux/workflow-server/blob/main/docs/development.md">Development guide</a></span>
+      </li>
+    </ul>
+    <p class="prose note">Recommended guide order: <a href="guide/getting-started.html">Getting started</a> → <a href="guide/ide-setup.html">IDE setup</a> → <a href="guide/concepts.html">Concepts</a> → <a href="guide/running-workflows.html">Running workflows</a>.</p>
+  </section>
+
   <section id="how-it-works" aria-labelledby="how-it-works-h">
     <h2 id="how-it-works-h">How it works</h2>
-    <p>A single always-applied <a href="https://github.com/m2ux/workflow-server/blob/main/docs/ide-setup.md">IDE rule</a> bootstraps the agent. From there, the server handles workflow discovery, session management, and step-by-step navigation:</p>
+
+    <h3>For users</h3>
+    <p class="prose">You speak in natural language. The agent matches your request to a workflow, works through its phases, and stops at checkpoints when you need to decide something. You never manage tool names or session tokens yourself.</p>
     <ol class="steps">
-      <li><strong>Discover.</strong> The agent calls <code>discover</code> to learn the available workflows and the bootstrap procedure.</li>
-      <li><strong>Start a session.</strong> <code>start_session</code> returns a session token, and <code>get_workflow</code> returns the workflow structure, its workflow-level techniques and rules, and the first activity.</li>
-      <li><strong>Navigate.</strong> <code>next_activity</code> advances the session; <code>get_activity</code> returns the activity's full definition — steps, checkpoints, transitions — with its bundled techniques. <code>get_resource</code> lazy-loads reference material.</li>
-      <li><strong>Execute.</strong> The agent works through the activities, pausing at checkpoints for your decisions, with transitions governing the flow between activities.</li>
+      <li><strong>Install and connect.</strong> Build the server and register it with your MCP client. See <a href="guide/getting-started.html">Getting started</a>.</li>
+      <li><strong>Add the IDE rule.</strong> One always-applied rule makes the agent call <code>discover</code> first. See <a href="guide/ide-setup.html">IDE setup</a>.</li>
+      <li><strong>Run or resume.</strong> Say "start a work package" or "resume the workflow." See <a href="guide/running-workflows.html">Running workflows</a>.</li>
+      <li><strong>Answer checkpoints.</strong> When the run pauses, pick an option. The workflow cannot advance until you respond.</li>
     </ol>
+
+    <details class="implementer-panel">
+      <summary>For agent implementers: the tool loop</summary>
+      <p class="prose">Under the hood, the agent follows a bootstrap procedure returned by <code>discover</code>. You do not call these tools yourself; the IDE rule routes workflow requests here.</p>
+      <ol class="steps">
+        <li><strong>Discover.</strong> <code>discover</code> returns available workflows and the bootstrap sequence.</li>
+        <li><strong>Start a session.</strong> <code>start_session</code> and <code>get_workflow</code> open a run and load the workflow structure.</li>
+        <li><strong>Navigate.</strong> <code>next_activity</code> and <code>get_activity</code> advance through phases. <code>get_resource</code> loads reference material on demand.</li>
+        <li><strong>Execute.</strong> The agent works each activity, yielding at checkpoints until the workflow completes.</li>
+      </ol>
+      <p class="prose">Full signatures: <a href="api/tools.html">MCP tool reference</a>. Call ordering and errors: <a href="api/protocol.html">Protocol guide</a>.</p>
+    </details>
 
     <figure class="diagram">
       <svg viewBox="0 0 960 215" role="img" aria-labelledby="session-title session-desc">
@@ -127,38 +226,38 @@
   </section>
 
   <section id="documentation" aria-labelledby="documentation-h">
-    <h2 id="documentation-h">Documentation</h2>
-    <p>The markdown files in the repository are the canonical documentation source; this site is the navigable, illustrated view over them, extended with two sections derived from the server source and the project's decision records. Five sections cover the material:</p>
+    <h2 id="documentation-h">All documentation</h2>
+    <p class="prose">This site is the browsable, illustrated view. Markdown in the <a href="https://github.com/m2ux/workflow-server">repository</a> is what you edit when you change the docs.</p>
     <ul class="card-grid">
       <li class="card">
         <h3>User guide</h3>
-        <p>Install the server, register it with an MCP client (Cursor, Claude Desktop, and others), set up the IDE bootstrap rule, and run your first workflow with natural-language requests.</p>
-        <span class="card-cta"><a href="guide/getting-started.html">Getting started</a> · <a href="guide/concepts.html">Concepts</a> · <a href="guide/running-workflows.html">Running workflows</a> · <a href="guide/ide-setup.html">IDE setup</a></span>
+        <p>Install, configure, and run workflows.</p>
+        <span class="card-cta"><a href="guide/getting-started.html">Getting started</a> · <a href="guide/ide-setup.html">IDE setup</a> · <a href="guide/concepts.html">Concepts</a> · <a href="guide/running-workflows.html">Running workflows</a></span>
       </li>
       <li class="card">
-        <h3>Technical specifications</h3>
-        <p>The six architecture models — hierarchical dispatch, just-in-time checkpoints, state management and deterministic transitions, artifact and workspace isolation, technique and resource resolution, and workflow fidelity.</p>
-        <span class="card-cta"><a href="specs/architecture.html">Architecture overview</a></span>
+        <h3>Architecture</h3>
+        <p>Six models that describe how the server enforces workflows.</p>
+        <span class="card-cta"><a href="specs/architecture.html">Overview</a> · <a href="specs/dispatch.html">Dispatch</a> · <a href="specs/checkpoints.html">Checkpoints</a> · <a href="specs/state-management.html">State</a> · <a href="specs/artifact-management.html">Artifacts</a> · <a href="specs/resource-resolution.html">Resolution</a> · <a href="specs/workflow-fidelity.html">Fidelity</a></span>
       </li>
       <li class="card">
-        <h3>API usage</h3>
-        <p>Full signatures for the 16 MCP tools, the JSON schemas that define workflows, activities, and techniques, and the protocol in practice — call ordering, errors, warnings, traces, and delivery.</p>
-        <span class="card-cta"><a href="api/tools.html">Tool reference</a> · <a href="api/schemas.html">Schema reference</a> · <a href="api/protocol.html">Protocol in practice</a></span>
+        <h3>API</h3>
+        <p>Tool signatures, JSON schemas, and protocol guidance.</p>
+        <span class="card-cta"><a href="api/tools.html">Tools</a> · <a href="api/schemas.html">Schemas</a> · <a href="api/protocol.html">Protocol guide</a></span>
       </li>
       <li class="card">
         <h3>Server internals</h3>
-        <p>The implementation view for contributors: how the code is organized, what happens inside one tool call, how session state stays trustworthy on disk, and the guard-and-test system the repository runs on itself.</p>
+        <p>Implementation view for contributors.</p>
         <span class="card-cta"><a href="internals/server-anatomy.html">Server anatomy</a> · <a href="internals/request-lifecycle.html">Request lifecycle</a> · <a href="internals/session-store.html">Session store</a> · <a href="internals/quality-system.html">Quality system</a></span>
       </li>
       <li class="card">
         <h3>Design rationale</h3>
-        <p>Why the system is shaped the way it is: server-owned state, determinism over model judgment, progressive disclosure, detection over prevention — the forces behind each decision, and the costs accepted.</p>
+        <p>Why the system is shaped the way it is.</p>
         <span class="card-cta"><a href="design/rationale.html">Design rationale</a></span>
       </li>
     </ul>
 
     <h3>MCP tools at a glance</h3>
-    <p>The server registers 16 MCP tools across six concerns:</p>
+    <p class="prose">Six concern groups; details in the <a href="api/tools.html">tool reference</a>.</p>
     <div class="table-wrap">
       <table>
         <thead>
@@ -177,26 +276,29 @@
   </section>
 
   <section id="docs-map" aria-labelledby="docs-map-h">
-    <h2 id="docs-map-h">Finding a document</h2>
-    <p>Every document has a defined purpose. Start from your question:</p>
+    <h2 id="docs-map-h">Where to start</h2>
+    <p class="prose">Match your question to a page. Site links are for reading; GitHub links are for editing source or docs with no HTML mirror.</p>
     <div class="table-wrap">
       <table>
         <thead>
           <tr><th scope="col">Your question</th><th scope="col">Read this</th></tr>
         </thead>
         <tbody>
-          <tr><td>What is this project and how do I get started?</td><td><a href="https://github.com/m2ux/workflow-server/blob/main/README.md">README</a></td></tr>
-          <tr><td>How do I install the server and wire it into my IDE or MCP client?</td><td><a href="https://github.com/m2ux/workflow-server/blob/main/SETUP.md">SETUP</a> and <a href="https://github.com/m2ux/workflow-server/blob/main/docs/ide-setup.md">IDE setup</a></td></tr>
-          <tr><td>What tools does the server expose, and with what signatures?</td><td><a href="https://github.com/m2ux/workflow-server/blob/main/docs/api-reference.md">API reference</a></td></tr>
-          <tr><td>How do I author or validate a workflow definition?</td><td><a href="https://github.com/m2ux/workflow-server/blob/main/schemas/README.md">Schema guide</a></td></tr>
-          <tr><td>How is the system designed?</td><td><a href="https://github.com/m2ux/workflow-server/blob/main/docs/architecture.md">Architecture overview</a>, which links each of the six model documents</td></tr>
-          <tr><td>Why is it designed this way?</td><td><a href="design/rationale.html">Design rationale</a> on this site, distilled from the project's decision records</td></tr>
-          <tr><td>How is the server implemented?</td><td>The <a href="internals/server-anatomy.html">server internals</a> section on this site, derived from the source</td></tr>
-          <tr><td>What do the server's errors and warnings mean in practice?</td><td><a href="api/protocol.html">The protocol in practice</a></td></tr>
-          <tr><td>What keeps an agent faithful to a workflow?</td><td><a href="https://github.com/m2ux/workflow-server/blob/main/docs/workflow-fidelity.md">Workflow fidelity</a></td></tr>
-          <tr><td>How do techniques declare their protocol and bindings?</td><td><a href="https://github.com/m2ux/workflow-server/blob/main/docs/technique-protocol-specification.md">Technique protocol specification</a></td></tr>
-          <tr><td>How do I contribute to the server itself?</td><td><a href="https://github.com/m2ux/workflow-server/blob/main/docs/development.md">Development guide</a></td></tr>
-          <tr><td>Where does new documentation belong?</td><td><a href="https://github.com/m2ux/workflow-server/blob/main/docs/documentation-system.md">Documentation system</a></td></tr>
+          <tr><td>What is this project?</td><td><a href="guide/getting-started.html">Getting started</a> or <a href="https://github.com/m2ux/workflow-server/blob/main/README.md">README (source)</a></td></tr>
+          <tr><td>How do I install and connect the server?</td><td><a href="guide/getting-started.html">Getting started</a> and <a href="https://github.com/m2ux/workflow-server/blob/main/SETUP.md">SETUP (source)</a></td></tr>
+          <tr><td>How do I wire the IDE bootstrap rule?</td><td><a href="guide/ide-setup.html">IDE setup</a></td></tr>
+          <tr><td>How do I run or resume a workflow?</td><td><a href="guide/running-workflows.html">Running workflows</a></td></tr>
+          <tr><td>What are workflows, sessions, and checkpoints?</td><td><a href="guide/concepts.html">Concepts</a></td></tr>
+          <tr><td>What tools does the server expose?</td><td><a href="api/tools.html">Tool reference</a> and <a href="https://github.com/m2ux/workflow-server/blob/main/docs/api-reference.md">API reference (source)</a></td></tr>
+          <tr><td>What do errors and warnings mean?</td><td><a href="api/protocol.html">Protocol guide</a></td></tr>
+          <tr><td>How do I author workflow definitions?</td><td><a href="api/schemas.html">Schema reference</a> and <a href="https://github.com/m2ux/workflow-server/blob/main/schemas/README.md">Schema guide (source)</a></td></tr>
+          <tr><td>How is the system designed?</td><td><a href="specs/architecture.html">Architecture overview</a> and the six model pages linked from it</td></tr>
+          <tr><td>Why is it designed this way?</td><td><a href="design/rationale.html">Design rationale</a></td></tr>
+          <tr><td>How is the server implemented?</td><td><a href="internals/server-anatomy.html">Server internals</a></td></tr>
+          <tr><td>What keeps agents faithful to a workflow?</td><td><a href="specs/workflow-fidelity.html">Workflow fidelity</a></td></tr>
+          <tr><td>How do techniques declare protocol and bindings?</td><td><a href="https://github.com/m2ux/workflow-server/blob/main/docs/technique-protocol-specification.md">Technique protocol (source)</a></td></tr>
+          <tr><td>How do I contribute to the server?</td><td><a href="internals/server-anatomy.html">Server anatomy</a> and <a href="https://github.com/m2ux/workflow-server/blob/main/docs/development.md">Development guide (source)</a></td></tr>
+          <tr><td>Where does new documentation belong?</td><td><a href="https://github.com/m2ux/workflow-server/blob/main/docs/documentation-system.md">Documentation system (source)</a></td></tr>
         </tbody>
       </table>
     </div>
@@ -204,10 +306,14 @@
 
 </main>
 
+
+<!-- BEGIN GENERATED PAGINATION -->
+
+<!-- END GENERATED PAGINATION -->
+
 <footer class="site-footer">
   <div class="site-footer__inner">
-    <span>Markdown in the <a href="https://github.com/m2ux/workflow-server">repository</a> is the canonical documentation source.</span>
-    <span><a href="https://github.com/m2ux/workflow-server/blob/main/LICENSE">MIT License</a></span>
+    <span>Source on <a href="https://github.com/m2ux/workflow-server">GitHub</a> · <a href="https://github.com/m2ux/workflow-server/blob/main/LICENSE">MIT License</a></span>
   </div>
 </footer>
 

--- a/site/internals/quality-system.html
+++ b/site/internals/quality-system.html
@@ -13,26 +13,88 @@
 <header class="site-header">
   <div class="site-header__inner">
     <a class="site-title" href="../">Workflow Server</a>
-    <nav class="site-nav" aria-label="Site">
-      <ul>
+    <!-- BEGIN GENERATED NAV -->
+    <nav class="site-nav" aria-label="Documentation">
+      <ul class="site-nav__primary">
         <li><a href="../">Home</a></li>
-        <li><a href="./server-anatomy.html">Server anatomy</a></li>
-        <li><a href="./request-lifecycle.html">Request lifecycle</a></li>
-        <li><a href="./session-store.html">Session store</a></li>
-        <li><a href="./quality-system.html" aria-current="page">Quality system</a></li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Guide</summary>
+            <ul>
+              <li><a href="../guide/getting-started.html">Getting started</a></li>
+              <li><a href="../guide/ide-setup.html">IDE setup</a></li>
+              <li><a href="../guide/concepts.html">Concepts</a></li>
+              <li><a href="../guide/running-workflows.html">Running workflows</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Architecture</summary>
+            <ul>
+              <li><a href="../specs/architecture.html">Overview</a></li>
+              <li><a href="../specs/dispatch.html">Dispatch</a></li>
+              <li><a href="../specs/checkpoints.html">Checkpoints</a></li>
+              <li><a href="../specs/state-management.html">State</a></li>
+              <li><a href="../specs/artifact-management.html">Artifacts</a></li>
+              <li><a href="../specs/resource-resolution.html">Resolution</a></li>
+              <li><a href="../specs/workflow-fidelity.html">Fidelity</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>API</summary>
+            <ul>
+              <li><a href="../api/tools.html">Tools</a></li>
+              <li><a href="../api/schemas.html">Schemas</a></li>
+              <li><a href="../api/protocol.html">Protocol guide</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group" open>
+            <summary>Internals</summary>
+            <ul>
+              <li><a href="./server-anatomy.html">Server anatomy</a></li>
+              <li><a href="./request-lifecycle.html">Request lifecycle</a></li>
+              <li><a href="./session-store.html">Session store</a></li>
+              <li><a href="./quality-system.html" aria-current="page">Quality system</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Design</summary>
+            <ul>
+              <li><a href="../design/rationale.html">Design rationale</a></li>
+            </ul>
+          </details>
+        </li>
         <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
       </ul>
     </nav>
+<!-- END GENERATED NAV -->
   </div>
 </header>
 
+
+<!-- BEGIN GENERATED BREADCRUMB -->
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li>Internals</li>
+      <li aria-current="page">Quality system</li>
+    </ol>
+  </nav>
+<!-- END GENERATED BREADCRUMB -->
+
 <main id="main">
   <h1>Quality system</h1>
-  <p class="lede">The server enforces workflow fidelity at runtime; the repository applies the same philosophy to itself. Every convention that matters — reference integrity, naming rules, schema truthfulness, even the geometry of this site's diagrams — is encoded as an executable guard, so a violation is a failing check, not a review comment.</p>
-  <p>The guards live in <a href="https://github.com/m2ux/workflow-server/tree/main/scripts"><code>scripts/</code></a> and run as <code>npm run check:*</code>; the tests live in <a href="https://github.com/m2ux/workflow-server/tree/main/tests"><code>tests/</code></a> under Vitest.</p>
+  <p class="lede prose">Executable guards encode conventions that matter: reference integrity, naming rules, schema truthfulness, and site link integrity.</p>
+  <p class="prose contributor-note">For contributors. Guards live in <a href="https://github.com/m2ux/workflow-server/tree/main/scripts"><code>scripts/</code></a> as <code>npm run check:*</code>; tests run under Vitest in <a href="https://github.com/m2ux/workflow-server/tree/main/tests"><code>tests/</code></a>.</p>
 
   <h2 id="guards">The guard suite</h2>
-  <p>Most guards audit the workflow corpus — the YAML and markdown definitions the server executes — because that content is data, not code, and the type checker cannot see into it:</p>
+  <p class="prose">Most guards audit the workflow corpus (YAML and markdown). A summary by category:</p>
   <div class="table-wrap">
     <table>
       <thead>
@@ -119,6 +181,13 @@
   <h2 id="next">Next</h2>
   <p>Why the project invests in mechanical guardrails rather than review vigilance is part of <a href="../design/rationale.html#guards">the design rationale</a>; the runtime half of the same philosophy is <a href="../specs/workflow-fidelity.html">workflow fidelity</a>.</p>
 </main>
+
+
+<!-- BEGIN GENERATED PAGINATION -->
+  <nav class="page-pagination" aria-label="Page sequence">
+    <a class="page-pagination__prev" href="./session-store.html">← Session store</a>
+  </nav>
+<!-- END GENERATED PAGINATION -->
 
 <footer class="site-footer">
   <div class="site-footer__inner">

--- a/site/internals/request-lifecycle.html
+++ b/site/internals/request-lifecycle.html
@@ -13,18 +13,80 @@
 <header class="site-header">
   <div class="site-header__inner">
     <a class="site-title" href="../">Workflow Server</a>
-    <nav class="site-nav" aria-label="Site">
-      <ul>
+    <!-- BEGIN GENERATED NAV -->
+    <nav class="site-nav" aria-label="Documentation">
+      <ul class="site-nav__primary">
         <li><a href="../">Home</a></li>
-        <li><a href="./server-anatomy.html">Server anatomy</a></li>
-        <li><a href="./request-lifecycle.html" aria-current="page">Request lifecycle</a></li>
-        <li><a href="./session-store.html">Session store</a></li>
-        <li><a href="./quality-system.html">Quality system</a></li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Guide</summary>
+            <ul>
+              <li><a href="../guide/getting-started.html">Getting started</a></li>
+              <li><a href="../guide/ide-setup.html">IDE setup</a></li>
+              <li><a href="../guide/concepts.html">Concepts</a></li>
+              <li><a href="../guide/running-workflows.html">Running workflows</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Architecture</summary>
+            <ul>
+              <li><a href="../specs/architecture.html">Overview</a></li>
+              <li><a href="../specs/dispatch.html">Dispatch</a></li>
+              <li><a href="../specs/checkpoints.html">Checkpoints</a></li>
+              <li><a href="../specs/state-management.html">State</a></li>
+              <li><a href="../specs/artifact-management.html">Artifacts</a></li>
+              <li><a href="../specs/resource-resolution.html">Resolution</a></li>
+              <li><a href="../specs/workflow-fidelity.html">Fidelity</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>API</summary>
+            <ul>
+              <li><a href="../api/tools.html">Tools</a></li>
+              <li><a href="../api/schemas.html">Schemas</a></li>
+              <li><a href="../api/protocol.html">Protocol guide</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group" open>
+            <summary>Internals</summary>
+            <ul>
+              <li><a href="./server-anatomy.html">Server anatomy</a></li>
+              <li><a href="./request-lifecycle.html" aria-current="page">Request lifecycle</a></li>
+              <li><a href="./session-store.html">Session store</a></li>
+              <li><a href="./quality-system.html">Quality system</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Design</summary>
+            <ul>
+              <li><a href="../design/rationale.html">Design rationale</a></li>
+            </ul>
+          </details>
+        </li>
         <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
       </ul>
     </nav>
+<!-- END GENERATED NAV -->
   </div>
 </header>
+
+
+<!-- BEGIN GENERATED BREADCRUMB -->
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li>Internals</li>
+      <li aria-current="page">Request lifecycle</li>
+    </ol>
+  </nav>
+<!-- END GENERATED BREADCRUMB -->
 
 <main id="main">
   <h1>Request lifecycle</h1>
@@ -114,6 +176,14 @@
   <h2 id="next">Next</h2>
   <p>The state this lifecycle protects is described field-by-field in <a href="./session-store.html">the session store</a>; the checks that guard the definitions themselves are in <a href="./quality-system.html">the quality system</a>.</p>
 </main>
+
+
+<!-- BEGIN GENERATED PAGINATION -->
+  <nav class="page-pagination" aria-label="Page sequence">
+    <a class="page-pagination__prev" href="./server-anatomy.html">← Server anatomy</a>
+    <a class="page-pagination__next" href="./session-store.html">Session store →</a>
+  </nav>
+<!-- END GENERATED PAGINATION -->
 
 <footer class="site-footer">
   <div class="site-footer__inner">

--- a/site/internals/server-anatomy.html
+++ b/site/internals/server-anatomy.html
@@ -13,23 +13,85 @@
 <header class="site-header">
   <div class="site-header__inner">
     <a class="site-title" href="../">Workflow Server</a>
-    <nav class="site-nav" aria-label="Site">
-      <ul>
+    <!-- BEGIN GENERATED NAV -->
+    <nav class="site-nav" aria-label="Documentation">
+      <ul class="site-nav__primary">
         <li><a href="../">Home</a></li>
-        <li><a href="./server-anatomy.html" aria-current="page">Server anatomy</a></li>
-        <li><a href="./request-lifecycle.html">Request lifecycle</a></li>
-        <li><a href="./session-store.html">Session store</a></li>
-        <li><a href="./quality-system.html">Quality system</a></li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Guide</summary>
+            <ul>
+              <li><a href="../guide/getting-started.html">Getting started</a></li>
+              <li><a href="../guide/ide-setup.html">IDE setup</a></li>
+              <li><a href="../guide/concepts.html">Concepts</a></li>
+              <li><a href="../guide/running-workflows.html">Running workflows</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Architecture</summary>
+            <ul>
+              <li><a href="../specs/architecture.html">Overview</a></li>
+              <li><a href="../specs/dispatch.html">Dispatch</a></li>
+              <li><a href="../specs/checkpoints.html">Checkpoints</a></li>
+              <li><a href="../specs/state-management.html">State</a></li>
+              <li><a href="../specs/artifact-management.html">Artifacts</a></li>
+              <li><a href="../specs/resource-resolution.html">Resolution</a></li>
+              <li><a href="../specs/workflow-fidelity.html">Fidelity</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>API</summary>
+            <ul>
+              <li><a href="../api/tools.html">Tools</a></li>
+              <li><a href="../api/schemas.html">Schemas</a></li>
+              <li><a href="../api/protocol.html">Protocol guide</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group" open>
+            <summary>Internals</summary>
+            <ul>
+              <li><a href="./server-anatomy.html" aria-current="page">Server anatomy</a></li>
+              <li><a href="./request-lifecycle.html">Request lifecycle</a></li>
+              <li><a href="./session-store.html">Session store</a></li>
+              <li><a href="./quality-system.html">Quality system</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Design</summary>
+            <ul>
+              <li><a href="../design/rationale.html">Design rationale</a></li>
+            </ul>
+          </details>
+        </li>
         <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
       </ul>
     </nav>
+<!-- END GENERATED NAV -->
   </div>
 </header>
 
+
+<!-- BEGIN GENERATED BREADCRUMB -->
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li>Internals</li>
+      <li aria-current="page">Server anatomy</li>
+    </ol>
+  </nav>
+<!-- END GENERATED BREADCRUMB -->
+
 <main id="main">
   <h1>Server anatomy</h1>
-  <p class="lede">The <a href="../specs/architecture.html">architecture models</a> describe what the server guarantees; this page describes the code that delivers it — roughly 5,400 lines of TypeScript in <a href="https://github.com/m2ux/workflow-server/tree/main/src"><code>src/</code></a>, organized around two tool registrars, a family of loaders, and a session store. It is the map for reading the source.</p>
-  <p>This page and the rest of the internals section are derived from the server source itself; each section links to the files it describes. The contributor's build-and-test guide is <a href="https://github.com/m2ux/workflow-server/blob/main/docs/development.md">docs/development.md</a>.</p>
+  <p class="lede prose">The <a href="../specs/architecture.html">architecture models</a> describe guarantees; this page maps them to code in <a href="https://github.com/m2ux/workflow-server/tree/main/src"><code>src/</code></a>.</p>
+  <p class="prose contributor-note">For contributors. Build and test instructions: <a href="https://github.com/m2ux/workflow-server/blob/main/docs/development.md">Development guide (source)</a>.</p>
 
   <h2 id="shape">The shape of the codebase</h2>
   <p>Startup is a short, linear path: the entry point parses configuration, a factory builds the MCP server, and two registrar functions attach all sixteen tools as closures. There is no routing layer and no dependency-injection framework — the registrars close over the <code>ServerConfig</code> and call shared machinery directly.</p>
@@ -76,22 +138,37 @@
   </figure>
 
   <h2 id="modules">Module map</h2>
-  <p>Each module owns one concern. The table lists them in the order a request touches them:</p>
+  <p class="prose">Grouped by what a request touches. Each row links to the primary source file.</p>
+  <h3>Startup</h3>
   <div class="table-wrap">
     <table>
-      <thead>
-        <tr><th scope="col">Module</th><th scope="col">Responsibility</th></tr>
-      </thead>
+      <thead><tr><th scope="col">Module</th><th scope="col">Role</th></tr></thead>
       <tbody>
-        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/index.ts"><code>index.ts</code></a>, <a href="https://github.com/m2ux/workflow-server/blob/main/src/config.ts"><code>config.ts</code></a>, <a href="https://github.com/m2ux/workflow-server/blob/main/src/server.ts"><code>server.ts</code></a></td><td>Entry point, <code>ServerConfig</code> (workflow directory, schemas directory, workspace root from <code>--workspace</code> or <code>WORKFLOW_WORKSPACE</code>), and the server factory.</td></tr>
-        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/tools/workflow-tools.ts"><code>tools/</code></a></td><td>The sixteen tool handlers. Navigation, checkpoint, and trace tools live in <code>workflow-tools.ts</code>; session creation and content fetching live in <code>resource-tools.ts</code>.</td></tr>
-        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/loaders/workflow-loader.ts"><code>loaders/</code></a></td><td>Reading definitions: workflow and activity YAML (<code>workflow-loader.ts</code>), technique resolution and composition (<code>technique-loader.ts</code>), markdown technique parsing (<code>markdown-technique-loader.ts</code>), resources (<code>resource-loader.ts</code>), and the generated JSON schemas (<code>schema-loader.ts</code>).</td></tr>
-        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/schema/workflow.schema.ts"><code>schema/</code></a></td><td>Zod definitions for every file shape the server reads or writes — workflow, activity, condition, technique, resource, session — plus identifier rules. The JSON schemas in <a href="../api/schemas.html"><code>schemas/</code></a> are generated from these sources.</td></tr>
-        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/utils/session/store.ts"><code>utils/session/</code></a></td><td>The session store: planning-folder resolution, atomic <code>session.json</code> writes, HMAC sealing (<code>crypto.ts</code>), deterministic session-index derivation (<code>derivation.ts</code>), legacy-layout migration (<code>migration.ts</code>), and the load/save resolver every tool uses.</td></tr>
-        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/utils/validation.ts"><code>utils/validation.ts</code></a></td><td>The runtime fidelity validators: activity transitions, workflow version drift, step and activity manifests, transition conditions, and technique-fetch cross-checks.</td></tr>
-        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/utils/delivery.ts"><code>utils/delivery.ts</code></a>, <a href="https://github.com/m2ux/workflow-server/blob/main/src/utils/binding-provenance.ts"><code>utils/binding-provenance.ts</code></a></td><td>Reference-not-repeat delivery (content hashing, the per-agent delivered ledger, <code>unchanged</code> markers) and the static provenance annotations on technique inputs and outputs.</td></tr>
-        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/trace.ts"><code>trace.ts</code></a>, <a href="https://github.com/m2ux/workflow-server/blob/main/src/logging.ts"><code>logging.ts</code></a></td><td>The in-process <code>TraceStore</code> (per-session event buffers, evicting the oldest beyond 1,000 sessions), HMAC-signed trace tokens, and the <code>withAuditLog</code> wrapper around every handler.</td></tr>
-        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/result.ts"><code>result.ts</code></a>, <a href="https://github.com/m2ux/workflow-server/blob/main/src/errors.ts"><code>errors.ts</code></a></td><td>The <code>Result&lt;T, E&gt;</code> type loaders return, and the typed domain errors (<a href="#errors">below</a>).</td></tr>
+        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/index.ts"><code>index.ts</code></a>, <a href="https://github.com/m2ux/workflow-server/blob/main/src/config.ts"><code>config.ts</code></a>, <a href="https://github.com/m2ux/workflow-server/blob/main/src/server.ts"><code>server.ts</code></a></td><td>Parse config, build MCP server, register tools.</td></tr>
+        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/tools/workflow-tools.ts"><code>tools/</code></a></td><td>Sixteen tool handlers across workflow and resource registrars.</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>Definitions and validation</h3>
+  <div class="table-wrap">
+    <table>
+      <thead><tr><th scope="col">Module</th><th scope="col">Role</th></tr></thead>
+      <tbody>
+        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/loaders/workflow-loader.ts"><code>loaders/</code></a></td><td>Read workflow YAML, compose techniques, load resources and schemas.</td></tr>
+        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/schema/workflow.schema.ts"><code>schema/</code></a></td><td>Zod shapes; JSON schemas in <a href="../api/schemas.html"><code>schemas/</code></a> are generated from here.</td></tr>
+        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/utils/validation.ts"><code>utils/validation.ts</code></a></td><td>Runtime fidelity validators for transitions and manifests.</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>Persistence and delivery</h3>
+  <div class="table-wrap">
+    <table>
+      <thead><tr><th scope="col">Module</th><th scope="col">Role</th></tr></thead>
+      <tbody>
+        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/utils/session/store.ts"><code>utils/session/</code></a></td><td>Planning folders, atomic writes, HMAC seals, session index derivation.</td></tr>
+        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/utils/delivery.ts"><code>utils/delivery.ts</code></a></td><td>Reference-not-repeat delivery and content hashing.</td></tr>
+        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/trace.ts"><code>trace.ts</code></a>, <a href="https://github.com/m2ux/workflow-server/blob/main/src/logging.ts"><code>logging.ts</code></a></td><td>Trace buffers, signed tokens, audit logging.</td></tr>
+        <tr><td><a href="https://github.com/m2ux/workflow-server/blob/main/src/result.ts"><code>result.ts</code></a>, <a href="https://github.com/m2ux/workflow-server/blob/main/src/errors.ts"><code>errors.ts</code></a></td><td>Typed errors loaders return across the tool boundary.</td></tr>
       </tbody>
     </table>
   </div>
@@ -132,6 +209,14 @@
   <h2 id="next">Next</h2>
   <p>Follow one request through this structure in <a href="./request-lifecycle.html">the request lifecycle</a>, or read how state is kept honest in <a href="./session-store.html">the session store</a>.</p>
 </main>
+
+
+<!-- BEGIN GENERATED PAGINATION -->
+  <nav class="page-pagination" aria-label="Page sequence">
+    <span></span>
+    <a class="page-pagination__next" href="./request-lifecycle.html">Request lifecycle →</a>
+  </nav>
+<!-- END GENERATED PAGINATION -->
 
 <footer class="site-footer">
   <div class="site-footer__inner">

--- a/site/internals/session-store.html
+++ b/site/internals/session-store.html
@@ -13,18 +13,80 @@
 <header class="site-header">
   <div class="site-header__inner">
     <a class="site-title" href="../">Workflow Server</a>
-    <nav class="site-nav" aria-label="Site">
-      <ul>
+    <!-- BEGIN GENERATED NAV -->
+    <nav class="site-nav" aria-label="Documentation">
+      <ul class="site-nav__primary">
         <li><a href="../">Home</a></li>
-        <li><a href="./server-anatomy.html">Server anatomy</a></li>
-        <li><a href="./request-lifecycle.html">Request lifecycle</a></li>
-        <li><a href="./session-store.html" aria-current="page">Session store</a></li>
-        <li><a href="./quality-system.html">Quality system</a></li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Guide</summary>
+            <ul>
+              <li><a href="../guide/getting-started.html">Getting started</a></li>
+              <li><a href="../guide/ide-setup.html">IDE setup</a></li>
+              <li><a href="../guide/concepts.html">Concepts</a></li>
+              <li><a href="../guide/running-workflows.html">Running workflows</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Architecture</summary>
+            <ul>
+              <li><a href="../specs/architecture.html">Overview</a></li>
+              <li><a href="../specs/dispatch.html">Dispatch</a></li>
+              <li><a href="../specs/checkpoints.html">Checkpoints</a></li>
+              <li><a href="../specs/state-management.html">State</a></li>
+              <li><a href="../specs/artifact-management.html">Artifacts</a></li>
+              <li><a href="../specs/resource-resolution.html">Resolution</a></li>
+              <li><a href="../specs/workflow-fidelity.html">Fidelity</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>API</summary>
+            <ul>
+              <li><a href="../api/tools.html">Tools</a></li>
+              <li><a href="../api/schemas.html">Schemas</a></li>
+              <li><a href="../api/protocol.html">Protocol guide</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group" open>
+            <summary>Internals</summary>
+            <ul>
+              <li><a href="./server-anatomy.html">Server anatomy</a></li>
+              <li><a href="./request-lifecycle.html">Request lifecycle</a></li>
+              <li><a href="./session-store.html" aria-current="page">Session store</a></li>
+              <li><a href="./quality-system.html">Quality system</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Design</summary>
+            <ul>
+              <li><a href="../design/rationale.html">Design rationale</a></li>
+            </ul>
+          </details>
+        </li>
         <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
       </ul>
     </nav>
+<!-- END GENERATED NAV -->
   </div>
 </header>
+
+
+<!-- BEGIN GENERATED BREADCRUMB -->
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li>Internals</li>
+      <li aria-current="page">Session store</li>
+    </ol>
+  </nav>
+<!-- END GENERATED BREADCRUMB -->
 
 <main id="main">
   <h1>Session store</h1>
@@ -110,6 +172,14 @@
   <h2 id="next">Next</h2>
   <p>How a tool call reads and writes this state safely is <a href="./request-lifecycle.html">the request lifecycle</a>; the checkpoint pause encoded in <code>activeCheckpoint</code> is <a href="../specs/checkpoints.html">the checkpoint model</a>.</p>
 </main>
+
+
+<!-- BEGIN GENERATED PAGINATION -->
+  <nav class="page-pagination" aria-label="Page sequence">
+    <a class="page-pagination__prev" href="./request-lifecycle.html">← Request lifecycle</a>
+    <a class="page-pagination__next" href="./quality-system.html">Quality system →</a>
+  </nav>
+<!-- END GENERATED PAGINATION -->
 
 <footer class="site-footer">
   <div class="site-footer__inner">

--- a/site/specs/architecture.html
+++ b/site/specs/architecture.html
@@ -13,22 +13,85 @@
 <header class="site-header">
   <div class="site-header__inner">
     <a class="site-title" href="../">Workflow Server</a>
-    <nav class="site-nav" aria-label="Site">
-      <ul>
+    <!-- BEGIN GENERATED NAV -->
+    <nav class="site-nav" aria-label="Documentation">
+      <ul class="site-nav__primary">
         <li><a href="../">Home</a></li>
-        <li><a href="./architecture.html" aria-current="page">Architecture</a></li>
-        <li><a href="../api/tools.html">Tools</a></li>
-        <li><a href="../api/schemas.html">Schemas</a></li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Guide</summary>
+            <ul>
+              <li><a href="../guide/getting-started.html">Getting started</a></li>
+              <li><a href="../guide/ide-setup.html">IDE setup</a></li>
+              <li><a href="../guide/concepts.html">Concepts</a></li>
+              <li><a href="../guide/running-workflows.html">Running workflows</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group" open>
+            <summary>Architecture</summary>
+            <ul>
+              <li><a href="./architecture.html" aria-current="page">Overview</a></li>
+              <li><a href="./dispatch.html">Dispatch</a></li>
+              <li><a href="./checkpoints.html">Checkpoints</a></li>
+              <li><a href="./state-management.html">State</a></li>
+              <li><a href="./artifact-management.html">Artifacts</a></li>
+              <li><a href="./resource-resolution.html">Resolution</a></li>
+              <li><a href="./workflow-fidelity.html">Fidelity</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>API</summary>
+            <ul>
+              <li><a href="../api/tools.html">Tools</a></li>
+              <li><a href="../api/schemas.html">Schemas</a></li>
+              <li><a href="../api/protocol.html">Protocol guide</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Internals</summary>
+            <ul>
+              <li><a href="../internals/server-anatomy.html">Server anatomy</a></li>
+              <li><a href="../internals/request-lifecycle.html">Request lifecycle</a></li>
+              <li><a href="../internals/session-store.html">Session store</a></li>
+              <li><a href="../internals/quality-system.html">Quality system</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Design</summary>
+            <ul>
+              <li><a href="../design/rationale.html">Design rationale</a></li>
+            </ul>
+          </details>
+        </li>
         <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
       </ul>
     </nav>
+<!-- END GENERATED NAV -->
   </div>
 </header>
 
+
+<!-- BEGIN GENERATED BREADCRUMB -->
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li>Architecture</li>
+      <li aria-current="page">Overview</li>
+    </ol>
+  </nav>
+<!-- END GENERATED BREADCRUMB -->
+
 <main id="main">
   <h1>Architecture</h1>
-  <p class="lede">The server is a small state machine wrapped in an MCP tool surface: agents call tools, the server enforces the workflow definition and owns the session state on disk. Six models describe how that works; this page is the map.</p>
-  <p>Canonical source: <a href="https://github.com/m2ux/workflow-server/blob/main/docs/architecture.md">docs/architecture.md</a>.</p>
+  <p class="lede prose">A small state machine wrapped in an MCP tool surface: agents call tools, the server enforces the workflow definition and owns session state on disk.</p>
+  <p class="prose">Canonical source: <a href="https://github.com/m2ux/workflow-server/blob/main/docs/architecture.md">docs/architecture.md (edit)</a>.</p>
 
   <figure class="diagram">
     <svg viewBox="0 0 960 300" role="img" aria-labelledby="arch-title arch-desc">
@@ -119,6 +182,11 @@
     <li><a href="../design/rationale.html"><strong>Design rationale</strong></a> — why the system is shaped this way: the forces behind each decision and the costs accepted.</li>
   </ul>
 </main>
+
+
+<!-- BEGIN GENERATED PAGINATION -->
+
+<!-- END GENERATED PAGINATION -->
 
 <footer class="site-footer">
   <div class="site-footer__inner">

--- a/site/specs/artifact-management.html
+++ b/site/specs/artifact-management.html
@@ -13,17 +13,80 @@
 <header class="site-header">
   <div class="site-header__inner">
     <a class="site-title" href="../">Workflow Server</a>
-    <nav class="site-nav" aria-label="Site">
-      <ul>
+    <!-- BEGIN GENERATED NAV -->
+    <nav class="site-nav" aria-label="Documentation">
+      <ul class="site-nav__primary">
         <li><a href="../">Home</a></li>
-        <li><a href="./architecture.html">Architecture</a></li>
-        <li><a href="../api/tools.html">Tools</a></li>
-        <li><a href="../api/schemas.html">Schemas</a></li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Guide</summary>
+            <ul>
+              <li><a href="../guide/getting-started.html">Getting started</a></li>
+              <li><a href="../guide/ide-setup.html">IDE setup</a></li>
+              <li><a href="../guide/concepts.html">Concepts</a></li>
+              <li><a href="../guide/running-workflows.html">Running workflows</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group" open>
+            <summary>Architecture</summary>
+            <ul>
+              <li><a href="./architecture.html">Overview</a></li>
+              <li><a href="./dispatch.html">Dispatch</a></li>
+              <li><a href="./checkpoints.html">Checkpoints</a></li>
+              <li><a href="./state-management.html">State</a></li>
+              <li><a href="./artifact-management.html" aria-current="page">Artifacts</a></li>
+              <li><a href="./resource-resolution.html">Resolution</a></li>
+              <li><a href="./workflow-fidelity.html">Fidelity</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>API</summary>
+            <ul>
+              <li><a href="../api/tools.html">Tools</a></li>
+              <li><a href="../api/schemas.html">Schemas</a></li>
+              <li><a href="../api/protocol.html">Protocol guide</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Internals</summary>
+            <ul>
+              <li><a href="../internals/server-anatomy.html">Server anatomy</a></li>
+              <li><a href="../internals/request-lifecycle.html">Request lifecycle</a></li>
+              <li><a href="../internals/session-store.html">Session store</a></li>
+              <li><a href="../internals/quality-system.html">Quality system</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Design</summary>
+            <ul>
+              <li><a href="../design/rationale.html">Design rationale</a></li>
+            </ul>
+          </details>
+        </li>
         <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
       </ul>
     </nav>
+<!-- END GENERATED NAV -->
   </div>
 </header>
+
+
+<!-- BEGIN GENERATED BREADCRUMB -->
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li><a href="./architecture.html">Architecture</a></li>
+      <li aria-current="page">Artifacts</li>
+    </ol>
+  </nav>
+<!-- END GENERATED BREADCRUMB -->
 
 <main id="main">
   <h1>Artifact and workspace isolation</h1>
@@ -67,6 +130,14 @@
   <h2 id="git">Git and submodule protocol</h2>
   <p>The <code>.engineering</code> tree typically lives as a Git submodule or orphan-branch worktree, so orchestration state is version-controlled independently of your product history. When the orchestrator commits artifacts it works inside the submodule first — stage, commit, push — then commits the updated submodule reference in the parent repository. Engineering metadata never pollutes product commits.</p>
 </main>
+
+
+<!-- BEGIN GENERATED PAGINATION -->
+  <nav class="page-pagination" aria-label="Page sequence">
+    <a class="page-pagination__prev" href="./state-management.html">← State</a>
+    <a class="page-pagination__next" href="./resource-resolution.html">Resolution →</a>
+  </nav>
+<!-- END GENERATED PAGINATION -->
 
 <footer class="site-footer">
   <div class="site-footer__inner">

--- a/site/specs/checkpoints.html
+++ b/site/specs/checkpoints.html
@@ -13,17 +13,80 @@
 <header class="site-header">
   <div class="site-header__inner">
     <a class="site-title" href="../">Workflow Server</a>
-    <nav class="site-nav" aria-label="Site">
-      <ul>
+    <!-- BEGIN GENERATED NAV -->
+    <nav class="site-nav" aria-label="Documentation">
+      <ul class="site-nav__primary">
         <li><a href="../">Home</a></li>
-        <li><a href="./architecture.html">Architecture</a></li>
-        <li><a href="../api/tools.html">Tools</a></li>
-        <li><a href="../api/schemas.html">Schemas</a></li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Guide</summary>
+            <ul>
+              <li><a href="../guide/getting-started.html">Getting started</a></li>
+              <li><a href="../guide/ide-setup.html">IDE setup</a></li>
+              <li><a href="../guide/concepts.html">Concepts</a></li>
+              <li><a href="../guide/running-workflows.html">Running workflows</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group" open>
+            <summary>Architecture</summary>
+            <ul>
+              <li><a href="./architecture.html">Overview</a></li>
+              <li><a href="./dispatch.html">Dispatch</a></li>
+              <li><a href="./checkpoints.html" aria-current="page">Checkpoints</a></li>
+              <li><a href="./state-management.html">State</a></li>
+              <li><a href="./artifact-management.html">Artifacts</a></li>
+              <li><a href="./resource-resolution.html">Resolution</a></li>
+              <li><a href="./workflow-fidelity.html">Fidelity</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>API</summary>
+            <ul>
+              <li><a href="../api/tools.html">Tools</a></li>
+              <li><a href="../api/schemas.html">Schemas</a></li>
+              <li><a href="../api/protocol.html">Protocol guide</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Internals</summary>
+            <ul>
+              <li><a href="../internals/server-anatomy.html">Server anatomy</a></li>
+              <li><a href="../internals/request-lifecycle.html">Request lifecycle</a></li>
+              <li><a href="../internals/session-store.html">Session store</a></li>
+              <li><a href="../internals/quality-system.html">Quality system</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Design</summary>
+            <ul>
+              <li><a href="../design/rationale.html">Design rationale</a></li>
+            </ul>
+          </details>
+        </li>
         <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
       </ul>
     </nav>
+<!-- END GENERATED NAV -->
   </div>
 </header>
+
+
+<!-- BEGIN GENERATED BREADCRUMB -->
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li><a href="./architecture.html">Architecture</a></li>
+      <li aria-current="page">Checkpoints</li>
+    </ol>
+  </nav>
+<!-- END GENERATED BREADCRUMB -->
 
 <main id="main">
   <h1>Just-in-time checkpoints</h1>
@@ -105,6 +168,14 @@
     <li><strong>Effects as data</strong> — your choice mutates workflow variables through declared effects, which is what makes <a href="./state-management.html">deterministic transitions</a> possible.</li>
   </ul>
 </main>
+
+
+<!-- BEGIN GENERATED PAGINATION -->
+  <nav class="page-pagination" aria-label="Page sequence">
+    <a class="page-pagination__prev" href="./dispatch.html">← Dispatch</a>
+    <a class="page-pagination__next" href="./state-management.html">State →</a>
+  </nav>
+<!-- END GENERATED PAGINATION -->
 
 <footer class="site-footer">
   <div class="site-footer__inner">

--- a/site/specs/dispatch.html
+++ b/site/specs/dispatch.html
@@ -13,21 +13,85 @@
 <header class="site-header">
   <div class="site-header__inner">
     <a class="site-title" href="../">Workflow Server</a>
-    <nav class="site-nav" aria-label="Site">
-      <ul>
+    <!-- BEGIN GENERATED NAV -->
+    <nav class="site-nav" aria-label="Documentation">
+      <ul class="site-nav__primary">
         <li><a href="../">Home</a></li>
-        <li><a href="./architecture.html">Architecture</a></li>
-        <li><a href="../api/tools.html">Tools</a></li>
-        <li><a href="../api/schemas.html">Schemas</a></li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Guide</summary>
+            <ul>
+              <li><a href="../guide/getting-started.html">Getting started</a></li>
+              <li><a href="../guide/ide-setup.html">IDE setup</a></li>
+              <li><a href="../guide/concepts.html">Concepts</a></li>
+              <li><a href="../guide/running-workflows.html">Running workflows</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group" open>
+            <summary>Architecture</summary>
+            <ul>
+              <li><a href="./architecture.html">Overview</a></li>
+              <li><a href="./dispatch.html" aria-current="page">Dispatch</a></li>
+              <li><a href="./checkpoints.html">Checkpoints</a></li>
+              <li><a href="./state-management.html">State</a></li>
+              <li><a href="./artifact-management.html">Artifacts</a></li>
+              <li><a href="./resource-resolution.html">Resolution</a></li>
+              <li><a href="./workflow-fidelity.html">Fidelity</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>API</summary>
+            <ul>
+              <li><a href="../api/tools.html">Tools</a></li>
+              <li><a href="../api/schemas.html">Schemas</a></li>
+              <li><a href="../api/protocol.html">Protocol guide</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Internals</summary>
+            <ul>
+              <li><a href="../internals/server-anatomy.html">Server anatomy</a></li>
+              <li><a href="../internals/request-lifecycle.html">Request lifecycle</a></li>
+              <li><a href="../internals/session-store.html">Session store</a></li>
+              <li><a href="../internals/quality-system.html">Quality system</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Design</summary>
+            <ul>
+              <li><a href="../design/rationale.html">Design rationale</a></li>
+            </ul>
+          </details>
+        </li>
         <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
       </ul>
     </nav>
+<!-- END GENERATED NAV -->
   </div>
 </header>
 
+
+<!-- BEGIN GENERATED BREADCRUMB -->
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li><a href="./architecture.html">Architecture</a></li>
+      <li aria-current="page">Dispatch</li>
+    </ol>
+  </nav>
+<!-- END GENERATED BREADCRUMB -->
+
 <main id="main">
   <h1>Hierarchical dispatch</h1>
-  <p class="lede">Workflows execute through multi-agent delegation: a user-facing agent dispatches a background orchestrator per workflow, which dispatches ephemeral workers per activity. Each layer has one job, and the boundaries keep user interaction, state management, and task execution from tangling.</p>
+  <p class="lede prose">Workflows run through three agent layers: user-facing orchestrator, background workflow orchestrator, and ephemeral activity workers.</p>
+  <p class="prose note"><strong>Layer key:</strong> L0 = user-facing meta orchestrator · L1 = workflow orchestrator (state owner) · L2 = activity worker (task executor).</p>
   <p>Canonical source: <a href="https://github.com/m2ux/workflow-server/blob/main/docs/dispatch_model.md">docs/dispatch_model.md</a>.</p>
 
   <figure class="diagram">
@@ -92,6 +156,14 @@
   <h2 id="related">Related</h2>
   <p>Checkpoints bubble up through these same layers — see the <a href="./checkpoints.html">checkpoint model</a>. Session state and the <code>session.json</code> file are covered in <a href="./state-management.html">state management</a>.</p>
 </main>
+
+
+<!-- BEGIN GENERATED PAGINATION -->
+  <nav class="page-pagination" aria-label="Page sequence">
+    <span></span>
+    <a class="page-pagination__next" href="./checkpoints.html">Checkpoints →</a>
+  </nav>
+<!-- END GENERATED PAGINATION -->
 
 <footer class="site-footer">
   <div class="site-footer__inner">

--- a/site/specs/resource-resolution.html
+++ b/site/specs/resource-resolution.html
@@ -13,17 +13,80 @@
 <header class="site-header">
   <div class="site-header__inner">
     <a class="site-title" href="../">Workflow Server</a>
-    <nav class="site-nav" aria-label="Site">
-      <ul>
+    <!-- BEGIN GENERATED NAV -->
+    <nav class="site-nav" aria-label="Documentation">
+      <ul class="site-nav__primary">
         <li><a href="../">Home</a></li>
-        <li><a href="./architecture.html">Architecture</a></li>
-        <li><a href="../api/tools.html">Tools</a></li>
-        <li><a href="../api/schemas.html">Schemas</a></li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Guide</summary>
+            <ul>
+              <li><a href="../guide/getting-started.html">Getting started</a></li>
+              <li><a href="../guide/ide-setup.html">IDE setup</a></li>
+              <li><a href="../guide/concepts.html">Concepts</a></li>
+              <li><a href="../guide/running-workflows.html">Running workflows</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group" open>
+            <summary>Architecture</summary>
+            <ul>
+              <li><a href="./architecture.html">Overview</a></li>
+              <li><a href="./dispatch.html">Dispatch</a></li>
+              <li><a href="./checkpoints.html">Checkpoints</a></li>
+              <li><a href="./state-management.html">State</a></li>
+              <li><a href="./artifact-management.html">Artifacts</a></li>
+              <li><a href="./resource-resolution.html" aria-current="page">Resolution</a></li>
+              <li><a href="./workflow-fidelity.html">Fidelity</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>API</summary>
+            <ul>
+              <li><a href="../api/tools.html">Tools</a></li>
+              <li><a href="../api/schemas.html">Schemas</a></li>
+              <li><a href="../api/protocol.html">Protocol guide</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Internals</summary>
+            <ul>
+              <li><a href="../internals/server-anatomy.html">Server anatomy</a></li>
+              <li><a href="../internals/request-lifecycle.html">Request lifecycle</a></li>
+              <li><a href="../internals/session-store.html">Session store</a></li>
+              <li><a href="../internals/quality-system.html">Quality system</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Design</summary>
+            <ul>
+              <li><a href="../design/rationale.html">Design rationale</a></li>
+            </ul>
+          </details>
+        </li>
         <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
       </ul>
     </nav>
+<!-- END GENERATED NAV -->
   </div>
 </header>
+
+
+<!-- BEGIN GENERATED BREADCRUMB -->
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li><a href="./architecture.html">Architecture</a></li>
+      <li aria-current="page">Resolution</li>
+    </ol>
+  </nav>
+<!-- END GENERATED BREADCRUMB -->
 
 <main id="main">
   <h1>Technique and resource resolution</h1>
@@ -92,6 +155,14 @@
   <h2 id="related">Related</h2>
   <p>How techniques declare inputs/outputs and how binding works is the <a href="https://github.com/m2ux/workflow-server/blob/main/docs/technique-protocol-specification.md">technique protocol specification</a>; what the resolved bundles look like on the wire is in the <a href="../api/tools.html">tool reference</a>.</p>
 </main>
+
+
+<!-- BEGIN GENERATED PAGINATION -->
+  <nav class="page-pagination" aria-label="Page sequence">
+    <a class="page-pagination__prev" href="./artifact-management.html">← Artifacts</a>
+    <a class="page-pagination__next" href="./workflow-fidelity.html">Fidelity →</a>
+  </nav>
+<!-- END GENERATED PAGINATION -->
 
 <footer class="site-footer">
   <div class="site-footer__inner">

--- a/site/specs/state-management.html
+++ b/site/specs/state-management.html
@@ -13,17 +13,80 @@
 <header class="site-header">
   <div class="site-header__inner">
     <a class="site-title" href="../">Workflow Server</a>
-    <nav class="site-nav" aria-label="Site">
-      <ul>
+    <!-- BEGIN GENERATED NAV -->
+    <nav class="site-nav" aria-label="Documentation">
+      <ul class="site-nav__primary">
         <li><a href="../">Home</a></li>
-        <li><a href="./architecture.html">Architecture</a></li>
-        <li><a href="../api/tools.html">Tools</a></li>
-        <li><a href="../api/schemas.html">Schemas</a></li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Guide</summary>
+            <ul>
+              <li><a href="../guide/getting-started.html">Getting started</a></li>
+              <li><a href="../guide/ide-setup.html">IDE setup</a></li>
+              <li><a href="../guide/concepts.html">Concepts</a></li>
+              <li><a href="../guide/running-workflows.html">Running workflows</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group" open>
+            <summary>Architecture</summary>
+            <ul>
+              <li><a href="./architecture.html">Overview</a></li>
+              <li><a href="./dispatch.html">Dispatch</a></li>
+              <li><a href="./checkpoints.html">Checkpoints</a></li>
+              <li><a href="./state-management.html" aria-current="page">State</a></li>
+              <li><a href="./artifact-management.html">Artifacts</a></li>
+              <li><a href="./resource-resolution.html">Resolution</a></li>
+              <li><a href="./workflow-fidelity.html">Fidelity</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>API</summary>
+            <ul>
+              <li><a href="../api/tools.html">Tools</a></li>
+              <li><a href="../api/schemas.html">Schemas</a></li>
+              <li><a href="../api/protocol.html">Protocol guide</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Internals</summary>
+            <ul>
+              <li><a href="../internals/server-anatomy.html">Server anatomy</a></li>
+              <li><a href="../internals/request-lifecycle.html">Request lifecycle</a></li>
+              <li><a href="../internals/session-store.html">Session store</a></li>
+              <li><a href="../internals/quality-system.html">Quality system</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Design</summary>
+            <ul>
+              <li><a href="../design/rationale.html">Design rationale</a></li>
+            </ul>
+          </details>
+        </li>
         <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
       </ul>
     </nav>
+<!-- END GENERATED NAV -->
   </div>
 </header>
+
+
+<!-- BEGIN GENERATED BREADCRUMB -->
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li><a href="./architecture.html">Architecture</a></li>
+      <li aria-current="page">State</li>
+    </ol>
+  </nav>
+<!-- END GENERATED BREADCRUMB -->
 
 <main id="main">
   <h1>State management and deterministic transitions</h1>
@@ -91,6 +154,14 @@
   <h2 id="related">Related</h2>
   <p>Checkpoint effects are defined in the <a href="./checkpoints.html">checkpoint model</a>; how the state files sit inside the planning folder is part of <a href="./artifact-management.html">artifact and workspace isolation</a>; the enforcement that keeps reported transitions honest is <a href="./workflow-fidelity.html">workflow fidelity</a>.</p>
 </main>
+
+
+<!-- BEGIN GENERATED PAGINATION -->
+  <nav class="page-pagination" aria-label="Page sequence">
+    <a class="page-pagination__prev" href="./checkpoints.html">← Checkpoints</a>
+    <a class="page-pagination__next" href="./artifact-management.html">Artifacts →</a>
+  </nav>
+<!-- END GENERATED PAGINATION -->
 
 <footer class="site-footer">
   <div class="site-footer__inner">

--- a/site/specs/workflow-fidelity.html
+++ b/site/specs/workflow-fidelity.html
@@ -13,17 +13,80 @@
 <header class="site-header">
   <div class="site-header__inner">
     <a class="site-title" href="../">Workflow Server</a>
-    <nav class="site-nav" aria-label="Site">
-      <ul>
+    <!-- BEGIN GENERATED NAV -->
+    <nav class="site-nav" aria-label="Documentation">
+      <ul class="site-nav__primary">
         <li><a href="../">Home</a></li>
-        <li><a href="./architecture.html">Architecture</a></li>
-        <li><a href="../api/tools.html">Tools</a></li>
-        <li><a href="../api/schemas.html">Schemas</a></li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Guide</summary>
+            <ul>
+              <li><a href="../guide/getting-started.html">Getting started</a></li>
+              <li><a href="../guide/ide-setup.html">IDE setup</a></li>
+              <li><a href="../guide/concepts.html">Concepts</a></li>
+              <li><a href="../guide/running-workflows.html">Running workflows</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group" open>
+            <summary>Architecture</summary>
+            <ul>
+              <li><a href="./architecture.html">Overview</a></li>
+              <li><a href="./dispatch.html">Dispatch</a></li>
+              <li><a href="./checkpoints.html">Checkpoints</a></li>
+              <li><a href="./state-management.html">State</a></li>
+              <li><a href="./artifact-management.html">Artifacts</a></li>
+              <li><a href="./resource-resolution.html">Resolution</a></li>
+              <li><a href="./workflow-fidelity.html" aria-current="page">Fidelity</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>API</summary>
+            <ul>
+              <li><a href="../api/tools.html">Tools</a></li>
+              <li><a href="../api/schemas.html">Schemas</a></li>
+              <li><a href="../api/protocol.html">Protocol guide</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Internals</summary>
+            <ul>
+              <li><a href="../internals/server-anatomy.html">Server anatomy</a></li>
+              <li><a href="../internals/request-lifecycle.html">Request lifecycle</a></li>
+              <li><a href="../internals/session-store.html">Session store</a></li>
+              <li><a href="../internals/quality-system.html">Quality system</a></li>
+            </ul>
+          </details>
+        </li>
+        <li>
+          <details class="site-nav__group">
+            <summary>Design</summary>
+            <ul>
+              <li><a href="../design/rationale.html">Design rationale</a></li>
+            </ul>
+          </details>
+        </li>
         <li><a href="https://github.com/m2ux/workflow-server">GitHub</a></li>
       </ul>
     </nav>
+<!-- END GENERATED NAV -->
   </div>
 </header>
+
+
+<!-- BEGIN GENERATED BREADCRUMB -->
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li><a href="./architecture.html">Architecture</a></li>
+      <li aria-current="page">Fidelity</li>
+    </ol>
+  </nav>
+<!-- END GENERATED BREADCRUMB -->
 
 <main id="main">
   <h1>Workflow fidelity</h1>
@@ -75,13 +138,18 @@
   <p><strong>Checkpoint gate (L2).</strong> While a checkpoint is active, transition tools hard-fail; only <code>present_checkpoint</code> and <code>respond_checkpoint</code> are exempt. Responses are validated against the checkpoint definition, and timing is enforced — a minimum response delay for user-answered checkpoints, the full <code>autoAdvanceMs</code> timer for auto-advanced ones — so an agent cannot instantly answer its own question. Details in the <a href="./checkpoints.html">checkpoint model</a>.</p>
 
   <h2 id="advisory">The advisory layers</h2>
-  <p>Layers 3–6 warn rather than block, on the principle that a confused agent should be able to self-correct while every violation stays visible. Warnings come back in the tool response's <code>_meta.validation</code> and are recorded in the trace:</p>
-  <ul>
-    <li><strong>Cross-activity validation (L3)</strong> — mid-session workflow switches, transitions that aren't in the graph, techniques the activity never declared, workflow definitions that changed on disk.</li>
-    <li><strong>Transition condition tracking (L4)</strong> — the condition an agent claims for a transition must actually map to the target activity; false "default" claims are flagged.</li>
-    <li><strong>Step manifest (L5)</strong> — the per-step summary submitted with <code>next_activity</code> is checked for missing steps, ordering, unexpected step ids, and empty outputs.</li>
-    <li><strong>Activity manifest (L6)</strong> — the workflow-level journey summary is checked against the definition: real activity ids, non-empty outcomes, conditions that exist.</li>
-  </ul>
+  <p class="prose">Layers 3-6 warn rather than block. Warnings appear in <code>_meta.validation</code> and the trace. See <a href="../api/protocol.html">protocol guide</a> for how to read them.</p>
+  <div class="table-wrap">
+    <table>
+      <thead><tr><th scope="col">Layer</th><th scope="col">When it runs</th><th scope="col">Effect</th><th scope="col">What to do</th></tr></thead>
+      <tbody>
+        <tr><td>L3 Cross-activity</td><td>Session navigation</td><td>Warns</td><td>Fix workflow switches, transitions, or stale definitions</td></tr>
+        <tr><td>L4 Transition condition</td><td><code>next_activity</code></td><td>Warns</td><td>Match claimed condition to a real transition</td></tr>
+        <tr><td>L5 Step manifest</td><td><code>next_activity</code></td><td>Warns</td><td>Report completed steps with valid ids and outputs</td></tr>
+        <tr><td>L6 Activity manifest</td><td><code>next_activity</code></td><td>Warns</td><td>Summarize completed activities with real outcomes</td></tr>
+      </tbody>
+    </table>
+  </div>
 
   <h2 id="trace">The trace (L7)</h2>
   <p>The server mechanically records every tool call — name, timing, status, workflow/activity/agent attribution, errors, and any validation warnings. At each activity transition the events are packaged into a compact, HMAC-signed trace token returned in <code>_meta.trace_token</code>; the agent accumulates these opaque strings and can resolve them at any time with <a href="../api/tools.html#get_trace"><code>get_trace</code></a>. Agents additionally write a semantic trace (step outputs, decisions, variable changes) to the planning folder; together the two give complete post-hoc visibility.</p>
@@ -92,6 +160,13 @@
   <h2 id="limits">Honest limitations</h2>
   <p>The enforcement is detection-oriented, not proof-oriented. The server verifies that steps were <em>reported</em>, not that the work was done; that a claimed condition maps to the target, not that it is true; that a checkpoint was <em>answered</em> after a plausible delay, not that a human saw it. The mechanical trace corroborates what tool calls actually happened, and post-hoc audit can cross-reference claims against checkpoint logs — the full list of limitations is in the <a href="https://github.com/m2ux/workflow-server/blob/main/docs/workflow-fidelity.md">canonical document</a>.</p>
 </main>
+
+
+<!-- BEGIN GENERATED PAGINATION -->
+  <nav class="page-pagination" aria-label="Page sequence">
+    <a class="page-pagination__prev" href="./resource-resolution.html">← Resolution</a>
+  </nav>
+<!-- END GENERATED PAGINATION -->
 
 <footer class="site-footer">
   <div class="site-footer__inner">

--- a/site/style.css
+++ b/site/style.css
@@ -83,6 +83,33 @@ body {
   line-height: 1.65;
 }
 
+/* Readable prose measure; tables and diagrams stay full shell width */
+.prose,
+.hero .lede,
+main > p,
+main > ul:not(.card-grid):not(.pill-row):not(.steps),
+main > ol:not(.steps),
+.card p,
+.tool-summary,
+.schema-summary,
+.note {
+  max-width: 65ch;
+}
+
+main > h1,
+main > h2,
+main > h3,
+.breadcrumb,
+.page-pagination,
+.audience-badge,
+.implementer-panel,
+figure.diagram,
+.table-wrap,
+.card-grid,
+.steps {
+  max-width: var(--shell);
+}
+
 /* Text and graphics both flow to the full shell width, left-aligned to the
    shell edge, so the page uses the available screen width consistently. */
 h1, h2, h3 {
@@ -177,10 +204,62 @@ main,
 .site-nav ul {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-3);
+  gap: var(--space-2) var(--space-3);
   list-style: none;
   margin: 0;
   padding: 0;
+}
+
+.site-nav__primary {
+  align-items: center;
+}
+
+.site-nav__group {
+  position: relative;
+}
+
+.site-nav__group summary {
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  list-style: none;
+  padding: 0.15em 0;
+}
+
+.site-nav__group summary::-webkit-details-marker { display: none; }
+
+.site-nav__group summary::after {
+  content: " ▾";
+  font-size: 0.8em;
+}
+
+.site-nav__group[open] summary::after { content: " ▴"; }
+
+.site-nav__group > ul {
+  position: absolute;
+  top: calc(100% + 0.35rem);
+  left: 0;
+  z-index: 20;
+  flex-direction: column;
+  align-items: stretch;
+  min-width: 11rem;
+  padding: var(--space-2);
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 0.08);
+}
+
+.site-nav__group > ul a {
+  display: block;
+  padding: 0.35em 0.5em;
+  border-radius: 4px;
+}
+
+.site-nav__group > ul a[aria-current="page"] {
+  background: var(--bg-inset);
+  color: var(--text);
+  font-weight: 600;
 }
 
 .site-nav a {
@@ -190,6 +269,115 @@ main,
 }
 
 .site-nav a:hover { color: var(--text); text-decoration: underline; }
+
+/* Breadcrumb */
+
+.breadcrumb {
+  max-width: var(--shell);
+  margin: var(--space-2) auto 0;
+  padding: 0 var(--space-3);
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.breadcrumb ol {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.breadcrumb li + li::before {
+  content: "/";
+  margin-right: var(--space-1);
+  color: var(--border);
+}
+
+.breadcrumb a { color: var(--link); }
+
+/* Page pagination */
+
+.page-pagination {
+  max-width: var(--shell);
+  margin: var(--space-4) auto 0;
+  padding: var(--space-3);
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-3);
+  border-top: 1px solid var(--border);
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.page-pagination a {
+  color: var(--link);
+  text-decoration: none;
+}
+
+.page-pagination a:hover { text-decoration: underline; }
+
+/* Audience and notes */
+
+.audience-badge {
+  margin: 0 0 var(--space-1);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.note {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.implementer-panel,
+.tool-details,
+.schema-details {
+  margin: var(--space-3) 0;
+  padding: var(--space-3);
+  background: var(--bg-inset);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  max-width: 65ch;
+}
+
+.implementer-panel > summary,
+.tool-details > summary,
+.schema-details > summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.table-caption {
+  margin: var(--space-2) 0 var(--space-1);
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.takeaway {
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: var(--space-2);
+}
+
+.contributor-note {
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-inset);
+  border-left: 3px solid var(--accent);
+  border-radius: 0 var(--radius) var(--radius) 0;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  max-width: 65ch;
+}
+
+.card-grid--personas {
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+}
 
 main { padding-top: var(--space-4); padding-bottom: var(--space-5); }
 
@@ -324,6 +512,8 @@ tbody tr:last-child td { border-bottom: none; }
 
 .tool + .tool { border-top: 1px solid var(--border); padding-top: var(--space-3); }
 
+.tool-summary { color: var(--text-muted); }
+
 .no-params { color: var(--text-muted); font-style: italic; }
 
 /* Footer */
@@ -342,4 +532,12 @@ tbody tr:last-child td { border-bottom: none; }
   flex-wrap: wrap;
   gap: var(--space-2) var(--space-4);
   justify-content: space-between;
+}
+
+@media (max-width: 768px) {
+  .site-nav__group > ul {
+    position: static;
+    margin-top: var(--space-1);
+    box-shadow: none;
+  }
 }

--- a/tests/site.test.ts
+++ b/tests/site.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { renderSitePages } from '../scripts/generate-site-data.js';
+import { renderSitePages, checkSiteNavigation } from '../scripts/generate-site-data.js';
 import { checkSiteLinks } from '../scripts/check-site-links.js';
 import { checkSvgLayout } from '../scripts/check-svg-layout.js';
 
@@ -13,6 +13,10 @@ describe('documentation site', () => {
       const committed = readFileSync(join(SITE_DIR, relPath), 'utf-8');
       expect(committed, `site/${relPath} is stale — run npm run build:site and commit the result`).toBe(content);
     }
+  });
+
+  it('every page has global navigation linking all registered routes', () => {
+    expect(checkSiteNavigation()).toEqual([]);
   });
 
   it('internal links, anchors, and GitHub repo links resolve', () => {


### PR DESCRIPTION
## Summary
- Add generated global navigation, breadcrumbs, and prev/next links across all 20 HTML pages via a central `SITE_ROUTES` registry in `scripts/generate-site-data.ts`.
- Rework the home page around task-based entry paths and an on-site-first "Where to start" index; fix guide order to IDE setup before running workflows.
- Improve readability with prose width limits, shorter copy, glossary terms, contributor notes, and progressive disclosure for generated API/schema reference content.

## Test plan
- [x] `npm run build:site`
- [x] `npm run check:site`
- [x] `npm run check:svg`
- [x] `npm run typecheck`
- [x] `npm test -- --run tests/site.test.ts`
- [ ] Spot-check home, guide, specs model pages, and API tools page in browser (light/dark)