### PR TITLE
feat(work-package): derive-first review activation (v3.32.0)

### DIFF
--- a/work-package/README.md
+++ b/work-package/README.md
@@ -163,7 +163,7 @@ This workflow supports **review mode** for reviewing existing PRs rather than im
 start-work-package → design-philosophy → implementation-analysis → plan-prepare → assumptions-review → lean-coding-audit → post-impl-review → validate → strategic-review → submit-for-review → END
 ```
 
-**Headless after activation:** Once review mode is confirmed, the run is headless — every review-reachable checkpoint auto-resolves to its recommended option, is gated out, or is bypassed by an unconditional transition. The only interactive gates a review-mode run actually stops at are the two activation prompts (`review-mode-detection`, `review-pr-reference`) and the single `review-summary-approval` confirmation before the review is posted to the PR.
+**Headless after activation:** Once review mode is active, the run is headless — every review-reachable checkpoint auto-resolves to its recommended option, is gated out, or is bypassed by an unconditional transition. Interactive gates in review mode are activation gap-fills only (`review-mode-detection` when mode is ambiguous, `review-pr-reference` when the PR is missing) plus the single `review-summary-approval` confirmation before the review is posted to the PR. Clear derive paths skip both activation confirms.
 
 **See [REVIEW-MODE.md](./REVIEW-MODE.md) for complete documentation.**
 

--- a/work-package/README.md
+++ b/work-package/README.md
@@ -1,6 +1,6 @@
 # Work Package Implementation Workflow
 
-> v3.30.0 — Defines how to plan and implement ONE work package from inception to merged PR. A work package is a discrete unit of work such as a feature, bug-fix, enhancement, refactoring, or any other deliverable change. **Supports review mode** for conducting structured reviews of existing PRs.
+> v3.31.0 — Defines how to plan and implement ONE work package from inception to merged PR. A work package is a discrete unit of work such as a feature, bug-fix, enhancement, refactoring, or any other deliverable change. **Supports review mode** for conducting structured reviews of existing PRs.
 
 ---
 

--- a/work-package/REVIEW-MODE.md
+++ b/work-package/REVIEW-MODE.md
@@ -20,15 +20,9 @@ When activated, review mode:
 
 ### State-Driven Activation
 
-Review mode has no dedicated schema construct. It is driven by a single boolean variable, `is_review_mode`, declared like any other workflow variable (default `false`):
+Review mode has no dedicated schema construct. It is driven by ordinary state: `is_review_mode`, plus gap flags `review_mode_ambiguous` and `review_pr_missing` when derivation cannot settle mode or PR identity.
 
-```
-- name: is_review_mode
-  type: boolean
-  defaultValue: false
-```
-
-A detection step early in `start-work-package` (`detect-review-mode`) recognizes review intent, confirms with the user, and sets `is_review_mode = true`. Everything mode-specific downstream is a conditional step, checkpoint, or transition that reads this variable. There is no `skipActivities` list and no mode `defaults` block: activities are "skipped" only because their steps and inbound transitions are gated on `is_review_mode`, and mode-specific variable values (e.g. `needs_elicitation = false`) are set by an ordinary control step gated the same way.
+A derive-first detection step early in `start-work-package` (`detect-review-mode`) recognizes review intent and PR identity from `{user_request}` / `{pr_reference}`. When mode and PR are clear, the run continues without activation confirms. When mode is ambiguous, `review-mode-detection` asks; when review mode is active but the PR is missing, `review-pr-reference` asks. Everything mode-specific downstream is a conditional step, checkpoint, or transition that reads `is_review_mode`. There is no `skipActivities` list and no mode `defaults` block: activities are "skipped" only because their steps and inbound transitions are gated on `is_review_mode`, and mode-specific variable values (e.g. `needs_elicitation = false`) are set by an ordinary control step gated the same way.
 
 ### Activity-Level Behavior
 
@@ -43,9 +37,9 @@ Per-activity review guidance is in `resources/review-mode.md`.
 
 ### Headless After Activation
 
-Once review mode is active, the run is **headless**: every review-reachable checkpoint either auto-resolves to its recommended option, is gated out, or is bypassed by an unconditional transition, so a review-mode run can be dispatched and left to complete without a human at each gate. Two classes of interaction remain:
+Once review mode is active, the run is **headless**: every review-reachable checkpoint either auto-resolves to its recommended option, is gated out, or is bypassed by an unconditional transition, so a review-mode run can be dispatched and left to complete without a human at each gate. Interaction remains only for:
 
-- **Activation prompts** — `review-mode-detection` and `review-pr-reference` (`start-work-package`) stay interactive. They run before review mode is confirmed and identify the PR under review.
+- **Activation gap-fills** — `review-mode-detection` (when `review_mode_ambiguous`) and `review-pr-reference` (when `review_pr_missing`) in `start-work-package`. Clear derive paths skip both.
 - **The single post-to-PR confirmation** — `review-summary-approval` (`submit-for-review`) stays interactive. It is the one review-mode checkpoint whose recommended option has an outward-facing side effect (posting the consolidated review as a comment on the GitHub PR), so it confirms with the user before that action.
 
 Every other review-reachable checkpoint is headless, by one of three mechanisms:
@@ -64,7 +58,7 @@ The `strategic-review :: review-findings` checkpoint is **not** made to auto-adv
 
 ## Activating Review Mode
 
-The `detect-review-mode` step in `start-work-package` recognizes review mode from user request patterns such as:
+The `detect-review-mode` step in `start-work-package` derives review mode from user request patterns such as:
 
 | Pattern | Example |
 |---------|---------|
@@ -72,14 +66,12 @@ The `detect-review-mode` step in `start-work-package` recognizes review mode fro
 | "review pr" | `Review PR #456` |
 | "review existing implementation" | `Review the existing implementation` |
 
-When detected, you'll be asked to confirm:
+Clear review intent with a parseable PR number or URL skips activation confirms and announces the derived mode. Confirms fire only on gaps:
 
-```
-This appears to be a review of an existing PR. Is that correct?
+- **Mode unclear** — `review_mode_ambiguous` → `review-mode-detection` (review vs new implementation)
+- **PR missing** — `review_pr_missing` → `review-pr-reference` (number or URL)
 
-- [Yes, review existing PR] - Review mode activated
-- [No, new implementation] - Standard workflow
-```
+When the first derive pass already checked out the PR branch, a second bind is skipped. When the PR was supplied only at the gap confirm, a follow-up `capture-pr-reference` bind completes checkout and ticket extract.
 
 ---
 
@@ -140,7 +132,7 @@ graph TD
 
 | Activity | Mode Override |
 |----------|---------------|
-| `start-work-package` | Detect mode, capture PR reference; the `issue-verification` and `pr-creation` checkpoints and branch/PR-creation steps are gated `is_review_mode != true` so no issue/branch/PR is created |
+| `start-work-package` | Derive mode and PR reference (gap-fill confirms only when ambiguous/missing); the `issue-verification` and `pr-creation` checkpoints and branch/PR-creation steps are gated `is_review_mode != true` so no issue/branch/PR is created |
 | `design-philosophy` | Assess ticket completeness, force skip elicitation; `ticket-completeness` auto-advances to `proceed-with-gaps`; `classification-and-path-confirmed` is gated `is_review_mode != true` so no path confirmation is prompted — a message records the classification and the run proceeds to `implementation-analysis` |
 | `plan-prepare` | Plan the review approach; the `update-pr::render` (initial) step and `approach-confirmed` checkpoint are gated `is_review_mode != true` so the reviewed PR's body is never overwritten and no approach-confirmation is prompted |
 | `requirements-elicitation`, `research` | **Not on the headless review path.** With the path variables at their defaults (`needs_elicitation`/`needs_research` both `false`), `codebase-comprehension` routes straight to `implementation-analysis`, so neither activity is entered in review mode. Neither carries review-mode-specific handling — they are simply off the review path (create mode only). |

--- a/work-package/activities/01-start-work-package.yaml
+++ b/work-package/activities/01-start-work-package.yaml
@@ -1,5 +1,5 @@
 id: start-work-package
-version: 3.12.0
+version: 3.13.0
 name: Start Work Package
 description: Initialize the work package with issue, branch, draft PR, dedicated worktree, and planning folder.
 required: true
@@ -12,19 +12,49 @@ steps:
   - kind: technique
     id: detect-review-mode
     technique: review-mode-detection
+  - kind: action
+    id: announce-derived-review-mode
     condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
