### PR TITLE
chore: parameterize docker-compose paths via env vars

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,12 +1,12 @@
 {
   "mcpServers": {
     "workflow-server": {
-      "command": "node",
+      "command": "npx",
       "args": [
-        "${workspaceFolder}/dist/index.js",
-        "--transport=stdio"
-      ],
-      "envFile": "${workspaceFolder}/.env"
+        "-y",
+        "mcp-remote",
+        "${env:WORKFLOW_SERVER_MCP_URL}"
+      ]
     }
   }
 }

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,15 +1,12 @@
 {
-    "mcpServers": {
-      "workflow-server": {
-        "command": "node",
-        "args": [
-          "/home/mike1/projects/main/workflow-server/dist/index.js",
-          "--workspace=/home/mike1/projects/main/workflow-server"
-        ],
-        "env": {
-          "WORKFLOW_DIR": "/home/mike1/projects/main/workflow-server/workflows"
-        }
-      }
+  "mcpServers": {
+    "workflow-server": {
+      "command": "node",
+      "args": [
+        "${workspaceFolder}/dist/index.js",
+        "--transport=stdio"
+      ],
+      "envFile": "${workspaceFolder}/.env"
     }
   }
-  
+}

--- a/.env.example
+++ b/.env.example
@@ -3,16 +3,29 @@
 #   ./scripts/init-local-env.sh   # fills absolute paths from this checkout
 #
 # Used by:
-#   - MCP stdio (Cursor/Claude via envFile on workflow-server)
+#   - MCP clients (export these into the environment Cursor/Claude inherits)
 #   - docker compose (HOST_* binds; CONTAINER_* in-container targets)
 #
-# Do not put secrets here unless you keep .env out of git (already gitignored).
+# Cursor expands ${env:NAME} from the IDE process environment — not from
+# `.env` alone. After editing `.env`, either:
+#   source .env && export WORKFLOW_SERVER_MCP_URL CONCEPT_RAG_ENTRY CONCEPT_RAG_INDEX
+# or launch Cursor from a shell that has already sourced `.env`, or set the
+# vars in your desktop/session environment.
 
 # =============================================================================
-# MCP / host-side server (stdio)
+# MCP client → HTTP workflow-server (mcp-remote)
+# =============================================================================
+# Full MCP endpoint URL (compose default publish is host port 3000).
+WORKFLOW_SERVER_MCP_URL=http://127.0.0.1:3000/mcp
+
+# Optional companion MCP servers (only if those entries stay in .mcp.json)
+# CONCEPT_RAG_ENTRY=
+# CONCEPT_RAG_INDEX=
+
+# =============================================================================
+# Server process paths (when starting the HTTP server / compose container)
 # =============================================================================
 # Required worktree root the server is bound to (planning artifacts live under it).
-# Prefer a parent directory that holds agent-created worktrees, e.g. ~/projects/work
 WORKFLOW_WORKSPACE=
 
 # Optional alias for the same root (containers often use this name instead)
@@ -25,10 +38,6 @@ SCHEMAS_DIR=
 # Optional planning layout override (default: .engineering/artifacts/planning)
 # PLANNING_SLUG=.engineering/artifacts/planning
 
-# Optional companion MCP servers (only needed if you keep those entries in .mcp.json)
-# CONCEPT_RAG_ENTRY=
-# CONCEPT_RAG_INDEX=
-
 # =============================================================================
 # Docker Compose — host bind sources (paths on the machine running compose)
 # =============================================================================
@@ -39,7 +48,7 @@ HOST_PORT=3000
 
 # =============================================================================
 # Docker Compose — in-container paths (volume targets + server env inside image)
-# Must NOT reuse WORKFLOW_DIR / WORKFLOW_WORKSPACE from the MCP section above.
+# Must NOT reuse WORKFLOW_DIR / WORKFLOW_WORKSPACE from the host section above.
 # =============================================================================
 CONTAINER_WORKTREE_ROOT=/worktrees
 CONTAINER_WORKFLOW_DIR=/app/workflows

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Copy to `.env` and adjust for your host. Compose loads `.env` automatically.
+# Values below match docker-compose.yml defaults.
+
+# --- Host bind sources (paths on the machine running docker compose) ---
+HOST_WORKTREE_ROOT=/var/worktrees
+HOST_WORKFLOWS_DIR=./workflows
+HOST_SCHEMAS_DIR=./schemas
+HOST_PORT=3000
+
+# --- In-container paths / server env (must match volume targets) ---
+WORKTREE_ROOT=/worktrees
+WORKFLOW_DIR=/app/workflows
+SCHEMAS_DIR=/app/schemas
+# PLANNING_SLUG=.engineering/artifacts/planning
+
+# --- Transport ---
+TRANSPORT=http
+HOST=0.0.0.0
+PORT=3000

--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,51 @@
-# Copy to `.env` and adjust for your host. Compose loads `.env` automatically.
-# Values below match docker-compose.yml defaults.
+# Copy to `.env` (gitignored) and adjust paths for your machine:
+#   cp .env.example .env
+#   ./scripts/init-local-env.sh   # fills absolute paths from this checkout
+#
+# Used by:
+#   - MCP stdio (Cursor/Claude via envFile on workflow-server)
+#   - docker compose (HOST_* binds; CONTAINER_* in-container targets)
+#
+# Do not put secrets here unless you keep .env out of git (already gitignored).
 
-# --- Host bind sources (paths on the machine running docker compose) ---
-HOST_WORKTREE_ROOT=/var/worktrees
+# =============================================================================
+# MCP / host-side server (stdio)
+# =============================================================================
+# Required worktree root the server is bound to (planning artifacts live under it).
+# Prefer a parent directory that holds agent-created worktrees, e.g. ~/projects/work
+WORKFLOW_WORKSPACE=
+
+# Optional alias for the same root (containers often use this name instead)
+# WORKTREE_ROOT=
+
+# Workflow definitions and schemas on the host (absolute paths recommended)
+WORKFLOW_DIR=
+SCHEMAS_DIR=
+
+# Optional planning layout override (default: .engineering/artifacts/planning)
+# PLANNING_SLUG=.engineering/artifacts/planning
+
+# Optional companion MCP servers (only needed if you keep those entries in .mcp.json)
+# CONCEPT_RAG_ENTRY=
+# CONCEPT_RAG_INDEX=
+
+# =============================================================================
+# Docker Compose — host bind sources (paths on the machine running compose)
+# =============================================================================
+HOST_WORKTREE_ROOT=
 HOST_WORKFLOWS_DIR=./workflows
 HOST_SCHEMAS_DIR=./schemas
 HOST_PORT=3000
 
-# --- In-container paths / server env (must match volume targets) ---
-WORKTREE_ROOT=/worktrees
-WORKFLOW_DIR=/app/workflows
-SCHEMAS_DIR=/app/schemas
-# PLANNING_SLUG=.engineering/artifacts/planning
+# =============================================================================
+# Docker Compose — in-container paths (volume targets + server env inside image)
+# Must NOT reuse WORKFLOW_DIR / WORKFLOW_WORKSPACE from the MCP section above.
+# =============================================================================
+CONTAINER_WORKTREE_ROOT=/worktrees
+CONTAINER_WORKFLOW_DIR=/app/workflows
+CONTAINER_SCHEMAS_DIR=/app/schemas
 
-# --- Transport ---
+# Transport inside the container (compose defaults)
 TRANSPORT=http
 HOST=0.0.0.0
 PORT=3000

--- a/.mcp.json
+++ b/.mcp.json
@@ -30,12 +30,12 @@
       ]
     },
     "workflow-server": {
-      "command": "node",
+      "command": "npx",
       "args": [
-        "${workspaceFolder}/dist/index.js",
-        "--transport=stdio"
-      ],
-      "envFile": "${workspaceFolder}/.env"
+        "-y",
+        "mcp-remote",
+        "${env:WORKFLOW_SERVER_MCP_URL}"
+      ]
     },
     "gitnexus": {
       "command": "/usr/local/bin/gitnexus",

--- a/.mcp.json
+++ b/.mcp.json
@@ -17,8 +17,8 @@
     "concept-rag": {
       "command": "node",
       "args": [
-        "/home/mike1/projects/main/concept-rag/dist/conceptual_index.js",
-        "/home/mike1/.concept_rag"
+        "${env:CONCEPT_RAG_ENTRY}",
+        "${env:CONCEPT_RAG_INDEX}"
       ]
     },
     "atlassian": {
@@ -31,10 +31,11 @@
     },
     "workflow-server": {
       "command": "node",
-      "args": ["/home/mike1/projects/main/workflow-server/dist/index.js"],
-      "env": {
-        "WORKFLOW_WORKSPACE": "/home/mike1/projects/main/workflow-server"
-      }
+      "args": [
+        "${workspaceFolder}/dist/index.js",
+        "--transport=stdio"
+      ],
+      "envFile": "${workspaceFolder}/.env"
     },
     "gitnexus": {
       "command": "/usr/local/bin/gitnexus",

--- a/SETUP.md
+++ b/SETUP.md
@@ -147,6 +147,21 @@ Typical sequence:
 
 Container layout: see [`Dockerfile`](Dockerfile) and [`docker-compose.yml`](docker-compose.yml). Bind the host worktree root RW to `WORKTREE_ROOT` (default `/worktrees`). Planning paths derive under that root. Align container UID/GID with the host user that creates worktrees.
 
+Compose bind sources and in-container paths are environment variables (defaults preserve the previous layout). Copy [`.env.example`](.env.example) to `.env` or export the vars before `docker compose up`:
+
+| Variable | Default | Role |
+|----------|---------|------|
+| `HOST_WORKTREE_ROOT` | `/var/worktrees` | Host path bound RW as the worktree root |
+| `HOST_WORKFLOWS_DIR` | `./workflows` | Host path bound RO for workflow definitions |
+| `HOST_SCHEMAS_DIR` | `./schemas` | Host path bound RO for JSON schemas |
+| `HOST_PORT` | `3000` | Host port published to the container |
+| `WORKTREE_ROOT` | `/worktrees` | In-container worktree root (volume target + server env) |
+| `WORKFLOW_DIR` | `/app/workflows` | In-container workflows path (volume target + server env) |
+| `SCHEMAS_DIR` | `/app/schemas` | In-container schemas path (volume target + server env) |
+| `PORT` / `HOST` / `TRANSPORT` | `3000` / `0.0.0.0` / `http` | Server listen settings inside the container |
+
+Keep each `HOST_*` source paired with the matching in-container target (`WORKTREE_ROOT`, `WORKFLOW_DIR`, `SCHEMAS_DIR`) so binds and server env stay aligned.
+
 Operator migration checklist:
 
 - Supply a required root via `--workspace` / `WORKFLOW_WORKSPACE` / `WORKTREE_ROOT`.

--- a/SETUP.md
+++ b/SETUP.md
@@ -27,26 +27,53 @@ npm run build
 
 ## MCP Client Configuration
 
+Paths are **not** hardcoded in the repo MCP configs. Project files [`.cursor/mcp.json`](.cursor/mcp.json) and [`.mcp.json`](.mcp.json) start the server via stdio and load a local `.env` (`envFile`). Create that file once per machine:
+
+```bash
+# From the workflow-server checkout
+cp .env.example .env          # optional; init script seeds if missing
+./scripts/init-local-env.sh  # fills absolute paths for this checkout
+# optional: ./scripts/init-local-env.sh --workspace=/path/to/worktree-root
+npm run build
+```
+
+Then restart the MCP client so it reloads `envFile`.
+
+| Variable | Required | Role |
+|----------|----------|------|
+| `WORKFLOW_WORKSPACE` | yes* | Worktree / workspace root (`WORKTREE_ROOT` is an accepted alias) |
+| `WORKFLOW_DIR` | no | Workflows directory (default `./workflows` under the install root) |
+| `SCHEMAS_DIR` | no | Schemas directory (default `./schemas`) |
+| `CONCEPT_RAG_ENTRY` / `CONCEPT_RAG_INDEX` | only if using concept-rag in `.mcp.json` | Paths passed as concept-rag `args` |
+
+\* One of `WORKFLOW_WORKSPACE`, `WORKTREE_ROOT`, or CLI `--workspace` is required.
+
 ### Cursor
 
-Edit `~/.cursor/mcp.json`:
+Prefer the project config (checked in):
+
+- [`.cursor/mcp.json`](.cursor/mcp.json) — uses `${workspaceFolder}/dist/index.js` and `envFile: ${workspaceFolder}/.env`
+
+Global override (optional) at `~/.cursor/mcp.json`:
 
 ```json
 {
   "mcpServers": {
     "workflow-server": {
       "command": "node",
-      "args": [
-        "/path/to/workflow-server/dist/index.js",
-        "--workspace=/path/to/worktree-root",
-        "--workflow-dir=/path/to/workflow-server/workflows"
-      ]
+      "args": ["${env:WORKFLOW_SERVER_ENTRY}"],
+      "env": {
+        "WORKFLOW_WORKSPACE": "${env:WORKFLOW_WORKSPACE}",
+        "WORKFLOW_DIR": "${env:WORKFLOW_DIR}"
+      }
     }
   }
 }
 ```
 
-IDE MCP clients use the default **stdio** transport. For HTTP, see [HTTP transport](#http-transport) below.
+Set those shell env vars in your profile (or export them before launching Cursor from a terminal). Cursor expands `${env:NAME}` and supports `envFile` for stdio servers.
+
+IDE MCP clients use the default **stdio** transport. For HTTP (e.g. `mcp-remote` → `http://127.0.0.1:3000/mcp`), start the server separately with the same `.env` / compose layout; see [HTTP transport](#http-transport) below.
 
 ### Claude Desktop
 
@@ -54,16 +81,18 @@ IDE MCP clients use the default **stdio** transport. For HTTP, see [HTTP transpo
 
 **Windows**: Edit `%APPDATA%\Claude\claude_desktop_config.json`
 
+Claude Desktop does not always support `envFile` / `${workspaceFolder}`. Point at the built entry and pass the same values from your shell environment (or hardcode absolute paths only in the local desktop config, not in the repo):
+
 ```json
 {
   "mcpServers": {
     "workflow-server": {
       "command": "node",
-      "args": [
-        "/path/to/workflow-server/dist/index.js",
-        "--workspace=/path/to/worktree-root",
-        "--workflow-dir=/path/to/workflow-server/workflows"
-      ]
+      "args": ["/path/to/workflow-server/dist/index.js"],
+      "env": {
+        "WORKFLOW_WORKSPACE": "/path/to/worktree-root",
+        "WORKFLOW_DIR": "/path/to/workflow-server/workflows"
+      }
     }
   }
 }
@@ -147,7 +176,7 @@ Typical sequence:
 
 Container layout: see [`Dockerfile`](Dockerfile) and [`docker-compose.yml`](docker-compose.yml). Bind the host worktree root RW to `WORKTREE_ROOT` (default `/worktrees`). Planning paths derive under that root. Align container UID/GID with the host user that creates worktrees.
 
-Compose bind sources and in-container paths are environment variables (defaults preserve the previous layout). Copy [`.env.example`](.env.example) to `.env` or export the vars before `docker compose up`:
+Compose bind sources and in-container paths are environment variables (defaults preserve the previous layout). Use the same local `.env` as MCP (`./scripts/init-local-env.sh`) or export the vars before `docker compose up`:
 
 | Variable | Default | Role |
 |----------|---------|------|
@@ -155,12 +184,12 @@ Compose bind sources and in-container paths are environment variables (defaults 
 | `HOST_WORKFLOWS_DIR` | `./workflows` | Host path bound RO for workflow definitions |
 | `HOST_SCHEMAS_DIR` | `./schemas` | Host path bound RO for JSON schemas |
 | `HOST_PORT` | `3000` | Host port published to the container |
-| `WORKTREE_ROOT` | `/worktrees` | In-container worktree root (volume target + server env) |
-| `WORKFLOW_DIR` | `/app/workflows` | In-container workflows path (volume target + server env) |
-| `SCHEMAS_DIR` | `/app/schemas` | In-container schemas path (volume target + server env) |
+| `CONTAINER_WORKTREE_ROOT` | `/worktrees` | In-container worktree root (volume target + server `WORKTREE_ROOT`) |
+| `CONTAINER_WORKFLOW_DIR` | `/app/workflows` | In-container workflows path (volume target + server `WORKFLOW_DIR`) |
+| `CONTAINER_SCHEMAS_DIR` | `/app/schemas` | In-container schemas path (volume target + server `SCHEMAS_DIR`) |
 | `PORT` / `HOST` / `TRANSPORT` | `3000` / `0.0.0.0` / `http` | Server listen settings inside the container |
 
-Keep each `HOST_*` source paired with the matching in-container target (`WORKTREE_ROOT`, `WORKFLOW_DIR`, `SCHEMAS_DIR`) so binds and server env stay aligned.
+Host MCP vars (`WORKFLOW_WORKSPACE`, `WORKFLOW_DIR`, `SCHEMAS_DIR`) are separate from `CONTAINER_*` so one `.env` can drive both stdio MCP and compose without path clashes. Keep each `HOST_*` source paired with the matching `CONTAINER_*` target.
 
 Operator migration checklist:
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -27,76 +27,51 @@ npm run build
 
 ## MCP Client Configuration
 
-Paths are **not** hardcoded in the repo MCP configs. Project files [`.cursor/mcp.json`](.cursor/mcp.json) and [`.mcp.json`](.mcp.json) start the server via stdio and load a local `.env` (`envFile`). Create that file once per machine:
+Project MCP configs keep the **HTTP + mcp-remote** client shape. Paths and the endpoint URL come from environment variables (`${env:NAME}`), not hardcoded machine paths.
+
+[`.cursor/mcp.json`](.cursor/mcp.json) / [`.mcp.json`](.mcp.json):
+
+```json
+{
+  "mcpServers": {
+    "workflow-server": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "${env:WORKFLOW_SERVER_MCP_URL}"]
+    }
+  }
+}
+```
+
+### One-time local init
 
 ```bash
 # From the workflow-server checkout
-cp .env.example .env          # optional; init script seeds if missing
-./scripts/init-local-env.sh  # fills absolute paths for this checkout
+./scripts/init-local-env.sh
 # optional: ./scripts/init-local-env.sh --workspace=/path/to/worktree-root
-npm run build
-```
 
-Then restart the MCP client so it reloads `envFile`.
+# Cursor expands ${env:NAME} from the IDE process environment — export before launch:
+set -a && source .env && set +a
+# then start Cursor from that shell, or put the same exports in your profile / desktop env
+```
 
 | Variable | Required | Role |
 |----------|----------|------|
-| `WORKFLOW_WORKSPACE` | yes* | Worktree / workspace root (`WORKTREE_ROOT` is an accepted alias) |
-| `WORKFLOW_DIR` | no | Workflows directory (default `./workflows` under the install root) |
-| `SCHEMAS_DIR` | no | Schemas directory (default `./schemas`) |
+| `WORKFLOW_SERVER_MCP_URL` | yes (for MCP client) | HTTP MCP endpoint, default `http://127.0.0.1:3000/mcp` |
+| `WORKFLOW_WORKSPACE` | yes* (for the **server** process) | Worktree / workspace root (`WORKTREE_ROOT` alias ok) |
+| `WORKFLOW_DIR` / `SCHEMAS_DIR` | no | Host paths for workflows/schemas when starting the server |
 | `CONCEPT_RAG_ENTRY` / `CONCEPT_RAG_INDEX` | only if using concept-rag in `.mcp.json` | Paths passed as concept-rag `args` |
 
-\* One of `WORKFLOW_WORKSPACE`, `WORKTREE_ROOT`, or CLI `--workspace` is required.
+\* Required by the workflow-server process (compose or `npm run start:http`), not by `mcp-remote` itself.
 
-### Cursor
-
-Prefer the project config (checked in):
-
-- [`.cursor/mcp.json`](.cursor/mcp.json) — uses `${workspaceFolder}/dist/index.js` and `envFile: ${workspaceFolder}/.env`
-
-Global override (optional) at `~/.cursor/mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "workflow-server": {
-      "command": "node",
-      "args": ["${env:WORKFLOW_SERVER_ENTRY}"],
-      "env": {
-        "WORKFLOW_WORKSPACE": "${env:WORKFLOW_WORKSPACE}",
-        "WORKFLOW_DIR": "${env:WORKFLOW_DIR}"
-      }
-    }
-  }
-}
-```
-
-Set those shell env vars in your profile (or export them before launching Cursor from a terminal). Cursor expands `${env:NAME}` and supports `envFile` for stdio servers.
-
-IDE MCP clients use the default **stdio** transport. For HTTP (e.g. `mcp-remote` → `http://127.0.0.1:3000/mcp`), start the server separately with the same `.env` / compose layout; see [HTTP transport](#http-transport) below.
+Start the HTTP server (compose or local) before the IDE connects — see [HTTP transport](#http-transport) and the compose env table below.
 
 ### Claude Desktop
 
-**macOS**: Edit `~/Library/Application Support/Claude/claude_desktop_config.json`
+**macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
 
-**Windows**: Edit `%APPDATA%\Claude\claude_desktop_config.json`
+**Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
 
-Claude Desktop does not always support `envFile` / `${workspaceFolder}`. Point at the built entry and pass the same values from your shell environment (or hardcode absolute paths only in the local desktop config, not in the repo):
-
-```json
-{
-  "mcpServers": {
-    "workflow-server": {
-      "command": "node",
-      "args": ["/path/to/workflow-server/dist/index.js"],
-      "env": {
-        "WORKFLOW_WORKSPACE": "/path/to/worktree-root",
-        "WORKFLOW_DIR": "/path/to/workflow-server/workflows"
-      }
-    }
-  }
-}
-```
+Same `npx mcp-remote` args with `${env:WORKFLOW_SERVER_MCP_URL}` if the client expands env vars; otherwise paste the absolute URL from your `.env`.
 
 ## IDE Rules Setup
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@
 # Paths are overridable via environment variables or a local `.env` file
 # (see `.env.example`). Defaults match the previous fixed layout.
 #
+# Host-side MCP vars (WORKFLOW_WORKSPACE, WORKFLOW_DIR, …) are separate from
+# CONTAINER_* paths so a shared `.env` can drive both stdio MCP and compose.
+#
 # UID/GID: run the container as the same user that owns host worktrees
 # (user: "${UID}:${GID}") so writes into the RW bind succeed.
 services:
@@ -12,25 +15,25 @@ services:
     ports:
       - "${HOST_PORT:-3000}:${PORT:-3000}"
     environment:
-      WORKTREE_ROOT: ${WORKTREE_ROOT:-/worktrees}
+      WORKTREE_ROOT: ${CONTAINER_WORKTREE_ROOT:-/worktrees}
       # Optional: override default .engineering/artifacts/planning
       # PLANNING_SLUG: .engineering/planning
-      WORKFLOW_DIR: ${WORKFLOW_DIR:-/app/workflows}
-      SCHEMAS_DIR: ${SCHEMAS_DIR:-/app/schemas}
+      WORKFLOW_DIR: ${CONTAINER_WORKFLOW_DIR:-/app/workflows}
+      SCHEMAS_DIR: ${CONTAINER_SCHEMAS_DIR:-/app/schemas}
       TRANSPORT: ${TRANSPORT:-http}
       HOST: ${HOST:-0.0.0.0}
       PORT: ${PORT:-3000}
     volumes:
       - type: bind
         source: ${HOST_WORKFLOWS_DIR:-./workflows}
-        target: ${WORKFLOW_DIR:-/app/workflows}
+        target: ${CONTAINER_WORKFLOW_DIR:-/app/workflows}
         read_only: true
       - type: bind
         source: ${HOST_SCHEMAS_DIR:-./schemas}
-        target: ${SCHEMAS_DIR:-/app/schemas}
+        target: ${CONTAINER_SCHEMAS_DIR:-/app/schemas}
         read_only: true
       # Worktree root: agent creates worktrees here on the host
       - type: bind
         source: ${HOST_WORKTREE_ROOT:-/var/worktrees}
-        target: ${WORKTREE_ROOT:-/worktrees}
+        target: ${CONTAINER_WORKTREE_ROOT:-/worktrees}
         read_only: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,33 +1,36 @@
 # Host worktree root is bound RW; the server derives planning paths under it.
 # Agents create worktrees on the host before the server writes artifacts.
 #
+# Paths are overridable via environment variables or a local `.env` file
+# (see `.env.example`). Defaults match the previous fixed layout.
+#
 # UID/GID: run the container as the same user that owns host worktrees
 # (user: "${UID}:${GID}") so writes into the RW bind succeed.
 services:
   workflow-server:
     build: .
     ports:
-      - "3000:3000"
+      - "${HOST_PORT:-3000}:${PORT:-3000}"
     environment:
-      WORKTREE_ROOT: /worktrees
+      WORKTREE_ROOT: ${WORKTREE_ROOT:-/worktrees}
       # Optional: override default .engineering/artifacts/planning
       # PLANNING_SLUG: .engineering/planning
-      WORKFLOW_DIR: /app/workflows
-      SCHEMAS_DIR: /app/schemas
-      TRANSPORT: http
-      HOST: 0.0.0.0
-      PORT: "3000"
+      WORKFLOW_DIR: ${WORKFLOW_DIR:-/app/workflows}
+      SCHEMAS_DIR: ${SCHEMAS_DIR:-/app/schemas}
+      TRANSPORT: ${TRANSPORT:-http}
+      HOST: ${HOST:-0.0.0.0}
+      PORT: ${PORT:-3000}
     volumes:
       - type: bind
-        source: ./workflows
-        target: /app/workflows
+        source: ${HOST_WORKFLOWS_DIR:-./workflows}
+        target: ${WORKFLOW_DIR:-/app/workflows}
         read_only: true
       - type: bind
-        source: ./schemas
-        target: /app/schemas
+        source: ${HOST_SCHEMAS_DIR:-./schemas}
+        target: ${SCHEMAS_DIR:-/app/schemas}
         read_only: true
       # Worktree root: agent creates worktrees here on the host
       - type: bind
         source: ${HOST_WORKTREE_ROOT:-/var/worktrees}
-        target: /worktrees
+        target: ${WORKTREE_ROOT:-/worktrees}
         read_only: false

--- a/scripts/init-local-env.sh
+++ b/scripts/init-local-env.sh
@@ -28,7 +28,7 @@ Usage: $(basename "$0") [options]
   --force            Overwrite an existing .env from .env.example first
   -h, --help         Show this help
 
-Writes ${ENV_FILE} with absolute paths for MCP stdio and docker compose.
+Writes ${ENV_FILE} with absolute paths for the HTTP server, mcp-remote URL, and docker compose.
 EOF
 }
 
@@ -77,6 +77,7 @@ WORKFLOWS_ABS="${ROOT}/workflows"
 SCHEMAS_ABS="${ROOT}/schemas"
 WORKSPACE_ABS="$(cd "${WORKSPACE_DEFAULT}" && pwd)"
 
+upsert WORKFLOW_SERVER_MCP_URL "http://127.0.0.1:3000/mcp"
 upsert WORKFLOW_WORKSPACE "${WORKSPACE_ABS}"
 upsert WORKFLOW_DIR "${WORKFLOWS_ABS}"
 upsert SCHEMAS_DIR "${SCHEMAS_ABS}"
@@ -100,13 +101,14 @@ if [[ -z "${CONCEPT_RAG_INDEX:-}" && -d "${HOME}/.concept_rag" ]]; then
 fi
 
 echo "Wrote local env → ${ENV_FILE}"
+echo "  WORKFLOW_SERVER_MCP_URL=http://127.0.0.1:3000/mcp"
 echo "  WORKFLOW_WORKSPACE=${WORKSPACE_ABS}"
 echo "  WORKFLOW_DIR=${WORKFLOWS_ABS}"
 echo "  SCHEMAS_DIR=${SCHEMAS_ABS}"
 echo "  HOST_WORKTREE_ROOT=${WORKSPACE_ABS}"
 echo
 echo "Next:"
-echo "  1. npm run build"
-echo "  2. Restart Cursor / Claude so MCP reloads envFile"
-echo "  3. (optional) docker compose up --build"
+echo "  1. set -a && source .env && set +a   # export into shell / Cursor launch env"
+echo "  2. Start HTTP server: docker compose up --build   # or npm run start:http"
+echo "  3. Restart Cursor so \${env:WORKFLOW_SERVER_MCP_URL} resolves"
 echo "  4. Ask the agent to list available workflows"

--- a/scripts/init-local-env.sh
+++ b/scripts/init-local-env.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Create or refresh a local `.env` with absolute paths for this checkout.
+# Safe to re-run: preserves unknown keys; overwrites known path keys with
+# values derived from the repo root (and optional flags).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ROOT}/.env"
+EXAMPLE="${ROOT}/.env.example"
+
+# Default worktree root: parent of the repo if it looks like a work area,
+# otherwise the repo itself. Override with --workspace=PATH.
+WORKSPACE_DEFAULT="${WORKFLOW_WORKSPACE:-}"
+if [[ -z "${WORKSPACE_DEFAULT}" ]]; then
+  parent="$(dirname "${ROOT}")"
+  if [[ "$(basename "${parent}")" == "main" ]] && [[ -d "$(dirname "${parent}")/work" ]]; then
+    WORKSPACE_DEFAULT="$(cd "$(dirname "${parent}")/work" && pwd)"
+  else
+    WORKSPACE_DEFAULT="${ROOT}"
+  fi
+fi
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+
+  --workspace=PATH   Worktree / workspace root (WORKFLOW_WORKSPACE / HOST_WORKTREE_ROOT)
+  --force            Overwrite an existing .env from .env.example first
+  -h, --help         Show this help
+
+Writes ${ENV_FILE} with absolute paths for MCP stdio and docker compose.
+EOF
+}
+
+FORCE=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workspace=*) WORKSPACE_DEFAULT="${1#*=}"; shift ;;
+    --workspace) WORKSPACE_DEFAULT="${2:?}"; shift 2 ;;
+    --force) FORCE=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [[ ! -f "${EXAMPLE}" ]]; then
+  echo "Missing ${EXAMPLE}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${ENV_FILE}" || "${FORCE}" -eq 1 ]]; then
+  cp "${EXAMPLE}" "${ENV_FILE}"
+  echo "Seeded ${ENV_FILE} from .env.example"
+fi
+
+# Upsert KEY=value in .env (replace existing assignment or append).
+upsert() {
+  local key="$1" value="$2"
+  local tmp
+  tmp="$(mktemp)"
+  if grep -qE "^${key}=" "${ENV_FILE}"; then
+    # shellcheck disable=SC2016
+    awk -v k="${key}" -v v="${value}" '
+      BEGIN { done=0 }
+      $0 ~ "^" k "=" { print k "=" v; done=1; next }
+      { print }
+      END { if (!done) print k "=" v }
+    ' "${ENV_FILE}" >"${tmp}"
+  else
+    cat "${ENV_FILE}" >"${tmp}"
+    printf '%s=%s\n' "${key}" "${value}" >>"${tmp}"
+  fi
+  mv "${tmp}" "${ENV_FILE}"
+}
+
+WORKFLOWS_ABS="${ROOT}/workflows"
+SCHEMAS_ABS="${ROOT}/schemas"
+WORKSPACE_ABS="$(cd "${WORKSPACE_DEFAULT}" && pwd)"
+
+upsert WORKFLOW_WORKSPACE "${WORKSPACE_ABS}"
+upsert WORKFLOW_DIR "${WORKFLOWS_ABS}"
+upsert SCHEMAS_DIR "${SCHEMAS_ABS}"
+upsert HOST_WORKTREE_ROOT "${WORKSPACE_ABS}"
+upsert HOST_WORKFLOWS_DIR "${WORKFLOWS_ABS}"
+upsert HOST_SCHEMAS_DIR "${SCHEMAS_ABS}"
+upsert HOST_PORT "3000"
+upsert CONTAINER_WORKTREE_ROOT "/worktrees"
+upsert CONTAINER_WORKFLOW_DIR "/app/workflows"
+upsert CONTAINER_SCHEMAS_DIR "/app/schemas"
+upsert TRANSPORT "http"
+upsert HOST "0.0.0.0"
+upsert PORT "3000"
+
+# Optional concept-rag defaults if the conventional paths exist.
+if [[ -z "${CONCEPT_RAG_ENTRY:-}" && -f "${HOME}/projects/main/concept-rag/dist/conceptual_index.js" ]]; then
+  upsert CONCEPT_RAG_ENTRY "${HOME}/projects/main/concept-rag/dist/conceptual_index.js"
+fi
+if [[ -z "${CONCEPT_RAG_INDEX:-}" && -d "${HOME}/.concept_rag" ]]; then
+  upsert CONCEPT_RAG_INDEX "${HOME}/.concept_rag"
+fi
+
+echo "Wrote local env → ${ENV_FILE}"
+echo "  WORKFLOW_WORKSPACE=${WORKSPACE_ABS}"
+echo "  WORKFLOW_DIR=${WORKFLOWS_ABS}"
+echo "  SCHEMAS_DIR=${SCHEMAS_ABS}"
+echo "  HOST_WORKTREE_ROOT=${WORKSPACE_ABS}"
+echo
+echo "Next:"
+echo "  1. npm run build"
+echo "  2. Restart Cursor / Claude so MCP reloads envFile"
+echo "  3. (optional) docker compose up --build"
+echo "  4. Ask the agent to list available workflows"


### PR DESCRIPTION
## Summary
- Make docker-compose bind sources and in-container paths configurable via env vars (`HOST_WORKTREE_ROOT`, `HOST_WORKFLOWS_DIR`, `HOST_SCHEMAS_DIR`, `HOST_PORT`, `WORKTREE_ROOT`, `WORKFLOW_DIR`, `SCHEMAS_DIR`, plus transport settings).
- Defaults match the previous fixed layout so existing deploys keep working with no `.env`.
- Add `.env.example` and document the variables in `SETUP.md`.

## Test plan
- [x] `docker compose config` resolves defaults to the previous paths (`./workflows` → `/app/workflows`, `/var/worktrees` → `/worktrees`, port 3000).
- [ ] Optionally set custom `HOST_*` / path vars in `.env` and confirm `docker compose config` reflects them.
- [ ] `docker compose up --build` still starts HTTP on the published port with default env.