### PR TITLE
fix(meta): kebab-case yield-checkpoint replay rule name

### DIFF
--- a/meta/techniques/workflow-engine/yield-checkpoint.md
+++ b/meta/techniques/workflow-engine/yield-checkpoint.md
@@ -28,6 +28,6 @@ ID of the checkpoint being yielded. Use the activity YAML `id` as written for on
 
 ## Rules
 
-### Replay is continue-not-error
+### replay-is-continue-not-error
 
 `status: "replayed"` means continue under the stored decision. It is not a fault, not a missing active checkpoint, and not a reason to stop the activity.


### PR DESCRIPTION
## Summary
- Renames `### Replay is continue-not-error` to kebab-case so the technique-template guard passes.

## Test plan
- [x] `npx vitest run tests/technique-template.test.ts` passes against this commit