### PR TITLE
ci: skip submodules in docker-publish checkout

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,9 +26,11 @@ jobs:
 
     steps:
       - name: Checkout repository
+        # No submodules: .engineering nests a private ai-metadata repo that CI
+        # cannot clone, and the Docker image only needs src/schemas/package files.
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
-          submodules: recursive
+          submodules: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Failed run: https://github.com/m2ux/workflow-server/actions/runs/30021933073/job/89256599661
- Root cause: `actions/checkout` with `submodules: recursive` tried to clone `.engineering/history` → private/missing `m2ux/ai-metadata`.
- Fix: set `submodules: false`. Docker image only needs `src/`, `schemas/`, and package files from the main tree.

## Test plan
- [ ] PR workflow **Build and Publish Docker Image** gets past Checkout
- [ ] After merge, push to GHCR succeeds for `:main`