+      type: and
+      conditions:
+        - type: simple
+          variable: is_review_mode
+          operator: ==
+          value: true
+        - type: simple
+          variable: review_mode_ambiguous
+          operator: "!="
+          value: true
+    actions:
+      - action: message
+        message: "Review mode derived from the request."
+  - kind: action
+    id: announce-derived-review-pr
+    condition:
+      type: and
+      conditions:
+        - type: simple
+          variable: is_review_mode
+          operator: ==
+          value: true
+        - type: simple
+          variable: review_pr_missing
+          operator: "!="
+          value: true
+        - type: simple
+          variable: pr_number
+          operator: exists
+    actions:
+      - action: message
+        message: "Review PR derived as #{pr_number}."
   - kind: checkpoint
     id: review-mode-detection
     condition:
       type: simple
-      variable: is_review_mode
+      variable: review_mode_ambiguous
       operator: ==
       value: true
-    message: This appears to be a review of an existing PR. Select whether to continue in review mode or treat this as new implementation.
+    message: Review vs new-implementation intent is unclear from the request. Select whether to continue in review mode or treat this as new implementation.
     options:
       - id: confirm-review
         label: Yes, review existing PR
@@ -32,28 +62,48 @@ steps:
         effect:
           setVariable:
             is_review_mode: true
+            review_mode_ambiguous: false
       - id: new-implementation
         label: No, new implementation
         description: This is new work, not a review
         effect:
           setVariable:
             is_review_mode: false
-  - kind: technique
-    id: capture-pr-reference
-    technique: review-mode-detection
+            review_mode_ambiguous: false
+  - kind: action
+    id: mark-review-pr-captured
     condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
+      type: and
+      conditions:
+        - type: simple
+          variable: is_review_mode
+          operator: ==
+          value: true
+        - type: simple
+          variable: review_pr_missing
+          operator: "!="
+          value: true
+        - type: simple
+          variable: pr_number
+          operator: exists
+    actions:
+      - action: set
+        target: review_pr_captured
+        value: true
   - kind: checkpoint
     id: review-pr-reference
     condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
-    message: "Please provide the PR to review (number or URL):"
+      type: and
+      conditions:
+        - type: simple
+          variable: is_review_mode
+          operator: ==
+          value: true
+        - type: simple
+          variable: review_pr_missing
+          operator: ==
+          value: true
+    message: "Review mode needs a PR reference (number or URL)."
     options:
       - id: pr-provided
         label: PR reference provided
@@ -61,12 +111,31 @@ steps:
         effect:
           setVariable:
             review_pr_captured: true
+            review_pr_missing: false
       - id: cancel-review
         label: Cancel review mode
         description: Switch to standard work package mode
         effect:
           setVariable:
             is_review_mode: false
+            review_pr_missing: false
+  - kind: technique
+    id: capture-pr-reference
+    technique: review-mode-detection
+    condition:
+      type: and
+      conditions:
+        - type: simple
+          variable: is_review_mode
+          operator: ==
+          value: true
+        - type: simple
+          variable: review_pr_captured
+          operator: ==
+          value: true
+        - type: simple
+          variable: branch_name
+          operator: notExists
   - kind: technique
     id: ingest-prior-feedback
     technique: review-existing-feedback
@@ -480,13 +549,41 @@ steps:
       - action: set
         target: existing_pr_number
         description: PR number from the list-prs result when one was found
+      - action: set
+        target: use_existing_pr
+        description: true when pr_exists and an already-bound pr_number equals existing_pr_number (continue this work); otherwise leave the default false so pr-check can ask
+      - action: set
+        target: pr_number
+        description: When use_existing_pr was set true by a pr_number/existing_pr_number match, bind pr_number from existing_pr_number; otherwise leave unchanged
+  - kind: action
+    id: announce-auto-use-existing-pr
+    condition:
+      type: and
+      conditions:
+        - type: simple
+          variable: pr_exists
+          operator: ==
+          value: true
+        - type: simple
+          variable: use_existing_pr
+          operator: ==
+          value: true
+    actions:
+      - action: message
+        message: "Continuing with existing PR #{existing_pr_number} (already bound for this branch)."
   - kind: checkpoint
     id: pr-check
     condition:
-      type: simple
-      variable: pr_exists
-      operator: ==
-      value: true
+      type: and
+      conditions:
+        - type: simple
+          variable: pr_exists
+          operator: ==
+          value: true
+        - type: simple
+          variable: use_existing_pr
+          operator: "!="
+          value: true
     message: "Found existing PR #{existing_pr_number} for this branch. Select whether to use it or create a new one."
     options:
       - id: use-existing

--- a/work-package/activities/01-start-work-package.yaml
+++ b/work-package/activities/01-start-work-package.yaml
@@ -24,7 +24,7 @@ steps:
       variable: is_review_mode
       operator: ==
       value: true
-    message: This appears to be a review of an existing PR. Is that correct?
+    message: This appears to be a review of an existing PR. Select whether to continue in review mode or treat this as new implementation.
     options:
       - id: confirm-review
         label: Yes, review existing PR
@@ -122,7 +122,7 @@ steps:
         - type: simple
           variable: issue_number
           operator: notExists
-    message: I didn't find a GitHub or Jira issue associated with this work package. Which option would you like?
+    message: No GitHub or Jira issue is associated with this work package. Select how to proceed.
     options:
       - id: provide-existing
         label: Provide existing issue
@@ -203,13 +203,13 @@ steps:
           variable: github_issue_found
           operator: ==
           value: false
-    message: No GitHub issue found for Jira ticket {jira_issue_key}. A linked GitHub issue enables PR traceability in the target repo. Create one now?
+    message: No GitHub issue found for Jira ticket {jira_issue_key}. A linked GitHub issue enables PR traceability in the target repo. Select whether to create one.
     blocking: false
     defaultOption: create
     autoAdvanceMs: 30000
     options:
       - id: create
-        label: Create GitHub issue (default — auto-creates after 30s)
+        label: Create GitHub issue
         description: Create a GitHub issue in the target repo mirroring the Jira ticket
         effect:
           setVariable:
@@ -238,7 +238,7 @@ steps:
       variable: issue_platform
       operator: ==
       value: jira
-    message: Which Jira project should I create this issue in?
+    message: Select the Jira project for the new issue.
     options:
       - id: select
         label: Select from list
@@ -259,7 +259,7 @@ steps:
       variable: needs_issue_creation
       operator: ==
       value: true
-    message: What type of issue is this?
+    message: Select the issue type.
     options:
       - id: feature
         label: Feature / Story
@@ -298,14 +298,14 @@ steps:
       variable: needs_issue_creation
       operator: ==
       value: true
-    message: Here's the drafted issue. Creating in 30s unless you intervene.
+    message: Here is the drafted issue. Select whether to create it, edit it, or cancel.
     blocking: false
     defaultOption: create
     autoAdvanceMs: 30000
     options:
       - id: create
         label: Create issue
-        description: Proceed to create the issue (default — auto-creates after 30s)
+        description: Proceed to create the issue
         effect:
           setVariable:
             issue_approved: true
@@ -336,7 +336,7 @@ steps:
       variable: needs_issue_creation
       operator: ==
       value: true
-    message: Which platform should I create this issue in?
+    message: Select the platform for the new issue.
     options:
       - id: github
         label: GitHub
@@ -487,7 +487,7 @@ steps:
       variable: pr_exists
       operator: ==
       value: true
-    message: "Found existing PR #{existing_pr_number} for this branch. Would you like to use it or create a new one?"
+    message: "Found existing PR #{existing_pr_number} for this branch. Select whether to use it or create a new one."
     options:
       - id: use-existing
         label: Use existing PR
@@ -542,7 +542,7 @@ steps:
           variable: use_existing_pr
           operator: "!="
           value: true
-    message: Issue confirmed. Creating feature branch and draft PR in 30s unless you intervene.
+    message: Issue confirmed. Ready to create the feature branch and draft PR.
     blocking: false
     defaultOption: proceed
     autoAdvanceMs: 30000

--- a/work-package/activities/02-design-philosophy.yaml
+++ b/work-package/activities/02-design-philosophy.yaml
@@ -60,7 +60,7 @@ steps:
         description: Well-defined issue — no additional discovery needed
         effect:
           setVariable:
-            path_gating_complexity: simple
+            problem_complexity: simple
             needs_elicitation: false
             needs_research: false
             skip_optional_activities: true
@@ -115,7 +115,7 @@ steps:
       variable: is_review_mode
       operator: ==
       value: true
-    message: Would you like to refactor the ticket based on the gaps found?
+    message: Ticket completeness gaps were identified. Select whether to refactor the ticket or proceed with gaps noted.
     blocking: false
     defaultOption: proceed-with-gaps
     autoAdvanceMs: 30000
@@ -128,7 +128,7 @@ steps:
             ticket_refactor_needed: true
       - id: proceed-with-gaps
         label: Proceed with gaps noted
-        description: Document gaps in assumptions-log.md and continue review with gaps as tracked findings
+        description: Document gaps in the [assumptions log]({assumptions_log}) and continue review with gaps as tracked findings
         effect:
           setVariable:
             ticket_refactor_needed: false
