### PR TITLE
docs(readme): unify planning-folder README structure via a canonical meta guide

### DIFF
--- a/meta/resources/README.md
+++ b/meta/resources/README.md
@@ -2,7 +2,7 @@
 
 > Part of the [Meta Workflow](../README.md)
 
-Markdown resources providing the bootstrap navigation primer and prompt templates for sub-agent dispatch.
+Markdown resources providing the bootstrap navigation primer, prompt templates for sub-agent dispatch, and shared cross-workflow reference structures (such as the canonical planning-folder README guide).
 
 Tool reference content for Atlassian, GitNexus, and state management has moved into the corresponding capability techniques' operations — each operation declares its own `tools` block and any `prose` reference content.
 
@@ -16,6 +16,7 @@ Tool reference content for Atlassian, GitNexus, and state management has moved i
 | `activity-worker-prompt` | [Activity Worker Prompt](./activity-worker-prompt.md) | Template prompt for spawning an activity-worker sub-agent |
 | `workflow-orchestrator-prompt` | [Workflow Orchestrator Prompt](./workflow-orchestrator-prompt.md) | Template prompt for spawning a workflow-orchestrator sub-agent |
 | `session-summary-template` | [Session Summary Template](./session-summary-template.md) | Skeleton for the markdown session summary composed at workflow close |
+| `planning-readme` | [Planning Folder README Guide](./planning-readme.md) | Canonical structure + rules for the `README.md` entry-point of any workflow's planning folder; per-workflow README templates conform to it |
 
 ### Removed in v5/v6
 

--- a/meta/resources/planning-readme.md
+++ b/meta/resources/planning-readme.md
@@ -1,0 +1,83 @@
+---
+name: planning-readme
+description: Canonical structure and rules for the README.md entry-point of any workflow's planning folder — the shared skeleton that per-workflow README templates conform to.
+---
+
+# Planning Folder README Guide
+
+The `README.md` is the entry point for a workflow's planning folder (git hosting renders it when browsing). It is an **index** — a hub of links answering "what is this work, and what is its current status?" in under two minutes. It never restates what a linked artifact records (single-source-and-link).
+
+This is the **canonical structure** shared across workflows. Each workflow supplies a concrete seed template that conforms to it (`work-package/readme`, `workflow-design/design-context-readme`), consumed by `work-package::manage-artifacts::create-readme` to seed the file and `verify-readme-conforms` to drift-check it. A workflow may **append domain-specific sections after Solution Overview**; those extra sections are documented in that workflow's own README resource, not here.
+
+## Skeleton
+
+```markdown
+# [Descriptive Name] — [Month Year]
+
+> [Classifier] · Created [YYYY-MM-DD] · **Status:** [status]
+
+> **Note:** effort estimates are agentic (AI-assisted) development time plus separate human review time.
+
+## 🎯 Executive Summary
+
+[2-3 sentences explaining what this delivers and why it matters]
+
+## Problem Overview
+
+*Populated by the producing step (a `stakeholder-overview` call).*
+
+## Solution Overview
+
+*Populated by the producing step (a `stakeholder-overview` call).*
+
+## 📊 Progress
+
+| # | Item | Description | Estimate | Status |
+|---|------|-------------|----------|--------|
+| NN | [Artifact](artifact.md) | 3-8 word summary | 15-30m | ⬚ Pending |
+
+## 🔗 Links
+
+| Resource | Link |
+|----------|------|
+| [External reference] | [link] |
+```
+
+## Rules
+
+### Header line
+
+- One blockquote line: `[Classifier] · Created [date] · **Status:** [status]`. The **classifier** is the workflow's one-word kind label (e.g. work-package type `Feature`/`Bug-Fix`/`Enhancement`/`Refactor`; workflow-design mode `Create`/`Update`/`Review`).
+- Status appears **once**, in this line (state-once-per-artifact) — no footer status section, no closing narrative paragraph. Outcomes live in the completion document; link it from Progress, don't copy (single-source-and-link).
+- When the README is updated after completion, append `· Revised YYYY-MM-DD`.
+- The `Note` blockquote is retained whenever the Progress table carries an Estimate column.
+
+### Executive Summary
+
+2-3 sentences answering: what does this deliver, why does it matter, what's the key benefit — the concrete problem and measurable impact where known, not a one-line restatement of the title.
+
+### Problem Overview / Solution Overview
+
+Plain-language sections for non-technical stakeholders, each exactly two paragraphs, written by the `stakeholder-overview` technique (heading passed as `readme_section_heading`); the placeholder is replaced when the producing step executes.
+
+- **Problem Overview** — what the system currently does and why it's problematic, then the consequences.
+- **Solution Overview** — what the change does and how it works at a high level; links the plan for the task breakdown rather than re-listing the problem.
+
+### Progress table
+
+The primary navigation for the planning folder.
+
+- Each Item is hyperlinked to its artifact file; items with no standalone artifact are plain text with `—` in the # column.
+- The # column is the artifact's numbered prefix, matching the producing activity (artifacts from the same activity share the number).
+- Description: 3-8 word summary. Estimate: expected agentic time — adjust template defaults to the work's complexity.
+- Omit skipped optional items entirely — list only items that were or will be produced.
+- Status vocabulary: `⬚ Pending`, `◐ In Progress`, `✅ Complete`, `❌ Blocked`, `⊘ Cancelled`.
+
+### Links table
+
+External references only (tracker issue, parent epic, PR). Artifact links belong in the Progress table.
+
+### Layout discipline
+
+- **No `---` separators** between sections — the headings carry the structure.
+- Single-source-and-link: never restate content a linked artifact already records.

