### PR TITLE
docs: align bootstrap docs with discover pre-session stub (#237)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -10,7 +10,7 @@ No `session_index` required.
 
 | Tool | Parameters | Returns | Description |
 |------|------------|---------|-------------|
-| `discover` | - | Server info and `discovery` instructions | Entry point for the workflow server. Returns the server name, version, and the bootstrap procedure an agent should follow. The `discovery` instructions describe how to call `list_workflows` and `start_session` to begin a session. |
+| `discover` | - | Server info and bootstrap procedure | Entry point for the workflow server. Returns the server name, version, and the pre-session bootstrap stub (schema fetch → `start_session` → `get_workflow`). Ongoing delivery policy is authoritative in techniques delivered with the `get_workflow` operations bundle. |
 | `list_workflows` | - | Array of workflow definitions (each with `id`, `title`, `version`, and `tags`) | Lists all available workflow definitions. Each entry in the returned array contains an `id` (unique workflow identifier), `title` (human-readable name), `version` (semver string), and `tags` (array of categorization strings for matching a user's goal to a workflow). |
 | `health_check` | - | Server status and stats | Returns the server health status. The response includes the server version, the number of workflows available, and the server uptime. |
 
@@ -67,10 +67,10 @@ Agents pass only the `session_index` on every authenticated tool call; they do n
 
 ### Lifecycle
 
-1. Call `discover` to learn the bootstrap procedure and available workflows
-2. Call `list_workflows` to match the user's goal to a workflow
-3. Call `start_session({ agent_id, planning_slug })` to get a `session_index` (defaults to the `meta` workflow when no `workflow_id` is provided). Resuming a session uses the same call shape with the same `planning_slug`. To start a session for a different workflow, pass `workflow_id`.
-4. Call `get_workflow({ session_index })` to load the workflow structure. The response begins with the technique bundle (`techniques`, `rules`, `unresolved`), followed by activity stubs and `initialActivity`.
+1. Call `discover` to learn the pre-session bootstrap procedure (inlined from `meta/bootstrap-protocol`)
+2. Fetch `workflow-server://schemas/workflow`, then call `start_session({ agent_id, planning_folder? })` to get a `session_index` (defaults to the `meta` workflow when no `workflow_id` is provided). Resuming a session uses the same call shape with the same planning folder. To start a session for a different workflow, pass `workflow_id`.
+3. Call `get_workflow({ session_index })` to load the workflow structure. The response begins with the technique bundle (`techniques`, `rules`, `unresolved`), followed by activity stubs and `initialActivity`. Follow the bundle for ongoing delivery policy.
+4. Optionally call `list_workflows` (no session required) when matching a user goal to a workflow id outside the meta discover-session path.
 5. Call `next_activity({ session_index, activity_id: initialActivity })` to transition to the first activity (returns `activity_id` and `name` only)
 6. Call `get_activity({ session_index })` to load the complete activity definition. The response begins with the technique bundle for the activity's `techniques[]` (`techniques`, `rules`, `unresolved`), followed by the raw activity body.
 7. Execute the steps and protocol of each technique in the bundle from step 6.

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -19,10 +19,9 @@ The rule wires natural-language requests ("start a work package", "resume the wo
 `discover` returns:
 
 - **Server name and version** — confirms which workflow server the agent is talking to.
-- **Bootstrap procedure** — the canonical tool-calling sequence the agent must follow (`list_workflows` → `start_session` → `get_workflow` → `next_activity` → `get_activity`, with checkpoint discipline rules layered in).
-- **Available workflows** — workflow IDs, titles, and tags. The agent matches the user's request against these.
+- **Bootstrap procedure** — the pre-session stub the agent must follow: fetch `workflow-server://schemas/workflow`, call `start_session`, then `get_workflow` and follow the returned operations bundle. Activity dispatch (`next_activity` / `get_activity`) and checkpoint discipline come from that bundle, not from the stub itself. `list_workflows` is available without a session and is typically used during meta `discover-session`, not as a required bootstrap step.
 
-Because `discover` is the entry point, the procedure stays in sync with the server. You do not need to maintain a separate copy of the protocol in your IDE rules — the rule above only has to enforce "call `discover` first."
+Because `discover` is the entry point, the procedure stays in sync with the server. You do not need to maintain a separate copy of the protocol in your IDE rules — the rule above only has to enforce "call `discover` first." Ongoing delivery policy (worker-fresh, resource `#section` vs whole file, force-full escapes) is authoritative in techniques delivered with the operations bundle after `get_workflow`.
 
 ## Delivery Context and Worker Parameters
 
@@ -42,7 +41,7 @@ After configuring the rule:
 
 1. Restart your MCP client.
 2. Ask the agent to `list available workflows`. It should call `list_workflows` (no session token required) and return the workflow inventory.
-3. Ask the agent to `start a work-package workflow`. It should first call `discover`, then proceed with `list_workflows`, `start_session`, and `get_workflow`.
+3. Ask the agent to `start a work-package workflow`. It should first call `discover`, then complete the returned bootstrap (schema fetch → `start_session` → `get_workflow`).
 
 If the agent skips `discover`, your rule has not been picked up — re-check the IDE's rule configuration.
 


### PR DESCRIPTION
## Summary
- Correct `docs/ide-setup.md` and `docs/api-reference.md` so bootstrap matches the discover stub: schema fetch → `start_session` → `get_workflow`
- Clarify that ongoing delivery policy lives in the operations bundle, and that `list_workflows` is optional / discover-session rather than a required bootstrap step

## Test plan
- [x] ide-setup “What the Bootstrap Returns” matches current `discover` output
- [x] api-reference Lifecycle step order matches the pre-session stub
- [x] Companion corpus PR (`fix/237-slim-bootstrap-protocol`) lands or is linked for the stub content itself — https://github.com/m2ux/workflow-server/pull/245

Related: #237