@@ -151,7 +151,7 @@ steps:
         target: needs_elicitation
         value: false
       - action: message
-        message: "Review mode: classification recorded ({problem_type}, {problem_complexity} complexity). The path-confirmation checkpoint is skipped in review mode — proceeding headlessly to implementation-analysis to establish the PR's pre-change baseline; elicitation and research are not run."
+        message: "Review mode: classification recorded ({problem_type}, {problem_complexity} complexity)."
 transitions:
   - to: codebase-comprehension
     isDefault: true

--- a/work-package/activities/03-requirements-elicitation.yaml
+++ b/work-package/activities/03-requirements-elicitation.yaml
@@ -55,14 +55,14 @@ steps:
     technique: review-assumptions::reconcile
   - kind: checkpoint
     id: elicitation-complete
-    message: All question domains have been covered. Proceeding in 30s unless you want to revisit.
+    message: All question domains have been covered. Select whether elicitation is complete or needs more work.
     blocking: false
     defaultOption: complete
     autoAdvanceMs: 30000
     options:
       - id: complete
         label: Elicitation complete
-        description: Requirements are captured — proceed to next activity (default — auto-proceeds after 30s)
+        description: Requirements are captured
         effect:
           setVariable:
             elicitation_complete: true

--- a/work-package/activities/04-research.yaml
+++ b/work-package/activities/04-research.yaml
@@ -1,5 +1,5 @@
 id: research
-version: 2.11.0
+version: 2.12.0
 name: Research
 description: Research the knowledge base and external sources to discover best practices, patterns, and resources to inform the plan-prepare activity.
 required: false
@@ -83,9 +83,33 @@ steps:
     actions:
       - action: message
         message: "**Resolved Assumptions** — the following assumptions were resolved through code analysis."
+  - kind: action
+    id: derive-context-scope
+    actions:
+      - action: set
+        target: context_scope
+        description: "From research run evidence — repo-only when no external web sources informed design; web-retrieval when only web did; mixed when both repository/kb and web did. Leave prior/default when evidence is insufficient and set context_scope_uncertain instead."
+      - action: set
+        target: context_scope_uncertain
+        description: true only when run evidence cannot decide among repo-only / web-retrieval / mixed; false when context_scope was derived confidently
+  - kind: action
+    id: announce-derived-context-scope
+    condition:
+      type: simple
+      variable: context_scope_uncertain
+      operator: "!="
+      value: true
+    actions:
+      - action: message
+        message: "Research context scope derived as `{context_scope}`."
   - kind: checkpoint
     id: context-scope-declaration
-    message: Declare the research context scope — repository only, or including external web sources.
+    condition:
+      type: simple
+      variable: context_scope_uncertain
+      operator: ==
+      value: true
+    message: Research context scope could not be derived from run evidence. Declare whether research used repository only, external web sources, or both.
     blocking: false
     defaultOption: repo-only
     autoAdvanceMs: 15000
@@ -96,18 +120,21 @@ steps:
         effect:
           setVariable:
             context_scope: repo-only
+            context_scope_uncertain: false
       - id: web-retrieval
         label: External web sources used for design decisions
         description: Web search, external docs, or third-party references informed the approach
         effect:
           setVariable:
             context_scope: web-retrieval
+            context_scope_uncertain: false
       - id: mixed
         label: Both repository and external sources used
         description: Mix of codebase analysis and external references
         effect:
           setVariable:
             context_scope: mixed
+            context_scope_uncertain: false
   - kind: technique
     id: interview-open-assumptions
     technique: review-assumptions::interview

--- a/work-package/activities/04-research.yaml
+++ b/work-package/activities/04-research.yaml
@@ -35,7 +35,7 @@ steps:
           variable: has_reconcilable_research
           operator: ==
           value: false
-        message: "Research has converged. Full candidate inventory (see kb-research.md → Open Research Candidates): {research_candidates}. Every research-reconcilable candidate was resolved; only irreconcilable items — or none — remain, each with its rationale and handoff target. Proceed to planning, or direct further research on a specific item?"
+        message: "Research has converged. Full candidate inventory ([Open Research Candidates]({research_document})): {research_candidates}. Every research-reconcilable candidate was resolved; only irreconcilable items — or none — remain, each with its rationale and handoff target. Select whether to accept research and proceed to planning, or direct further research on a specific item."
         blocking: false
         defaultOption: accept-research
         autoAdvanceMs: 30000
@@ -85,7 +85,7 @@ steps:
         message: "**Resolved Assumptions** — the following assumptions were resolved through code analysis."
   - kind: checkpoint
     id: context-scope-declaration
-    message: Did research use external web sources (web search, documentation URLs, external references)?
+    message: Declare the research context scope — repository only, or including external web sources.
     blocking: false
     defaultOption: repo-only
     autoAdvanceMs: 15000

--- a/work-package/activities/05-implementation-analysis.yaml
+++ b/work-package/activities/05-implementation-analysis.yaml
@@ -28,14 +28,14 @@ steps:
     technique: document
   - kind: checkpoint
     id: analysis-confirmed
-    message: Implementation analysis complete. Proceeding in 30s unless you intervene.
+    message: Implementation analysis is complete. Select whether to confirm, clarify, or request more analysis.
     blocking: false
     defaultOption: confirmed
     autoAdvanceMs: 30000
     options:
       - id: confirmed
         label: Analysis confirmed
-        description: Proceed to determine next steps (default — auto-confirms after 30s)
+        description: Proceed to determine next steps
       - id: clarify
         label: Need clarification
         description: Some findings need discussion

--- a/work-package/activities/06-plan-prepare.yaml
+++ b/work-package/activities/06-plan-prepare.yaml
@@ -100,14 +100,14 @@ steps:
       variable: is_review_mode
       operator: "!="
       value: true
-    message: Approach presented above. Confirming in 30s unless you want to revise.
+    message: Approach presented above. Select whether to confirm or revise.
     blocking: false
     defaultOption: confirmed
     autoAdvanceMs: 30000
     options:
       - id: confirmed
         label: Approach confirmed
-        description: Proceed with this approach (default — auto-confirms after 30s)
+        description: Proceed with this approach
       - id: revise
         label: Revise approach
         description: Adjust the approach before planning continues

--- a/work-package/activities/07-assumptions-review.yaml
+++ b/work-package/activities/07-assumptions-review.yaml
@@ -114,14 +114,14 @@ steps:
           variable: has_deferred_assumptions
           operator: ==
           value: true
-    message: Some assumptions were deferred and need external stakeholder attention. Post summary to {issue_platform}? Posting in 30s unless you intervene.
+    message: Some assumptions were deferred and need external stakeholder attention. Select whether to post the summary to {issue_platform}.
     blocking: false
     defaultOption: post-summary
     autoAdvanceMs: 30000
     options:
       - id: post-summary
         label: Post summary to issue tracker
-        description: Post the resolution summary (default — auto-posts after 30s)
+        description: Post the resolution summary
       - id: skip-posting
         label: Skip posting
         description: Do not post to issue tracker

--- a/work-package/activities/09-lean-coding-audit.yaml
+++ b/work-package/activities/09-lean-coding-audit.yaml
@@ -24,7 +24,7 @@ steps:
       variable: is_review_mode
       operator: "!="
       value: true
-    message: "Lean-coding audit complete. Accept the audit as-is, apply the recommended simplifications, or flag the findings for correction?"
+    message: "Lean-coding audit complete. Select whether to accept the audit as-is, apply the recommended simplifications, or flag the findings for correction."
     blocking: true
     options:
       - id: audit-accepted

--- a/work-package/activities/10-post-impl-review.yaml
+++ b/work-package/activities/10-post-impl-review.yaml
@@ -28,7 +28,7 @@ steps:
         description: Agent rationale paragraphs are accurate. All changes understood. Proceed with automated reviews.
       - id: rationale-confirmed-with-issues
         label: Rationale confirmed (with corrections) — issues found
-        description: Provide rationale corrections (recorded in manual-diff-review-report.md) and comma-separated block indices with issues
+        description: Provide rationale corrections (recorded in the [manual diff review report]({code_review_report})) and comma-separated block indices with issues
         effect:
           setVariable:
             has_flagged_blocks: true
@@ -45,7 +45,7 @@ steps:
       variable: has_flagged_blocks
       operator: ==
       value: true
-    message: "Reviewing block {current_block_index}: {block_path}:{block_line_range}. What's the issue with this change?"
+    message: "Reviewing block {current_block_index}: {block_path}:{block_line_range}. Record the issue with this change, or mark it as a critical blocker."
     blocking: false
     defaultOption: issue-recorded
     autoAdvanceMs: 30000

--- a/work-package/activities/10-post-impl-review.yaml
+++ b/work-package/activities/10-post-impl-review.yaml
@@ -18,7 +18,7 @@ steps:
     technique: review-diff
   - kind: checkpoint
     id: file-index-table