--- a/meta/techniques/workflow-engine/finalize-activity.md
+++ b/meta/techniques/workflow-engine/finalize-activity.md
@@ -53,5 +53,5 @@ optional — the transition target to take instead of the default, set when a ch
 
 ## Protocol
 
-1. Update the planning folder's `README.md` Progress table with one row per entry in `{artifacts_produced}`, then refresh the footer status.
+1. Update the planning folder's `README.md` Progress table with one row per entry in `{artifacts_produced}`, then refresh the header Status line (status is stated once, in the header — no footer; see the [planning-readme](../../resources/planning-readme.md) guide).
 2. Compile the `{activity_result}` envelope by folding `{steps_completed}`, `{checkpoints_responded}`, and `{artifacts_produced}` into the `activity_complete` object; include `{transition_override}` if a checkpoint effect specified `transitionTo`. Return `{activity_result}`.

--- a/meta/workflow.yaml
+++ b/meta/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: meta
-version: 5.3.0
+version: 5.4.0
 title: Meta Workflow
 description: Top-level lifecycle workflow that orchestrates client workflow sessions. Excluded from list_workflows — bootstrap navigates here directly.
 author: m2ux

--- a/work-package/resources/readme.md
+++ b/work-package/resources/readme.md
@@ -2,14 +2,14 @@
 name: readme
 description: Guidelines for creating the README.md entry-point document for work package planning folders.
 metadata:
-  version: 3.2.0
+  version: 3.3.0
   order: 1
   legacy_id: 1
 ---
 
 # Work Package README Guide
 
-The `README.md` is the entry point for a work package planning folder (git hosting renders it when browsing). It is an **index** — a hub of links answering "what is this work package and what's its current status?" in under 2 minutes. It never restates what a linked artifact records (single-source-and-link).
+The `README.md` is the entry point for a work package planning folder (git hosting renders it when browsing). It follows the canonical [Planning Folder README Guide](../../meta/resources/planning-readme.md); this resource supplies the concrete work-package seed template and the work-package-specific specifics below.
 
 ## Template
 
