### PR TITLE
feat(workflow-design): planning-artifact canonical homes

### DIFF
--- a/workflow-design/README.md
+++ b/workflow-design/README.md
@@ -1,6 +1,6 @@
 # Workflow Design Workflow
 
-> v1.24.4 — Guides agents through creating, updating, or reviewing workflow definitions. In create/update modes, accepts a free-form user description and systematically elicits design details through sequential checkpoints. In review mode, audits one or more existing workflows against the design principles and produces a compliance report.
+> v1.25.0 — Guides agents through creating, updating, or reviewing workflow definitions. In create/update modes, accepts a free-form user description and systematically elicits design details through sequential checkpoints. In review mode, audits one or more existing workflows against the design principles and produces a compliance report.
 
 ---
 
@@ -14,7 +14,7 @@ This workflow manages the complete lifecycle of workflow definition authoring th
 | 03 | [**Requirements Refinement**](./activities/README.md#03-requirements-refinement) | Create, Update | Elicit the spec one dimension at a time (forEach over the design dimensions), then surface, reconcile, and review the design assumptions |
 | 04 | [**Pattern Analysis**](./activities/README.md#04-pattern-analysis) | Create only | Audit 2+ reference workflows for reusable patterns |
 | 05 | [**Impact Analysis**](./activities/README.md#05-impact-analysis) | Update only | Enumerate affected files, check integrity, flag removals |
-| 06 | [**Scope and Draft**](./activities/README.md#06-scope-and-draft) | Create, Update | Define file manifest, then draft and validate each file per-file |
+| 06 | [**Scope and Draft**](./activities/README.md#06-scope-and-draft) | Create, Update | Define file manifest, draft and validate each file per-file, then verify planning artifacts against the design canonical-home map |
 | 08 | [**Quality Review**](./activities/README.md#08-quality-review) | All | Expressiveness, conformance, rule-hygiene, and rule-enforcement audits, then a bounded fix-revalidate loop (max 3) with a critical-blocker gate (full compliance audit in review mode; forEach over `target_workflow_ids`) |
 | 09 | [**Validate and Commit**](./activities/README.md#09-validate-and-commit) | All | Schema validation, then commit on a feature branch + open a PR against `workflows` (create/update) or save the compliance report (review) |
 | 10 | [**Post-Update Review**](./activities/README.md#10-post-update-review) | Update only | Automatic post-commit compliance audit of the updated workflow |
@@ -127,19 +127,20 @@ The `techniques/` directory is a flat library of workflow-local standalone techn
 | Technique | Capability | Bound by |
 |-----------|------------|----------|
 | [`intake-classification`](./techniques/intake-classification.md) | Classify the request as create/update/review and set mode + target | Intake and Context |
-| [`context-loading`](./techniques/context-loading.md) | Load schemas, survey references, persist format-conventions + applicable-constructs | Intake and Context |
+| [`context-loading`](./techniques/context-loading.md) | Load schemas, survey references; persist format-conventions + applicable-constructs in create mode | Intake and Context |
 | [`derive-design-dimensions`](./techniques/derive-design-dimensions.md) | Derive the ordered design dimensions to elicit, per mode | Requirements Refinement |
 | [`prepare-dimension`](./techniques/prepare-dimension.md) | Assemble elicitation questions for one design dimension | Requirements Refinement |
 | [`capture-dimension`](./techniques/capture-dimension.md) | Record answers for one design dimension and fold into accumulated design | Requirements Refinement |
-| [`synthesize-update-specification`](./techniques/synthesize-update-specification.md) | Assemble the update-mode specification from the change request (no per-dimension elicitation) | Requirements Refinement |
+| [`synthesize-update-specification`](./techniques/synthesize-update-specification.md) | Assemble the update-mode specification from changed dimensions only (no per-dimension elicitation) | Requirements Refinement |
 | [`persist-design-specification`](./techniques/persist-design-specification.md) | Persist the elicited design specification for linked review | Requirements Refinement |
 | [`reconcile-design-assumptions`](./techniques/reconcile-design-assumptions.md) | Autonomously resolve audit-resolvable design assumptions, leaving only genuine judgements open | Requirements Refinement |
 | [`pattern-analysis`](./techniques/pattern-analysis.md) | Extract patterns from reference workflows and persist the comparison | Pattern Analysis |
 | [`impact-analysis`](./techniques/impact-analysis.md) | Assess change impact on files, transitions, and references | Impact Analysis |
-| [`scope-definition`](./techniques/scope-definition.md) | Enumerate the complete file manifest and structural design | Scope and Draft |
+| [`scope-definition`](./techniques/scope-definition.md) | Enumerate the file manifest with lean structural design and drafting order | Scope and Draft |
 | [`assemble-file-approach`](./techniques/assemble-file-approach.md) | Assemble and persist the per-file drafting plan | Scope and Draft |
 | [`review-drafted-file`](./techniques/review-drafted-file.md) | Assemble and persist a per-file review note (including update-mode removals) | Scope and Draft |
 | [`yaml-authoring`](./techniques/yaml-authoring.md) | Author syntactically valid YAML files that pass schema validation | Scope and Draft |
+| [`verify-artifact-conforms`](./techniques/verify-artifact-conforms.md) | Verify planning artifacts against the design canonical-home map and fix drift in place | Scope and Draft |
 | [`audit-expressiveness`](./techniques/audit-expressiveness.md) | Walk prose against the schema construct inventory | Quality Review (create/update), Post-Update |
 | [`audit-conformance`](./techniques/audit-conformance.md) | Apply convention-conformance against reference workflows | Quality Review (create/update), Post-Update |
 | [`audit-rule-hygiene`](./techniques/audit-rule-hygiene.md) | Apply Rule Hygiene anti-patterns to `rules[]` | Quality Review (create/update) |
@@ -210,7 +211,7 @@ workflows/workflow-design/
 │   ├── 03-requirements-refinement.yaml   # Elicit design details one question at a time
 │   ├── 04-pattern-analysis.yaml          # Audit reference workflows (create only)
 │   ├── 05-impact-analysis.yaml           # Impact analysis (update mode)
-│   ├── 06-scope-and-draft.yaml           # Define file manifest, then draft/validate per file
+│   ├── 06-scope-and-draft.yaml           # Manifest, draft/validate per file, verify artifact homes
 │   ├── 08-quality-review.yaml            # Audit passes (full compliance audit in review mode)
 │   ├── 09-validate-and-commit.yaml       # Validate and commit
 │   ├── 10-post-update-review.yaml        # Post-commit compliance audit (update mode)
@@ -245,6 +246,7 @@ workflows/workflow-design/
 │   ├── audit-rule-enforcement.md
 │   ├── verify-high-findings.md
 │   ├── review-draft-yaml.md
+│   ├── verify-artifact-conforms.md
 │   ├── apply-audit-fixes.md
 │   ├── scope-audit.md
 │   ├── create-completion-doc.md

--- a/workflow-design/activities/06-scope-and-draft.yaml
+++ b/workflow-design/activities/06-scope-and-draft.yaml
@@ -1,7 +1,7 @@
 id: scope-and-draft
-version: 1.8.0
+version: 1.9.0
 name: Scope and Draft
-description: A complete file manifest and structural design for the target workflow, drafted and reviewed file by file with schema validation on each YAML file.
+description: A complete file manifest and structural design for the target workflow, drafted and reviewed file by file with schema validation on each YAML file, then planning-artifact conformance verify.
 required: true
 techniques:
   - scatter-gather
@@ -165,6 +165,9 @@ steps:
       - id: redraft-all
         label: Redraft all changes
         description: Entire drafting pass requires restart from scratch.
+  - kind: technique
+    id: verify-artifact-conforms
+    technique: verify-artifact-conforms
 transitions:
   - to: quality-review
     isDefault: true
@@ -173,3 +176,4 @@ outcome:
   - The folder structure and activity flow are agreed against established patterns, so the workflow's shape is sound before any file is written
   - The full workflow is drafted with create-mode per-file review or a single update-mode batch attestation, giving the user a known-good body of content rather than an unreviewed dump
   - Every YAML file is schema-valid, so downstream loading and validation start from clean, conformant content
+  - Planning artifacts conform to the design canonical-home map and template line budgets before quality-review audits

--- a/workflow-design/resources/design-context-readme.md
+++ b/workflow-design/resources/design-context-readme.md
@@ -2,7 +2,7 @@
 name: design-context-readme
 description: Template and guidelines for the README.md entry-point of a workflow-design session's planning folder. Conforms to the canonical meta planning-readme guide, with design-session sections appended.
 metadata:
-  version: 1.0.1
+  version: 1.1.0
   order: 5
 ---
 
@@ -25,11 +25,11 @@ The `README.md` is the entry point for a workflow-design session's planning fold
 
 ## Problem Overview
 
-*[What the current workflow does and why this session is needed — filled when known.]*
+[One-line pointer + link to design-specification.md — do not restate the purpose essay.]
 
 ## Solution Overview
 
-*[What the change does at a high level; link the scope manifest for the file breakdown — filled when known.]*
+[One or two short pointer sentences + links to design-specification.md and scope-manifest.md — do not restate the spec body.]
 
 ## Design Decisions
 
@@ -65,11 +65,11 @@ The `README.md` is the entry point for a workflow-design session's planning fold
 
 ## Rules
 
-The shared header-line, Executive Summary, Problem/Solution Overview, Progress-table, and Links-table rules are defined in the canonical [Planning Folder README Guide](../../meta/resources/planning-readme.md). Design-session specifics:
+The shared header-line, Executive Summary, Progress-table, and Links-table rules are defined in the canonical [Planning Folder README Guide](../../meta/resources/planning-readme.md). Design-session specifics:
 
 - **Classifier** — the session mode: `Create`, `Update`, or `Review`. Status values: `Planning`, `Drafting`, `Reviewing`, `Complete`.
-- **Problem Overview** — what the current workflow does and why it needs changing.
-- **Solution Overview** — what the change does at a high level; links the scope manifest for the file breakdown.
+- **Problem Overview** — link-only slot: pointer + link to `design-specification.md` (canonical home for purpose / change goals). Do not restate the purpose essay.
+- **Solution Overview** — link-only slot: short pointer + links to `design-specification.md` and `scope-manifest.md` for the file breakdown. Do not restate the spec body.
 - **Progress table** — one row per activity the active mode runs, seeded from the workflow definition (not a hard-coded list in this template).
 
 ### Design Decisions

--- a/workflow-design/resources/design-specification.md
+++ b/workflow-design/resources/design-specification.md
@@ -2,12 +2,13 @@
 name: design-specification
 description: Guidelines for creating the design-specification planning artifact (purpose + dimension deltas).
 metadata:
+  version: 1.1.0
   order: 14
 ---
 
 # Design Specification Guide
 
-Confirmed design surface for create/update. Answers: what stays the same, and what changes per design dimension? Primary human gate at `spec-confirmed`.
+Confirmed design surface for create/update. Answers: what stays the same, and what changes per design dimension? Primary human gate at `spec-confirmed`. Canonical home for purpose and dimension deltas ([canonical-home map](../techniques/TECHNIQUE.md#canonical-home-map)).
 
 ## Template
 
@@ -32,6 +33,8 @@ Confirmed design surface for create/update. Answers: what stays the same, and wh
 | … | … |
 
 **Out of scope:** [bullets]
+
+**Also see:** [assumptions log](NN-assumptions-log.md) · [impact](NN-impact-analysis.md) when update
 
 ---
 
@@ -80,5 +83,6 @@ Confirmed design surface for create/update. Answers: what stays the same, and wh
 
 - **Purpose + dimension deltas only.** Omit encyclopedia restatement of unchanged dimensions.
 - **Tables over narrative.** Unchanged mode branches get one line, not a reprint of the workflow.
-- **Single-source:** README Design Decisions links here; do not restate the body in README or COMPLETE.
+- **Own facts only.** Assumptions, impact, inventory, and scope live in their homes — link, do not restate ([canonical-home map](../techniques/TECHNIQUE.md#canonical-home-map)).
+- **Single-source:** README Problem/Solution and Design Decisions link here; do not restate the body in README or COMPLETE.
 - **Line budget:** ~120 lines for update; create may run longer but still delta-shaped.

--- a/workflow-design/resources/impact-analysis.md
+++ b/workflow-design/resources/impact-analysis.md
@@ -2,12 +2,13 @@
 name: impact-analysis
 description: Guidelines for creating the impact-analysis planning artifact (classification, integrity, removals).
 metadata:
+  version: 1.1.0
   order: 15
 ---
 
 # Impact Analysis Guide
 
-Update-mode decision surface. Answers: what is touched, is integrity intact, and which removals are intentional? Human gate at impact-and-preservation.
+Update-mode decision surface. Answers: what is touched, is integrity intact, and which removals are intentional? Human gate at impact-and-preservation. Canonical home for impact classification, integrity, and removals ([canonical-home map](../techniques/TECHNIQUE.md#canonical-home-map)).
 
 ## Template
 
@@ -80,4 +81,5 @@ Confirm impact scope and intentional removals — or revise / preserve.
 - **No unaffected per-file essays** — summary note only.
 - **Every material removal** gets a removed-vs-preserved row (content-preservation).
 - **Integrity** is verdict + one line, not a walkthrough.
+- **Own facts only.** Link design-specification and structural-inventory; do not restate purpose or inventory body ([canonical-home map](../techniques/TECHNIQUE.md#canonical-home-map)).
 - **Line budget:** ~100 lines unless removals inventory is long (then table rows are the length).

--- a/workflow-design/resources/scope-manifest.md
+++ b/workflow-design/resources/scope-manifest.md
@@ -1,13 +1,14 @@
 ---
 name: scope-manifest
-description: Guidelines for creating the scope-manifest planning artifact (file list + minimal structure/order).
+description: Guidelines for creating the scope-manifest planning artifact (file table + lean structural notes).
 metadata:
+  version: 1.0.0
   order: 17
 ---
 
 # Scope Manifest Guide
 
-Authoritative file list for drafting and commit verify. Answers: which files, what action, in what order? Human gate at scope-and-structure.
+Activity-layer decision surface for create/update. Answers: which files, what structural shape, and in what drafting order? Human gate at `scope-and-structure-confirmed`. Canonical home for the file manifest, structural design, and drafting order ([canonical-home map](../techniques/TECHNIQUE.md#canonical-home-map)).
 
 ## Template
 
@@ -59,7 +60,7 @@ Authoritative file list for drafting and commit verify. Answers: which files, wh
 
 ## Rules
 
-- **File table is canonical** — README Scope Manifest links here; do not mirror the full list in README.
-- **Minimal structural/drafting sections** — tree + short order; no pattern essay.
-- **Every in-scope file** appears exactly once with action and one-line change.
-- **Line budget:** ~80 lines plus one row per file.
+- **File table is the payload** — structural design and drafting order stay compact.
+- **Own facts only.** Link design-specification and impact-analysis; do not restate purpose or removals essays ([canonical-home map](../techniques/TECHNIQUE.md#canonical-home-map)).
+- **Update:** folder layout may be "unchanged"; still enumerate every touched file.
+- **Line budget:** ~80 lines unless the file table is long (then table rows are the length).

--- a/workflow-design/techniques/README.md
+++ b/workflow-design/techniques/README.md
@@ -19,7 +19,7 @@ For the full technique-to-activity table with capability summaries, see the [wor
 | **Intake** | `intake-classification`, `context-loading`, `reload-workflow` |
 | **Elicitation** | `derive-design-dimensions`, `prepare-dimension`, `capture-dimension`, `synthesize-update-specification`, `reconcile-design-assumptions` |
 | **Analysis** | `pattern-analysis`, `impact-analysis` |
-| **Scope & draft** | `scope-definition`, `assemble-file-approach`, `review-drafted-file`, `yaml-authoring`, `review-draft-yaml` |
+| **Scope & draft** | `scope-definition`, `assemble-file-approach`, `review-drafted-file`, `yaml-authoring`, `review-draft-yaml`, `verify-artifact-conforms` |
 | **Quality audits** | `audit-expressiveness`, `audit-conformance`, `audit-rule-hygiene`, `audit-rule-enforcement`, `verify-high-findings`, `audit-principles`, `audit-anti-patterns`, `audit-schema-validation`, `apply-audit-fixes`, `scope-audit` |
 | **Reporting** | `compile-report`, `summarize-findings`, `persist-report` |
 | **Validate, commit & PR** | `scope-verification`, `readme-authoring`, `commit-verification`, `prepare-workflow-branch`, `publish-workflow-pr` |

--- a/workflow-design/techniques/TECHNIQUE.md
+++ b/workflow-design/techniques/TECHNIQUE.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.1
+  version: 1.1.0
 ---
 
 ## Capability
@@ -60,3 +60,30 @@ Before relying on a referenced resource's content, load that resource. Do not re
 ### apply-anti-patterns-when-authoring
 
 When authoring or revising workflow definition content (YAML prose fields, technique/resource markdown, README orientation), apply [anti-patterns](../resources/anti-patterns.md) as write-time constraints — especially Schema Expressiveness and Description Hygiene — rather than deferring discovery to a later audit. Do not restate entry Detect criteria here.
+
+### single-source-and-link
+
+Every planning fact has exactly one canonical artifact. When another artifact or the session README needs it, link to the canonical home with at most a one-line pointer — never restate the body.
+
+### canonical-home-map
+
+The canonical home for each shared design-session fact category. Templates carry link-only slots for every category they don't home; [verify-artifact-conforms](./verify-artifact-conforms.md) enforces the map at the end of `scope-and-draft`.
+
+| Fact category | Canonical home |
+|---|---|
+| Purpose, dimension deltas, change goals | `design-specification.md` |
+| Assumptions and outcomes | `assumptions-log.md` |
+| Impact classification, integrity, removals | `impact-analysis.md` |
+| File manifest, structural design, drafting order | `scope-manifest.md` |
+| Format / YAML literacy | `format-conventions.md` |
+| Applicable schema constructs | `applicable-constructs.md` |
+| Structural inventory baseline | `structural-inventory.md` |
+| Pattern analysis findings | `pattern-analysis.md` |
+| Compliance / audit findings | `compliance-report.md` (and findings satellites) |
+| Session index (Progress, Links, Design Decisions pointers) | `README.md` |
+
+README Problem Overview and Solution Overview are link-only slots pointing at `design-specification.md` (Solution also links `scope-manifest.md` for the file breakdown).
+
+### line-budget
+
+Fill-template `## Rules` line budgets are hard under [verify-artifact-conforms](./verify-artifact-conforms.md) — over-budget prose is a `line-budget` violation.

--- a/workflow-design/techniques/context-loading.md
+++ b/workflow-design/techniques/context-loading.md
@@ -1,17 +1,17 @@
 ---
 metadata:
-  version: 1.2.2
+  version: 1.3.0
 ---
 
 ## Capability
 
-Internalize the schema system and YAML-format conventions: load the authoritative JSON schemas and their documentation, survey reference workflows and sample YAML files, identify the schema constructs applicable to the design intent, and persist lean literacy surfaces for review.
+Internalize the schema system and YAML-format conventions: load the authoritative JSON schemas and their documentation, survey reference workflows and sample YAML files, identify the schema constructs applicable to the design intent, and persist the literacy surfaces for review when the mode requires them.
 
 ## Outputs
 
 ### format_conventions_path
 
-Absolute path to the written format-conventions artifact.
+Absolute path to the written format-conventions artifact (create mode only).
 
 #### artifact
 
@@ -19,7 +19,7 @@ Absolute path to the written format-conventions artifact.
 
 ### applicable_constructs_path
 
-Absolute path to the written applicable-constructs artifact.
+Absolute path to the written applicable-constructs artifact (create mode only).
 
 #### artifact
 
@@ -51,10 +51,10 @@ Absolute path to the written applicable-constructs artifact.
 
 ### 6. Persist Format Conventions
 
-- When `{planning_folder_path}` is bound and review mode is not active: persist the literacy surface via [write-artifact](../../work-package/techniques/manage-artifacts/write-artifact.md) with *target_dir* `{planning_folder_path}` and bare filename `format-conventions.md`, following the [Format Conventions Guide](../resources/format-conventions.md#template); capture `{format_conventions_path}`
-- Skip in review mode
+- When `{operation_type}` is `create` and `{planning_folder_path}` is bound: persist a concise format-conventions summary (YAML syntax rules and observed project conventions — naming, folder structure, field ordering, versions, transition and checkpoint shapes) via [write-artifact](../../work-package/techniques/manage-artifacts/write-artifact.md) with *target_dir* `{planning_folder_path}` and bare filename `format-conventions.md`; capture `{format_conventions_path}`
+- Skip when `{operation_type}` is `update` or `review`
 
 ### 7. Persist Applicable Constructs
 
-- When `{planning_folder_path}` is bound and review mode is not active: persist the construct table via [write-artifact](../../work-package/techniques/manage-artifacts/write-artifact.md) with *target_dir* `{planning_folder_path}` and bare filename `applicable-constructs.md`, following the [Applicable Constructs Guide](../resources/applicable-constructs.md#template); capture `{applicable_constructs_path}`
-- Skip in review mode
+- When `{operation_type}` is `create` and `{planning_folder_path}` is bound: persist the applicable-constructs list (construct name, why it applies, reference example) via [write-artifact](../../work-package/techniques/manage-artifacts/write-artifact.md) with *target_dir* `{planning_folder_path}` and bare filename `applicable-constructs.md`; capture `{applicable_constructs_path}`
+- Skip when `{operation_type}` is `update` or `review`

--- a/workflow-design/techniques/impact-analysis.md
+++ b/workflow-design/techniques/impact-analysis.md
@@ -1,11 +1,11 @@
 ---
 metadata:
-  version: 1.1.2
+  version: 1.2.0
 ---
 
 ## Capability
 
-Assess the impact of proposed changes against an existing workflow: classify what the change touches, verify transition/reference/variable integrity, and inventory material removals — as a decision-facing report.
+Assess the impact of proposed changes against an existing workflow: enumerate its files, classify each file's impact, verify transition-chain, reference, and variable integrity, and record a diff-style inventory of material being removed.
 
 ## Outputs
 
@@ -29,8 +29,7 @@ Absolute path to the written impact-analysis artifact.
 
 ### 2. Classify Impact
 
-- Classify files the change touches as directly modified, indirectly affected, or removed, each with a one-line justification, per the [Impact Analysis Guide](../resources/impact-analysis.md#template)
-- Summarize unaffected files in one short note (counts / categories)
+- Classify each file as unaffected, directly modified (the change explicitly affects it), indirectly affected (a side-effect such as a broken transition chain), or removed (the change makes it obsolete), with justification
 
 ### 3. Check Transition Integrity
 
@@ -55,7 +54,8 @@ Absolute path to the written impact-analysis artifact.
 
 ### 7. Persist Report
 
-- Persist the report via [write-artifact](../../work-package/techniques/manage-artifacts/write-artifact.md) with *target_dir* `{planning_folder_path}` and bare filename `impact-analysis.md`, following the [Impact Analysis Guide](../resources/impact-analysis.md#template)
+- Persist classification, integrity checks, and the removals inventory via [write-artifact](../../work-package/techniques/manage-artifacts/write-artifact.md) with *target_dir* `{planning_folder_path}` and bare filename `impact-analysis.md`, following [impact-analysis](../resources/impact-analysis.md#template)
+- Own facts only: link [design-specification](../resources/design-specification.md) and structural inventory rather than restating them
 - Capture the written location as `{impact_analysis_path}`
 
 ## Rules

--- a/workflow-design/techniques/persist-design-specification.md
+++ b/workflow-design/techniques/persist-design-specification.md
@@ -1,11 +1,11 @@
 ---
 metadata:
-  version: 1.1.4
+  version: 1.2.0
 ---
 
 ## Capability
 
-Persist the accumulated design specification as a decision surface per the [Design Specification Guide](../resources/design-specification.md#template).
+Persist the accumulated design specification elicited across the design dimensions into the planning folder as a durable review surface — own facts only; link non-home content.
 
 ## Outputs
 
@@ -21,14 +21,15 @@ Absolute path to the written design-specification artifact.
 
 ### 1. Assemble Specification
 
-- Assemble from `{accumulated_design}` when bound (create elicitation or update synthesis); otherwise from the elicited dimensions that ran for this mode
-- Follow the [Design Specification Guide](../resources/design-specification.md#template) — purpose + dimension deltas only
+- Assemble the specification from `{accumulated_design}` when bound (create elicitation or update synthesis); otherwise from the elicited dimensions that ran for this mode
+- Include only facts this artifact homes per the [canonical-home map](./TECHNIQUE.md#canonical-home-map) and [design-specification](../resources/design-specification.md) — purpose and dimension deltas
+- Link assumptions, impact, inventory, and other non-home content; do not restate them
 
 ### 2. Persist Specification Artifact
 
-- Persist it via [write-artifact](../../work-package/techniques/manage-artifacts/write-artifact.md) with *target_dir* `{planning_folder_path}` and bare filename `design-specification.md` per [design-specification](../resources/design-specification.md#template)
+- Persist it via [write-artifact](../../work-package/techniques/manage-artifacts/write-artifact.md) with *target_dir* `{planning_folder_path}` and bare filename `design-specification.md`, following [design-specification](../resources/design-specification.md#template)
 - Capture the written location as `{specification_path}`
 
 ### 3. Mirror Decisions To README
 
-- Add a short pointer under the planning README Design Decisions section linking this artifact (single-source-and-link — do not restate the spec body)
+- Mirror key decisions into the planning README Design Decisions section as links to this artifact ([single-source-and-link](./TECHNIQUE.md#single-source-and-link) — do not restate the full spec in the README)

--- a/workflow-design/techniques/scope-definition.md
+++ b/workflow-design/techniques/scope-definition.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.3.1
+  version: 1.3.0
 ---
 
 ## Capability
@@ -41,12 +41,14 @@ Absolute path to the written scope-manifest artifact (includes structural design
 
 ### 4. Assemble Structural Design
 
-- Assemble `{$structural_design}` for the Structural design section of the [Scope Manifest Guide](../resources/scope-manifest.md#template): directory tree (or "unchanged" for update), short transition note when topology changes, and a compact pattern-alignment table — not a pattern-comparison essay
+- Assemble `{$structural_design}` for the Structural design section of [scope-manifest](../resources/scope-manifest.md#template): directory tree (or "unchanged" for update), short transition note when topology changes, and a compact pattern-alignment table — not a pattern-comparison essay
 
 ### 5. Assemble Drafting Order
 
-- Assemble `{$drafting_order}` for the Drafting order section of the [Scope Manifest Guide](../resources/scope-manifest.md#template): drafting order (`workflow.yaml`, activities, techniques, resources, README) with a one-line rationale per tier
+- Assemble `{$drafting_order}` for the Drafting order section of [scope-manifest](../resources/scope-manifest.md#template): drafting order (`workflow.yaml`, activities, techniques, resources, README) with a one-line rationale per tier
 
 ### 6. Persist Scope Manifest
 
-- Persist `{scope_manifest}` together with `{structural_design}` and `{drafting_order}` via [write-artifact](../../work-package/techniques/manage-artifacts/write-artifact.md) with *target_dir* `{planning_folder_path}` and bare filename `scope-manifest.md`, following the [Scope Manifest Guide](../resources/scope-manifest.md#template); capture `{scope_manifest_path}`
+- Persist `{scope_manifest}` together with `{$structural_design}` and `{$drafting_order}` via [write-artifact](../../work-package/techniques/manage-artifacts/write-artifact.md) with *target_dir* `{planning_folder_path}` and bare filename `scope-manifest.md`, following [scope-manifest](../resources/scope-manifest.md#template)
+- Own facts only: link impact analysis and design specification rather than restating them
+- Capture `{scope_manifest_path}`

--- a/workflow-design/techniques/synthesize-update-specification.md
+++ b/workflow-design/techniques/synthesize-update-specification.md
@@ -1,11 +1,11 @@
 ---
 metadata:
-  version: 1.0.1
+  version: 1.1.0
 ---
 
 ## Capability
 
-Assemble the update-mode design specification from the settled change request — compliance report when present, otherwise `{change_category}` / `{user_description}` and `{structural_inventory}` — without per-dimension elicitation.
+Assemble the update-mode design specification from the settled change request — compliance report when present, otherwise `{change_category}` / `{user_description}` and `{structural_inventory}` — emitting only dimensions that change.
 
 ## Inputs
 
@@ -29,7 +29,7 @@ Baseline structural inventory of the target workflow.
 
 ### accumulated_design
 
-The assembled update specification covering the update dimension set (purpose, activity list, checkpoints, artifacts, rules) as derived from the change request and baseline — ready for persist and batch confirmation.
+The assembled update specification covering **changed** members of the update dimension set (purpose, activity list, checkpoints, artifacts, rules) — ready for persist and batch confirmation. Unchanged dimensions are omitted.
 
 ## Protocol
 
@@ -38,7 +38,8 @@ The assembled update specification covering the update dimension set (purpose, a
 - Load `{change_category}`, `{user_description}`, and `{structural_inventory}`
 - When `{report_path}` is non-empty, load that report as the primary change specification
 
-### 2. Assemble Update Specification
+### 2. Assemble Changed Dimensions Only
 
-- Assemble `{accumulated_design}` for the update dimension set in [elicitation-guide](../resources/elicitation-guide.md) `## Mode Dimension Sets`: purpose, activity list, checkpoints, artifacts, and rules
-- Derive each dimension from the change sources and baseline — do not invent unrelated structural changes; prefer additive edits named by findings or the change request
+- From the update dimension set in [elicitation-guide](../resources/elicitation-guide.md) `## Mode Dimension Sets` (purpose, activity list, checkpoints, artifacts, rules), emit only dimensions that change relative to the baseline and change request
+- Omit unchanged dimensions from `{accumulated_design}` — do not assemble the full five every update
+- Derive each included dimension from the change sources and baseline; prefer additive edits named by findings or the change request; do not invent unrelated structural changes

--- a/workflow-design/techniques/verify-artifact-conforms.md
+++ b/workflow-design/techniques/verify-artifact-conforms.md
@@ -1,0 +1,41 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Verify every planning artifact in the design-session folder against this workflow's output-discipline rules — canonical-home sections not duplicated, link-only slots not restated, null sections omitted, per-template line budgets respected — and fix violations in place. Thin design-local peer of [work-package manage-artifacts verify-artifact-conforms](../../work-package/techniques/manage-artifacts/verify-artifact-conforms.md); applies the **design** [canonical-home map](./TECHNIQUE.md#canonical-home-map), not the work-package map.
+
+## Outputs
+
+### artifact_conformance
+
+The conformance envelope — the violation list plus the aggregate verdict:
+
+#### conforms
+
+true iff the `violations` array is empty after fixes are applied.
+
+#### violations
+
+array of `{ file, rule, detail, fixed }` entries — one per detected violation, where `rule` names the output-discipline rule breached (`single-source-and-link`, `state-once-per-artifact`, `omit-null-sections`, `exception-only-reporting`, or `line-budget`) and `fixed` records whether the in-place fix was applied.
+
+## Protocol
+
+1. Enumerate the planning artifacts in `{planning_folder_path}` — every `.md` file except `session.json`-adjacent state files.
+2. Check each artifact against this workflow's output-discipline rules and the design [canonical-home map](./TECHNIQUE.md#canonical-home-map):
+   - a section restating content whose canonical home is another artifact (map lookup) breaches `single-source-and-link`;
+   - a link-only slot (a template section defined as a one-line pointer) carrying more than a link plus one line breaches `single-source-and-link`;
+   - a section whose content is "None", "N/A", or a statement of non-applicability breaches `omit-null-sections`;
+   - a recap table or closing summary restating the artifact's own sections breaches `state-once-per-artifact`;
+   - an all-pass status table breaches `exception-only-reporting`;
+   - an artifact exceeding a line budget declared in its template's `## Rules` breaches `line-budget`.
+3. Fix each violation in place: replace restatement with a link to the canonical home, delete null sections and recap tables, collapse all-pass tables to one line, and condense over-budget prose. Preserve any content the user explicitly requested.
+4. Compose `{artifact_conformance}`: its `violations` array lists every detected violation with its fix status; its `conforms` verdict is true iff the list is empty after fixes. Report exceptions only — a fully conformant folder is the one-line result, not a per-file table.
+
+## Rules
+
+### design-map-not-work-package
+
+Always read [canonical-home-map](./TECHNIQUE.md#canonical-home-map) from this workflow's `techniques/TECHNIQUE.md`. Do not bind or follow the work-package manage-artifacts map for design-session artifacts.

--- a/workflow-design/workflow.yaml
+++ b/workflow-design/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: workflow-design
-version: 1.24.4
+version: 1.25.0
 title: Workflow Design Workflow
 description: Guide agents through creating, updating, or reviewing workflow definitions.
 author: m2ux


### PR DESCRIPTION
## Summary

Update `workflow-design` to v1.25.0 so each design-session planning fact has one canonical home: lean templates, delta-only update synthesis, create-only literacy persists, and a design-local `verify-artifact-conforms` gate at the end of `scope-and-draft`.

### Scope (14 files + README sync)

| Path | Action |
|------|--------|
| `techniques/TECHNIQUE.md` | modify — `canonical-home-map` / `single-source-and-link` / `line-budget` |
| `techniques/context-loading.md` | modify — create-only literacy persists |
| `techniques/synthesize-update-specification.md` | modify — changed dimensions only |
| `techniques/persist-design-specification.md` | modify — own-facts persist |
| `techniques/impact-analysis.md` | modify — own-facts persist |
| `techniques/scope-definition.md` | modify — lean scope-manifest fill |
| `techniques/verify-artifact-conforms.md` | create — design-local verify |
| `resources/design-context-readme.md` | modify — Problem/Solution link-only |
| `resources/design-specification.md` | modify — fill budgets / home links |
| `resources/impact-analysis.md` | modify — fill budgets / home links |
| `resources/scope-manifest.md` | modify — lean template |
| `activities/06-scope-and-draft.yaml` | modify — bind verify after attestation |
| `workflow.yaml` | modify — v1.25.0 |
| `techniques/README.md` | modify — index new technique |
| `README.md` | modify — version + technique discoverability |

### Planning

- Folder: `.engineering/artifacts/planning/2026-07-18-workflow-design-planning-artifact-homes/`
- Design specification / scope manifest / draft attestation / quality review (0 findings)

## Test plan

- [ ] Schema validation + `check-all-refs` + `check-binding-fidelity` clean for `workflow-design`
- [ ] Smoke create/update path: literacy persists skipped on update; verify step runs after draft attestation
- [ ] Confirm planning README Problem/Solution stay link-only to design-spec / scope-manifest