### PR TITLE
fix(mcp): trim verbose tools/list description tax (#241)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,6 +2,8 @@
 
 ## MCP Tools
 
+MCP tool and parameter descriptions registered with the server are intentionally terse (call contract and footguns only). This document is the canonical deep reference for behavior, delivery modes, and response shapes; `discover` / runtime payloads remain self-describing at call time.
+
 ### Bootstrap Tools
 
 No `session_index` required.

--- a/site/api/tools.html
+++ b/site/api/tools.html
@@ -86,7 +86,7 @@
       <p>Callable without a session_index.</p>
       <section class="tool" id="discover">
         <h3><code>discover</code></h3>
-        <p class="tool-summary">Entry point for this server.</p>
+        <p class="tool-summary">Entry point — call before other tools.</p>
         <details class="tool-details">
           <summary>Full description</summary>
           <p>Call this first. Returns the server name, version, and the bootstrap steps for starting a workflow.</p>
@@ -96,7 +96,7 @@
       </section>
       <section class="tool" id="list_workflows">
         <h3><code>list_workflows</code></h3>
-        <p class="tool-summary">List all available workflow definitions with their ID, title, version, and tags.</p>
+        <p class="tool-summary">List available workflows (id, title, version, tags).</p>
         <details class="tool-details">
           <summary>Full description</summary>
           <p>Lists every workflow the server can run, with id, title, version, and tags.</p>
@@ -106,7 +106,7 @@
       </section>
       <section class="tool" id="health_check">
         <h3><code>health_check</code></h3>
-        <p class="tool-summary">Check server health and availability.</p>
+        <p class="tool-summary">Server health: status, name, version, workflow count, uptime.</p>
         <details class="tool-details">
           <summary>Full description</summary>
           <p>Quick ping to confirm the server is up. Returns status, name, version, workflow count, and uptime.</p>
@@ -142,7 +142,7 @@
       </section>
       <section class="tool" id="get_workflow_status">
         <h3><code>get_workflow_status</code></h3>
-        <p class="tool-summary">Check the status of a workflow session.</p>
+        <p class="tool-summary">Session status (active/blocked/completed), current activity, completed activities, last checkpoint, and parent context if nested.</p>
         <details class="tool-details">
           <summary>Full description</summary>
           <p>Returns whether the session is active, blocked at a checkpoint, or completed, plus the current activity and completed steps.</p>
@@ -159,7 +159,7 @@
       </section>
       <section class="tool" id="inspect_session">
         <h3><code>inspect_session</code></h3>
-        <p class="tool-summary">Read-only inspection of a workflow session's on-disk state.</p>
+        <p class="tool-summary">Read-only compact projection of session state (never raw session.</p>
         <details class="tool-details">
           <summary>Full description</summary>
           <p>Read-only look at a session's stored state. Pick a <code>view</code>: <code>summary</code> (everything), <code>identity</code>, <code>variables</code>, <code>checkpoints</code>, <code>activities</code>, <code>history</code>, or <code>children</code>.</p>
@@ -172,9 +172,9 @@
           <thead><tr><th scope="col">Parameter</th><th scope="col">Type</th><th scope="col">Required</th><th scope="col">Description</th></tr></thead>
           <tbody>
           <tr><td><code>session_index</code></td><td><code>string</code></td><td>yes</td><td>Six-character token from <code>start_session</code>. Use the same value for every call in this session.</td></tr>
-          <tr><td><code>view</code></td><td><code>&quot;summary&quot; | &quot;identity&quot; | &quot;variables&quot; | &quot;checkpoints&quot; | &quot;activities&quot; | &quot;history&quot; | &quot;children&quot;</code></td><td>no</td><td>Which projection to return. <code>summary</code> (default) is the composite of all views. <code>identity</code> = workflow/session/agent header + position; <code>variables</code> = the variable bag; <code>checkpoints</code> = checkpoint responses (option, timestamp, variables set); <code>activities</code> = completed/skipped/current; <code>history</code> = event count + per-type tally + milestone sub-sequence; <code>children</code> = one-line digest per triggeredWorkflows child. Default: <code>&quot;summary&quot;</code></td></tr>
-          <tr><td><code>child_index</code></td><td><code>integer</code></td><td>no</td><td>Optional positional index into the addressed session's <code>triggeredWorkflows</code>. When given, the tool descends one level to <code>triggeredWorkflows[child_index].state</code> and projects that child instead of the addressed session. Out of range yields the NOT_FOUND message. Deeper children are reached by passing that child's own session_index instead of stacking indices.</td></tr>
-          <tr><td><code>variable</code></td><td><code>string</code></td><td>no</td><td>Optional single variable name. Only meaningful with <code>view: variables</code> — narrows the result to that one key's value instead of the whole bag.</td></tr>
+          <tr><td><code>view</code></td><td><code>&quot;summary&quot; | &quot;identity&quot; | &quot;variables&quot; | &quot;checkpoints&quot; | &quot;activities&quot; | &quot;history&quot; | &quot;children&quot;</code></td><td>no</td><td>Projection: summary (default), identity, variables, checkpoints, activities, history, or children. Default: <code>&quot;summary&quot;</code></td></tr>
+          <tr><td><code>child_index</code></td><td><code>integer</code></td><td>no</td><td>Optional. Project triggeredWorkflows[child_index].state instead of the parent session.</td></tr>
+          <tr><td><code>variable</code></td><td><code>string</code></td><td>no</td><td>Optional. With view=variables, return a single variable by name.</td></tr>
           </tbody>
         </table>
         </div>
@@ -206,7 +206,7 @@
       <p>Load workflow structure and advance through activities.</p>
       <section class="tool" id="get_workflow">
         <h3><code>get_workflow</code></h3>
-        <p class="tool-summary">Load the workflow definition for the current session.</p>
+        <p class="tool-summary">Orchestrator tool: load the session workflow.</p>
         <details class="tool-details">
           <summary>Full description</summary>
           <p>Loads the workflow definition for the current session.</p>
@@ -226,7 +226,7 @@
       </section>
       <section class="tool" id="next_activity">
         <h3><code>next_activity</code></h3>
-        <p class="tool-summary">Transition to the specified activity.</p>
+        <p class="tool-summary">Orchestrator tool: transition to <code>activity_id</code> (does not return the activity body — the worker calls <code>get_activity</code>).</p>
         <details class="tool-details">
           <summary>Full description</summary>
           <p>Moves the session to a new activity. This is the orchestrator's advance call — it updates state and records the trace but does not return the activity body.</p>
@@ -288,7 +288,7 @@
       <p>Yield to the orchestrator, present decisions to the user, and resume.</p>
       <section class="tool" id="yield_checkpoint">
         <h3><code>yield_checkpoint</code></h3>
-        <p class="tool-summary">Yield execution to the orchestrator at a checkpoint.</p>
+        <p class="tool-summary">Worker tool: mark a checkpoint active and yield to the orchestrator (emit <code>&lt;checkpoint_yield&gt;</code> with the returned session_index).</p>
         <details class="tool-details">
           <summary>Full description</summary>
           <p>Call when a checkpoint step tells you to stop and hand control to the orchestrator.</p>
@@ -306,7 +306,7 @@
       </section>
       <section class="tool" id="resume_checkpoint">
         <h3><code>resume_checkpoint</code></h3>
-        <p class="tool-summary">Resume execution after the orchestrator resolves a checkpoint.</p>
+        <p class="tool-summary">Worker tool: continue after the orchestrator resolves a checkpoint.</p>
         <details class="tool-details">
           <summary>Full description</summary>
           <p>Call after the orchestrator resolves a checkpoint and resumes you.</p>
@@ -323,7 +323,7 @@
       </section>
       <section class="tool" id="present_checkpoint">
         <h3><code>present_checkpoint</code></h3>
-        <p class="tool-summary">Load the full details of the currently-active checkpoint for the session.</p>
+        <p class="tool-summary">Load the active checkpoint (message, options, effects, auto-advance) for presenting to the user.</p>
         <details class="tool-details">
           <summary>Full description</summary>
           <p>Loads the active checkpoint's message, options, and effects so you can show it to the user.</p>
@@ -340,7 +340,7 @@
       </section>
       <section class="tool" id="respond_checkpoint">
         <h3><code>respond_checkpoint</code></h3>
-        <p class="tool-summary">Submit a checkpoint response to clear the active-checkpoint gate.</p>
+        <p class="tool-summary">Clear the active-checkpoint gate.</p>
         <details class="tool-details">
           <summary>Full description</summary>
           <p>Submits the user's checkpoint decision and clears the active checkpoint.</p>
@@ -364,7 +364,7 @@
       <p>Fetch technique definitions and lazy-loaded reference material.</p>
       <section class="tool" id="get_technique">
         <h3><code>get_technique</code></h3>
-        <p class="tool-summary">Load one fully composed technique.</p>
+        <p class="tool-summary">Load one fully composed technique (step-bound when <code>step_id</code> is set; otherwise the activity's or workflow's first).</p>
         <details class="tool-details">
           <summary>Full description</summary>
           <p>Fetches one technique for the current workflow or activity.</p>
@@ -386,7 +386,7 @@
       </section>
       <section class="tool" id="get_resource">
         <h3><code>get_resource</code></h3>
-        <p class="tool-summary">Load a resource by its id, optionally narrowed to a single section.</p>
+        <p class="tool-summary">Load a resource by id (optional <code>#section</code>).</p>
         <details class="tool-details">
           <summary>Full description</summary>
           <p>Loads reference material by id — templates, guides, or other markdown resources linked from techniques.</p>
@@ -410,7 +410,7 @@
       <p>Execution history for debugging and audit.</p>
       <section class="tool" id="get_trace">
         <h3><code>get_trace</code></h3>
-        <p class="tool-summary">Retrieve the execution trace for the current workflow session.</p>
+        <p class="tool-summary">Retrieve the session execution trace.</p>
         <details class="tool-details">
           <summary>Full description</summary>
           <p>Returns the tool-call history for debugging or audit.</p>

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -142,20 +142,16 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
     'start_session',
     {
       description:
-        'Start or resume the TOP-LEVEL workflow session. Identifies the planning folder via `planning_folder` — an absolute path whose basename is the slug (e.g., `/home/user/repo/.engineering/artifacts/planning/2026-05-28-my-slug` → slug `2026-05-28-my-slug`). Only the basename is consumed; the path part is a hint and is otherwise ignored, so a stale or off-workspace path passed by the agent is harmless. The server always resolves the slug against its own workspace planning root. ' +
-        'Returns a 6-character base32 `session_index` for the root session, plus basic workflow metadata, plus the canonical server-side `planning_folder_path` (the absolute path of the folder under THIS server\'s workspace) — the agent can pick up the current location from this response without doing any path math. ' +
-        'Behaviour: if a folder for that slug already exists under the server\'s workspace planning root with `session.json`, the server resumes it (workflow_id taken from state — caller cannot rebrand a live session). Otherwise the folder is created (for non-meta workflows) or a transient tmp folder is used (for meta-bootstrap), and a fresh session is written with its variable bag seeded from the workflow\'s declared `defaultValue`s (recorded as a `variables_seeded` history event; resumes never re-seed). When `planning_folder` is omitted entirely, a fresh meta-bootstrap session is created in `os.tmpdir()` and a synthetic UUID slug is registered so subsequent `dispatch_child` calls can promote it. ' +
-        'The full resolved absolute path is persisted as `planningFolderPath` inside session.json; on resume, if the folder has been renamed or moved within the planning root, the recorded value is silently overwritten with its current location. ' +
-        'Other tools identify the session by `session_index` (returned here) — they do not need the path, because session.json carries it. ' +
-        'Child workflows are not created through start_session — call `dispatch_child({ session_index, workflow_id })` from inside the parent session to append a child under `triggeredWorkflows[]` (embedded inline; the whole work-package tree lives in the top-level session.json). ' +
-        'If the resolved folder contains legacy `workflow-state.json` + `.session-token` artefacts, the server migrates them in place. ' +
-        'The agent_id parameter is stored on `session.json#agentId`, distinguishing orchestrator from worker calls in the trace.',
+        'Start or resume the top-level workflow session. Returns `session_index`, workflow metadata, and canonical `planning_folder_path`. ' +
+        'Pass `planning_folder` as an absolute path (basename = slug; resolved against the server planning root). Omit it for a transient meta bootstrap. ' +
+        'Children use `dispatch_child`, not this tool. ' +
+        '`context_mode: "persistent"` is ONLY for solo (same agent context; no worker spawn); omit/`"fresh"` for disposable workers.',
       inputSchema: z
         .object({
-          workflow_id: z.string().optional().describe('Optional. Target workflow ID for a fresh top-level session (e.g., "work-package"). Defaults to "meta". Ignored when the slug already resolves to an existing `session.json` (the workflow is taken from the resumed state).'),
-          planning_folder: z.string().optional().describe('Optional. Absolute path whose basename is treated as the planning slug. The path part is informational — the slug is resolved against the SERVER\'s own workspace planning root, not the path you pass. Bare slugs and relative paths are rejected. When omitted, the server mints a transitional UUID slug and registers it for the meta bootstrap session.'),
-          agent_id: z.string().default('orchestrator').describe('Sets the agentId field inside the session state. Distinguishes agents sharing a session in the trace. Defaults to "orchestrator" if omitted.'),
-          context_mode: z.enum(['persistent', 'fresh']).optional().describe('Optional. Declares the delivery context model for the session. "persistent" opts into reference-not-repeat delivery: get_activity replaces bundle content already delivered to this session+agent with short { unchanged: true, content_hash } markers, and get_technique answers a byte-identical refetch with an unchanged-reference (full: true re-fetches). Use ONLY when a single agent context runs the whole session and retains earlier payloads in its own context. Omit (or pass "fresh") for disposable-worker topologies — every call then receives full content. On resume, a supplied value overwrites the recorded mode.'),
+          workflow_id: z.string().optional().describe('Optional. Fresh-session workflow id (default "meta"). Ignored on resume.'),
+          planning_folder: z.string().optional().describe('Optional. Absolute path; basename is the planning slug. Bare/relative paths rejected. Omit for transient meta bootstrap.'),
+          agent_id: z.string().default('orchestrator').describe('Agent identity stored on the session (default "orchestrator"). Use one canonical id for solo persistent walks.'),
+          context_mode: z.enum(['persistent', 'fresh']).optional().describe('Optional. "persistent" = reference delivery; ONLY for solo (same agent retains payloads). Omit/"fresh" for disposable workers. Resume overwrites recorded mode.'),
         })
         .strict(),
     },
@@ -374,16 +370,15 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
     'dispatch_child',
     {
       description:
-        'Dispatch a child workflow from the current session. Pass `session_index` of the parent (any depth) and `workflow_id` of the child workflow. ' +
-        'The server appends a child entry under the parent\'s `triggeredWorkflows[]` with the child\'s full SessionFile embedded inline (the entire work-package tree lives in the top-level session.json). The child\'s variable bag is seeded from the CHILD workflow\'s own declared `defaultValue`s; the parent\'s bag is untouched. ' +
-        'Returns the child\'s `session_index`, which the agent threads to subsequent authenticated tool calls operating on the child, plus the canonical `planning_folder_path` — the absolute path of the planning folder under THIS server\'s workspace (the `.engineering` root supplied at init). All work-package artifacts are written under that absolute path; the agent never composes the location relative to its CWD or the target component repo. ' +
-        'Special case: when the parent is a transient orchestrator-bootstrap session (e.g. meta), the parent\'s state is promoted onto disk under a stable workspace planning folder before the child is embedded. The slug is taken from (in order): the optional `planning_slug` argument; the slug registered at start_session; a `YYYY-MM-DD-<workflow-id>` fallback. The parent\'s tmp folder is discarded post-promotion, but the parent\'s session_index is retained — the orchestrator can keep using its original index to authenticate subsequent calls (it resolves to the promoted folder for the lifetime of this server process). The on-disk shape matches the persistent-parent case — parent at the top of the file, child under `triggeredWorkflows[0].state`.',
+        'Dispatch a child workflow under the parent session. Returns the child `session_index` and canonical `planning_folder_path`. ' +
+        'Transient meta parents are promoted to a workspace planning folder first (optional `planning_slug`). ' +
+        'Never set `context_mode: "persistent"` on disposable-worker children — workers need fresh/full delivery.',
       inputSchema: z.object({
         ...sessionIndexParam,
-        workflow_id: z.string().describe('Workflow id for the child (e.g. "work-package"). Must resolve to a workflow definition in the workflows directory.'),
-        agent_id: z.string().default('worker').describe('agent_id stored on the child SessionFile. Defaults to "worker".'),
-        planning_slug: z.string().optional().describe('Optional. When the parent is a transient orchestrator-bootstrap session, the slug used for the promoted workspace folder. Takes precedence over any slug registered at start_session. Ignored when the parent is already persistent (the persistent parent owns the slug).'),
-        context_mode: z.enum(['persistent', 'fresh']).optional().describe('Optional. Delivery context model stored on the child SessionFile (see start_session). "persistent" activates reference-not-repeat delivery for calls against the child session; use ONLY when a single agent context executes the whole child workflow.'),
+        workflow_id: z.string().describe('Child workflow id (e.g. "work-package").'),
+        agent_id: z.string().default('worker').describe('Child agent_id (default "worker").'),
+        planning_slug: z.string().optional().describe('Optional. Promotion slug when the parent is a transient meta bootstrap. Ignored if the parent is already persistent.'),
+        context_mode: z.enum(['persistent', 'fresh']).optional().describe('Optional. Child delivery mode. "persistent" ONLY for solo child walks; omit/"fresh" for disposable workers.'),
       }).strict(),
     },
     withAuditLog('dispatch_child', withSessionStoreErrors(async ({ session_index, workflow_id, agent_id, planning_slug, context_mode }) => {
@@ -506,11 +501,13 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
 
   server.tool(
     'get_technique',
-    'Load one fully composed technique. With step_id, loads the technique bound to that step; without it, the activity\'s (or, before next_activity, the workflow\'s) first technique. The result inherits its workflow-root `techniques/TECHNIQUE.md` contract recursively (never the meta root for a non-meta workflow): contract inputs/outputs arrive as marked `inherited_inputs`/`inherited_outputs` blocks distinct from the technique\'s own, rules are merged, and ancestor Initial/Final protocol blocks wrap and renumber the protocol. A step-bound fetch annotates the binding seam — own inputs carry a `source:`, remapped outputs a `destination:`, plus a `provenance_note`; annotations are static per corpus and step. Under context_mode "persistent", a byte-identical refetch returns a short unchanged-reference ({ delivery: unchanged, content_hash }) instead of the payload, and on a new technique any shared inherited_inputs/inherited_outputs/rules block already delivered by a sibling is replaced with that marker while the core stays full; full: true forces full content (every block). Every fetch is recorded as a technique_fetched event that next_activity\'s manifest validation reads (advisory).',
+    'Load one fully composed technique (step-bound when `step_id` is set; otherwise the activity\'s or workflow\'s first). ' +
+    'Under `context_mode: "persistent"`, a byte-identical refetch may return an unchanged-reference; pass `full: true` when earlier content was summarized away. ' +
+    'Workers in fresh contexts must not rely on reference collapse — use full delivery.',
     {
       ...sessionIndexParam,
-      step_id: z.string().optional().describe('Optional. Step ID within the current activity (e.g., "define-problem"). If omitted, returns the activity\'s first declared technique, or the workflow\'s first declared technique if no activity is active.'),
-      full: z.boolean().optional().describe('Optional. Set true to force full content delivery even when the session\'s persistent context mode would answer a byte-identical refetch with an unchanged-reference. Use when your context no longer holds the earlier delivery (e.g. it was summarized away).'),
+      step_id: z.string().optional().describe('Optional. Step id whose bound technique to load; omit for the activity/workflow first technique.'),
+      full: z.boolean().optional().describe('Optional. Force full content when persistent mode would return an unchanged-reference (e.g. after summarization).'),
     },
     withAuditLog('get_technique', withSessionStoreErrors(async ({ session_index, step_id, full }) => {
       const loaded = await loadSessionForTool(config.workspaceDir, session_index);
@@ -686,11 +683,13 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
 
   server.tool(
     'get_resource',
-    'Load a resource by its id, optionally narrowed to a single section. Use this to fetch resources referenced in technique content (e.g. a template hyperlinked from an Input/Output). The resource_id is a text-only slug — bare (e.g., "review-mode") resolves within the session\'s workflow, or prefixed cross-workflow (e.g., "meta/bootstrap-protocol") resolves from the named workflow. Append a `#section` anchor (GitHub-style heading slug, e.g. "assumption-reconciliation#integration-with-assumptions-log") to return only that section and its body — used to fetch just the template a technique references without the whole file. Returns the resource content, id, and version. Under context_mode "persistent", a byte-identical refetch of the same resource_id (including any #section) returns a short unchanged-reference ({ delivery: unchanged, content_hash }) instead of the body; full: true forces full content. Each fetch is recorded in the session history as a resource_fetched event (observability only — no validation reads it), including when the answer is an unchanged-reference.',
+    'Load a resource by id (optional `#section`). Bare slug = session workflow; `workflow/slug` = cross-workflow. ' +
+    'Under `context_mode: "persistent"`, a byte-identical refetch may return an unchanged-reference; pass `full: true` when content was summarized away. ' +
+    'Never use persistent/`bundle: "reference"` assumptions on disposable workers — they need fresh/full delivery.',
     {
       ...sessionIndexParam,
-      resource_id: z.string().describe('Resource ref — bare slug ("review-mode"), cross-workflow prefixed ("meta/bootstrap-protocol"), each optionally suffixed with a "#section" heading anchor to return only that section (e.g. "assumption-reconciliation#integration-with-assumptions-log")'),
-      full: z.boolean().optional().describe('Optional. Set true to force full content delivery even when the session\'s persistent context mode would answer a byte-identical refetch with an unchanged-reference. Use when your context no longer holds the earlier delivery (e.g. it was summarized away).'),
+      resource_id: z.string().describe('Resource ref: bare slug, `workflow/slug`, optional `#section` anchor.'),
+      full: z.boolean().optional().describe('Optional. Force full content when persistent mode would return an unchanged-reference (e.g. after summarization).'),
     },
     withAuditLog('get_resource', withSessionStoreErrors(async ({ session_index, resource_id, full }) => {
       const loaded = await loadSessionForTool(config.workspaceDir, session_index);

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -34,13 +34,13 @@ import type { TraceEvent, TraceTokenPayload } from '../trace.js';
 const stepManifestSchema = z.array(z.object({
   step_id: z.string(),
   output: z.string(),
-})).optional().describe('Array of completed-step entries from the previous activity, e.g. [{"step_id":"detect-review-mode","output":"is_review_mode=false"}]. Each entry has two string fields: step_id (the literal id from the activity\'s steps[] — note the field is step_id, not id) and output. output is a short summary of what the step produced; for a step with more than one declared output, report a JSON object keyed by output id, e.g. {"step_id":"resolve-reference","output":"{\\"reference_path\\":\\"lib/x\\",\\"component_name\\":\\"x\\"}"}. Omit the parameter entirely when no steps ran; do not pass an empty array or empty string.');
+})).optional().describe('Completed steps from the previous activity: [{step_id, output}]. Use literal step ids (field is step_id, not id). Multi-output steps: JSON object keyed by output id. Omit entirely when no steps ran — not [].');
 
 const activityManifestSchema = z.array(z.object({
   activity_id: z.string(),
   outcome: z.string(),
   transition_condition: z.string().optional(),
-})).optional().describe('Activity completion manifest from the orchestrator. Reports the sequence of activities completed so far with outcomes and transition conditions.');
+})).optional().describe('Orchestrator activity-completion manifest: [{activity_id, outcome, transition_condition?}].');
 
 /**
  * Wrap a tool handler so any thrown `SessionStoreError` is re-thrown with a
@@ -257,7 +257,7 @@ export function projectSessionView(
 export function registerWorkflowTools(server: McpServer, config: ServerConfig): void {
   const traceOpts = config.traceStore ? { traceStore: config.traceStore } : undefined;
 
-  server.tool('discover', 'Entry point for this server. Call this before any other tool to learn the bootstrap procedure for starting a session. Returns the server name, version, and the bootstrap guide explaining the full tool-calling sequence. Use list_workflows to discover available workflows. No parameters required and no session_index needed.', {},
+  server.tool('discover', 'Entry point — call before other tools. Returns server info and the bootstrap procedure. No session_index required.', {},
     withAuditLog('discover', async () => {
       const bootstrapResult = await readResourceRaw(config.workflowDir, 'meta', 'bootstrap-protocol');
       const lines = [
@@ -270,7 +270,7 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
     }));
 
-  server.tool('list_workflows', 'List all available workflow definitions with their ID, title, version, and tags. Use this when you need to discover or filter available workflows. Returns an array of workflow summaries with tag-based categorization. If any workflow definition fails to load (unreadable file or manifest missing id/title/version), the response is instead an object with `workflows` (the loadable entries) and `load_errors` (one entry per failed file). Does not require a session_index.', {},
+  server.tool('list_workflows', 'List available workflows (id, title, version, tags). On load failures returns `{workflows, load_errors}`. No session_index required.', {},
     withAuditLog('list_workflows', async () => {
       const { workflows, errors } = await listWorkflowsWithDiagnostics(config.workflowDir);
       // Additive shape: the payload stays a plain array unless something failed to load.
@@ -278,7 +278,7 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       return { content: [{ type: 'text' as const, text: stringifyForResponse(payload) }] };
     }));
 
-  server.tool('get_workflow', 'Load the workflow definition for the current session. The response begins with the resolved orchestrator technique bundle, then a `---` separator, then lightweight workflow metadata: rules, variables, the initialActivity field (which activity to load first), and a stub list of all activities with their IDs and names. If any activity file failed to load (invalid or unparsable YAML), the response includes `activity_load_errors` listing each failed file with its error — those activities are absent from the activity list. Call this after start_session to learn the workflow structure — the initialActivity field in the response tells you which activity_id to pass to your first next_activity call. This is the only tool that provides initialActivity. The response also carries `planning_folder_path`: the canonical absolute planning folder for this session under THIS server\'s workspace `.engineering` root — bind it as the single artifact location and never recompose it relative to your CWD or the target component repo.',
+  server.tool('get_workflow', 'Orchestrator tool: load the session workflow. Response is the orchestrator technique bundle, then `---`, then metadata including `initialActivity` (use for the first next_activity) and activity stubs. Also returns canonical `planning_folder_path` — do not recompose it.',
     {
       ...sessionIndexParam,
     },
@@ -370,11 +370,11 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       };
     }), traceOpts));
 
-  server.tool('next_activity', 'Transition to the specified activity. This is the orchestrator\'s tool for advancing the workflow — it validates the transition, advances the session state on disk, and records the trace, but does NOT return the activity definition. After calling next_activity, the worker should call get_activity to load the complete activity definition including steps, checkpoints, transitions, and technique references. For the first call, use the initialActivity value from get_workflow. For subsequent calls, use the activity IDs from the transitions field of the current activity\'s response. Optionally include a step_manifest summarizing completed steps and a transition_condition to enable server-side validation. Manifest validation also cross-checks fidelity (warn-only): a manifested technique step with no technique_fetched event recorded during the activity (see get_technique) — and no technique_bundled event from a bundling activity\'s get_activity — draws a warning.',
+  server.tool('next_activity', 'Orchestrator tool: transition to `activity_id` (does not return the activity body — the worker calls `get_activity`). First call: `initialActivity` from get_workflow; later: an id from the current activity\'s transitions. Optional manifests enable advisory validation.',
     {
       ...sessionIndexParam,
-      activity_id: z.string().describe('Activity ID to transition to. For the first call, use initialActivity from get_workflow. For subsequent calls, use an activity ID from the transitions field of the current activity.'),
-      transition_condition: z.string().optional().describe('The transition condition that led to this activity (from the transitions field of the previous activity). Enables server-side validation of condition-activity consistency.'),
+      activity_id: z.string().describe('Target activity id. First call: initialActivity from get_workflow; later: from current activity transitions.'),
+      transition_condition: z.string().optional().describe('Optional. Transition condition text from the previous activity (advisory validation).'),
       step_manifest: stepManifestSchema,
       activity_manifest: activityManifestSchema,
     },
@@ -518,11 +518,13 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       };
     }), traceOpts));
 
-  server.tool('get_activity', 'Load the current activity\'s full definition (steps, checkpoints, transitions, rules, technique references) — everything needed to execute it. The activity is read from session state, so no activity_id is needed. context_tokens is REQUIRED: the worker declares its context window and the server derives an eager bundling budget (headroom × token→char factor, server config), inlining the activity\'s ungated step-bound techniques that fit, in document order. Eligible techniques arrive corpus-wide under a step_techniques map (keyed by step id, each a discrete ▼ STEP block identical to a get_technique { step_id } fetch — engage them in order without refetching); gated steps and any technique overflowing the budget or a per-activity bundleTechniques.maxChars cap (maxChars 0 opts out) stay lazy. Under reference delivery (context_mode "persistent" or bundle: "reference"), already-delivered inherited techniques/rules collapse to { delivery: "unchanged", content_hash } markers, including block-by-block within an otherwise-full step technique (its shared inherited_inputs/inherited_outputs/rules); bundle: "full" forces full delivery. Bundled deliveries are recorded as technique_bundled events counting as fetch coverage for next_activity\'s manifest check.',
+  server.tool('get_activity', 'Worker tool: load the current activity definition (from session state — no activity_id). `context_tokens` is REQUIRED for eager step-technique bundling. ' +
+    'Under persistent/`bundle: "reference"`, already-delivered content may collapse to unchanged markers — ONLY valid when THIS agent received the earlier payloads. ' +
+    'Use `bundle: "full"` after summarization or for disposable workers (never `bundle: "reference"` on fresh workers).',
     {
       ...sessionIndexParam,
       ...contextTokensParam,
-      bundle: z.enum(['reference', 'full']).optional().describe('Optional delivery-mode override for the inherited techniques/rules bundle. "reference" replaces bundle content already delivered to this session+agent with short { delivery: "unchanged", content_hash } markers — only correct when THIS calling context received the earlier deliveries. "full" forces full delivery. Defaults from the session\'s context_mode ("persistent" → reference, otherwise full).'),
+      bundle: z.enum(['reference', 'full']).optional().describe('Optional. "reference" collapses already-delivered bundle content (solo only). "full" forces full delivery. Defaults from context_mode.'),
     },
     withAuditLog('get_activity', withSessionStoreErrors(async ({ session_index, context_tokens, bundle }) => {
       const loaded = await loadSessionForTool(config.workspaceDir, session_index);
@@ -826,10 +828,10 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       };
     }), traceOpts));
 
-  server.tool('yield_checkpoint', 'Yield execution to the orchestrator at a checkpoint. Call this tool when you encounter a checkpoint step during activity execution. It records the checkpoint as active in the session state and returns the session_index, which the worker yields back to the orchestrator via a <checkpoint_yield> block.',
+  server.tool('yield_checkpoint', 'Worker tool: mark a checkpoint active and yield to the orchestrator (emit `<checkpoint_yield>` with the returned session_index).',
     {
       ...sessionIndexParam,
-      checkpoint_id: z.string().describe('The ID of the checkpoint being yielded.'),
+      checkpoint_id: z.string().describe('Checkpoint id being yielded.'),
     },
     withAuditLog('yield_checkpoint', withSessionStoreErrors(async ({ session_index, checkpoint_id }) => {
       const loaded = await loadSessionForTool(config.workspaceDir, session_index);
@@ -925,7 +927,7 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       };
     }), traceOpts));
 
-  server.tool('resume_checkpoint', 'Resume execution after the orchestrator resolves a checkpoint. Call this tool when the orchestrator resumes you with a checkpoint response. It verifies the checkpoint was resolved (no activeCheckpoint in state) and returns any variable updates you need to apply to your state.',
+  server.tool('resume_checkpoint', 'Worker tool: continue after the orchestrator resolves a checkpoint. Verifies no activeCheckpoint and returns variable updates to apply.',
     {
       ...sessionIndexParam,
     },
@@ -953,7 +955,7 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       };
     }), traceOpts));
 
-  server.tool('present_checkpoint', 'Load the full details of the currently-active checkpoint for the session. Returns the checkpoint definition including its message, user-facing options (with labels, descriptions, and effects like variable assignments), and any auto-advance configuration. Use this when you need to present a checkpoint interaction to the user based on a worker\'s yield. Reads the active checkpoint from state.activeCheckpoint — no separate checkpoint handle is needed.',
+  server.tool('present_checkpoint', 'Load the active checkpoint (message, options, effects, auto-advance) for presenting to the user. Reads state.activeCheckpoint.',
     {
       ...sessionIndexParam,
     },
@@ -988,18 +990,13 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
   const MIN_RESPONSE_SECONDS = config.minCheckpointResponseSeconds ?? 3;
 
   server.tool('respond_checkpoint',
-    'Submit a checkpoint response to clear the active-checkpoint gate. *MUST* present the checkpoint to the user and wait for their input. ' +
-    'Exactly one of option_id, auto_advance, or condition_not_met must be provided. ' +
-    'option_id: the user\'s selected option (works for all checkpoint types, enforces minimum response time). ' +
-    'auto_advance: use the checkpoint\'s defaultOption (only for checkpoints with autoAdvanceMs; the server enforces the full timer). ' +
-    'condition_not_met: dismiss a conditional checkpoint whose condition evaluated to false (only valid when the checkpoint has a condition field). ' +
-    'setVariable effects are validated against the declared variable type, warn-only: mismatches are stored as written and surfaced in _meta.validation. ' +
-    'Reads the active checkpoint from state.activeCheckpoint — no separate checkpoint handle is needed.',
+    'Clear the active-checkpoint gate. *MUST* present the checkpoint to the user first. ' +
+    'Provide exactly one of `option_id`, `auto_advance`, or `condition_not_met`.',
     {
       ...sessionIndexParam,
-      option_id: z.string().optional().describe('The option ID selected by the user. Must match one of the checkpoint\'s defined options.'),
-      auto_advance: z.boolean().optional().describe('Set to true to auto-advance a checkpoint using its defaultOption. Only valid for checkpoints with defaultOption and autoAdvanceMs. The server enforces the autoAdvanceMs timer. If you use auto_advance, present a message to the user that you are proceeding with the default option because no input was provided.'),
-      condition_not_met: z.boolean().optional().describe('Set to true to dismiss a conditional checkpoint whose condition was not met. Only valid for checkpoints that have a condition field.'),
+      option_id: z.string().optional().describe('User-selected option id (must match a defined option).'),
+      auto_advance: z.boolean().optional().describe('Use defaultOption after autoAdvanceMs with no user input. Only valid when the checkpoint has both.'),
+      condition_not_met: z.boolean().optional().describe('Dismiss a conditional checkpoint whose condition was not met.'),
     },
     withAuditLog('respond_checkpoint', withSessionStoreErrors(async ({ session_index, option_id, auto_advance, condition_not_met }) => {
       const loaded = await loadSessionForTool(config.workspaceDir, session_index);
@@ -1174,10 +1171,10 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       };
     }), traceOpts));
 
-  server.tool('get_trace', 'Retrieve the execution trace for the current workflow session. Accepts an optional array of trace_tokens accumulated from next_activity _meta.trace_token responses to reconstruct a specific trace segment. If no trace_tokens are provided, returns the full in-memory trace for the current session (requires server-side tracing to be enabled). Use this for debugging, auditing, or reviewing the sequence of tool calls made during the session.',
+  server.tool('get_trace', 'Retrieve the session execution trace. With `trace_tokens`, decode those segments; otherwise return the in-memory session trace (if tracing is enabled).',
     {
       ...sessionIndexParam,
-      trace_tokens: z.array(z.string()).optional().describe('Accumulated trace tokens from next_activity _meta.trace_token responses. If not provided, returns the full in-memory trace for the current session.'),
+      trace_tokens: z.array(z.string()).optional().describe('Optional. Trace tokens from next_activity `_meta.trace_token`; omit for the full in-memory session trace.'),
     },
     withAuditLog('get_trace', withSessionStoreErrors(async ({ session_index, trace_tokens }) => {
       const loaded = await loadSessionForTool(config.workspaceDir, session_index);
@@ -1219,7 +1216,7 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       };
     }), traceOpts ? { ...traceOpts, excludeFromTrace: true } : undefined));
 
-  server.tool('health_check', 'Check server health and availability. Returns server status, name, version, number of available workflows, and uptime in seconds. Does not require a session_index. Use this to verify the server is running before starting a workflow.', {},
+  server.tool('health_check', 'Server health: status, name, version, workflow count, uptime. No session_index required.', {},
     withAuditLog('health_check', async () => {
       const workflows = await listWorkflows(config.workflowDir);
       return {
@@ -1231,8 +1228,7 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
     }));
 
   server.tool('get_workflow_status',
-    'Check the status of a workflow session. Returns the session status (active/blocked/completed), current activity, ' +
-    'completed activities trace, last checkpoint info, and parent context if nested. Requires a session_index.',
+    'Session status (active/blocked/completed), current activity, completed activities, last checkpoint, and parent context if nested.',
     {
       ...sessionIndexParam,
     },
@@ -1312,27 +1308,15 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
     }), traceOpts ? { ...traceOpts, excludeFromTrace: true } : undefined));
 
   server.tool('inspect_session',
-    'Read-only inspection of a workflow session\'s on-disk state. Returns a compact structured ' +
-    'projection (never the raw session.json) of the addressed session, selected by `view`. Reads ' +
-    'through the same sealed load path as other tools, so it verifies integrity but performs no ' +
-    'mutation — safe to call at any time, including while a checkpoint is active (unlike mutating ' +
-    'tools, it is not gated). Requires a session_index.',
+    'Read-only compact projection of session state (never raw session.json). Not gated by active checkpoints.',
     {
       ...sessionIndexParam,
       view: z.enum(INSPECT_SESSION_VIEWS).default('summary')
-        .describe('Which projection to return. `summary` (default) is the composite of all views. ' +
-          '`identity` = workflow/session/agent header + position; `variables` = the variable bag; ' +
-          '`checkpoints` = checkpoint responses (option, timestamp, variables set); `activities` = ' +
-          'completed/skipped/current; `history` = event count + per-type tally + milestone sub-sequence; ' +
-          '`children` = one-line digest per triggeredWorkflows child.'),
+        .describe('Projection: summary (default), identity, variables, checkpoints, activities, history, or children.'),
       child_index: z.number().int().nonnegative().optional()
-        .describe('Optional positional index into the addressed session\'s `triggeredWorkflows`. When ' +
-          'given, the tool descends one level to `triggeredWorkflows[child_index].state` and projects ' +
-          'that child instead of the addressed session. Out of range yields the NOT_FOUND message. ' +
-          'Deeper children are reached by passing that child\'s own session_index instead of stacking indices.'),
+        .describe('Optional. Project triggeredWorkflows[child_index].state instead of the parent session.'),
       variable: z.string().optional()
-        .describe('Optional single variable name. Only meaningful with `view: variables` — narrows the ' +
-          'result to that one key\'s value instead of the whole bag.'),
+        .describe('Optional. With view=variables, return a single variable by name.'),
     },
     withAuditLog('inspect_session', withSessionStoreErrors(async ({ session_index, view, child_index, variable }) => {
       const loaded = await loadSessionForTool(config.workspaceDir, session_index);

--- a/src/utils/session/params.ts
+++ b/src/utils/session/params.ts
@@ -9,8 +9,9 @@ import { z } from 'zod';
 export const sessionIndexParam = {
   session_index: z.string()
     .regex(/^[A-Z2-7]{6}$/, 'session_index must be a 6-character RFC 4648 base32 string (A-Z, 2-7)')
-    .describe('REQUIRED. The 6-character session_index returned by start_session. The server resolves this index to a planning folder under .engineering/artifacts/planning/ and reads/writes session.json there. The index is stable across all tool calls in the session — there is no rotation discipline.'),
+    .describe('REQUIRED. Stable 6-character session_index from start_session; pass on every authenticated call.'),
 };
+
 
 /**
  * Zod parameter spread for the REQUIRED `context_tokens` parameter on
@@ -24,8 +25,9 @@ export const sessionIndexParam = {
  */
 export const contextTokensParam = {
   context_tokens: z.number().int().positive()
-    .describe('REQUIRED. The calling worker\'s total context window in tokens. The server derives the eager step-technique bundling budget from this value (availability headroom × a token→char factor, both server config) and inlines the activity\'s ungated step-bound techniques that fit, in document order, under that budget; the remainder stay lazy via get_technique. Per-agent and per-call — never stored on the session, never defaulted. Omitting it is a validation error.'),
+    .describe('REQUIRED. Caller\'s context window in tokens; used for eager step-technique bundling. Per-call, never defaulted — omitting it is a validation error.'),
 };
+
 
 /**
  * Throws if the SessionFile has an active checkpoint. Call this in every


### PR DESCRIPTION
## Summary
- Trim MCP tool and parameter description strings in `workflow-tools.ts`, `resource-tools.ts`, and shared `session/params.ts` (~69% combined char reduction vs tip) to cut the recurring `tools/list` context tax ([#241](https://github.com/m2ux/workflow-server/issues/241)).
- Keep fidelity-critical footguns: solo-only `context_mode: "persistent"`, `full` / `bundle: "full"` escapes after summarization, fresh/full delivery for disposable workers, orchestrator vs worker tool split, and required `context_tokens` / `session_index`.
- Note in `docs/api-reference.md` that MCP descriptions are intentionally terse; regenerate `site/api/tools.html` from the shorter source strings.

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run` (584 passed)
- [x] `npm run build:site`
- [ ] Spot-check hot tools in an MCP client (`get_activity`, `get_technique`, `get_resource`, `start_session`) still surface solo/persistent and force-full guidance
- [ ] Confirm deep behavior remains documented in `docs/api-reference.md`