### PR TITLE
docs(techniques): advise inspect_session in close-out techniques (#193)

### DIFF
--- a/meta/techniques/workflow-engine/generate-summary.md
+++ b/meta/techniques/workflow-engine/generate-summary.md
@@ -26,6 +26,7 @@ Completed activities, checkpoint decisions, artifacts produced
 ## Protocol
 
 1. Draw from `{execution_trace}` to compose the summary sections: workflow id and title, start/completion timestamps, activities completed, key checkpoint decisions, artifacts with paths, outcomes satisfied vs. unmet, follow-up items. Return the assembled markdown as `{completion_summary}`.
+   > Obtain the execution trace through the `inspect_session` tool — `view: activities` for completed activities, `view: checkpoints` for checkpoint decisions, `view: history` for the event trace, or `view: summary` for all of it — rather than reading `session.json` directly.
 
 ## Rules
 

--- a/meta/techniques/workflow-engine/verify-outcomes.md
+++ b/meta/techniques/workflow-engine/verify-outcomes.md
@@ -26,3 +26,4 @@ Array of unsatisfied outcomes
 ## Protocol
 
 1. For each entry in `{outcomes}`, evaluate satisfaction against state variables, artifact presence in `planning_folder_path`, and the completed-activities trace; collect every unmet item into `{gaps}`.
+   > Read the state variables and completed-activities trace through the `inspect_session` tool (`view: variables` and `view: activities`, or `view: summary` for both) rather than reading `session.json` directly.

--- a/work-package/techniques/conduct-retrospective/retrospective.md
+++ b/work-package/techniques/conduct-retrospective/retrospective.md
@@ -32,6 +32,7 @@ Workflow [retrospective](../../resources/workflow-retrospective.md#output-sectio
 ### 1. Capture History
 
 - If metadata repository exists, capture session history.
+  > Obtain session state through the `inspect_session` tool (e.g. `view: history` for the event trace, `view: summary` for the full picture) rather than reading `session.json` directly.
 
 ### 2. Conduct Retrospective
 

--- a/work-package/techniques/conduct-retrospective/select-next.md
+++ b/work-package/techniques/conduct-retrospective/select-next.md
@@ -25,3 +25,4 @@ The identified next work package (when applicable) together with the context pre
 
 - Identify next work package if applicable.
 - Prepare context for transition.
+  > When carried context depends on the session's own record (variables, completed activities, checkpoint decisions), read it through the `inspect_session` tool (`view: summary`, or a narrower view) rather than reading `session.json` directly.


### PR DESCRIPTION
## Summary

Companion workflows-content change for issue #193. Adds an advisory note to the four close-out techniques directing workers to read session state via the new read-only `inspect_session` tool rather than reading `session.json` directly.

Pairs with the server-side tool in [PR #215](https://github.com/m2ux/workflow-server/pull/215) (targets `main`). This PR carries only the workflow-content half and targets the `workflows` orphan branch.

## Changes

- `meta/techniques/workflow-engine/verify-outcomes.md` — advise `inspect_session` (`view: variables`/`activities`/`summary`) for the outcome-satisfaction read.
- `meta/techniques/workflow-engine/generate-summary.md` — advise `inspect_session` for the activity/checkpoint/child-trace read.
- `work-package/techniques/conduct-retrospective/retrospective.md` — advise `inspect_session` for the retrospective's variable-bag/history read.
- `work-package/techniques/conduct-retrospective/select-next.md` — advise `inspect_session` for the carried-context read.

Content-only advisory blockquotes; no schema or version change.

Refs #193
