### PR TITLE
ci: pin codeql-action/upload-sarif to v3

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -125,7 +125,9 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload scan results
-        uses: github/codeql-action/upload-sarif@8dca8a82e2fa1a2c8908956f711300f9c4a4f4f6
+        # Pinned to codeql-action v3.37.3 (v1/v2 upload-sarif are deprecated).
+        # Moving pin: refs/tags/v3 → 4187e74 (2026-07-22).
+        uses: github/codeql-action/upload-sarif@4187e74d05793876e9989daffde9c3e66b4acd07 # v3.37.3
         if: github.event_name != 'pull_request' && always()
         continue-on-error: true
         with:


### PR DESCRIPTION
## Summary
- CI warning/error: CodeQL Action major versions v1 and v2 are deprecated; upload-sarif must use v3+.
- Bump `github/codeql-action/upload-sarif` pin from `8dca8a82…` (legacy) to `4187e74d…` (**v3.37.3**, current `refs/tags/v3`).
- Trivy action pin unchanged (`57a97c7e…`).

## Test plan
- [ ] After merge, **Build and Publish Docker Image** SARIF upload step no longer reports CodeQL v1/v2 deprecation error
- [ ] Node 20 deprecation notice may still appear from other actions (separate follow-up if desired)