-    message: "File index: {change_block_index}, one rationale paragraph per change block. Review the diff in your side-by-side app, then reply with the row numbers of any blocks with issues (e.g. '24, 31') or 'none', plus any rationale corrections (recorded in code-review.md's Manual Diff Review section). Your confirmation is the provenance attestation for each change."
+    message: "File index: {change_block_index}, one rationale paragraph per change block. Review the diff in your side-by-side app, then reply with the row numbers of any blocks with issues (e.g. '24, 31') or 'none', plus any rationale corrections (recorded in the [manual diff review report]({code_review_report}) Manual Diff Review section). Your confirmation is the provenance attestation for each change."
     blocking: false
     defaultOption: rationale-confirmed
     autoAdvanceMs: 30000

--- a/work-package/activities/12-strategic-review.yaml
+++ b/work-package/activities/12-strategic-review.yaml
@@ -14,7 +14,7 @@ steps:
       variable: unsigned_commits_in_pr
       operator: ==
       value: true
-    message: "Signature scan reports one or more commits without a valid GPG signature in this branch range: {unsigned_commit_list_summary}. Re-sign all unsigned commits now? This rewrites branch history and may require force-with-lease push."
+    message: "Signature scan reports one or more commits without a valid GPG signature in this branch range: {unsigned_commit_list_summary}. Select whether to re-sign all unsigned commits now. Re-signing rewrites branch history and may require force-with-lease push."
     blocking: true
     options:
       - id: resign-all

--- a/work-package/activities/13-submit-for-review.yaml
+++ b/work-package/activities/13-submit-for-review.yaml
@@ -40,7 +40,7 @@ steps:
       variable: is_review_mode
       operator: ==
       value: true
-    message: Here is the consolidated review summary. Ready to post to the PR?
+    message: Here is the consolidated review summary. Select whether to post it to the PR, refine it, or keep it local.
     options:
       - id: post-review
         label: Post review to PR
@@ -100,10 +100,10 @@ steps:
     options:
       - id: certify
         label: I certify all of the above — proceed
-        description: DCO attestation recorded. Timestamp and identity logged to provenance-log.md.
+        description: DCO attestation recorded. Timestamp and identity logged to the [provenance log]({provenance_log_path}).
       - id: flag-legal
         label: I have reservations — flag for legal review
-        description: Document concern in provenance-log.md before proceeding. Consider escalating to legal or OSS program review.
+        description: Document concern in the [provenance log]({provenance_log_path}) before proceeding. Consider escalating to legal or OSS program review.
   - kind: technique
     id: verify-push-remote
     technique: manage-git::verify-remote-private
@@ -119,7 +119,7 @@ steps:
       variable: stealth_mode
       operator: ==
       value: true
-    message: "FINAL ISOLATION CHECK: you are about to push to remote '{push_remote}' ({push_remote_url}). Is this the verified PRIVATE remote? (Never push to a public remote in stealth mode.)"
+    message: "FINAL ISOLATION CHECK: you are about to push to remote '{push_remote}' ({push_remote_url}). Confirm this is the verified PRIVATE remote — never push to a public remote in stealth mode."
     blocking: true
     options:
       - id: confirmed
@@ -143,7 +143,7 @@ steps:
       variable: stealth_mode
       operator: ==
       value: true
-    message: Ready to push the fix to the private remote '{push_remote}'. Confirm to proceed?
+    message: Push to the private remote '{push_remote}' is prepared. Select whether to confirm the push or cancel.
     blocking: true
     options:
       - id: confirm
@@ -330,7 +330,7 @@ steps:
               variable: stealth_mode
               operator: "!="
               value: true
-        message: Has the PR received manual review feedback?
+        message: Select whether the PR has received manual review feedback, or is still waiting.
         options:
           - id: yes-review
             label: Yes, review comments received
@@ -391,7 +391,7 @@ steps:
       Reviewer comments:
       {review_comments_summary}
 
-      Recommended outcome: {recommended_outcome}. Auto-advancing in 30s.
+      Recommended outcome: {recommended_outcome}.
     blocking: false
     defaultOption: approved
     autoAdvanceMs: 30000

--- a/work-package/activities/13-submit-for-review.yaml
+++ b/work-package/activities/13-submit-for-review.yaml
@@ -119,7 +119,7 @@ steps:
       variable: stealth_mode
       operator: ==
       value: true
-    message: "FINAL ISOLATION CHECK: you are about to push to remote '{push_remote}' ({push_remote_url}). Confirm this is the verified PRIVATE remote — never push to a public remote in stealth mode."
+    message: "FINAL ISOLATION CHECK: push target is remote '{push_remote}' ({push_remote_url}). Select whether this is the verified PRIVATE remote — never push to a public remote in stealth mode."
     blocking: true
     options:
       - id: confirmed
@@ -218,7 +218,7 @@ steps:
       Findings:
       {body_findings}
 
-      How do you want to proceed?
+      Select whether to proceed with override, provide missing input, or abort submission.
     blocking: true
     options:
       - id: proceed-with-override

--- a/work-package/activities/15-codebase-comprehension.yaml
+++ b/work-package/activities/15-codebase-comprehension.yaml
@@ -60,14 +60,14 @@ steps:
           variable: has_open_questions
           operator: ==
           value: true
-        message: Open questions remain after deep-dive (see above). Proceeding in 30s — intervene to explore further.
+        message: Open questions remain after deep-dive (see above). Select whether understanding is sufficient or further exploration is needed.
         blocking: false
         defaultOption: sufficient
         autoAdvanceMs: 30000
         options:
           - id: sufficient
             label: Understanding sufficient
-            description: Accept remaining gaps and proceed (default — auto-proceeds after 30s)
+            description: Accept remaining gaps and proceed
             effect:
               setVariable:
                 needs_comprehension: false

--- a/work-package/resources/README.md
+++ b/work-package/resources/README.md
@@ -2,12 +2,12 @@
 
 > Part of the [Work Package Implementation Workflow](../README.md)
 
-The workflow includes 27 resources that provide templates, guidance, and reference material for techniques and activities. Each resource lives as `resources/<id>.md` and is loaded by id (e.g. `get_resource({ resource_id: "pr-description" })`). The numbering system is deprecated — resources are obtained by id only.
+The workflow includes 27 resources that provide templates, guidance, and reference material for techniques and activities. Each resource lives as `resources/<id>.md` and is loaded by resource id (for example `pr-description`). Resource ids are the sole load key.
 
 | Resource ID | Title | Purpose |
 |-------------|-------|---------|
 | `readme` | README Guide | Entry point and artifact index template for planning folders |
-| `readme-deprecated-notice` | README Guide (deprecated) | **Deprecated** — consolidated into `readme` as of v2.0.0; retained as a redirect stub. New planning-folder work uses `id: readme`. |
+| `readme-deprecated-notice` | README Guide redirect | Redirect stub that points loaders at `readme` for planning-folder work |
 | `github-issue-creation` | GitHub Issue Creation | Guide for creating well-structured GitHub issues |
 | `jira-issue-creation` | Jira Issue Creation | Guide for creating Jira issues with proper field mapping |
 | `requirements-elicitation` | Requirements Elicitation | Question domains and elicitation output template |

--- a/work-package/techniques/assess-ticket-completeness.md
+++ b/work-package/techniques/assess-ticket-completeness.md
@@ -40,7 +40,7 @@ True when the user elects to refactor the ticket to address the identified gaps;
 - Set `{ticket_gaps_documented}` once the gaps are recorded.
 - Documented gaps are persistent findings, not ephemeral status text — they live in the assumptions log so review can proceed with them visible regardless of whether the ticket is refactored.
 
-### 3. Offer to Refactor
+### 3. Emit Gaps for Activity Decision
 
-- Present the gaps to the user and offer to refactor the ticket to address them.
-- Set `{ticket_refactor_needed}` from the user's decision: true to refactor, false to proceed with gaps noted or when no significant gaps were found.
+- Emit the documented gaps as bindable output for the binding activity to surface (refactor vs proceed-with-gaps).
+- `{ticket_refactor_needed}` is set from the activity checkpoint effect: true to refactor, false to proceed with gaps noted or when no significant gaps were found.

--- a/work-package/techniques/codebase-comprehension/deep-dive.md
+++ b/work-package/techniques/codebase-comprehension/deep-dive.md
@@ -39,8 +39,8 @@ Targeted exploration subsections appended for the selected area: traced data flo
 
 ### 1. Deep Dive
 
