### PR TITLE
fix(work-package): hold submit-for-review until review received (3.29.0)

### DIFF
--- a/work-package/README.md
+++ b/work-package/README.md
@@ -74,7 +74,9 @@ graph TD
     SRD -->|"yes"| SFR["13 submit-for-review"]
     SRD -->|"rework"| PP
 
-    SFR --> RVD{"review outcome?"}
+    SFR --> RCV{"review received?"}
+    RCV -->|"no, still waiting"| RCV
+    RCV -->|"yes"| RVD{"review outcome?"}
     RVD -->|"approved/minor"| COMP["14 complete"]
     RVD -->|"significant changes"| PP
 

--- a/work-package/activities/13-submit-for-review.yaml
+++ b/work-package/activities/13-submit-for-review.yaml
@@ -1,5 +1,5 @@
 id: submit-for-review
-version: 1.10.0
+version: 1.11.0
 name: Submit for Review
 description: Submit the work for review — PR review lifecycle normally; a verified private-remote push in stealth mode.
 required: true
@@ -303,31 +303,47 @@ steps:
           variable: stealth_mode
           operator: "!="
           value: true
-  - kind: action
-    id: await-review
-    when: stealth_mode != true
-    actions: []
-  - kind: checkpoint
-    id: review-received
+  - kind: loop
+    id: await-review-loop
+    name: Await Review Loop
+    loopType: doWhile
     condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: is_review_mode
-          operator: "!="
-          value: true
-        - type: simple
-          variable: stealth_mode
-          operator: "!="
-          value: true
-    message: Has the PR received manual review feedback?
-    options:
-      - id: yes-review
-        label: Yes, review comments received
-        description: Proceed to analyze and respond to review comments
-      - id: no-waiting
-        label: No, still waiting for review
-        description: Continue waiting for review
+      type: simple
+      variable: awaiting_review
+      operator: ==
+      value: true
+    steps:
+      - kind: action
+        id: await-review
+        when: stealth_mode != true
+        actions: []
+      - kind: checkpoint
+        id: review-received
+        condition:
+          type: and
+          conditions:
+            - type: simple
+              variable: is_review_mode
+              operator: "!="
+              value: true
+            - type: simple
+              variable: stealth_mode
+              operator: "!="
+              value: true
+        message: Has the PR received manual review feedback?
+        options:
+          - id: yes-review
+            label: Yes, review comments received
+            description: Analyze and respond to the review comments now
+            effect:
+              setVariable:
+                awaiting_review: false
+          - id: no-waiting
+            label: No, still waiting for review
+            description: Keep holding; re-presented until review arrives
+            effect:
+              setVariable:
+                awaiting_review: true
   - kind: technique
     id: process-review-comments
     technique: respond-to-pr-review

--- a/work-package/workflow.yaml
+++ b/work-package/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: work-package
-version: 3.28.0
+version: 3.29.0
 title: Work Package Implementation Workflow
 description: Defines how to plan and implement ONE work package from inception to merged PR. A work package is a discrete unit of work such as a feature, bug-fix, enhancement, refactoring, or any other deliverable change. For multiple related work packages, use the work-packages workflow to create a roadmap first.
 author: m2ux
@@ -146,6 +146,10 @@ variables:
   - name: review_requires_changes
     type: boolean
     description: Whether PR review feedback requires returning to planning
+    defaultValue: false
+  - name: awaiting_review
+    type: boolean
+    description: Drives submit-for-review's await-review hold loop; while true the review-received checkpoint is re-presented until feedback arrives.
     defaultValue: false
   - name: needs_issue_creation
     type: boolean


### PR DESCRIPTION
## Problem

In `submit-for-review`, the `review-received` checkpoint's options (`yes-review` / `no-waiting`) carried **no effect and no transition**, and the review-response steps were gated on mode only. So picking **"No, still waiting for review"** set nothing, `review_requires_changes` stayed at its `false` default, and the **default transition fired straight to `complete`** — closing out the work package (worktree removal, retrospective) before any human review happened. "Still waiting" didn't wait.

## Fix

Wrap `await-review` + `review-received` in a **`doWhile` `await-review-loop`** keyed on a new `awaiting_review` variable, mirroring the shipped `research-reconciliation` loop idiom:

- **`no-waiting`** → `awaiting_review: true` → the loop re-presents `review-received` (a **live, resumable hold**; on resume the loop re-enters and re-prompts rather than replaying the stale answer or advancing).
- **`yes-review`** → `awaiting_review: false` → loop exits → `process-review-comments` → `review-outcome` → `complete` / `plan-prepare`.

The loop is **human-gated with no `maxIterations`**, so a stalled review can never be forced past the hold. The session only ever leaves `submit-for-review` once review is acknowledged.

Review-mode and stealth paths are unchanged (the checkpoint stays gated off; the loop makes one no-op pass and exits).

## Changes

- `workflow.yaml` — add `awaiting_review` (boolean, default `false`); version 3.28.0 → **3.29.0**.
- `activities/13-submit-for-review.yaml` (1.10.0 → **1.11.0**) — loop-wrap the review gate; give `review-received` options their `setVariable` effects.
- `README.md` — mermaid shows the `review-received` self-loop hold.

## Validation

Against this worktree via `--root`: schema `PASS` (all 15 activities); `check:variable-model` OK; `check:review-mode` OK (0 new); `check:stealth` OK; `check:identifiers` OK. No technique I/O touched, so `check:binding` is unaffected (its one drift item is the pre-existing `workflow-design` baseline staleness, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
