### PR TITLE
docs(checkpoints): teach agents replay vs #instance loop yields

### DIFF
--- a/meta/resources/activity-worker-prompt.md
+++ b/meta/resources/activity-worker-prompt.md
@@ -28,9 +28,14 @@ You are an autonomous worker agent executing a single activity for the `{workflo
 
 ## Checkpoint handling
 
-When a step reaches a checkpoint, call `yield_checkpoint { session_index, checkpoint_id }`. The response `status` tells you what happened:
+When a step reaches a checkpoint, call `yield_checkpoint { session_index, checkpoint_id }`. Choose `checkpoint_id` as follows:
+
+- **Outside a loop, or when every iteration should reuse one decision** (e.g. a drafting-loop approach gate confirmed once for all files): yield the checkpoint's declared `id` as written in the activity YAML.
+- **Inside a `forEach` / `while` / `doWhile` body when each iteration needs its own user decision**: yield an instance-qualified id `<baseId>#<instance>`. `<baseId>` is the portion before `#` in the declared id (so `dimension-confirmed#{current_dimension}` and `dimension-confirmed` share base `dimension-confirmed`). `<instance>` is a stable discriminator for this iteration — expand a `#{...}` template in the declared id against the current loop variable, or otherwise use the loop item's id/slug (e.g. `dimension-confirmed#activity-list`, `assumption-decision#RE-1`). The server resolves the definition by base id and records the response under the full qualified id, so later iterations do not collide.
+
+The response `status` tells you what happened:
 
 - `status: "yielded"` — the orchestrator will resolve the checkpoint. Emit a `<checkpoint_yield>...</checkpoint_yield>` block to hand control to the orchestrator and STOP execution; it resumes you with the user's response.
-- `status: "replayed"` — the server detected that this checkpoint already has a recorded response from a prior run (the session is being resumed). The response carries `resolved_option` and an optional `effect`; apply the effect to your local working state (the server has already mirrored variable changes into the session bag) and CONTINUE with the next step. Do NOT yield and do NOT re-prompt the user — the decision was already made.
+- `status: "replayed"` — this exact `checkpoint_id` already has a recorded response in `state.checkpointResponses` for the current activity (session resume, or a later loop iteration that reuses the same bare/qualified id). The response carries `resolved_option` and an optional `effect`; apply the effect to your local working state (the server has already mirrored variable changes into the session bag) and CONTINUE with the next step. Do NOT re-call `yield_checkpoint`, do NOT call `present_checkpoint`, do NOT emit `<checkpoint_yield>`, and do NOT re-prompt the user — the decision was already made. If this iteration was supposed to get a fresh gate, you yielded the wrong id (use `#<instance>` next time); do not treat replay as a server fault.
 
-Response replay only fires for a checkpoint whose response is already in `state.checkpointResponses` for the current activity. Fresh activities never replay.
+Response replay keys on the full `checkpoint_id` string you pass. Fresh activities with no prior response under that key never replay.

--- a/meta/techniques/workflow-engine/yield-checkpoint.md
+++ b/meta/techniques/workflow-engine/yield-checkpoint.md
@@ -1,26 +1,33 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
 
-Pause at a checkpoint and surface the yield.
+Pause at a checkpoint and surface the yield — or continue immediately when the server replays a recorded response.
 
 ## Inputs
 
 ### checkpoint_id
 