-- Present candidate areas based on architecture survey and problem relevance. When open questions already exist in the artifact, present them as the default selection rather than generating new candidates from scratch (per `question-driven-exploration`).
-- On the mandatory initial pass, attempt to resolve every open question without user selection; only subsequent iterations are user-selected by area.
+- Emit candidate areas based on architecture survey and problem relevance as bindable output for the binding activity to surface. When open questions already exist in the artifact, prefer them as the default selection rather than generating new candidates from scratch (per `question-driven-exploration`).
+- On the mandatory initial pass, attempt to resolve every open question without a selection gate; only subsequent iterations consume an activity-selected area.
 - For selected area: trace data flows, examine implementation details, document edge cases
 - When GitNexus is available: apply [gitnexus-operations](../../../meta/techniques/gitnexus-operations/TECHNIQUE.md)::[context](../../../meta/techniques/gitnexus-operations/context.md) to trace callers/callees, read process resources for full execution traces, and [gitnexus-operations](../../../meta/techniques/gitnexus-operations/TECHNIQUE.md)::[cypher](../../../meta/techniques/gitnexus-operations/cypher.md) for custom call chain queries
 - Append findings as dedicated subsections in the comprehension artifact

--- a/work-package/techniques/finalize-documentation/render-token-usage.md
+++ b/work-package/techniques/finalize-documentation/render-token-usage.md
@@ -25,7 +25,7 @@ Per-activity token table, per-workflow totals, and cost estimate (labelled an es
 
 ## Protocol
 
-1. Read rolled-up usage from session state via `inspect_session { view: "usage" }` (or `get_workflow_status` for the same session). When `usage` is absent, skip artifact creation and README update — do not fabricate figures.
+1. Read rolled-up usage from session state via the `inspect_session` usage view (or `get_workflow_status` for the same session). When `usage` is absent, skip artifact creation and README update — do not fabricate figures.
 2. Create `{token_usage_document}` at `{planning_folder_path}` (with the server-provided `artifactPrefix` on the filename) containing:
    - A title identifying this as a token-use and cost **estimate** for the work package.
    - A per-activity table: activity id, input/output/total tokens, cache-read and cache-write columns when present, model, `priceTableVersion`, and per-activity cost (or `unknown` when `cost_usd` is null).

--- a/work-package/techniques/finalize-documentation/render-token-usage.md
+++ b/work-package/techniques/finalize-documentation/render-token-usage.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.0.1
 ---
 
 ## Capability
@@ -25,7 +25,7 @@ Per-activity token table, per-workflow totals, and cost estimate (labelled an es
 
 ## Protocol
 
-1. Read rolled-up usage from session state via the `inspect_session` usage view (or `get_workflow_status` for the same session). When `usage` is absent, skip artifact creation and README update — do not fabricate figures.
+1. Read rolled-up usage from session state. When usage is absent, skip artifact creation and README update — do not fabricate figures.
 2. Create `{token_usage_document}` at `{planning_folder_path}` (with the server-provided `artifactPrefix` on the filename) containing:
    - A title identifying this as a token-use and cost **estimate** for the work package.
    - A per-activity table: activity id, input/output/total tokens, cache-read and cache-write columns when present, model, `priceTableVersion`, and per-activity cost (or `unknown` when `cost_usd` is null).

--- a/work-package/techniques/manage-git/instruct-merge-strategy.md
+++ b/work-package/techniques/manage-git/instruct-merge-strategy.md
@@ -5,7 +5,7 @@ metadata:
 
 ## Capability
 
-Present DCO-compliant merge guidance for the PR, branching on whether the repo allows squash merges. Advisory and read-only — it instructs the human on the correct merge procedure and performs no merge itself.
+Assemble DCO-compliant merge guidance for the PR, branching on whether the repo allows squash merges. Advisory and read-only — it emits guidance on the correct merge procedure and performs no merge itself.
 
 ## Inputs
 
@@ -25,7 +25,7 @@ The PR number being merged
 
 ### presented_merge_guidance
 
-The DCO-compliant merge guidance presented to the human for the `{pr_number}` PR, branched on `{squash_merge_supported}`: the local GPG-signed squash-merge flow when squash merge is supported, or the plain-branch-merge note when it is not. This op is advisory and read-only — it sets no workflow state and performs no merge; the output is solely the guidance shown for the human to act on.
+The DCO-compliant merge guidance for the `{pr_number}` PR, branched on `{squash_merge_supported}`: the local GPG-signed squash-merge flow when squash merge is supported, or the plain-branch-merge note when it is not. This op is advisory and read-only — it sets no workflow state and performs no merge; the output is solely the bindable guidance text for the binding activity to surface.
 
 ## Protocol
 
@@ -37,4 +37,4 @@ The DCO-compliant merge guidance presented to the human for the `{pr_number}` PR
    git push
    ```
 2. When `{squash_merge_supported}` is false, instruct the human that branch commits land as-is on a plain branch merge — no local signing flow is required.
-3. Present the guidance as advice the human acts on; do not perform the merge.
+3. Emit `{presented_merge_guidance}` as advice for the human to act on; do not perform the merge.

--- a/work-package/techniques/manage-git/remove-worktree.md
+++ b/work-package/techniques/manage-git/remove-worktree.md
@@ -26,5 +26,5 @@ Set to false on successful removal
 ## Protocol
 
 1. Run only when `{worktree_created}` is true. Identify the component git directory `{$component_git_dir}` the same way [create-worktree](./create-worktree.md) does (`{reference_path}/{component_name}` or `{reference_path}` itself).
-2. Run `git -C {component_git_dir} worktree remove {target_path}`. If the worktree has uncommitted edits, the command fails — surface this to the user rather than passing `--force`, since they may have intentional unfinished work; only remove after their explicit confirmation.
+2. Run `git -C {component_git_dir} worktree remove {target_path}`. If the worktree has uncommitted edits, the command fails — emit a conflict signal (uncommitted edits present) rather than passing `--force`; the binding activity decides whether to retry with force or abort.
 3. After successful removal, set `{worktree_created}` = false and emit a one-line confirmation.

--- a/work-package/techniques/respond-to-pr-review.md
+++ b/work-package/techniques/respond-to-pr-review.md
@@ -60,8 +60,8 @@ Whether the changes are significant enough to require substantial rework
 
 ### 3. Address Comments
 
-- For each review item with follow-up actions, present the item and its actions to the user. Ask which to implement (e.g., '1,3' or 'all' or 'none').
-- Only implement actions explicitly selected by the user
+- For each review item with follow-up actions, emit the item and its candidate actions as structured bindable output for the binding activity to surface and collect selection (e.g., '1,3' or 'all' or 'none').
+- Only implement actions explicitly selected via the activity response
 - Commit fix changes per concern
 - Document which comments require substantial rework vs inline fixes
 - Group related fixes into logical commits, not one giant commit
@@ -69,7 +69,7 @@ Whether the changes are significant enough to require substantial rework
 ### 4. Post Responses
 
 - Draft each response per the [response format template](../resources/pr-review-response.md#response-format-template) and the response-crafting rules below
-- Present drafted PR responses for user approval before posting
+- Emit drafted PR responses as bindable output for the binding activity to approve before posting
 - Post approved responses to the PR comment thread
 - If disagreeing with a reviewer, explain reasoning explicitly
 

--- a/work-package/techniques/review-assumptions/interview.md
+++ b/work-package/techniques/review-assumptions/interview.md
@@ -1,17 +1,17 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
 
-Present the open (stakeholder-dependent, non-code-resolvable) assumptions to the user as judgement-augmentation, framing the decision space and trade-offs so the user can resolve or defer each one.
+Assemble judgement-augmentation context for open (stakeholder-dependent, non-code-resolvable) assumptions — decision space, trade-offs, and technical context — as bindable `{assumption_review_presentation}` for the binding activity to surface.
 
 ## Inputs
 
 ### open_assumptions
 
-The open (non-code-resolvable) assumptions to present for review. In interview mode the current one is bound as `current_assumption`; in batch mode the whole list is presented together.
+The open (non-code-resolvable) assumptions to assemble. In interview mode the current one is bound as `current_assumption`; in batch mode the whole list is assembled together.
 
 ### assumptions_log
 
@@ -21,26 +21,27 @@ The assumptions [log](../../resources/assumptions-review.md#assumptions-log-temp
 
 ### assumption_review_presentation
 
-A side-effect output: the structured judgement-augmentation context presented to the user for decision. For each open assumption it contains the decision space (alternatives + trade-offs), non-resolvability rationale, technical context, the agent's current position, a reversibility flag, and a link to the assumptions log. Produces no new stored variable — the user's decision is captured and written back by [record](./record.md).
+Structured judgement-augmentation context for decision. For each open assumption it contains the decision space (alternatives + trade-offs), non-resolvability rationale, technical context, the agent's current position, a reversibility flag, and a link to the assumptions log. Produces no new stored variable — the user's decision is captured and written back by [record](./record.md).
 
 ## Protocol
 
 ### 1. Format Judgement Context
 
 - For each open (non-code-resolvable) assumption, assemble structured context: (1) the decision space — what alternatives exist, (2) trade-off analysis for each alternative, (3) why the agent could not resolve it through code analysis, (4) relevant technical context discovered during reconciliation — code patterns found, constraints identified, related implementation details, (5) which alternative the agent's current assumption favors and why
-- Present the decision space (alternatives and trade-offs) before stating which option the agent's current assumption favors. This ordering reduces anchoring bias — the user encounters the options before being anchored to the agent's interpretation
+- Order the decision space (alternatives and trade-offs) before the agent's favored option. This ordering reduces anchoring bias — the options appear before the agent's interpretation
 - Trade-off analysis should cover relevant dimensions from: implementation complexity, maintenance burden, consistency with existing patterns, risk of unintended side-effects, decision reversibility (how hard to change course later), alignment with stated requirements, and time/effort cost. Include only dimensions that meaningfully differentiate the alternatives for each specific assumption
-- If reconciliation produced partial evidence (e.g. validated one aspect but not another), include that evidence so the user understands what is already known
-- If no open assumptions remain after reconciliation, skip the judgement augmentation format and present a summary confirming all assumptions were resolved through code analysis
+- If reconciliation produced partial evidence (e.g. validated one aspect but not another), include that evidence so what is already known is clear
+- If no open assumptions remain after reconciliation, skip the judgement-augmentation format and emit a summary confirming all assumptions were resolved through code analysis
 - Focus trade-offs on measurable differences between alternatives, not uniform property lists. If two options are equivalent on a dimension, omit that dimension — it adds noise without aiding the decision
-- Flag decision reversibility: mark each assumption as easily-reversible (low-cost to change later) or path-committing (high-cost to reverse). This helps the user calibrate how much deliberation to invest
+- Flag decision reversibility: mark each assumption as easily-reversible (low-cost to change later) or path-committing (high-cost to reverse). This calibrates how much deliberation to invest
 - Apply [gitnexus-operations](../../../meta/techniques/gitnexus-operations/TECHNIQUE.md)::[reversibility-signal](../../../meta/techniques/gitnexus-operations/reversibility-signal.md)(name: `{$symbol}`) to set the flag — high caller fan-out and broad process participation → path-committing; isolated symbols → easily-reversible.
 
-### 2. Present For Review
+### 2. Emit Presentation Output
 
-- This technique supports two presentation modes. Batch mode: present all open assumptions together as a structured list, ordered by decision impact. Interview mode: present assumptions one at a time. Use whichever mode the supplied inputs indicate.
-- In both modes, each assumption should contain the decision space, trade-offs, non-resolvability rationale, technical context, the agent's current position, and a reversibility flag as assembled by format-judgement-context. Order by decision impact: assumptions whose resolution most affects the implementation approach come first.
+- Support two assembly modes. Batch mode: assemble all open assumptions together as a structured list, ordered by decision impact. Interview mode: assemble assumptions one at a time. Use whichever mode the supplied inputs indicate.
+- In both modes, each assumption contains the decision space, trade-offs, non-resolvability rationale, technical context, the agent's current position, and a reversibility flag as assembled by format-judgement-context. Order by decision impact: assumptions whose resolution most affects the implementation approach come first.
 - Include a clickable markdown link to the assumptions-log for full details and reconciliation history
-- Frame the review as judgement augmentation: the user is making informed decisions on genuinely open questions, not performing triage or rubber-stamping. The agent has already resolved everything it can.
-- Do not present code-resolved assumptions for re-confirmation — they are already validated with evidence in the assumptions log
-- When presenting 5 or more open assumptions in batch mode, group related assumptions by theme or domain to reduce cognitive load. Present the group heading before its assumptions so the user can orient before diving into details.
+- Frame the output as judgement augmentation: informed decisions on genuinely open questions, not triage or rubber-stamping. Everything code-resolvable is already resolved.
+- Omit code-resolved assumptions from the output — they are already validated with evidence in the assumptions log
+- When assembling 5 or more open assumptions in batch mode, group related assumptions by theme or domain to reduce cognitive load. Emit the group heading before its assumptions so the reader can orient before diving into details.
+- Emit `{assumption_review_presentation}` for the binding activity to surface.

--- a/work-package/techniques/review-assumptions/reconcile.md
+++ b/work-package/techniques/review-assumptions/reconcile.md
@@ -57,7 +57,7 @@ Boolean gate — true iff stakeholder-dependent assumptions remain open after co
 
 - Update the `{assumptions_log}` rows in place: write finding + evidence into the Resolution column and Validated / Invalidated / Partially Validated into the Outcome column; remove the Open Assumptions entry of any assumption that resolved
 - Add any newly surfaced assumptions as new rows, Outcome `Open`, with their classification (code-resolvable or not)
-- Present the scorecard (see [assumption-reconciliation](../../resources/assumption-reconciliation.md#scorecard)) in the session after each pass; do NOT persist count tables in the log — the rows are the record
+- Emit the scorecard data (see [assumption-reconciliation](../../resources/assumption-reconciliation.md#scorecard)) as a bindable pass result after each pass; do NOT persist count tables in the log — the rows are the record
 - In Open Assumptions entries, each bold-label line MUST end with two trailing spaces to produce a line break in rendered markdown (no bullet prefixes) — see the [markdown-line-breaks](../manage-artifacts/TECHNIQUE.md#markdown-line-breaks) rule
 
 ### 4. Check Convergence
@@ -77,11 +77,11 @@ Boolean gate — true iff stakeholder-dependent assumptions remain open after co
 
 ### no-user-interaction
 
-Reconciliation runs autonomously, without user interaction. The user is presented only the final converged result.
+Reconciliation runs autonomously, without user interaction. Converged results bind as outputs for the activity to surface.
 
 ### classification-transparency
 
-When presenting the converged result, include the classification rationale for each remaining open assumption — explain why it cannot be resolved through code analysis.
+When emitting the converged result, include the classification rationale for each remaining open assumption — explain why it cannot be resolved through code analysis.
 
 ### code-resolvable
 

--- a/work-package/techniques/review-code.md
+++ b/work-package/techniques/review-code.md
@@ -65,10 +65,7 @@ When the diff changes a `Config` impl, an associated type, or any trait-implemen
 
 - Document each finding with severity (critical, high, medium, low, informational)
 - Create the `{code_review_report}` in `{planning_folder_path}` — or update it in place when an earlier review (manual diff, structural analysis, lean-coding) already created it; each contributing review owns its `##` section and this review writes the code-review sections
-
-### 5. Present Summary
-
-- Summarize critical and high findings
+- Emit a brief summary of critical and high findings as part of the bindable report output for the binding activity to surface
 
 ## Rules
 

--- a/work-package/techniques/review-diff.md
+++ b/work-package/techniques/review-diff.md
@@ -73,26 +73,21 @@ True if any block marked as critical blocker
 - Open the index with the lean-header summary line (branches compared · file count · hunk count · review-time estimate) and the reviewer instructions block from the header form
 - Below the index table, generate a '## Block Rationale' section containing one subsection per block (### Block N) with a descriptive paragraph per the rationale-quality rule
 - When a block centres on a graph-resolvable symbol, enrich the Block Rationale with caller/callee/process context from [gitnexus-operations](../../meta/techniques/gitnexus-operations/TECHNIQUE.md)::[context](../../meta/techniques/gitnexus-operations/context.md)(name: `{$symbol}`) so the reviewer understands why the diff matters and which execution flows it touches.
-- Write index to the `{change_block_index}` under `{planning_folder_path}`
+- Write index to the `{change_block_index}` under `{planning_folder_path}` — the binding activity surfaces the index for external diff-tool review
 
-### 4. Present Index
+### 4. Collect Flagged
 
-- Present index to user for external diff tool review (VS Code, Meld, etc.)
-- User identifies issues in their external diff tool; agent does not pre-judge
-
-### 5. Collect Flagged
-
-- Collect flagged rows from the user, reported as row numbers only: `3, 7, 12` (those rows have issues) or `none` (skip the interview loop, proceed to automated reviews)
+- Consume flagged rows from the activity response, reported as row numbers only: `3, 7, 12` (those rows have issues) or `none` (skip the interview loop, proceed to automated reviews)
 - A bare row number covers all changes in that file; a row with a line reference (e.g. `3-L42`) focuses the interview on that specific line
 
-### 6. Interview Blocks
+### 5. Interview Blocks
 
-- For each flagged row: display the full diff content for that file (filename and path), then ask what the issue is
-- Record the user's description verbatim, noting severity if mentioned (critical, minor, etc.)
-- If user marks block as critical blocker, set `{has_critical_blocker}`=true
+- For each flagged row: assemble the full diff content for that file (filename and path) into the interview context the binding activity surfaces
+- Record the user's description verbatim from the activity response, noting severity if mentioned (critical, minor, etc.)
+- If the response marks the block as a critical blocker, set `{has_critical_blocker}`=true
 - Continue to the next flagged row until all are addressed
 
-### 7. Create Report
+### 6. Create Report
 
 - Write the `{manual_diff_review_report}` as the `## Manual Diff Review` section of `code-review.md`, following the [section template](../resources/manual-diff-review.md#manual-diff-review-section-template) (creating the artifact if this review runs first)
 - Include flagged rows, interview responses verbatim, and severity; when the user reported `none`, the section is its one-line header only

--- a/work-package/techniques/review-mode-detection.md
+++ b/work-package/techniques/review-mode-detection.md
@@ -42,8 +42,8 @@ The originating user request and any context gathered so far — the signal sour
 ## Protocol
 
 1. Inspect `{user_request}` for signals that it is a review of an existing PR rather than new work (an explicit "review", a PR number or URL, "is this safe to merge", and similar). Decide whether review mode applies.
-2. Set `is_review_mode` to `true` when review is indicated, otherwise `false`. When the signal is ambiguous, confirm with the user before committing the value.
-3. When `is_review_mode` is `true`, obtain the PR reference: take `{pr_reference}` if supplied, otherwise prompt the user for the PR number or URL. Record `review_pr_url`.
+2. Set `is_review_mode` to `true` when review is indicated, otherwise `false`. When the signal is ambiguous, emit an ambiguity flag and leave `is_review_mode` unset until the binding activity resolves it.
+3. When `is_review_mode` is `true`, obtain the PR reference: take `{pr_reference}` if supplied, otherwise emit that a PR number or URL is required and record `review_pr_url` from the activity response.
 4. Resolve the PR number from the reference and record `pr_number`.
 5. Check out the PR branch and record `branch_name` from it so downstream steps that skip branch derivation in review mode have it available.
 6. Extract the associated tracker ticket from the PR body or commit messages (e.g. a Jira key or GitHub issue reference) and record it as `review_ticket_ref` when present.

--- a/work-package/techniques/review-mode-detection.md
+++ b/work-package/techniques/review-mode-detection.md
@@ -1,11 +1,11 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
 
-Detect whether a request is a review of an existing pull request (review mode) rather than new implementation, and when it is, capture the PR reference and the branch and tracker ticket it carries.
+Detect whether a request is a review of an existing pull request (review mode) rather than new implementation, and when it is, capture the PR reference and the branch and tracker ticket it carries — derive-first, with gap flags when mode or PR identity cannot be settled from the request alone.
 
 ## Inputs
 
@@ -15,21 +15,29 @@ The originating user request and any context gathered so far — the signal sour
 
 ### pr_reference
 
-*(optional)* A pull-request number or URL supplied by the user. When absent in review mode, it is prompted for.
+*(optional)* A pull-request number or URL supplied by the user. When absent in review mode and no reference can be parsed from `{user_request}`, set `review_pr_missing` so the activity can prompt.
 
 ## Outputs
 
 ### is_review_mode
 
-`true` when the request is a review of an existing PR, `false` for new implementation.
+`true` when the request is a clear review of an existing PR, `false` for clear new implementation. Leave unset when `review_mode_ambiguous` is `true` until the binding activity resolves the gap.
+
+### review_mode_ambiguous
+
+`true` only when review vs create intent cannot be derived confidently from `{user_request}` (rare). Common clear-intent paths leave this `false`.
 
 ### review_pr_url
 
-*(optional)* The PR number or URL under review (set in review mode).
+*(optional)* The PR number or URL under review (set in review mode when known).
 
 ### pr_number
 
-*(optional)* The numeric PR identifier resolved from the reference (set in review mode).
+*(optional)* The numeric PR identifier resolved from the reference (set in review mode when known). Empty when unresolved.
+
+### review_pr_missing
+
+`true` when review mode is active (or will be after an ambiguity confirm) and no PR number or URL could be derived from `{pr_reference}` or `{user_request}`. `false` when a PR identity is already known.
 
 ### branch_name
 
@@ -41,9 +49,8 @@ The originating user request and any context gathered so far — the signal sour
 
 ## Protocol
 
-1. Inspect `{user_request}` for signals that it is a review of an existing PR rather than new work (an explicit "review", a PR number or URL, "is this safe to merge", and similar). Decide whether review mode applies.
-2. Set `is_review_mode` to `true` when review is indicated, otherwise `false`. When the signal is ambiguous, emit an ambiguity flag and leave `is_review_mode` unset until the binding activity resolves it.
-3. When `is_review_mode` is `true`, obtain the PR reference: take `{pr_reference}` if supplied, otherwise emit that a PR number or URL is required and record `review_pr_url` from the activity response.
-4. Resolve the PR number from the reference and record `pr_number`.
-5. Check out the PR branch and record `branch_name` from it so downstream steps that skip branch derivation in review mode have it available.
-6. Extract the associated tracker ticket from the PR body or commit messages (e.g. a Jira key or GitHub issue reference) and record it as `review_ticket_ref` when present.
+1. Inspect `{user_request}` for signals that it is a review of an existing PR rather than new work (an explicit "review", a PR number or URL, "is this safe to merge", and similar). Prefer an immediate derive: clear "review" / review-intent language → review mode; clear create/implement intent without review signals → not review mode.
+2. When intent is clear, set `is_review_mode` accordingly and set `review_mode_ambiguous` to `false`. When the signal is ambiguous, set `review_mode_ambiguous` to `true` and leave `is_review_mode` unset until the binding activity resolves it — do not invent a mode confirm when intent is already clear.
+3. When `is_review_mode` is `true` (or will be after a gap confirm that selected review), obtain the PR reference in one pass: take `{pr_reference}` if supplied, else parse a PR number or URL from `{user_request}`. When a reference is present, record `review_pr_url` and `pr_number`, set `review_pr_missing` to `false`. When none can be derived, set `review_pr_missing` to `true` and leave `pr_number` / `review_pr_url` empty — do not prompt inside this technique; the activity gap-gates that confirm.
+4. When a PR reference is known, check out the PR branch and record `branch_name` from it so downstream steps that skip branch derivation in review mode have it available.
+5. Extract the associated tracker ticket from the PR body or commit messages (e.g. a Jira key or GitHub issue reference) and record it as `review_ticket_ref` when present.

--- a/work-package/techniques/review-summary.md
+++ b/work-package/techniques/review-summary.md
@@ -5,7 +5,7 @@ metadata:
 
 ## Capability
 
-Author a structured consolidated review summary from the consolidated review findings, following the [Consolidated Review Format](../resources/review-mode.md#consolidated-review-format) template defined in the review-mode resource, ready for confirmation and posting to the PR.
+Author a structured consolidated review summary from the consolidated review findings, following the [Consolidated Review Format](../resources/review-mode.md#consolidated-review-format) template defined in the review-mode resource, as bindable `{review_summary}` text for the binding activity to surface and post.
 
 ## Inputs
 
@@ -33,7 +33,7 @@ The authored surface — the PR's changed-files set. Used to enforce the finding
 
 ### review_summary
 
-The structured consolidated review summary text, organized per the Consolidated Review Format — executive summary, per-category findings, action items, and severity definitions — ready to present and post.
+The structured consolidated review summary text, organized per the Consolidated Review Format — executive summary, per-category findings, action items, and severity definitions — verbatim source for the posting step.
 
 ## Protocol
 
@@ -52,8 +52,4 @@ The structured consolidated review summary text, organized per the Consolidated 
 - Apply `{rating_cap}` to the Overall Rating: when the cap is the request-changes tier, the Overall Rating is held at or below Request Changes — never Approve or Comment Only — even if the review's own findings are light.
 - Render the attribution footer that closes the format template — resolving `{user}` and `{sha}` per the format's instruction — so `{review_summary}` carries it and the posted comment reaches the PR with it intact.
 - Produce `{review_summary}` as the rendered text.
-- Follow the loaded format exactly — do not invent a parallel structure; the review-mode resource is the authoritative owner of the format. `{review_summary}` is the verbatim source the posting step (`update-pr::post-review-comment`) emits, so what is confirmed is exactly what reaches the PR.
-
-### 3. Present for Confirmation
-
-- Present the rendered `{review_summary}` verbatim (or a faithful excerpt when long) at the approval checkpoint — never a paraphrase or a re-described summary. The bytes shown are the bytes posted.
+- Follow the loaded format exactly — do not invent a parallel structure; the review-mode resource is the authoritative owner of the format. `{review_summary}` is the verbatim source the posting step (`update-pr::post-review-comment`) emits — the bytes bound here are the bytes posted.

--- a/work-package/techniques/review-test-suite.md
+++ b/work-package/techniques/review-test-suite.md
@@ -77,10 +77,7 @@ When `{prior_feedback_triage}` is present, every entry tagged as a reported runt
 
 - Document findings with severity and recommendations
 - Create the `{test_suite_review_report}` in `{planning_folder_path}`
-
-### 6. Present Summary
-
-- Summarize coverage gaps and critical issues
+- Emit a brief summary of coverage gaps and critical issues as part of the bindable report output for the binding activity to surface
 
 ## Rules
 

--- a/work-package/techniques/stakeholder-overview.md
+++ b/work-package/techniques/stakeholder-overview.md
@@ -32,8 +32,7 @@ The two-paragraph plain-language overview written under `{readme_section_heading
 1. Synthesize a plain-language overview from `{source_material}`.
 2. Write exactly two paragraphs in simple, accessible language suitable for non-technical stakeholders; do not use jargon without explanation.
 3. Frame the first paragraph as the situation or what the work does, and the second paragraph as the consequences or guarantees — what matters and why — tailoring the framing to `{readme_section_heading}` and `{source_material}`.
-4. Present the overview to the user.
-5. Write it into `{planning_folder_path}`/`README.md` by replacing the placeholder text under the `{readme_section_heading}` section.
+4. Write it into `{planning_folder_path}`/`README.md` by replacing the placeholder text under the `{readme_section_heading}` section, and emit `{stakeholder_overview}` as the bindable overview text.
 
 ## Rules
 

--- a/work-package/workflow.yaml
+++ b/work-package/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: work-package
-version: 3.30.0
+version: 3.31.0
 title: Work Package Implementation Workflow
 description: Defines how to plan and implement ONE work package from inception to merged PR. A work package is a discrete unit of work such as a feature, bug-fix, enhancement, refactoring, or any other deliverable change. For multiple related work packages, use the work-packages workflow to create a roadmap first.
 author: m2ux
@@ -58,7 +58,7 @@ techniques:
 variables:
   - name: target_path
     type: string
-    description: Path to the working directory where edits, branch creation, builds, and PR operations occur. As of work-package 3.10, this is a dedicated git worktree of the component repo at the canonical path '~/projects/work/{component_name}/{wp-slug}/' — NOT the component's checkout inside the reference monorepo.
+    description: Path to the working directory where edits, branch creation, builds, and PR operations occur — a dedicated git worktree of the component repo at '~/projects/work/{component_name}/{wp-slug}/', distinct from the component's checkout inside the reference monorepo.
   - name: reference_path
     type: string
     description: Path to the reference checkout used for codebase comprehension, GitNexus indexing, and code-resolvable assumption analysis. When the component is a submodule of a monorepo, this is the monorepo root; when the component is a standalone repo, this equals the component's primary checkout. NOT used for edits — edits happen in target_path. Resolved by start-work-package's resolve-target step from the path the user originally pointed at. No default — absence drives the start-work-package exists gate on reference-dependent steps.
@@ -405,10 +405,6 @@ variables:
     type: boolean
     description: True when abort was selected on body-non-conformant.
     defaultValue: false
-  - name: path_gating_complexity
-    type: string
-    description: Path-gating mirror of problem_complexity. Used by design-philosophy's classification-and-path-confirmed.skip-optional effect.
-    defaultValue: ""
   - name: gitnexus_indexed
     type: boolean
     description: Whether reference_path has a usable GitNexus index (gates GitNexus-dependent steps and protocol phases).

--- a/work-package/workflow.yaml
+++ b/work-package/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: work-package
-version: 3.31.0
+version: 3.32.0
 title: Work Package Implementation Workflow
 description: Defines how to plan and implement ONE work package from inception to merged PR. A work package is a discrete unit of work such as a feature, bug-fix, enhancement, refactoring, or any other deliverable change. For multiple related work packages, use the work-packages workflow to create a roadmap first.
 author: m2ux
@@ -21,7 +21,7 @@ rules:
     - report-before-apply - The over-engineering review, debt harvest, and gain report are read-only - they list findings into their artifacts and change no code. Code is only ever changed in the simplification-apply-cycle, and only on simplifications the user accepted at the audit-findings-confirmed gate.
     - leanness-reported-honestly - The net-lines scoreboard and gain figures are reported honestly - the harvested debt ledger is the source of the real per-change count; aggregate or benchmark figures never overstate the gain.
     - complementary-not-duplicative-with-strategic-review - The lean-coding audit applies the over-engineering and leanness lens; it does not re-adjudicate scope-vs-issue fit, which remains strategic-review's concern. The two stages stay complementary.
-    - review-mode-headless-auto-advance - Once is_review_mode == true the run is headless. Every review-reachable checkpoint that carries defaultOption + autoAdvanceMs is resolved by calling respond_checkpoint with auto_advance:true (which applies the default option's full side effects unchanged) and surfacing the outcome as a plain message — never as an AskUserQuestion dialog. A checkpoint gated is_review_mode != true is cleared with respond_checkpoint condition_not_met. The only checkpoints presented interactively in review mode are the activation prompts (review-mode-detection, review-pr-reference) and review-summary-approval.
+    - "review-mode-headless-auto-advance - Once is_review_mode == true the run is headless. Every review-reachable checkpoint that carries defaultOption + autoAdvanceMs is resolved by calling respond_checkpoint with auto_advance:true (which applies the default option's full side effects unchanged) and surfacing the outcome as a plain message — never as an AskUserQuestion dialog. A checkpoint gated is_review_mode != true is cleared with respond_checkpoint condition_not_met. Interactive in review mode only when their gap conditions fire — review-mode-detection (when review_mode_ambiguous) and review-pr-reference (when review_pr_missing). review-summary-approval remains always interactive in review mode."
   activity:
     - On completing each activity, update the planning-folder README.md progress tracker — mark this activity's artifacts as ✅ Complete and set the work-package Status to reflect the current milestone.
 fragments:
@@ -89,6 +89,10 @@ variables:
   - name: is_review_mode
     type: boolean
     description: True when the work package reviews an existing PR instead of producing a new implementation.
+  - name: review_mode_ambiguous
+    type: boolean
+    description: True when review vs create intent cannot be derived confidently from the request; gates the review-mode-detection confirm.
+    defaultValue: false
   - name: pr_number
     type: string
     description: Pull request number
@@ -98,6 +102,10 @@ variables:
   - name: review_pr_url
     type: string
     description: URL of the PR being reviewed (review mode only)
+  - name: review_pr_missing
+    type: boolean
+    description: True when review mode is active but no PR number or URL could be derived; gates the review-pr-reference prompt.
+    defaultValue: false
   - name: needs_elicitation
     type: boolean
     description: Whether requirements elicitation is needed
@@ -335,6 +343,10 @@ variables:
     type: string
     description: "Provenance scope of AI-generated code in this work package. Values: repo-only (all context from repository), web-retrieval (web sources used), mixed (both). Recorded in the provenance log and PR description."
     defaultValue: repo-only
+  - name: context_scope_uncertain
+    type: boolean
+    description: True when research run evidence cannot decide repo-only vs web-retrieval vs mixed for context_scope; gates the context-scope-declaration confirm.
+    defaultValue: false
   - name: recommended_outcome
     type: string
     description: Agent-recommended PR review outcome (approved|minor-changes|significant-changes).


### PR DESCRIPTION
## Summary

Update `work-package` to **v3.32.0** with derive-first review activation: skip mode/PR confirms when intent and PR identity are already clear; gap-gate activation and research `context_scope` confirms only when derivation cannot decide.

- Gap flags: `review_mode_ambiguous`, `review_pr_missing`, `context_scope_uncertain`
- Rewrite `review-mode-headless-auto-advance` for gap-gated interactive set; `review-summary-approval` stays always interactive
- Docs (`REVIEW-MODE.md`, `README.md`) match the new activation narrative
- Stealth / `13-submit-for-review` gates unchanged (out of scope)

## Scope (6 files)

| Path | Change |
|------|--------|
| `work-package/workflow.yaml` | v3.32.0; gap flags; headless rule |
| `work-package/techniques/review-mode-detection.md` | Derive-first + gap outputs |
| `work-package/activities/01-start-work-package.yaml` | Unconditional derive; gap-gated confirms; light `pr-check` skip |
| `work-package/activities/04-research.yaml` | Auto-derive `context_scope`; gated confirm |
| `work-package/REVIEW-MODE.md` | Derive-first activation narrative |
| `work-package/README.md` | Headless-after-activation prose |

## Planning

`.engineering/artifacts/planning/2026-07-17-work-package-checkpoint-elimination/`

## Note

Branch is based on the v3.31.0 compliance-hygiene tip (also in open PR #253), rebased onto current `workflows`. This PR is distinct from #253 and adds the checkpoint-elimination commit on top.

## Test plan

- [ ] Schema validation: `npx tsx scripts/validate-workflow-yaml.ts workflows/work-package`
- [ ] Review-mode run with clear PR in request — no activation confirms
- [ ] Ambiguous mode / missing PR — gap confirms still fire
- [ ] `review-summary-approval` remains interactive
- [ ] Research `context_scope` auto-derives when evidence is clear