@@ -61,33 +61,10 @@ The `README.md` is the entry point for a work package planning folder (git hosti
 
 ## Rules
 
-### Header line
+The shared header-line, Executive Summary, Problem/Solution Overview, Progress-table, Links-table, and layout-discipline rules (status stated once, no footer, no `---`, single-source-and-link) are defined in the canonical [Planning Folder README Guide](../../meta/resources/planning-readme.md). Work-package specifics:
 
-- One blockquote line: type · creation date · status (lean-header). Status values: `Planning`, `Ready`, `In Progress`, `Complete`.
-- Status appears **once**, in this line (state-once-per-artifact) — no footer status section, no closing narrative paragraph. Outcomes live in COMPLETE.md and deferred items in the [deferred-items register](deferred-items.md); link them from Progress, don't copy (single-source-and-link).
-- When the README is updated after completion, append `· Revised YYYY-MM-DD`.
-
-### Executive Summary
-
-2-3 sentences answering: what does this deliver, why does it matter, what's the key benefit. Include the concrete problem and measurable impact where known — not a one-line restatement of the title.
-
-### Problem Overview / Solution Overview
-
-Plain-language sections for non-technical stakeholders, each exactly two paragraphs; the placeholder is replaced when the producing step executes.
-
-- **Problem Overview** — `present-problem-overview` step (`start-work-package`): what the system currently does and why it's problematic, then the consequences.
-- **Solution Overview** — `present-solution-overview` step (`plan-prepare`): what the fix does and how it works at a high level. Links the work package plan for the task breakdown rather than re-listing the problem items.
-
-### Progress Table
-
-The primary navigation for the planning folder.
-
-- Each Item is hyperlinked to its artifact file; items with no standalone artifact (Implementation, Validation, PR review) are plain text with "—" in the # column.
-- The # column is the artifact's numbered prefix, matching the producing activity (artifacts from the same activity share the number).
-- Description: 3-8 word summary. Estimate: expected agentic time — adjust template defaults to the work package's complexity.
-- Omit skipped optional activities entirely — list only items that were or will be produced.
-- Status vocabulary: `⬚ Pending`, `◐ In Progress`, `✅ Complete`, `❌ Blocked`, `⊘ Cancelled`.
-
-### Links Table
-
-External references only (Jira ticket, parent epic, PR). Artifact links belong in the Progress table.
+- **Classifier** — the work-package type: `Feature`, `Bug-Fix`, `Enhancement`, `Refactor`. Status values: `Planning`, `Ready`, `In Progress`, `Complete`.
+- **Problem Overview** — written by the `present-problem-overview` step (`start-work-package` activity).
+- **Solution Overview** — written by the `present-solution-overview` step (`plan-prepare` activity); links the work package plan rather than re-listing the problem items.
+- **Outcomes and deferred items** live in [COMPLETE.md](complete-wp.md) and the [deferred-items register](deferred-items.md); link them from Progress, don't copy.
+- **Links table** — Jira ticket, parent epic, PR.

--- a/workflow-design/activities/01-intake-and-context.yaml
+++ b/workflow-design/activities/01-intake-and-context.yaml
@@ -1,5 +1,5 @@
 id: intake-and-context
-version: 1.0.0
+version: 1.1.0
 name: Intake and Context
 description: "Establish the operation type, mode, and target for the request, and internalize the schema system and YAML-format conventions that ground all drafting."
 required: true
@@ -65,8 +65,23 @@ steps:
     technique:
       name: work-package::manage-artifacts::create-readme
       inputs:
-        entity_context: "entity_title={workflow_id}; entity_type=workflow-design-session; status=Planning"
+        entity_context: "entity_title={workflow_id}; entity_type={operation_type}; status=Planning"
         readme_template: workflow-design/design-context-readme
+    condition:
+      type: simple
+      variable: is_review_mode
+      operator: "!="
+      value: true
+  - kind: technique
+    id: present-problem-overview
+    technique:
+      name: work-package::stakeholder-overview
+      inputs:
+        readme_section_heading: "## Problem Overview"
+        source_material: the requested change, the target workflow's current shape, and any context gathered during this activity
+    actions:
+      - action: message
+        message: "**Problem Overview** (plain-language summary for stakeholder reference)"
     condition:
       type: simple
       variable: is_review_mode

--- a/workflow-design/activities/06-scope-and-draft.yaml
+++ b/workflow-design/activities/06-scope-and-draft.yaml
@@ -1,5 +1,5 @@
 id: scope-and-draft
-version: 1.3.0
+version: 1.4.0
 name: Scope and Draft
 description: A complete file manifest and structural design for the target workflow, drafted and reviewed file by file with schema validation on each YAML file.
 required: true
@@ -25,6 +25,16 @@ steps:
       - id: revise
         label: Needs revision
         description: File manifest or implementation order requires adjustment.
+  - kind: technique
+    id: present-solution-overview
+    technique:
+      name: work-package::stakeholder-overview
+      inputs:
+        readme_section_heading: "## Solution Overview"
+        source_material: the confirmed scope manifest and the structural design for the target workflow
+    actions:
+      - action: message
+        message: "**Solution Overview** (plain-language summary for stakeholder reference)"
   - kind: loop
     id: file-drafting-loop
     name: File Drafting Loop

--- a/workflow-design/resources/README.md
+++ b/workflow-design/resources/README.md
@@ -76,7 +76,7 @@ Supplementary guide for review mode. The audit procedure itself is canonical in 
 
 ### 05 — Design Context README
 
-Template and section guidelines for the `README.md` entry-point of a workflow-design session's planning folder — the workflow-design counterpart of the work-package readme guide. Sections: header (workflow id / mode / status), Executive Summary, Design Decisions, Compliance Findings, Scope Manifest, Activity Progress table, Links.
+Template and section guidelines for the `README.md` entry-point of a workflow-design session's planning folder. Conforms to the canonical [meta planning-readme guide](../../meta/resources/planning-readme.md) — shared with the work-package readme guide — and appends the design-session sections. Sections: header (mode · created · status), Executive Summary, Problem Overview, Solution Overview, Design Decisions, Compliance Findings, Scope Manifest, Progress table, Links.
 
 ### 06 — Completion Artifact
 

--- a/workflow-design/resources/design-context-readme.md
+++ b/workflow-design/resources/design-context-readme.md
@@ -1,44 +1,39 @@
 ---
 name: design-context-readme
-description: Template and guidelines for the README.md entry-point of a workflow-design session's planning folder.
+description: Template and guidelines for the README.md entry-point of a workflow-design session's planning folder. Conforms to the canonical meta planning-readme guide, with design-session sections appended.
 metadata:
+  version: 1.0.0
   order: 5
 ---
 
 # Design Session README Guide
 
-**Purpose:** Guidelines for creating the `README.md` entry-point document for a workflow-design session's planning folder. It is the workflow-design counterpart of the work-package [readme](../../work-package/resources/readme.md) guide.
-
----
-
-## Overview
-
-The `README.md` is the entry point and executive summary for a workflow-design session. It answers "which workflow is being created/updated/reviewed, in what mode, and how far along is the work?" in under two minutes, and links the session's planning artifacts (compliance report, review snapshot) by phase.
-
----
+The `README.md` is the entry point for a workflow-design session's planning folder. It follows the canonical [Planning Folder README Guide](../../meta/resources/planning-readme.md); this resource supplies the concrete design-session seed template and documents the design-session-specific sections (Design Decisions, Compliance Findings, Scope Manifest) appended after Solution Overview.
 
 ## Template
 
 ```markdown
-# [Workflow ID] — Design Session
+# [Descriptive Change Name] — [Month Year]
 
-**Created:** [Date]  
-**Mode:** [Create/Update/Review]  
-**Status:** [Planning/Drafting/Reviewing/Complete]
+> [Create/Update/Review] · Created [YYYY-MM-DD] · **Status:** [Planning/Drafting/Reviewing/Complete]
 
----
+> **Note:** effort estimates are agentic (AI-assisted) development time plus separate human review time.
 
 ## 🎯 Executive Summary
 
 [2-3 sentences: what this workflow does (or what is changing), and why this session is being run]
 
----
+## Problem Overview
+
+*Populated by the present-problem-overview step (intake-and-context activity).*
+
+## Solution Overview
+
+*Populated by the present-solution-overview step (scope-and-draft activity).*
 
 ## Design Decisions
 
 *Key design decisions and their rationale, captured as the session progresses (activity sequencing, checkpoint necessity, technique bindings, rule enforcement). Left as placeholder until requirements refinement populates it.*
-
----
 
 ## Compliance Findings
 
@@ -48,28 +43,24 @@ The `README.md` is the entry point and executive summary for a workflow-design s
 |----------|---------|----------|-----|
 | — | *None yet* | — | — |
 
----
-
 ## Scope Manifest
 
 *Files to create, modify, or remove for this workflow, confirmed during scope-and-draft. Left as placeholder until then.*
 
----
+## 📊 Progress
 
-## 📊 Activity Progress
-
-| # | Activity | Mode | Status |
-|---|----------|------|--------|
-| 01 | Intake and Context | All | ⬚ Pending |
-| 03 | Requirements Refinement | Create, Update | ⬚ Pending |
-| 04 | Pattern Analysis / Impact Analysis | Create / Update | ⬚ Pending |
-| 06 | Scope and Draft | Create, Update | ⬚ Pending |
-| 08 | Quality Review | All | ⬚ Pending |
-| 09 | Validate and Commit | All | ⬚ Pending |
-| 10 | Post-Update Review | Update | ⬚ Pending |
-| 11 | Retrospective | Create, Update | ⬚ Pending |
-
----
+| # | Item | Description | Estimate | Status |
+|---|------|-------------|----------|--------|
+| 01 | Intake and Context | Classify mode; load schema + format baseline | 10-20m | ⬚ Pending |
+| 03 | Requirements Refinement | Elicit and refine the change requirements | 20-45m | ⬚ Pending |
+| 04 | Pattern Analysis | Corpus reuse survey (create mode) | 15-30m | ⬚ Pending |
+| 05 | Impact Analysis | Blast radius of the change (update mode) | 15-30m | ⬚ Pending |
+| 06 | Scope and Draft | Confirm scope manifest; draft the definition files | 30-90m | ⬚ Pending |
+| 08 | Quality Review | Multi-lens audit vs schema, principles, anti-patterns | 20-45m | ⬚ Pending |
+| 09 | Validate and Commit | Verify scope, README, build; commit | 10-20m | ⬚ Pending |
+| 10 | Post-Update Review | Update-mode regression review | 15-30m | ⬚ Pending |
+| 11 | Retrospective | Session lessons and follow-ups | 10-20m | ⬚ Pending |
+| 08 | [Close-out (COMPLETE.md)](COMPLETE.md) | Deliverables, design decisions, limitations | 10-20m | ⬚ Pending |
 
 ## 🔗 Links
 
@@ -77,32 +68,21 @@ The `README.md` is the entry point and executive summary for a workflow-design s
 |----------|------|
 | Target workflow | `workflows/[workflow-id]/` |
 | Related workflow | [name](../../[related]/README.md) |
-
----
-
-**Status:** Ready for drafting
+| PR | [#N](https://{repo_host}/{org}/{repo}/pull/N) |
 ```
 
----
+## Rules
 
-## Section Guidelines
+The shared header-line, Executive Summary, Problem/Solution Overview, Progress-table, Links-table, and layout-discipline rules (status stated once, no footer, no `---`, single-source-and-link) are defined in the canonical [Planning Folder README Guide](../../meta/resources/planning-readme.md). Design-session specifics:
 
-### Header Block
-
-| Field | Description | Example |
-|-------|-------------|---------|
-| **Workflow ID** | The workflow being created, updated, or reviewed | `incident-response` |
-| **Created** | Exact creation date | `2026-06-26` |
-| **Mode** | The operation type set at intake | `Create`, `Update`, `Review` |
-| **Status** | Current state of the session | `Planning`, `Drafting`, `Reviewing`, `Complete` |
-
-### Executive Summary
-
-Two to three sentences answering: what does this workflow do (or what is changing), and why is this session being run.
+- **Classifier** — the session mode: `Create`, `Update`, or `Review`. Status values: `Planning`, `Drafting`, `Reviewing`, `Complete`.
+- **Problem Overview** — written by the `present-problem-overview` step (`intake-and-context` activity): what the current workflow does and why it needs changing.
+- **Solution Overview** — written by the `present-solution-overview` step (`scope-and-draft` activity): what the change does at a high level; links the scope manifest rather than re-listing it.
+- **Progress table** — lists the session's activities as Items; omit activities the active mode skips. Review mode branches straight to quality review and has no planning README.
 
 ### Design Decisions
 
-Capture the non-obvious design choices and their rationale as they are confirmed — activity boundaries, which constraints become checkpoints, technique bindings chosen, rule scope. This is the durable record of *why* the workflow is shaped the way it is.
+Capture the non-obvious design choices and their rationale as they are confirmed — activity boundaries, which constraints become checkpoints, technique bindings chosen, rule scope. This is the durable record of *why* the workflow is shaped the way it is; COMPLETE.md draws its Design Decisions from here.
 
 ### Compliance Findings
 
@@ -112,17 +92,8 @@ Populated by the quality-review (create/update) and post-update-review (update) 
 
 The complete list of files to create, modify, or remove, confirmed before drafting. Mirrors the `scope_manifest` variable.
 
-### Activity Progress
-
-The primary navigation for the planning folder. Use the status indicators ⬚ Pending, ◐ In Progress, ✅ Complete, ❌ Blocked, ⊘ Cancelled. Omit activities that the active mode skips. The # column matches the producing activity's number so artifacts sort by phase.
-
-### Links Table
-
-The target workflow's location in the `workflows/` worktree, plus any related workflows. Planning artifacts (compliance report, review snapshot) are reached from the Activity Progress rows, not here.
-
----
-
 ## Related Guides
 
-- [Work Package README Guide](../../work-package/resources/readme.md) — the work-package counterpart this template parallels
+- [Planning Folder README Guide](../../meta/resources/planning-readme.md) — the canonical structure this template conforms to
+- [Work Package README Guide](../../work-package/resources/readme.md) — the work-package counterpart, conforming to the same canonical structure
 - [Workflow Design Workflow](../README.md)

--- a/workflow-design/techniques/README.md
+++ b/workflow-design/techniques/README.md
@@ -32,5 +32,6 @@ These operations are referenced cross-workflow (resolved directly from the named
 | Reference | Used for |
 |-----------|----------|
 | [`work-package::manage-artifacts`](../../work-package/techniques/manage-artifacts/TECHNIQUE.md) | `create-readme` (seed the planning README), `write-artifact` (numbered artifacts), `verify-readme-conforms` (drift check) |
+| [`work-package::stakeholder-overview`](../../work-package/techniques/stakeholder-overview.md) | Plain-language Problem Overview (intake) and Solution Overview (scope-and-draft) sections of the planning README |
 | [`work-package::review-assumptions`](../../work-package/techniques/review-assumptions/TECHNIQUE.md) | `collect`, `interview`, `record` for the design-assumption lifecycle |
 | [`meta::version-control`](../../meta/techniques/version-control/TECHNIQUE.md) | `commit-regular-files` for committing artifacts |

--- a/workflow-design/workflow.yaml
+++ b/workflow-design/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: workflow-design
-version: 1.8.0
+version: 1.9.0
 title: Workflow Design Workflow
 description: Guide agents through creating, updating, or reviewing workflow definitions.
 author: m2ux
@@ -34,7 +34,7 @@ rules:
     - Present approach before implementation — show what will change, how, and in what order before modifying any file
     - Corrections must persist — record corrections and verify compliance at every subsequent checkpoint
     - All YAML files must pass schema validation before commit — run validation on every produced file
-    - On completing each activity, update the planning-folder `README.md` progress tracker — mark this activity's row ✅ Complete in the Activity Progress table and set the session Status to the current milestone. (No session README exists in review mode, where the seed step is skipped.)
+    - On completing each activity, update the planning-folder `README.md` progress tracker — mark this activity's row ✅ Complete in the 📊 Progress table and set the header Status line to the current lifecycle state (Planning/Drafting/Reviewing/Complete). (No session README exists in review mode, where the seed step is skipped.)
 techniques:
   activity:
     - variable-binding


### PR DESCRIPTION
## What & why

The `work-package` and `workflow-design` workflows each seed a planning-folder `README.md` from a template resource, using the *same* borrowed machinery (`create-readme` / `verify-readme-conforms`) — only the template resource differed, and the two had drifted into different house styles (3-line vs blockquote header, `---` separators + footer status vs none, `Activity Progress` vs `Progress`, different column sets). A reader browsing the two folders saw two different document shapes.

This factors the shared skeleton + discipline rules into a **canonical meta guide** both workflows conform to, and brings `workflow-design` into line with the `work-package` house style while keeping its design-session-specific sections.

## Changes

**meta**
- **New `meta/resources/planning-readme.md`** — canonical structure (title · `> Classifier · Created · Status` blockquote · effort note · 🎯 Executive Summary · Problem Overview · Solution Overview · 📊 Progress · 🔗 Links) + shared rules (status stated once in the header, single-source-and-link). Indexed in `meta/resources/README.md`.
- `finalize-activity` protocol aligned to the canonical header Status (was "refresh the footer status").
- v5.3.0 → **v5.4.0**

**work-package**
- `readme.md` keeps its concrete seed template; the duplicated rule prose is replaced with a pointer to the meta guide. **No change to what WP instances render.**
- Resource `readme` frontmatter v3.2.0 → **v3.3.0**. `work-package/workflow.yaml` version is left untouched to avoid colliding with the concurrent PR #228 bump to 3.30.0.

**workflow-design**
- `design-context-readme.md` rewritten to the canonical layout — blockquote header (Mode as the classifier), effort note, **Problem/Solution Overview added**, `📊 Progress` 5-col table (dropped the per-session `Mode` column), `---` separators and duplicate footer status removed — while **keeping** the Design Decisions / Compliance Findings / Scope Manifest design-session sections after Solution Overview.
- Added `present-problem-overview` (intake) and `present-solution-overview` (scope-and-draft) steps borrowing `work-package::stakeholder-overview`, so the two new sections are actually written; `operation_type` fed as the header classifier; borrow noted in `techniques/README.md`; progress-update rule text aligned.
- v1.8.0 → **v1.9.0**

## Validation

All corpus guards pass against this branch (anchors, binding, identifiers, variable-model, review-mode, fragments, technique-template, audience, activity-tech, self-input, stealth). Full vitest suite: **41 files / 572 tests pass**, including every test exercising workflow-design, the borrowed-technique resolver, loader, and schema.

The `binding-fidelity` and `e2e/snapshot` tests fail **identically on the unmodified `workflows` HEAD** — pre-existing baseline/snapshot drift, handled by the separate server-side regen on the next submodule pointer bump. This change introduces **zero** binding-fidelity delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
