### PR TITLE
fix: exclude engineering infra submodules from monorepo detection

### DIFF
--- a/meta/activities/02-resolve-target.yaml
+++ b/meta/activities/02-resolve-target.yaml
@@ -5,7 +5,7 @@ description: Detect the target repository structure (regular directory vs. submo
 required: true
 rules:
   - target_path MUST resolve to a directory containing a working git tree
-  - The workflows and .engineering infrastructure submodules are never a target component and never classify a repo as a monorepo on their own
+  - Infrastructure submodules whose path equals `workflows`, equals `.engineering`, or is under `.engineering/` (`path` is `.engineering` or starts with `.engineering/`) are never a target component and never classify a repo as a monorepo on their own
 steps:
   - kind: action
     id: announce-start

--- a/meta/activities/02-resolve-target.yaml
+++ b/meta/activities/02-resolve-target.yaml
@@ -5,7 +5,7 @@ description: Detect the target repository structure (regular directory vs. submo
 required: true
 rules:
   - target_path MUST resolve to a directory containing a working git tree
-  - Infrastructure submodules whose path equals `workflows`, equals `.engineering`, or starts with `.engineering/` are never a target component and never classify a repo as a monorepo on their own
+  - Exclude infrastructure submodules per version-control::infrastructure-submodule-paths
 steps:
   - kind: action
     id: announce-start

--- a/meta/activities/02-resolve-target.yaml
+++ b/meta/activities/02-resolve-target.yaml
@@ -5,7 +5,7 @@ description: Detect the target repository structure (regular directory vs. submo
 required: true
 rules:
   - target_path MUST resolve to a directory containing a working git tree
-  - Infrastructure submodules whose path equals `workflows`, equals `.engineering`, or is under `.engineering/` (`path` is `.engineering` or starts with `.engineering/`) are never a target component and never classify a repo as a monorepo on their own
+  - Infrastructure submodules whose path equals `workflows`, equals `.engineering`, or starts with `.engineering/` are never a target component and never classify a repo as a monorepo on their own
 steps:
   - kind: action
     id: announce-start

--- a/meta/techniques/version-control/TECHNIQUE.md
+++ b/meta/techniques/version-control/TECHNIQUE.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 5.0.0
+  version: 5.1.0
 ---
 
 ## Capability
@@ -32,3 +32,7 @@ Follow Conventional Commits: `type(optional-scope): description`. Common types: 
 ### dco-sign-off
 
 All commits made via this technique use `git commit -s`. The `Signed-off-by` trailer is required by DCO and harmless when not. Adding it by default avoids the failure-then-retry pattern when target repos enforce DCO via a pre-commit hook.
+
+### infrastructure-submodule-paths
+
+A submodule is infrastructure when its `path` equals `workflows`, equals `.engineering`, or starts with `.engineering/`. Infrastructure submodules are never target components and never classify a repo as a monorepo on their own.

--- a/meta/techniques/version-control/detect-repo-type.md
+++ b/meta/techniques/version-control/detect-repo-type.md
@@ -1,17 +1,17 @@
 ---
 metadata:
-  version: 1.1.1
+  version: 1.1.2
 ---
 
 ## Capability
 
-Determine whether the working directory is a regular repo or a submodule monorepo, ignoring infrastructure submodules that every project carries — a submodule whose `path` equals `workflows`, equals `.engineering`, or starts with `.engineering/`. These are never a target component and must not, on their own, classify a repo as a monorepo.
+Determine whether the working directory is a regular repo or a submodule monorepo, excluding infrastructure submodules per [version-control](./TECHNIQUE.md)::infrastructure-submodule-paths.
 
 ## Outputs
 
 ### is_monorepo
 
-true when `.gitmodules` declares at least one submodule whose path is NOT an infrastructure submodule (`path` equals `workflows`, equals `.engineering`, or starts with `.engineering/`); false otherwise.
+true when `.gitmodules` declares at least one non-infrastructure submodule (per [version-control](./TECHNIQUE.md)::infrastructure-submodule-paths); false otherwise.
 
 ### target_path
 
@@ -20,5 +20,5 @@ true when `.gitmodules` declares at least one submodule whose path is NOT an inf
 ## Protocol
 
 1. If `.gitmodules` does not exist at the repo root, set `{is_monorepo}` = false and `{target_path}` = `.` — a regular repo. Done.
-2. Parse `.gitmodules` and collect the `path` of every `[submodule "..."]` section. Discard any whose `path` equals `workflows`, equals `.engineering`, or starts with `.engineering/` — the infrastructure submodules present in every project.
+2. Parse `.gitmodules` and collect the `path` of every `[submodule "..."]` section. Discard infrastructure submodules — apply [version-control](./TECHNIQUE.md)::infrastructure-submodule-paths.
 3. If one or more submodule paths remain, set `{is_monorepo}` = true and leave `{target_path}` for submodule selection. Otherwise set `{is_monorepo}` = false and `{target_path}` = `.` — the `.gitmodules` file declared only infrastructure submodules, so this is effectively a regular repo.

--- a/meta/techniques/version-control/detect-repo-type.md
+++ b/meta/techniques/version-control/detect-repo-type.md
@@ -5,13 +5,13 @@ metadata:
 
 ## Capability
 
-Determine whether the working directory is a regular repo or a submodule monorepo, ignoring infrastructure submodules that every project carries — a submodule whose `path` equals `workflows`, equals `.engineering`, or is under `.engineering/` (`path` is `.engineering` or starts with `.engineering/`). Exact matches for top-level `workflows` and `.engineering` are retained. These are never a target component and must not, on their own, classify a repo as a monorepo.
+Determine whether the working directory is a regular repo or a submodule monorepo, ignoring infrastructure submodules that every project carries — a submodule whose `path` equals `workflows`, equals `.engineering`, or starts with `.engineering/`. These are never a target component and must not, on their own, classify a repo as a monorepo.
 
 ## Outputs
 
 ### is_monorepo
 
-true when `.gitmodules` declares at least one submodule whose path is NOT an infrastructure submodule (`path` equals `workflows`, equals `.engineering`, or is under `.engineering/` (`path` is `.engineering` or starts with `.engineering/`)); false otherwise.
+true when `.gitmodules` declares at least one submodule whose path is NOT an infrastructure submodule (`path` equals `workflows`, equals `.engineering`, or starts with `.engineering/`); false otherwise.
 
 ### target_path
 
@@ -20,5 +20,5 @@ true when `.gitmodules` declares at least one submodule whose path is NOT an inf
 ## Protocol
 
 1. If `.gitmodules` does not exist at the repo root, set `{is_monorepo}` = false and `{target_path}` = `.` — a regular repo. Done.
-2. Parse `.gitmodules` and collect the `path` of every `[submodule "..."]` section. Discard any whose `path` equals `workflows`, equals `.engineering`, or is under `.engineering/` (`path` is `.engineering` or starts with `.engineering/`) — the infrastructure submodules present in every project (legacy exact matches for top-level `workflows` and `.engineering` retained).
+2. Parse `.gitmodules` and collect the `path` of every `[submodule "..."]` section. Discard any whose `path` equals `workflows`, equals `.engineering`, or starts with `.engineering/` — the infrastructure submodules present in every project.
 3. If one or more submodule paths remain, set `{is_monorepo}` = true and leave `{target_path}` for submodule selection. Otherwise set `{is_monorepo}` = false and `{target_path}` = `.` — the `.gitmodules` file declared only infrastructure submodules, so this is effectively a regular repo.

--- a/meta/techniques/version-control/detect-repo-type.md
+++ b/meta/techniques/version-control/detect-repo-type.md
@@ -1,17 +1,17 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.1.1
 ---
 
 ## Capability
 
-Determine whether the working directory is a regular repo or a submodule monorepo, ignoring the `workflows` and `.engineering` infrastructure submodules that every project carries — they are never a target component and must not, on their own, classify a repo as a monorepo.
+Determine whether the working directory is a regular repo or a submodule monorepo, ignoring infrastructure submodules that every project carries — a submodule whose `path` equals `workflows`, equals `.engineering`, or is under `.engineering/` (`path` is `.engineering` or starts with `.engineering/`). Exact matches for top-level `workflows` and `.engineering` are retained. These are never a target component and must not, on their own, classify a repo as a monorepo.
 
 ## Outputs
 
 ### is_monorepo
 
-true when `.gitmodules` declares at least one submodule whose path is NOT an infrastructure submodule (`workflows`, `.engineering`); false otherwise.
+true when `.gitmodules` declares at least one submodule whose path is NOT an infrastructure submodule (`path` equals `workflows`, equals `.engineering`, or is under `.engineering/` (`path` is `.engineering` or starts with `.engineering/`)); false otherwise.
 
 ### target_path
 
@@ -20,5 +20,5 @@ true when `.gitmodules` declares at least one submodule whose path is NOT an inf
 ## Protocol
 
 1. If `.gitmodules` does not exist at the repo root, set `{is_monorepo}` = false and `{target_path}` = `.` — a regular repo. Done.
-2. Parse `.gitmodules` and collect the `path` of every `[submodule "..."]` section. Discard any whose path is `workflows` or `.engineering` (the infrastructure submodules present in every project).
+2. Parse `.gitmodules` and collect the `path` of every `[submodule "..."]` section. Discard any whose `path` equals `workflows`, equals `.engineering`, or is under `.engineering/` (`path` is `.engineering` or starts with `.engineering/`) — the infrastructure submodules present in every project (legacy exact matches for top-level `workflows` and `.engineering` retained).
 3. If one or more submodule paths remain, set `{is_monorepo}` = true and leave `{target_path}` for submodule selection. Otherwise set `{is_monorepo}` = false and `{target_path}` = `.` — the `.gitmodules` file declared only infrastructure submodules, so this is effectively a regular repo.

--- a/meta/techniques/version-control/list-submodules.md
+++ b/meta/techniques/version-control/list-submodules.md
@@ -1,19 +1,19 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.1.1
 ---
 
 ## Capability
 
-Read and parse `.gitmodules` to enumerate the target-component submodules, excluding the `workflows` and `.engineering` infrastructure submodules that every project carries.
+Read and parse `.gitmodules` to enumerate the target-component submodules, excluding infrastructure submodules that every project carries — a submodule whose `path` equals `workflows`, equals `.engineering`, or is under `.engineering/` (`path` is `.engineering` or starts with `.engineering/`). Exact matches for top-level `workflows` and `.engineering` are retained. These are never a target component.
 
 ## Outputs
 
 ### submodules
 
-Array of `{ path, name, url }` entries, one per target-component submodule. The `workflows` and `.engineering` infrastructure submodules are omitted.
+Array of `{ path, name, url }` entries, one per target-component submodule. Infrastructure submodules whose `path` equals `workflows`, equals `.engineering`, or is under `.engineering/` (`path` is `.engineering` or starts with `.engineering/`) are omitted.
 
 ## Protocol
 
 1. Read `.gitmodules`; parse each `[submodule "name"]` section to extract `path` and `url`.
-2. Omit any section whose `path` is `workflows` or `.engineering` (infrastructure submodules, never a target component). Collect one entry per remaining section into `{submodules}`.
+2. Omit any section whose `path` equals `workflows`, equals `.engineering`, or is under `.engineering/` (`path` is `.engineering` or starts with `.engineering/`) — the infrastructure submodules present in every project (legacy exact matches for top-level `workflows` and `.engineering` retained). Collect one entry per remaining section into `{submodules}`.

--- a/meta/techniques/version-control/list-submodules.md
+++ b/meta/techniques/version-control/list-submodules.md
@@ -1,19 +1,19 @@
 ---
 metadata:
-  version: 1.1.1
+  version: 1.1.2
 ---
 
 ## Capability
 
-Read and parse `.gitmodules` to enumerate the target-component submodules, excluding infrastructure submodules that every project carries — a submodule whose `path` equals `workflows`, equals `.engineering`, or starts with `.engineering/`. These are never a target component.
+Read and parse `.gitmodules` to enumerate the target-component submodules, excluding infrastructure submodules per [version-control](./TECHNIQUE.md)::infrastructure-submodule-paths.
 
 ## Outputs
 
 ### submodules
 
-Array of `{ path, name, url }` entries, one per target-component submodule. Infrastructure submodules whose `path` equals `workflows`, equals `.engineering`, or starts with `.engineering/` are omitted.
+Array of `{ path, name, url }` entries, one per target-component submodule. Infrastructure submodules (per [version-control](./TECHNIQUE.md)::infrastructure-submodule-paths) are omitted.
 
 ## Protocol
 
 1. Read `.gitmodules`; parse each `[submodule "name"]` section to extract `path` and `url`.
-2. Omit any section whose `path` equals `workflows`, equals `.engineering`, or starts with `.engineering/` — the infrastructure submodules present in every project. Collect one entry per remaining section into `{submodules}`.
+2. Omit infrastructure submodules — apply [version-control](./TECHNIQUE.md)::infrastructure-submodule-paths. Collect one entry per remaining section into `{submodules}`.

--- a/meta/techniques/version-control/list-submodules.md
+++ b/meta/techniques/version-control/list-submodules.md
@@ -5,15 +5,15 @@ metadata:
 
 ## Capability
 
-Read and parse `.gitmodules` to enumerate the target-component submodules, excluding infrastructure submodules that every project carries — a submodule whose `path` equals `workflows`, equals `.engineering`, or is under `.engineering/` (`path` is `.engineering` or starts with `.engineering/`). Exact matches for top-level `workflows` and `.engineering` are retained. These are never a target component.
+Read and parse `.gitmodules` to enumerate the target-component submodules, excluding infrastructure submodules that every project carries — a submodule whose `path` equals `workflows`, equals `.engineering`, or starts with `.engineering/`. These are never a target component.
 
 ## Outputs
 
 ### submodules
 
-Array of `{ path, name, url }` entries, one per target-component submodule. Infrastructure submodules whose `path` equals `workflows`, equals `.engineering`, or is under `.engineering/` (`path` is `.engineering` or starts with `.engineering/`) are omitted.
+Array of `{ path, name, url }` entries, one per target-component submodule. Infrastructure submodules whose `path` equals `workflows`, equals `.engineering`, or starts with `.engineering/` are omitted.
 
 ## Protocol
 
 1. Read `.gitmodules`; parse each `[submodule "name"]` section to extract `path` and `url`.
-2. Omit any section whose `path` equals `workflows`, equals `.engineering`, or is under `.engineering/` (`path` is `.engineering` or starts with `.engineering/`) — the infrastructure submodules present in every project (legacy exact matches for top-level `workflows` and `.engineering` retained). Collect one entry per remaining section into `{submodules}`.
+2. Omit any section whose `path` equals `workflows`, equals `.engineering`, or starts with `.engineering/` — the infrastructure submodules present in every project. Collect one entry per remaining section into `{submodules}`.

--- a/meta/workflow.yaml
+++ b/meta/workflow.yaml
@@ -74,7 +74,7 @@ variables:
     defaultValue: .
   - name: component_selection_needed
     type: boolean
-    description: Whether the monorepo has more than one target-component submodule (after excluding infrastructure submodules whose path equals `workflows`, equals `.engineering`, or is under `.engineering/` (`path` is `.engineering` or starts with `.engineering/`)), requiring the user to pick. Set by resolve-target's select-target-component step; gates the submodule-selection checkpoint so a single-component monorepo resolves headlessly.
+    description: Whether the monorepo has more than one target-component submodule (after excluding infrastructure submodules whose path equals `workflows`, equals `.engineering`, or starts with `.engineering/`), requiring the user to pick. Set by resolve-target's select-target-component step; gates the submodule-selection checkpoint so a single-component monorepo resolves headlessly.
     defaultValue: false
   - name: client_workflow_completed
     type: boolean

--- a/meta/workflow.yaml
+++ b/meta/workflow.yaml
@@ -74,7 +74,7 @@ variables:
     defaultValue: .
   - name: component_selection_needed
     type: boolean
-    description: Whether the monorepo has more than one target-component submodule (after excluding the workflows and .engineering infrastructure submodules), requiring the user to pick. Set by resolve-target's select-target-component step; gates the submodule-selection checkpoint so a single-component monorepo resolves headlessly.
+    description: Whether the monorepo has more than one target-component submodule (after excluding infrastructure submodules whose path equals `workflows`, equals `.engineering`, or is under `.engineering/` (`path` is `.engineering` or starts with `.engineering/`)), requiring the user to pick. Set by resolve-target's select-target-component step; gates the submodule-selection checkpoint so a single-component monorepo resolves headlessly.
     defaultValue: false
   - name: client_workflow_completed
     type: boolean

--- a/meta/workflow.yaml
+++ b/meta/workflow.yaml
@@ -74,7 +74,7 @@ variables:
     defaultValue: .
   - name: component_selection_needed
     type: boolean
-    description: Whether the monorepo has more than one target-component submodule (after excluding infrastructure submodules whose path equals `workflows`, equals `.engineering`, or starts with `.engineering/`), requiring the user to pick. Set by resolve-target's select-target-component step; gates the submodule-selection checkpoint so a single-component monorepo resolves headlessly.
+    description: Whether the monorepo has more than one target-component submodule (after excluding infrastructure submodules per version-control::infrastructure-submodule-paths), requiring the user to pick. Set by resolve-target's select-target-component step; gates the submodule-selection checkpoint so a single-component monorepo resolves headlessly.
     defaultValue: false
   - name: client_workflow_completed
     type: boolean


### PR DESCRIPTION
## Summary

Factor the infrastructure-submodule exclusion into one named rule on the version-control technique group, and have detect/list apply it by reference so nested `.engineering/*` paths stay out of monorepo target selection without lockstep full-phrase restatement.

🐛 _Issue: skipped_  📐 [Engineering](https://github.com/shieldedtech/midnight-agent-eng/blob/mike/.engineering/artifacts/planning/2026-07-16-exclude-engineering-infra-submodules/README.md)

---

## Motivation

Target selection currently treats nested infrastructure checkouts under `.engineering/` as if they were product components, which wastes selection time and can mis-classify a repo as a monorepo. A first pass restated the exclusion predicate on every surface; review feedback requires a single authoritative definition with short pointers elsewhere so the rule cannot drift and does not duplicate itself.

---

## Changes

**Implementation (replan — named-rule factoring):**
- Add `infrastructure-submodule-paths` under version-control `TECHNIQUE.md` (sole full three-disjunct definition; group version → 5.1.0)
- Point `detect-repo-type` and `list-submodules` Protocol filter steps at that named rule; slim Capability/Outputs to short pointers (technique versions → 1.1.2)
- Slim resolve-target activity rule and `component_selection_needed` workflow prose to the same short pointer
- Predicate semantics unchanged: nested `.engineering/*` excluded; legacy exact matches retained; platform top-level components unchanged

---

## 📌 Submission Checklist

- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: docs/protocol-only meta techniques
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] No new todos introduced

---

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other
- [x] N/A

---

## 🗹 TODO before merging

- [ ] Confirm approach (named-rule factoring)
- [ ] Implement factoring on this branch
- [ ] Ready for re-review
