### PR TITLE
docs(readme): state planning-README rules positively (follow-up to #229)

### DIFF
--- a/meta/resources/planning-readme.md
+++ b/meta/resources/planning-readme.md
@@ -5,9 +5,9 @@ description: Canonical structure and rules for the README.md entry-point of any 
 
 # Planning Folder README Guide
 
-The `README.md` is the entry point for a workflow's planning folder (git hosting renders it when browsing). It is an **index** — a hub of links answering "what is this work, and what is its current status?" in under two minutes. It never restates what a linked artifact records (single-source-and-link).
+The `README.md` is the entry point for a workflow's planning folder (git hosting renders it when browsing). It is an **index** — a hub of links answering "what is this work, and what is its current status?" in under two minutes. Each linked artifact is the single home of its own content; the README links to it (single-source-and-link).
 
-This is the **canonical structure** shared across workflows. Each workflow supplies a concrete seed template that conforms to it (`work-package/readme`, `workflow-design/design-context-readme`), consumed by `work-package::manage-artifacts::create-readme` to seed the file and `verify-readme-conforms` to drift-check it. A workflow may **append domain-specific sections after Solution Overview**; those extra sections are documented in that workflow's own README resource, not here.
+This is the **canonical structure** shared across workflows. Each workflow supplies a concrete seed template that conforms to it (`work-package/readme`, `workflow-design/design-context-readme`), consumed by `work-package::manage-artifacts::create-readme` to seed the file and `verify-readme-conforms` to drift-check it. A workflow may **append domain-specific sections after Solution Overview**; those extra sections are documented in that workflow's own README resource.
 
 ## Skeleton
 
@@ -48,36 +48,31 @@ This is the **canonical structure** shared across workflows. Each workflow suppl
 ### Header line
 
 - One blockquote line: `[Classifier] · Created [date] · **Status:** [status]`. The **classifier** is the workflow's one-word kind label (e.g. work-package type `Feature`/`Bug-Fix`/`Enhancement`/`Refactor`; workflow-design mode `Create`/`Update`/`Review`).
-- Status appears **once**, in this line (state-once-per-artifact) — no footer status section, no closing narrative paragraph. Outcomes live in the completion document; link it from Progress, don't copy (single-source-and-link).
+- State the status once, in this line (state-once-per-artifact). Outcomes live in the completion document, linked from Progress (single-source-and-link).
 - When the README is updated after completion, append `· Revised YYYY-MM-DD`.
 - The `Note` blockquote is retained whenever the Progress table carries an Estimate column.
 
 ### Executive Summary
 
-2-3 sentences answering: what does this deliver, why does it matter, what's the key benefit — the concrete problem and measurable impact where known, not a one-line restatement of the title.
+2-3 sentences answering: what does this deliver, why does it matter, what's the key benefit — with the concrete problem and measurable impact where known.
 
 ### Problem Overview / Solution Overview
 
 Plain-language sections for non-technical stakeholders, each exactly two paragraphs, written by the `stakeholder-overview` technique (heading passed as `readme_section_heading`); the placeholder is replaced when the producing step executes.
 
 - **Problem Overview** — what the system currently does and why it's problematic, then the consequences.
-- **Solution Overview** — what the change does and how it works at a high level; links the plan for the task breakdown rather than re-listing the problem.
+- **Solution Overview** — what the change does and how it works at a high level; links the plan for the task breakdown.
 
 ### Progress table
 
 The primary navigation for the planning folder.
 
-- Each Item is hyperlinked to its artifact file; items with no standalone artifact are plain text with `—` in the # column.
+- Items link their artifact files. An inline item such as Implementation or Validation is plain text with `—` in the # column.
 - The # column is the artifact's numbered prefix, matching the producing activity (artifacts from the same activity share the number).
 - Description: 3-8 word summary. Estimate: expected agentic time — adjust template defaults to the work's complexity.
-- Omit skipped optional items entirely — list only items that were or will be produced.
+- List the items that were or will be produced.
 - Status vocabulary: `⬚ Pending`, `◐ In Progress`, `✅ Complete`, `❌ Blocked`, `⊘ Cancelled`.
 
 ### Links table
 
-External references only (tracker issue, parent epic, PR). Artifact links belong in the Progress table.
-
-### Layout discipline
-
-- **No `---` separators** between sections — the headings carry the structure.
-- Single-source-and-link: never restate content a linked artifact already records.
+Holds external references — tracker issue, parent epic, PR. Artifact links belong in the Progress table.

--- a/meta/techniques/workflow-engine/finalize-activity.md
+++ b/meta/techniques/workflow-engine/finalize-activity.md
@@ -53,5 +53,5 @@ optional — the transition target to take instead of the default, set when a ch
 
 ## Protocol
 
-1. Update the planning folder's `README.md` Progress table with one row per entry in `{artifacts_produced}`, then refresh the header Status line (status is stated once, in the header — no footer; see the [planning-readme](../../resources/planning-readme.md) guide).
+1. Update the planning folder's `README.md` Progress table with one row per entry in `{artifacts_produced}`, then update the header Status line to the current state (see the [planning-readme](../../resources/planning-readme.md) guide).
 2. Compile the `{activity_result}` envelope by folding `{steps_completed}`, `{checkpoints_responded}`, and `{artifacts_produced}` into the `activity_complete` object; include `{transition_override}` if a checkpoint effect specified `transitionTo`. Return `{activity_result}`.

--- a/work-package/resources/readme.md
+++ b/work-package/resources/readme.md
@@ -61,10 +61,10 @@ The `README.md` is the entry point for a work package planning folder (git hosti
 
 ## Rules
 
-The shared header-line, Executive Summary, Problem/Solution Overview, Progress-table, Links-table, and layout-discipline rules (status stated once, no footer, no `---`, single-source-and-link) are defined in the canonical [Planning Folder README Guide](../../meta/resources/planning-readme.md). Work-package specifics:
+The shared header-line, Executive Summary, Problem/Solution Overview, Progress-table, and Links-table rules are defined in the canonical [Planning Folder README Guide](../../meta/resources/planning-readme.md). Work-package specifics:
 
 - **Classifier** — the work-package type: `Feature`, `Bug-Fix`, `Enhancement`, `Refactor`. Status values: `Planning`, `Ready`, `In Progress`, `Complete`.
 - **Problem Overview** — written by the `present-problem-overview` step (`start-work-package` activity).
-- **Solution Overview** — written by the `present-solution-overview` step (`plan-prepare` activity); links the work package plan rather than re-listing the problem items.
-- **Outcomes and deferred items** live in [COMPLETE.md](complete-wp.md) and the [deferred-items register](deferred-items.md); link them from Progress, don't copy.
+- **Solution Overview** — written by the `present-solution-overview` step (`plan-prepare` activity); links the work package plan for the task breakdown.
+- **Outcomes and deferred items** live in [COMPLETE.md](complete-wp.md) and the [deferred-items register](deferred-items.md), linked from Progress (single-source-and-link).
 - **Links table** — Jira ticket, parent epic, PR.

--- a/workflow-design/resources/design-context-readme.md
+++ b/workflow-design/resources/design-context-readme.md
@@ -73,12 +73,12 @@ The `README.md` is the entry point for a workflow-design session's planning fold
 
 ## Rules
 
-The shared header-line, Executive Summary, Problem/Solution Overview, Progress-table, Links-table, and layout-discipline rules (status stated once, no footer, no `---`, single-source-and-link) are defined in the canonical [Planning Folder README Guide](../../meta/resources/planning-readme.md). Design-session specifics:
+The shared header-line, Executive Summary, Problem/Solution Overview, Progress-table, and Links-table rules are defined in the canonical [Planning Folder README Guide](../../meta/resources/planning-readme.md). Design-session specifics:
 
 - **Classifier** — the session mode: `Create`, `Update`, or `Review`. Status values: `Planning`, `Drafting`, `Reviewing`, `Complete`.
 - **Problem Overview** — written by the `present-problem-overview` step (`intake-and-context` activity): what the current workflow does and why it needs changing.
-- **Solution Overview** — written by the `present-solution-overview` step (`scope-and-draft` activity): what the change does at a high level; links the scope manifest rather than re-listing it.
-- **Progress table** — lists the session's activities as Items; omit activities the active mode skips. Review mode branches straight to quality review and has no planning README.
+- **Solution Overview** — written by the `present-solution-overview` step (`scope-and-draft` activity): what the change does at a high level; links the scope manifest for the file breakdown.
+- **Progress table** — lists the activities the active mode runs, as Items. The planning README is seeded in create and update modes; review mode branches straight to quality review.
 
 ### Design Decisions
 

--- a/workflow-design/workflow.yaml
+++ b/workflow-design/workflow.yaml
@@ -34,7 +34,7 @@ rules:
     - Present approach before implementation — show what will change, how, and in what order before modifying any file
     - Corrections must persist — record corrections and verify compliance at every subsequent checkpoint
     - All YAML files must pass schema validation before commit — run validation on every produced file
-    - On completing each activity, update the planning-folder `README.md` progress tracker — mark this activity's row ✅ Complete in the 📊 Progress table and set the header Status line to the current lifecycle state (Planning/Drafting/Reviewing/Complete). (No session README exists in review mode, where the seed step is skipped.)
+    - On completing each activity, update the planning-folder `README.md` progress tracker — mark this activity's row ✅ Complete in the 📊 Progress table and set the header Status line to the current lifecycle state (Planning/Drafting/Reviewing/Complete). (The session README is present in create and update modes, where the seed step runs.)
 techniques:
   activity:
     - variable-binding


### PR DESCRIPTION
## What & why

Follow-up to #229. The canonical planning-README guide (`meta/planning-readme`) and the two conforming resources phrased several rules as **prohibitions** — "no footer status section", "No `---` separators", "never restate", "omit skipped items", "rather than re-listing". Documentation should describe the system *as it is*; enumerating what isn't there is unbounded and adds noise. This rewrites each rule as a positive statement and lets the template demonstrate the layout.

#229 merged at the pre-fix commit, so these edits land as a separate PR.

## Changes (5 files, docs-only)

- **`meta/resources/planning-readme.md`** — "state the status once, in the header line"; single-source-and-link stated affirmatively; dropped the all-negative "Layout discipline" subsection (the template already shows the layout); "Items link their artifact files; an inline item such as Implementation is plain text with `—`".
- **`meta/techniques/workflow-engine/finalize-activity.md`** — "update the header Status line to the current state".
- **`work-package/resources/readme.md`** & **`workflow-design/resources/design-context-readme.md`** — dropped the "(status stated once, no footer, no `---`, …)" parentheticals and the "rather than re-listing" clauses.
- **`workflow-design/workflow.yaml`** — "the session README is present in create and update modes" instead of "no session README exists in review mode".

## Validation

`check:anchors` and `check:technique-template` pass against this branch; the change is documentation prose only (no schema, binding, or structural change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
