### PR TITLE
fix(work-package,workflow-design): remediate dual-target compliance findings

### DIFF
--- a/work-package/README.md
+++ b/work-package/README.md
@@ -1,6 +1,6 @@
 # Work Package Implementation Workflow
 
-> v3.14.0 — Defines how to plan and implement ONE work package from inception to merged PR. A work package is a discrete unit of work such as a feature, bug-fix, enhancement, refactoring, or any other deliverable change. **Supports review mode** for conducting structured reviews of existing PRs.
+> v3.30.0 — Defines how to plan and implement ONE work package from inception to merged PR. A work package is a discrete unit of work such as a feature, bug-fix, enhancement, refactoring, or any other deliverable change. **Supports review mode** for conducting structured reviews of existing PRs.
 
 ---
 
@@ -29,7 +29,7 @@ This workflow guides the complete lifecycle of a single work package through 15 
 **Detailed documentation:**
 
 - **Activities:** See [activities/README.md](./activities/README.md) for per-activity orientation (purpose, role, and a flow diagram) and a link to each activity's authoritative YAML definition.
-- **Techniques:** See [techniques/](./techniques/) for the technique inventory and protocol flows.
+- **Techniques:** See [techniques/README.md](./techniques/README.md) for the technique inventory orientation; per-technique protocols live in the technique files.
 - **Resources:** See [resources/README.md](./resources/README.md) for the resource index (26 resources).
 
 Each activity binds its step operations through `step.technique`. Every step carries its own `step.technique` operation binding. The cross-cutting [`variable-binding`](../meta/techniques/variable-binding.md) technique (governing how steps read and write workflow variables) is declared once at `workflow.techniques.activity` and inherited by every activity — injected into every `get_activity` — so it is never listed per-activity. An activity declares its own `techniques[]` block only for an activity-specific strategy technique such as [`scatter-gather`](../meta/techniques/scatter-gather.md) (present on activities that aggregate per-item outputs across `forEach` iteration loops). Steps reference operation techniques either by bare id (e.g. `create-test-plan`) or by namespaced id (e.g. `cargo-operations::run-suite`, `design-philosophy::classify`).

