### PR TITLE
fix(scripts): treat italic op args as anchored in protocol-ref check

### DIFF
--- a/scripts/validate-workflow-yaml.ts
+++ b/scripts/validate-workflow-yaml.ts
@@ -65,7 +65,16 @@ function checkTechniqueProtocolRefs(file: string): string[] {
   const rest = s.slice(m.index + 1);
   const next = rest.search(/^##\s+(?!#)/m);
   const protocol = next === -1 ? s.slice(m.index) : s.slice(m.index, m.index + 1 + next);
-  const stripCode = (t: string) => t.replace(/```[\s\S]*?```/g, '').replace(/`[^`]*`/g, '');
+  // Strip fenced/inline code and italic/bold emphasis so op argument names
+  // (*arg* / **arg**) and code tokens are not flagged as bare designators.
+  const stripCode = (t: string) =>
+    t
+      .replace(/```[\s\S]*?```/g, '')
+      .replace(/`[^`]*`/g, '')
+      .replace(/\*\*([^*]+)\*\*/g, '')
+      .replace(/\*([^*]+)\*/g, '')
+      .replace(/__([^_]+)__/g, '')
+      .replace(/_([^_]+)_/g, '');
   const bare = new Set<string>();
   for (const rawLine of protocol.split('\n')) {
     if (/^\s*#{1,4}\s/.test(rawLine)) continue; // skip headings


### PR DESCRIPTION
## Summary
- `validate-workflow-yaml.ts` protocol-ref scanner strips italic/bold emphasis the same way it strips code spans, so P15 `*arg*` operation argument names are not flagged as bare designators.
- Unblocks `npx tsx scripts/validate-workflow-yaml.ts` for workflow-design on #251 (v1.24.x italic arg style).

## Test plan
- [x] `npx tsx scripts/validate-workflow-yaml.ts <worktree>/workflow-design` → All YAML files valid (with italic `*target_dir*` protocol args)
- [ ] Spot-check: bare multi-word snake_case in Protocol still fails