-ID of the checkpoint being yielded.
+ID of the checkpoint being yielded. Use the activity YAML `id` as written for one-shot gates and for loop-body gates whose first answer should apply to every later iteration. For loop-body gates that need a distinct user decision per iteration, pass `<baseId>#<instance>` (base id before `#`, plus a stable per-iteration discriminator — expand a declared `#{...}` template, or use the loop item's id/slug). The server matches the definition on the base id and keys the recorded response on the full string.
 
 ## Outputs
 
 ### yielded_checkpoint
 
-`<checkpoint_yield>` block signalling the pause
+`<checkpoint_yield>` block signalling the pause (only when status is `yielded`)
 
 ## Protocol
 
-1. Call `yield_checkpoint { session_index, checkpoint_id }`; the server records the checkpoint as active under `session.json#activeCheckpoint`.
-2. Emit the `{yielded_checkpoint}` `<checkpoint_yield>` block (no payload required — the active checkpoint is server-resident and is read by the orchestrator via `present_checkpoint`).
-3. STOP — make no further tool calls until the orchestrator resumes you.
+1. Call `yield_checkpoint { session_index, checkpoint_id }` with the id chosen per Inputs.
+2. Branch on the response `status`:
+   - **`yielded`** — the server recorded `session.json#activeCheckpoint`. Emit the `{yielded_checkpoint}` `<checkpoint_yield>` block (no payload required — the active checkpoint is server-resident and is read by the orchestrator via `present_checkpoint`). STOP — make no further tool calls until the orchestrator resumes you.
+   - **`replayed`** — a response for this exact `checkpoint_id` is already recorded. Apply any returned `effect` / `resolved_option` to local state and CONTINUE with the next step. Do not emit `<checkpoint_yield>`, do not call `present_checkpoint`, and do not re-yield the same id.
+
+## Rules
+
+### Replay is continue-not-error
+
+`status: "replayed"` means continue under the stored decision. It is not a fault, not a missing active checkpoint, and not a reason to stop the activity.

--- a/work-package/activities/07-assumptions-review.yaml
+++ b/work-package/activities/07-assumptions-review.yaml
@@ -1,5 +1,5 @@
 id: assumptions-review
-version: 2.3.0
+version: 2.4.0
 name: Assumptions Review
 description: Review each open assumption with the user.
 required: true
@@ -34,7 +34,7 @@ steps:
         id: present-assumption
         technique: review-assumptions::interview
       - kind: checkpoint
-        id: assumption-decision
+        id: assumption-decision#{current_assumption.id}
         condition:
           type: simple
           variable: is_review_mode

--- a/workflow-design/activities/03-requirements-refinement.yaml
+++ b/workflow-design/activities/03-requirements-refinement.yaml
@@ -1,5 +1,5 @@
 id: requirements-refinement
-version: 1.4.0
+version: 1.5.0
 name: Requirements Refinement
 description: A confirmed workflow specification across its design dimensions, with the design assumptions it rests on surfaced, reconciled, and reviewed.
 required: true
@@ -34,7 +34,7 @@ steps:
         id: elicit-dimension
         technique: elicitation
       - kind: checkpoint
-        id: dimension-confirmed
+        id: dimension-confirmed#{current_dimension}
         message: "Here is the {current_dimension} I've captured. Is it accurate and complete?"
         blocking: true
         options:
@@ -71,7 +71,7 @@ steps:
         id: present-assumption
         technique: work-package::review-assumptions::interview
       - kind: checkpoint
-        id: assumption-decision
+        id: assumption-decision#{current_assumption.id}
         message: "Assumption {current_assumption.id}: {current_assumption.statement}"
         blocking: true
         options:

--- a/workflow-design/resources/design-principles.md
+++ b/workflow-design/resources/design-principles.md
@@ -30,7 +30,7 @@ Condensed, agent-executable reference of the 15 design principles governing work
 
 **Rule:** Each elicitation question and each checkpoint is atomic. Never combine multiple questions. Wait for the response before proceeding.
 
-**Enforcement:** `03-requirements-refinement` elicits one dimension at a time via a `forEach` over `design_dimensions`, each iteration gated by the `dimension-confirmed` checkpoint.
+**Enforcement:** `03-requirements-refinement` elicits one dimension at a time via a `forEach` over `design_dimensions`, each iteration gated by the instance-qualified `dimension-confirmed#{current_dimension}` checkpoint.
 
 ## 4. Maximize Schema Expressiveness
 


### PR DESCRIPTION
## Summary
- Document checkpoint replay (`status: replayed` → continue) and instance-qualified yields (`<baseId>#<instance>`) in the activity worker prompt and `yield-checkpoint` technique.
- Template loop-body gates that need a fresh decision per iteration: `dimension-confirmed#{current_dimension}` and `assumption-decision#{current_assumption.id}` in workflow-design requirements-refinement and work-package assumptions-review.

## Test plan
- [ ] Load `workflow-design` and confirm `getCheckpoint(..., 'dimension-confirmed#activity-list')` resolves to the templated definition
- [ ] In a dimension-elicitation loop, yield `dimension-confirmed#<slug>` on iteration 2+ and confirm `status: yielded` (not replay of iteration 1)
- [ ] Yield a bare drafting-loop checkpoint twice and confirm intentional `replayed` on the second call
- [ ] Confirm a worker that receives `replayed` continues without `present_checkpoint` / re-yield