--- a/work-package/techniques/README.md
+++ b/work-package/techniques/README.md
@@ -1,0 +1,28 @@
+# Work Package Techniques
+
+> Part of the [Work Package Implementation Workflow](../README.md)
+
+The technique library for the work-package workflow. Each technique is one capability an activity step binds via `step.technique`; the authoritative protocol, inputs, outputs, and rules live in the per-technique `.md` file (or group `TECHNIQUE.md` + operation files) and are served by `get_technique`. This file orients readers to the library layout and points to those authoritative sources.
+
+[`TECHNIQUE.md`](./TECHNIQUE.md) is the workflow-root base contract inherited by every technique here (its inputs/outputs/rules merge into each, and its `Initial`/`Final` protocol blocks wrap each technique's protocol).
+
+The cross-cutting meta strategy techniques [`variable-binding`](../../meta/techniques/variable-binding.md) and [`scatter-gather`](../../meta/techniques/scatter-gather.md) are declared at the workflow/activity level and inherited by every activity.
+
+For the full technique-to-activity table with capability summaries, see the [workflow README](../README.md#techniques).
+
+---
+
+## Technique groups by area
+
+| Area | Group / techniques |
+|------|--------------------|
+| **Start & setup** | `start-work-package/`, `manage-git/`, `manage-artifacts/` |
+| **Design & requirements** | `design-philosophy/`, `requirements-elicitation/`, `review-assumptions/`, `stakeholder-overview` |
+| **Research & analysis** | `research/`, `implementation-analysis/`, `codebase-comprehension/` |
+| **Plan & implement** | `plan-prepare/`, `implement/`, `cargo-operations/` |
+| **Review & quality** | `post-impl-review/`, `strategic-review/`, `lean-coding-audit/`, `validate/` |
+| **Submit & complete** | `submit-for-review/`, `finalize-documentation/`, `complete/` |
+
+## Cross-workflow techniques
+
+Operations under `meta/` (e.g. `gitnexus-operations`, `version-control`, `workflow-engine`) are referenced by qualified id from this workflow.

--- a/work-package/techniques/finalize-documentation/ensure-docs.md
+++ b/work-package/techniques/finalize-documentation/ensure-docs.md
@@ -11,13 +11,13 @@ Ensure public/exported APIs in the diff carry inline documentation.
 
 ### changed_files
 
-The diff's changed files, scoping which public/exported APIs are enumerated for doc-comment coverage. The applied [public-api-enum](../../../meta/techniques/gitnexus-operations/public-api-enum.md) op derives the changed-symbol set from this diff.
+The diff's changed files, scoping which public/exported APIs are enumerated for doc-comment coverage.
 
 ## Outputs
 
 ### documented_apis
 
-The public/exported APIs in the diff, each verified to carry inline documentation — missing doc comments added in place. The enumerated `public_api_symbols` from [public-api-enum](../../../meta/techniques/gitnexus-operations/public-api-enum.md) define the work list this op brings to full doc-comment coverage.
+The public/exported APIs in the diff, each verified to carry inline documentation — missing doc comments added in place. The enumerated `public_api_symbols` define the work list this op brings to full doc-comment coverage.
 
 ## Protocol
 

--- a/work-package/techniques/manage-git/instruct-merge-strategy.md
+++ b/work-package/techniques/manage-git/instruct-merge-strategy.md
@@ -11,7 +11,7 @@ Present DCO-compliant merge guidance for the PR, branching on whether the repo a
 
 ### squash_merge_supported
 
-Boolean — true when the repo allows squash merges (from [detect-merge-strategy](./detect-merge-strategy.md))
+Boolean — true when the repo allows squash merges
 
 ### branch_name
 

--- a/work-package/techniques/plan-prepare/create-todos.md
+++ b/work-package/techniques/plan-prepare/create-todos.md
@@ -11,11 +11,11 @@ Break the work package plan into actionable, atomic TODO tasks for implementatio
 
 ### plan_document
 
-Work package plan from [plan](./plan.md); its task breakdown, dependencies, and ordering are the source for the TODO list.
+Work package plan; its task breakdown, dependencies, and ordering are the source for the TODO list.
 
 ### tasks
 
-Atomic tasks with dependencies and ordering carried on `{plan_document}` (from [plan](./plan.md)); broken out into individual TODO items.
+Atomic tasks with dependencies and ordering carried on `{plan_document}`; broken out into individual TODO items.
 
 ## Outputs
 

--- a/work-package/techniques/requirements-elicitation/create-document.md
+++ b/work-package/techniques/requirements-elicitation/create-document.md
@@ -11,15 +11,15 @@ Create the requirements document artifact capturing elicited requirements, succe
 
 ### requirements
 
-The captured requirements list from [elicit](./elicit.md), recorded into the artifact.
+The captured requirements list, recorded into the artifact.
 
 ### success_criteria
 
-The defined success criteria with verification methods from [elicit](./elicit.md), recorded into the artifact.
+The defined success criteria with verification methods, recorded into the artifact.
 
 ### scope_boundaries
 
-The in/out scope definitions from [elicit](./elicit.md), recorded into the artifact.
+The in/out scope definitions, recorded into the artifact.
 
 ### planning_folder_path
 

--- a/work-package/workflow.yaml
+++ b/work-package/workflow.yaml
@@ -58,7 +58,7 @@ techniques:
 variables:
   - name: target_path
     type: string
-    description: Path to the working directory where edits, branch creation, builds, and PR operations occur. As of work-package 3.10, this is a dedicated git worktree of the component repo at the canonical path '~/projects/work/{component_name}/{wp-slug}/' — NOT the component's checkout inside the reference monorepo. Set by start-work-package's compute-canonical-target-path step after the work-package slug is known. All downstream activities (cargo-operations, manage-git, validate, strategic-review, etc.) operate on this path.
+    description: Path to the working directory where edits, branch creation, builds, and PR operations occur. As of work-package 3.10, this is a dedicated git worktree of the component repo at the canonical path '~/projects/work/{component_name}/{wp-slug}/' — NOT the component's checkout inside the reference monorepo.
   - name: reference_path
     type: string
     description: Path to the reference checkout used for codebase comprehension, GitNexus indexing, and code-resolvable assumption analysis. When the component is a submodule of a monorepo, this is the monorepo root; when the component is a standalone repo, this equals the component's primary checkout. NOT used for edits — edits happen in target_path. Resolved by start-work-package's resolve-target step from the path the user originally pointed at. No default — absence drives the start-work-package exists gate on reference-dependent steps.
@@ -68,7 +68,7 @@ variables:
     defaultValue: ""
   - name: worktree_created
     type: boolean
-    description: "True once start-work-package's create-component-worktree step has successfully created (or reused) a worktree at target_path. Drives the remove-worktree gate in complete: only worktrees this workflow created get cleaned up."
+    description: "True when a worktree at target_path was created or reused by this workflow run (only those worktrees are eligible for cleanup)."
     defaultValue: false
   - name: planning_folder_path
     type: string
@@ -85,10 +85,10 @@ variables:
     description: Issue tracking platform (github|jira)
   - name: jira_project
     type: string
-    description: How the Jira project was resolved during issue creation ('selected' from the project list, or 'specified' directly by the user). Set by start-work-package's jira-project-selection checkpoint.
+    description: How the Jira project was resolved during issue creation ('selected' from the project list, or 'specified' directly by the user).
   - name: is_review_mode
     type: boolean
-    description: True when the work package reviews an existing PR instead of producing a new implementation. Detected agent-side by start-work-package's detect-review-mode step and confirmed via the review-mode-detection checkpoint; gates the review-mode steps across the workflow.
+    description: True when the work package reviews an existing PR instead of producing a new implementation.
   - name: pr_number
     type: string
     description: Pull request number
@@ -112,14 +112,14 @@ variables:
     defaultValue: false
   - name: needs_comprehension
     type: boolean
-    description: Whether codebase comprehension is needed. Always true after design-philosophy (comprehension is mandatory). May be re-set to true by assumptions-review if stakeholder feedback requires deeper understanding.
+    description: Whether codebase comprehension is needed (mandatory after design-philosophy; may be re-requested after stakeholder feedback).
     defaultValue: true
   - name: problem_complexity
     type: string
-    description: Problem complexity assessed during design-philosophy (simple|moderate|complex). Drives ADR creation.
+    description: Problem complexity assessed during design-philosophy (simple|moderate|complex).
   - name: project_type
     type: string
-    description: Detected project type (e.g. rust-substrate); produced by project-type-detection and gates rust-substrate-specific validation steps.
+    description: Detected project type (e.g. rust-substrate); used to gate rust-substrate-specific validation steps.
   - name: elicitation_complete
     type: boolean
     description: Whether requirements elicitation is finished
@@ -130,7 +130,7 @@ variables:
     defaultValue: false
   - name: validation_results
     type: object
-    description: Aggregate validation envelope emitted by cargo-operations::run-suite — { check_status, clippy_status, test_status, fmt_status, validation_passed }. The validate activity reads its fields by dotted path (e.g. validation_results.validation_passed) to drive the fix-revalidate loop.
+    description: Aggregate validation envelope — { check_status, clippy_status, test_status, fmt_status, validation_passed }.
   - name: review_passed
     type: boolean
     description: Whether strategic review passed
@@ -149,7 +149,7 @@ variables:
     defaultValue: false
   - name: awaiting_review
     type: boolean
-    description: Drives submit-for-review's await-review hold loop; while true the review-received checkpoint is re-presented until feedback arrives.
+    description: True while submit-for-review is waiting for reviewer feedback.
     defaultValue: false
   - name: needs_issue_creation
     type: boolean
@@ -231,14 +231,14 @@ variables:
     defaultValue: false
   - name: has_resolvable_assumptions
     type: boolean
-    description: Whether code-resolvable assumptions exist that can be validated through targeted analysis. Drives the assumption reconciliation loop.
+    description: Whether code-resolvable assumptions exist that can be validated through targeted analysis.
     defaultValue: false
   - name: research_candidates
     type: array
-    description: "Inventory of open research gaps surfaced after synthesis, each triaged as reconcilable-by-research or irreconcilable, with rationale and (for irreconcilable candidates) a handoff target. Drives the research reconciliation loop and the full-picture presentation at the research-convergence checkpoint. Sub-shape per entry: { id, statement, status (Reconcilable|Resolved|Partially Resolved|Irreconcilable), rationale, handoff (stakeholder|code-analysis|out-of-scope, irreconcilable only) }."
+    description: "Inventory of open research gaps surfaced after synthesis, each triaged as reconcilable-by-research or irreconcilable, with rationale and (for irreconcilable candidates) a handoff target. Sub-shape per entry: { id, statement, status (Reconcilable|Resolved|Partially Resolved|Irreconcilable), rationale, handoff (stakeholder|code-analysis|out-of-scope, irreconcilable only) }."
   - name: has_reconcilable_research
     type: boolean
-    description: "Whether open research-reconcilable candidates remain — gaps further knowledge-base or web research could close. Drives the research reconciliation loop: true while another research pass is warranted, false once research converges (only irreconcilable candidates, or none, remain)."
+    description: "Whether open research-reconcilable candidates remain — gaps further knowledge-base or web research could close. True while another research pass is warranted; false once research converges (only irreconcilable candidates, or none, remain)."
     defaultValue: false
   - name: has_open_questions
     type: boolean
@@ -266,11 +266,11 @@ variables:
     defaultValue: false
   - name: strategic_fixes_selective
     type: boolean
-    description: Whether the user chose to fix only selected strategic-review findings (by priority) rather than all of them. Set by the strategic-review review-findings checkpoint's selective-fixes option alongside needs_strategic_fixes; a structural record of the selective-fix intent for the plan-prepare re-loop.
+    description: Whether the user chose to fix only selected strategic-review findings (by priority) rather than all of them.
     defaultValue: false
   - name: strategic_findings_deferred
     type: boolean
-    description: Whether the user chose to defer strategic-review findings (note them for later but proceed to submission now). Set by the strategic-review review-findings checkpoint's defer-findings option alongside review_passed; differentiates a deliberate defer from a clean accept.
+    description: Whether the user chose to defer strategic-review findings (note them for later but proceed to submission now).
     defaultValue: false
   - name: needs_cleanup
     type: boolean
@@ -326,21 +326,21 @@ variables:
     defaultValue: false
   - name: recommended_strategic_option
     type: string
-    description: Agent-recommended action after strategic review analysis (fix-findings|acceptable). Set by analyze-strategic-findings step.
+    description: Agent-recommended action after strategic review analysis (fix-findings|acceptable).
   - name: squash_merge_supported
     type: boolean
-    description: "True when the target repo allows squash merges (allow_squash_merge=true from GitHub API). Detected during start-work-package. Drives DCO merge strategy: squash-merge path when true, unsigned-commit path when false."
+    description: "True when the target repo allows squash merges (allow_squash_merge=true from GitHub API). When true, DCO uses the squash-merge path; otherwise the unsigned-commit path."
     defaultValue: false
   - name: context_scope
     type: string
-    description: "Provenance scope of AI-generated code in this work package. Set during research phase. Values: repo-only (all context from repository), web-retrieval (web sources used), mixed (both). Recorded in the provenance log and PR description."
+    description: "Provenance scope of AI-generated code in this work package. Values: repo-only (all context from repository), web-retrieval (web sources used), mixed (both). Recorded in the provenance log and PR description."
     defaultValue: repo-only
   - name: recommended_outcome
     type: string
-    description: Agent-recommended PR review outcome (approved|minor-changes|significant-changes). Set by analyze-review-outcome step.
+    description: Agent-recommended PR review outcome (approved|minor-changes|significant-changes).
   - name: current_branch
     type: string
-    description: Active git branch in the target repo at the moment a step is executing. Set after manage-git checks out a branch; read by checkpoints and PR-creation steps that reference the branch by name.
+    description: Active git branch in the target repo at the moment a step is executing.
     defaultValue: ""
   - name: existing_pr_number
     type: string
@@ -352,7 +352,7 @@ variables:
     defaultValue: ""
   - name: comprehension_artifact
     type: string
-    description: Absolute path to the comprehension artifact for the current codebase area, set by create-comprehension-artifact and read by downstream activities that reference comprehension findings.
+    description: Absolute path to the comprehension artifact for the current codebase area.
     defaultValue: ""
   - name: block_path
     type: string
@@ -372,22 +372,22 @@ variables:
     defaultValue: ""
   - name: implementation_plan
     type: object
-    description: "Implementation plan produced by plan-prepare. Sub-shape: { task_count: number — count of tasks in the plan; tasks: array of { id: string, description: string, status: string } }. Fields actually interpolated in messages today: task_count, tasks[].id, tasks[].description. Additional fields are tolerated."
+    description: "Implementation plan. Sub-shape: { task_count: number; tasks: array of { id: string, description: string, status: string } }. Additional fields are tolerated."
   - name: strategic_findings_summary
     type: string
-    description: Concise multi-line summary of strategic-review findings (severity tag + one-line description per finding). Empty string when no findings. Interpolated into the strategic-review review-findings checkpoint message so the user sees findings alongside the options without an extra round-trip. Set by analyze-strategic-findings.
+    description: Concise multi-line summary of strategic-review findings (severity tag + one-line description per finding). Empty string when no findings.
     defaultValue: ""
   - name: review_comments_summary
     type: string
-    description: Concise multi-line summary of reviewer comments captured during submit-for-review (severity tag + one-line description per comment, grouped by reviewer when multiple). Empty string when no comments. Interpolated into the submit-for-review review-outcome checkpoint message so the user sees the comments alongside the options without an extra round-trip. Set by analyze-review-outcome.
+    description: Concise multi-line summary of reviewer comments captured during submit-for-review (severity tag + one-line description per comment, grouped by reviewer when multiple). Empty string when no comments.
     defaultValue: ""
   - name: has_uncertain_symbols
     type: boolean
-    description: True when the current implement task's self-review flagged one or more symbols whose provenance could not be confirmed. Drives the symbol-provenance-confirmed checkpoint condition — when false, the loop continues without prompting the user. Set by the implement task-cycle self-review step.
+    description: True when the current implement task's self-review flagged one or more symbols whose provenance could not be confirmed.
     defaultValue: false
   - name: uncertain_symbols
     type: string
-    description: "Multi-line list of symbols flagged by the implement task-cycle self-review whose provenance could not be confirmed (one per line: symbol name + file/line context). Empty string when has_uncertain_symbols is false. Interpolated into the symbol-provenance-confirmed checkpoint message."
+    description: "Multi-line list of symbols flagged by the implement task-cycle self-review whose provenance could not be confirmed (one per line: symbol name + file/line context). Empty string when has_uncertain_symbols is false."
     defaultValue: ""
   - name: body_conforms
     type: boolean
@@ -411,14 +411,14 @@ variables:
     defaultValue: ""
   - name: gitnexus_indexed
     type: boolean
-    description: Whether reference_path has a usable GitNexus index. Set by start-work-package's analyze-reference-with-gitnexus step. Gates GitNexus-dependent steps and protocol phases across the workflow (e.g., post-impl-review's gitnexus-detect-changes-preflight step, implement-task's pre-edit-impact-check / post-edit-verification phases).
+    description: Whether reference_path has a usable GitNexus index (gates GitNexus-dependent steps and protocol phases).
     defaultValue: false
   - name: problem_type
     type: string
-    description: Problem or inventive-goal classification set during design-philosophy (e.g. defect, inventive-improvement). Interpolated into the classification-and-path-confirmed checkpoint message.
+    description: Problem or inventive-goal classification (e.g. defect, inventive-improvement).
   - name: pr_url
     type: string
-    description: URL of the pull request created during start-work-package. Captured alongside pr_number and recorded on the linked issue.
+    description: URL of the pull request for this work package (alongside pr_number).
     defaultValue: ""
   - name: discovered_path
     type: string
@@ -428,15 +428,15 @@ variables:
     description: Tracker issue/ticket title; used by naming-conventions to derive the branch name.
   - name: audit_confirmed
     type: boolean
-    description: True once the user has resolved the lean-coding-audit's audit-findings-confirmed gate (accept, apply-simplifications, or dispute). Marks the audit findings as reviewed before the pipeline proceeds to post-impl-review.
+    description: True once the user has resolved the lean-coding-audit findings gate (accept, apply-simplifications, or dispute).
     defaultValue: false
   - name: needs_simplification
     type: boolean
-    description: Whether accepted simplifications remain to apply at the audit-findings-confirmed gate. Drives the simplification-apply-cycle loop in lean-coding-audit; re-assessed each iteration after the safety floor is re-validated and cleared once the re-score surfaces no further accepted simplifications.
+    description: Whether accepted simplifications remain to apply at the audit-findings-confirmed gate.
     defaultValue: false
   - name: has_debt_markers
     type: boolean
-    description: Whether the harvest-debt step found at least one ponytail marker in the tree. Set by lean-coding-audit's harvest-debt step (ponytail/harvest-debt output); gates the report-gain step.
+    description: Whether at least one ponytail debt marker was found in the tree.
     defaultValue: false
   - name: stealth_mode
     type: boolean
@@ -448,7 +448,7 @@ variables:
     defaultValue: origin
   - name: push_remote_url
     type: string
-    description: URL the push remote resolves to, captured by manage-git::verify-remote-private and interpolated into the stealth-mode isolation confirmation.
+    description: URL the push remote resolves to (used in stealth-mode isolation confirmation).
     defaultValue: ""
   - name: unsigned_commits_in_pr
     type: boolean

--- a/workflow-design/README.md
+++ b/workflow-design/README.md
@@ -1,24 +1,24 @@
 # Workflow Design Workflow
 
-> v1.7.0 — Guides agents through creating, updating, or reviewing workflow definitions. In create/update modes, accepts a free-form user description and systematically elicits design details through sequential checkpoints. In review mode, audits an existing workflow against the 15 design principles and produces a compliance report.
+> v1.9.0 — Guides agents through creating, updating, or reviewing workflow definitions. In create/update modes, accepts a free-form user description and systematically elicits design details through sequential checkpoints. In review mode, audits one or more existing workflows against the 15 design principles and produces a compliance report.
 
 ---
 
 ## Overview
 
-This workflow manages the complete lifecycle of workflow definition authoring through nine activities, with three modes (create, update, review) that control which activities execute. All modes enforce schema expressiveness, convention conformance, and structural enforcement of critical constraints.
+This workflow manages the complete lifecycle of workflow definition authoring through nine activities, with three modes (create, update, review) that control which activities execute. All modes enforce schema expressiveness, convention conformance, and structural enforcement of critical constraints. Activity `#` columns below match on-disk `NN-` file prefixes (gaps at 02/07 are intentional).
 
 | # | Activity | Mode | Purpose |
 |---|----------|------|---------|
 | 01 | [**Intake and Context**](./activities/README.md#01-intake-and-context) | All | Classify create/update/review, set mode + target, internalize schemas and YAML format |
-| 02 | [**Requirements Refinement**](./activities/README.md#02-requirements-refinement) | Create, Update | Elicit the spec one dimension at a time (forEach over the design dimensions), then surface, reconcile, and review the design assumptions |
-| 03 | [**Pattern Analysis**](./activities/README.md#03-pattern-analysis) | Create only | Audit 2+ reference workflows for reusable patterns |
-| 04 | [**Impact Analysis**](./activities/README.md#04-impact-analysis) | Update only | Enumerate affected files, check integrity, flag removals |
-| 05 | [**Scope and Draft**](./activities/README.md#05-scope-and-draft) | Create, Update | Define file manifest, then draft and validate each file per-file |
-| 06 | [**Quality Review**](./activities/README.md#06-quality-review) | All | Expressiveness, conformance, rule-hygiene, and rule-enforcement audits, then a bounded fix-revalidate loop (max 3) with a critical-blocker gate (full compliance audit in review mode) |
-| 07 | [**Validate and Commit**](./activities/README.md#07-validate-and-commit) | All | Schema validation, then commit on a feature branch + open a PR against `workflows` (create/update) or save the compliance report (review) |
-| 08 | [**Post-Update Review**](./activities/README.md#08-post-update-review) | Update only | Automatic post-commit compliance audit of the updated workflow |
-| 09 | [**Retrospective**](./activities/README.md#09-retrospective) | All | Record a completion summary (create/update) and conduct a session retrospective |
+| 03 | [**Requirements Refinement**](./activities/README.md#03-requirements-refinement) | Create, Update | Elicit the spec one dimension at a time (forEach over the design dimensions), then surface, reconcile, and review the design assumptions |
+| 04 | [**Pattern Analysis**](./activities/README.md#04-pattern-analysis) | Create only | Audit 2+ reference workflows for reusable patterns |
+| 05 | [**Impact Analysis**](./activities/README.md#05-impact-analysis) | Update only | Enumerate affected files, check integrity, flag removals |
+| 06 | [**Scope and Draft**](./activities/README.md#06-scope-and-draft) | Create, Update | Define file manifest, then draft and validate each file per-file |
+| 08 | [**Quality Review**](./activities/README.md#08-quality-review) | All | Expressiveness, conformance, rule-hygiene, and rule-enforcement audits, then a bounded fix-revalidate loop (max 3) with a critical-blocker gate (full compliance audit in review mode; forEach over `target_workflow_ids`) |
+| 09 | [**Validate and Commit**](./activities/README.md#09-validate-and-commit) | All | Schema validation, then commit on a feature branch + open a PR against `workflows` (create/update) or save the compliance report (review) |
+| 10 | [**Post-Update Review**](./activities/README.md#10-post-update-review) | Update only | Automatic post-commit compliance audit of the updated workflow |
+| 11 | [**Retrospective**](./activities/README.md#11-retrospective) | All | Record a completion summary (create/update) and conduct a session retrospective |
 
 **Detailed documentation:**
 
@@ -45,26 +45,26 @@ graph TD
     startNode(["Start"]) --> INT["01 intake-and-context"]
 
     INT --> MODE{"mode?"}
-    MODE -->|"create"| REQ["02 requirements-refinement"]
+    MODE -->|"create"| REQ["03 requirements-refinement"]
     MODE -->|"update"| REQ
     MODE -->|"review"| QR
 
     REQ --> CREATE{"create?"}
-    CREATE -->|"yes"| PAT["03 pattern-analysis"]
-    CREATE -->|"no (update)"| IMP["04 impact-analysis"]
+    CREATE -->|"yes"| PAT["04 pattern-analysis"]
+    CREATE -->|"no (update)"| IMP["05 impact-analysis"]
 
-    PAT --> SCD["05 scope-and-draft"]
+    PAT --> SCD["06 scope-and-draft"]
     IMP --> SCD
 
-    SCD --> QR["06 quality-review"]
+    SCD --> QR["08 quality-review"]
 
     QR -->|"critical blocker"| SCD
     QR -.->|"review: fix issues"| INT
-    QR --> VAL["07 validate-and-commit"]
+    QR --> VAL["09 validate-and-commit"]
     VAL -.->|"return to drafting"| SCD
 
-    VAL -->|"create / review"| RETRO["09 retrospective"]
-    VAL -->|"update"| PUR["08 post-update-review"]
+    VAL -->|"create / review"| RETRO["11 retrospective"]
+    VAL -->|"update"| PUR["10 post-update-review"]
     PUR -->|"accept"| RETRO
     PUR -.->|"fix / revert"| INT
     RETRO --> doneNode(["End"])
@@ -82,7 +82,7 @@ The roles, the dispatch protocol, and the checkpoint protocol are defined once i
 
 ## Review Mode
 
-Review mode audits an existing workflow against:
+Review mode audits one or more existing workflows (`target_workflow_ids`, with each iteration binding `target_workflow_id`) against:
 
 1. **Schema expressiveness** — flags prose that should be formal constructs
 2. **Convention conformance** — checks naming, structure, and field ordering
@@ -101,19 +101,19 @@ This workflow encodes 15 design principles derived from analysis of 175+ histori
 | # | Principle | Enforcement |
 |---|-----------|-------------|
 | 1 | Internalize before producing | [Intake and Context](./activities/README.md#01-intake-and-context) gate checkpoints |
-| 2 | Define complete scope before execution | [Scope and Draft](./activities/README.md#05-scope-and-draft) `scope-and-structure-confirmed` checkpoint |
-| 3 | One question at a time | [Requirements Refinement](./activities/README.md#02-requirements-refinement) — per-dimension checkpoints |
-| 4 | Maximize schema expressiveness | [Quality Review](./activities/README.md#06-quality-review) `expressiveness-confirmed` checkpoint |
-| 5 | Convention over invention | [Quality Review](./activities/README.md#06-quality-review) `conformance-confirmed` checkpoint |
+| 2 | Define complete scope before execution | [Scope and Draft](./activities/README.md#06-scope-and-draft) `scope-and-structure-confirmed` checkpoint |
+| 3 | One question at a time | [Requirements Refinement](./activities/README.md#03-requirements-refinement) — per-dimension checkpoints |
+| 4 | Maximize schema expressiveness | [Quality Review](./activities/README.md#08-quality-review) `expressiveness-confirmed` checkpoint |
+| 5 | Convention over invention | [Quality Review](./activities/README.md#08-quality-review) `conformance-confirmed` checkpoint |
 | 6 | Never modify upward | Schema validation on every YAML file |
-| 7 | Confirm before irreversible changes | [Impact Analysis](./activities/README.md#04-impact-analysis) checkpoints (update mode) |
+| 7 | Confirm before irreversible changes | [Impact Analysis](./activities/README.md#05-impact-analysis) checkpoints (update mode) |
 | 8 | Corrections must persist | Cross-cutting: tracked throughout all activities |
-| 9 | Modular over inline | [Quality Review](./activities/README.md#06-quality-review) conformance check |
-| 10 | Encode constraints as structure | [Quality Review](./activities/README.md#06-quality-review) `enforcement-confirmed` checkpoint |
-| 11 | Plan before acting | [Scope and Draft](./activities/README.md#05-scope-and-draft) `file-approach-confirmed` checkpoint |
-| 12 | Non-destructive updates | [Scope and Draft](./activities/README.md#05-scope-and-draft) `preservation-check` checkpoint (update mode) |
+| 9 | Modular over inline | [Quality Review](./activities/README.md#08-quality-review) conformance check |
+| 10 | Encode constraints as structure | [Quality Review](./activities/README.md#08-quality-review) `enforcement-confirmed` checkpoint |
+| 11 | Plan before acting | [Scope and Draft](./activities/README.md#06-scope-and-draft) `file-approach-confirmed` checkpoint |
+| 12 | Non-destructive updates | [Scope and Draft](./activities/README.md#06-scope-and-draft) `preservation-check` checkpoint (update mode) |
 | 13 | Format literacy before content | [Intake and Context](./activities/README.md#01-intake-and-context) `format-literacy` checkpoint |
-| 14 | Complete documentation structure | [Validate and Commit](./activities/README.md#07-validate-and-commit) README generation/update |
+| 14 | Complete documentation structure | [Validate and Commit](./activities/README.md#09-validate-and-commit) README generation/update |
 | 15 | Output economy | Single terminal `COMPLETE.md`; single-row logs; no vestigial marker steps |
 
 ---
@@ -189,7 +189,7 @@ In create and update modes the workflow seeds and maintains a **planning folder*
 
 **Review mode:** A compliance report committed in the planning folder.
 
-Every mode ends with the [Retrospective](./activities/README.md#09-retrospective) activity, which records a session retrospective in the planning folder; create and update modes also produce a `COMPLETE.md` completion summary there.
+Every mode ends with the [Retrospective](./activities/README.md#11-retrospective) activity, which records a session retrospective in the planning folder; create and update modes also produce a `COMPLETE.md` completion summary there.
 
 ---
 

--- a/workflow-design/activities/01-intake-and-context.yaml
+++ b/workflow-design/activities/01-intake-and-context.yaml
@@ -1,5 +1,5 @@
 id: intake-and-context
-version: 1.1.0
+version: 1.2.0
 name: Intake and Context
 description: "Establish the operation type, mode, and target for the request, and internalize the schema system and YAML-format conventions that ground all drafting."
 required: true
@@ -36,18 +36,18 @@ steps:
       variable: is_review_mode
       operator: ==
       value: true
-    message: Compliance review is scoped to workflow '{target_workflow_id}'. Is this the correct target?
+    message: "Compliance review is scoped to workflow id(s): {target_workflow_ids}. Confirm this target set?"
     blocking: true
     options:
       - id: confirm-review-target
-        label: Yes — audit this workflow
-        description: Target confirmed; flow continues with the current `target_workflow_id`.
+        label: Yes — audit this target set
+        description: Target set confirmed; review-mode quality-review iterates `target_workflow_ids` (binding each to `target_workflow_id` per iteration).
         effect:
           setVariable:
             review_scope_confirmed: true
       - id: wrong-review-target
-        label: No — wrong target
-        description: Target rejected; checkpoint remains blocking until a correct `target_workflow_id` is supplied.
+        label: No — wrong target set
+        description: Target set rejected; checkpoint remains blocking until a correct `target_workflow_ids` list is supplied.
         effect:
           setVariable:
             review_scope_confirmed: false

--- a/workflow-design/activities/08-quality-review.yaml
+++ b/workflow-design/activities/08-quality-review.yaml
@@ -1,65 +1,43 @@
 id: quality-review
-version: 1.5.0
+version: 1.6.0
 name: Quality Review
 description: Quality review of drafted workflow content.
 required: true
 steps:
-  - kind: technique
-    id: load-all-workflow-files
-    technique: reload-workflow
+  - kind: loop
+    id: multi-target-review-loop
+    name: Multi-Target Review Loop
+    loopType: forEach
+    variable: target_workflow_id
+    over: target_workflow_ids
+    maxIterations: 20
     condition:
       type: simple
       variable: is_review_mode
       operator: ==
       value: true
-  - kind: technique
-    id: principle-compliance-audit
-    technique: audit-principles
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
-  - kind: technique
-    id: anti-pattern-scan
-    technique: audit-anti-patterns
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
-  - kind: technique
-    id: schema-validation-check
-    technique: audit-schema-validation
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
-  - kind: technique
-    id: tool-technique-doc-consistency
-    technique: audit-consistency
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
-  - kind: technique
-    id: verify-high-findings-review
-    technique: verify-high-findings
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
-  - kind: technique
-    id: compile-report
-    technique: compile-report
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
+    steps:
+      - kind: technique
+        id: load-all-workflow-files
+        technique: reload-workflow
+      - kind: technique
+        id: principle-compliance-audit
+        technique: audit-principles
+      - kind: technique
+        id: anti-pattern-scan
+        technique: audit-anti-patterns
+      - kind: technique
+        id: schema-validation-check
+        technique: audit-schema-validation
+      - kind: technique
+        id: tool-technique-doc-consistency
+        technique: audit-consistency
+      - kind: technique
+        id: verify-high-findings-review
+        technique: verify-high-findings
+      - kind: technique
+        id: compile-report
+        technique: compile-report
   - kind: checkpoint
     id: review-disposition
     condition:
@@ -67,7 +45,7 @@ steps:
       variable: is_review_mode
       operator: ==
       value: true
-    message: Compliance report complete. {review_findings_count} findings identified. Would you like to fix the issues?
+    message: Compliance report complete. {review_findings_count} findings identified across {target_workflow_ids}. Would you like to fix the issues?
     options:
       - id: fix-issues
         label: Fix identified issues

--- a/workflow-design/activities/README.md
+++ b/workflow-design/activities/README.md
@@ -4,75 +4,77 @@
 
 Nine activities that guide an agent from free-form description to validated, committed workflow files and a closing retrospective. `requirements-refinement`, `pattern-analysis`, `impact-analysis`, and `scope-and-draft` are mode-dependent (skipped in review mode); `pattern-analysis` is also skipped in update mode. `post-update-review` runs only in update mode as an automatic post-commit compliance audit. `retrospective` is the terminal activity in every mode.
 
+Heading numbers below match on-disk `NN-` file prefixes (gaps at 02/07 are intentional).
+
 This file is an orientation map. The authoritative definition of each activity — its steps, checkpoints, decisions, loops, and transitions — lives in the per-activity YAML linked from each section below and is served by `get_activity`.
 
 ---
 
 ### 01. Intake and Context
 
-Classify the request as create, update, or review, set the corresponding mode + target, then internalize the schema system and YAML format conventions before any drafting begins. It also binds the session's planning folder and, in create/update modes, seeds its `README.md` from the [design-context-readme](../resources/design-context-readme.md) template via `work-package::manage-artifacts::create-readme` — the entry point whose progress tracker every later activity updates. In update mode it loads the existing workflow first; in review mode it confirms the audit target and branches straight to quality review. This is the literacy gate: nothing downstream proceeds until the agent has the schema and format baseline.
+Classify the request as create, update, or review, set the corresponding mode + target (`target_workflow_id` for update; `target_workflow_ids` for review), then internalize the schema system and YAML format conventions before any drafting begins. It also binds the session's planning folder and, in create/update modes, seeds its `README.md` from the [design-context-readme](../resources/design-context-readme.md) template via `work-package::manage-artifacts::create-readme` — the entry point whose progress tracker every later activity updates. In update mode it loads the existing workflow first; in review mode it confirms the audit target set and branches straight to quality review. This is the literacy gate: nothing downstream proceeds until the agent has the schema and format baseline.
 
-Definition: [`01-intake-and-context.yaml`](./01-intake-and-context.yaml). Leads to [Requirements Refinement](#02-requirements-refinement), or directly to [Quality Review](#06-quality-review) in review mode.
+Definition: [`01-intake-and-context.yaml`](./01-intake-and-context.yaml). Leads to [Requirements Refinement](#03-requirements-refinement), or directly to [Quality Review](#08-quality-review) in review mode.
 
 ---
 
-### 02. Requirements Refinement
+### 03. Requirements Refinement
 
 Guided, one-dimension-at-a-time elicitation of the workflow specification: an optional design-context checkpoint, then a `forEach` over the design dimensions (purpose, activity list, model, checkpoints, artifacts, variables, techniques, rules — the list set per mode) that elicits and confirms each in turn. It then surfaces the design assumptions the spec rests on (`work-package::review-assumptions::collect`), reconciles the audit-resolvable ones autonomously (`reconcile-design-assumptions`), and interviews the user on the genuinely open ones (`work-package::review-assumptions::interview`/`record`) — mirroring work-package's elicitation-with-assumptions structure. The value is a confirmed specification plus a vetted set of design decisions, captured incrementally.
 
-Definition: [`03-requirements-refinement.yaml`](./03-requirements-refinement.yaml). Skipped in review mode; leads to [Pattern Analysis](#03-pattern-analysis) (create) or [Impact Analysis](#04-impact-analysis) (update).
+Definition: [`03-requirements-refinement.yaml`](./03-requirements-refinement.yaml). Skipped in review mode; leads to [Pattern Analysis](#04-pattern-analysis) (create) or [Impact Analysis](#05-impact-analysis) (update).
 
 ---
 
-### 03. Pattern Analysis
+### 04. Pattern Analysis
 
 Extract structural and content patterns from comparable existing workflows so the target workflow reuses proven conventions rather than reinventing them, and present those patterns alongside the proposed structure. Create mode only.
 
-Definition: [`04-pattern-analysis.yaml`](./04-pattern-analysis.yaml). Leads to [Scope and Draft](#05-scope-and-draft).
+Definition: [`04-pattern-analysis.yaml`](./04-pattern-analysis.yaml). Leads to [Scope and Draft](#06-scope-and-draft).
 
 ---
 
-### 04. Impact Analysis
+### 05. Impact Analysis
 
 Assess the impact of proposed changes against an existing workflow's files, transitions, and references, and flag any content that will be removed so removals are deliberate rather than silent. Update mode only.
 
-Definition: [`05-impact-analysis.yaml`](./05-impact-analysis.yaml). Leads to [Scope and Draft](#05-scope-and-draft).
+Definition: [`05-impact-analysis.yaml`](./05-impact-analysis.yaml). Leads to [Scope and Draft](#06-scope-and-draft).
 
 ---
 
-### 05. Scope and Draft
+### 06. Scope and Draft
 
 Define the complete file manifest and structural design up front, then run a per-file drafting and review pass over every entry in the confirmed manifest, validating each YAML file against its schema as it is written. After drafting, a block-indexed review of the full drafted set (`review-draft-yaml`) captures a draft attestation before the audit passes run. The value is a complete, pre-approved scope and a set of drafted files that are individually reviewed, attested, and schema-valid. Carries a per-file user checkpoint in create mode and a content-preservation guard in update mode.
 
-Definition: [`06-scope-and-draft.yaml`](./06-scope-and-draft.yaml). Skipped in review mode; leads to [Quality Review](#06-quality-review).
+Definition: [`06-scope-and-draft.yaml`](./06-scope-and-draft.yaml). Skipped in review mode; leads to [Quality Review](#08-quality-review).
 
 ---
 
-### 06. Quality Review
+### 08. Quality Review
 
-Quality review of the drafted content. In create/update modes it runs the expressiveness, conformance, rule-hygiene, and rule-enforcement audit passes, then a bounded fix-revalidate loop — apply the selected fixes via `apply-audit-fixes`, re-run the audits, up to 3 iterations — and a critical-blocker gate that returns to Scope and Draft when a Critical finding remains. In review mode it runs the full compliance audit (load all files, principle compliance, anti-pattern scan, schema validation, tool-technique-doc consistency) and compiles a severity-rated report, after which the user chooses whether to fix the findings. The value is workflow content that has been checked against the design principles and conventions, and had its fixable findings resolved in place, before it is committed.
+Quality review of the drafted content. In create/update modes it runs the expressiveness, conformance, rule-hygiene, and rule-enforcement audit passes, then a bounded fix-revalidate loop — apply the selected fixes via `apply-audit-fixes`, re-run the audits, up to 3 iterations — and a critical-blocker gate that returns to Scope and Draft when a Critical finding remains. In review mode it `forEach`es over `target_workflow_ids` (binding each to `target_workflow_id`) and runs the full compliance audit (load all files, principle compliance, anti-pattern scan, schema validation, tool-technique-doc consistency) per target, then compiles a severity-rated report, after which the user chooses whether to fix the findings. The value is workflow content that has been checked against the design principles and conventions, and had its fixable findings resolved in place, before it is committed.
 
-Definition: [`08-quality-review.yaml`](./08-quality-review.yaml). Leads to [Validate and Commit](#07-validate-and-commit).
+Definition: [`08-quality-review.yaml`](./08-quality-review.yaml). Leads to [Validate and Commit](#09-validate-and-commit).
 
 ---
 
-### 07. Validate and Commit
+### 09. Validate and Commit
 
 Final schema validation, scope verification, and README generation/update, then — in create/update modes — a blocking pre-commit attestation gate, a feature branch in the workflows repo (`prepare-workflow-branch`), a commit, and a pull request opened against the `workflows` branch and marked ready (`publish-workflow-pr`); workflow changes never land straight on `workflows`. In review mode it instead saves and commits the compliance report directly. The value is a workflow that is guaranteed loadable, has nothing left undone from its scope, has a human-readable entry point, and is delivered through a reviewable pull request after a deliberate sign-off.
 
-Definition: [`09-validate-and-commit.yaml`](./09-validate-and-commit.yaml). Terminal in create and review modes; leads to [Post-Update Review](#08-post-update-review) in update mode.
+Definition: [`09-validate-and-commit.yaml`](./09-validate-and-commit.yaml). Terminal in create and review modes; leads to [Post-Update Review](#10-post-update-review) in update mode.
 
 ---
 
-### 08. Post-Update Review
+### 10. Post-Update Review
 
 Automatic post-commit compliance audit of the updated workflow against the design principles and anti-patterns. It reloads the committed state from the workflow-server (not cached data), runs a scope-discipline audit (`scope-audit`) comparing the committed change set against the scope manifest to flag drift, and produces a severity-rated findings summary persisted as a review snapshot, so update work is verified against the principles after it lands. Update mode only.
 
-Definition: [`10-post-update-review.yaml`](./10-post-update-review.yaml). The accept disposition proceeds to the [Retrospective](#09-retrospective); the fix/revert dispositions restart the workflow at [Intake and Context](#01-intake-and-context).
+Definition: [`10-post-update-review.yaml`](./10-post-update-review.yaml). The accept disposition proceeds to the [Retrospective](#11-retrospective); the fix/revert dispositions restart the workflow at [Intake and Context](#01-intake-and-context).
 
 ---
 
-### 09. Retrospective
+### 11. Retrospective
 
 Terminal activity for every mode. In create/update modes it records a `COMPLETE.md` completion summary (`create-completion-doc`) — what was delivered, the design decisions and alternatives rejected, scope outcome, and known limitations — then conducts a session retrospective (`conduct-retrospective`) that analyses the non-checkpoint interactions and records prioritized workflow improvements. It is the workflow-design counterpart of work-package's Complete activity, minus the PR-merge and next-package-selection steps (workflow-design commits directly and has no package portfolio). A trivial session skips the retrospective.
 

--- a/workflow-design/resources/review-mode-guide.md
+++ b/workflow-design/resources/review-mode-guide.md
@@ -8,7 +8,7 @@ metadata:
 
 # Review Mode Guide
 
-Guidance for auditing existing workflows against the 15 design principles. Review mode produces a compliance report without modifying the target workflow, then offers to switch to update mode for remediation.
+Guidance for auditing existing workflows against the 15 design principles. Review mode produces a compliance report without modifying the target workflow(s), then offers to switch to update mode for remediation.
 
 This guide carries the **supplementary** material for review mode: activation/flow framing, the compliance report template, and the transition-to-update-mode contract. The **audit procedure itself** is canonical in the `quality-review` activity's bound `audit-*` techniques — the worker loads each via `get_technique` and executes its protocol. This file does not restate the procedure.
 
@@ -18,12 +18,14 @@ This guide carries the **supplementary** material for review mode: activation/fl
 
 `intake-classification` classifies the request as review when it matches recognition signals such as "review workflow", "audit workflow", "check workflow compliance", "workflow review", "assess workflow quality", or "evaluate workflow", and produces `operation_type` = `review` with `is_review_mode` = `true` as its declared outputs (landed via the worker's `variables-changed` channel). These signals inform the classification; the mode flag is set structurally by the technique's outputs, not by this prose.
 
+Multi-target review is first-class: name one or more workflow ids in the request. Intake sets `target_workflow_ids` (array) and seeds `target_workflow_id` to the first element. Single-target review is a one-element list on that array.
+
 ## Activity Flow
 
 Review mode follows a shortened activity sequence:
 
-1. **Intake and Context** — Load the target workflow, enumerate its contents, internalize the schemas as the audit baseline, then the `review-scope-confirmed` checkpoint (blocking) confirms `target_workflow_id` before continuing.
-2. **Quality Review** — Run the audit passes against the existing workflow. This is the core of review mode.
+1. **Intake and Context** — Load each target workflow in `target_workflow_ids`, enumerate contents, internalize the schemas as the audit baseline, then the `review-scope-confirmed` checkpoint (blocking) confirms the full target set before continuing.
+2. **Quality Review** — `forEach` over `target_workflow_ids`, binding each id to `target_workflow_id` and running the audit passes (reload, principles, anti-patterns, schema validation, consistency, verify-high-findings, compile-report). The `review-disposition` checkpoint runs once after all targets. This is the core of review mode.
 3. **Validate and Commit** — Save the compliance report as an artifact.
 4. **Retrospective** — Capture a session retrospective.
 

--- a/workflow-design/techniques/TECHNIQUE.md
+++ b/workflow-design/techniques/TECHNIQUE.md
@@ -15,7 +15,11 @@ Free-form description of the workflow the user wants to create or modify
 
 ### target_workflow_id
 
-*(optional)* Existing workflow id to modify (update mode) or to audit (review mode)
+*(optional)* Existing workflow id to modify (update mode), or the current review-mode audit target. In multi-target review, the quality-review `forEach` over `{target_workflow_ids}` binds this id once per iteration.
+
+### target_workflow_ids
+
+*(optional)* Ordered list of workflow ids to audit in review mode. Single-target review uses a one-element list. Update/create modes leave this unset and use `{target_workflow_id}` alone.
 
 ## Outputs
 

--- a/workflow-design/techniques/intake-classification.md
+++ b/workflow-design/techniques/intake-classification.md
@@ -27,15 +27,20 @@ The id of the workflow being created or updated.
 
 ### target_workflow_id
 
-The id of the existing workflow to modify (update) or audit (review); unset in create mode.
+The id of the existing workflow to modify (update), or the primary/current audit target (review). In multi-target review this is the first id in `{target_workflow_ids}` at intake and is rebound per quality-review iteration; unset in create mode.
+
+### target_workflow_ids
+
+Ordered list of workflow ids to audit in review mode. One element for single-target review; two or more when the request names multiple workflows (e.g. `work-package` and `workflow-design`). Unset in create/update modes.
 
 ## Protocol
 
 ### 1. Load Baseline
 
-- For update or review mode, load the committed workflow catalog via [list-workflows](../../meta/techniques/workflow-engine/list-workflows.md) and source the target's definition for `{target_workflow_id}` from the workflow-server context the orchestrator supplies — the executing worker does not call `get_workflow` directly
-- Build a structural inventory of the target: file counts and entity counts (activities, techniques, resources, checkpoints, transitions)
-- Present the loaded structure to the user as the scope-confirmation surface
+- For update or review mode, load the committed workflow catalog via [list-workflows](../../meta/techniques/workflow-engine/list-workflows.md) and source each target's definition from the workflow-server context the orchestrator supplies — the executing worker does not call `get_workflow` directly
+- In review mode, resolve `{target_workflow_ids}` from the request (one or more ids) and set `{target_workflow_id}` to the first element for singular bind sites; in update mode set `{target_workflow_id}` only
+- Build a structural inventory of each target: file counts and entity counts (activities, techniques, resources, checkpoints, transitions)
+- Present the loaded structure(s) to the user as the scope-confirmation surface
 
 ### 2. Parse Change Request
 
@@ -45,4 +50,4 @@ The id of the existing workflow to modify (update) or audit (review); unset in c
 
 - Accept the `{user_description}` and summarize key design intent — purpose, domain, rough activity count, and constraints
 - Set `{operation_type}` and the corresponding `{is_update_mode}` / `{is_review_mode}` flags: an existing-workflow reference for a change signals update, for an audit signals review, otherwise create
-- Present the classification and distilled intent for confirmation
+- Present the classification, target set (`{target_workflow_ids}` in review), and distilled intent for confirmation

--- a/workflow-design/techniques/reload-workflow.md
+++ b/workflow-design/techniques/reload-workflow.md
@@ -11,4 +11,5 @@ Load the committed workflow definition fresh as the post-commit audit baseline, 
 
 ### 1. Reload Workflow
 
-- Refresh the committed workflow catalog via [list-workflows](../../meta/techniques/workflow-engine/list-workflows.md) and source the full definition for `{target_workflow_id}` fresh from the workflow-server context the orchestrator supplies — do not reuse cached pre-update state, and do not call `get_workflow` directly (the executing worker sources the definition from orchestrator-provided context)
+- Refresh the committed workflow catalog via [list-workflows](../../meta/techniques/workflow-engine/list-workflows.md) and source the full definition for the current `{target_workflow_id}` fresh from the workflow-server context the orchestrator supplies — the executing worker sources the definition from orchestrator-provided context (fresh load each time; no direct `get_workflow` call)
+- In review mode inside the multi-target `forEach`, `{target_workflow_id}` is the loop-bound current id from `{target_workflow_ids}`; reload that id only for this iteration.

--- a/workflow-design/workflow.yaml
+++ b/workflow-design/workflow.yaml
@@ -63,7 +63,10 @@ variables:
     defaultValue: false
   - name: target_workflow_id
     type: string
-    description: ID of the existing workflow to modify (update mode) or to audit (review mode)
+    description: ID of the existing workflow to modify (update mode) or the current review-mode audit target (bound per iteration when reviewing multiple workflows)
+  - name: target_workflow_ids
+    type: array
+    description: Ordered list of workflow ids to audit in review mode (one or more). Single-target review uses a one-element list; update mode leaves this unset and uses target_workflow_id.
   - name: workflow_id
     type: string
     description: The ID of the workflow being created or updated


### PR DESCRIPTION
## Summary

Dual-target **update** remediation for existing `work-package` and `workflow-design` workflows (no new workflow). Addresses seven compliance findings from the dual-target quality review.

- **DOC-01 / LOW-02:** Sync README version banners (`work-package` → v3.30.0, `workflow-design` → v1.9.0)
- **DOC-02:** Add `work-package/techniques/README.md` orientation file
- **DOC-03:** Align `workflow-design` README tables/headings/anchors to on-disk `NN-` prefixes
- **MULTI-01:** First-class `target_workflow_ids` array + review-mode `forEach` over targets
- **AP41-01:** Genericize work-package technique I/O prose (drop sibling-producer coupling)
- **LOW-01:** Trim producer/gate narration from `work-package` variable descriptions

## Scope manifest (16 files)

| # | Path | Action |
|---|------|--------|
| 1 | `work-package/techniques/README.md` | create |
| 2–7 | `work-package` README, workflow.yaml, 4 AP41 techniques | modify |
| 8–16 | `workflow-design` yaml, activities, techniques, resource, READMEs | modify |

## Planning

`.engineering/artifacts/planning/2026-07-16-review-work-package-workflow-design`

## Validation

- `validate-workflow-yaml.ts` — PASS (work-package + workflow-design)
- `check-all-refs.ts` — 0 unresolved
- `check-binding-fidelity.ts` — 0 new drift

## Test plan

- [ ] Confirm create/update paths for both workflows unchanged
- [ ] Confirm review mode iterates `target_workflow_ids` and binds `target_workflow_id` per iteration
- [ ] Spot-check README banners and orientation numbering
- [ ] Loader loads both workflows after merge to `workflows`