### PR TITLE
fix(bootstrap): surface multi-root repo binding before promotion

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -24,15 +24,15 @@ Most tools take a `session_index` from `start_session`. Bootstrap tools do not. 
 
 | Tool | Parameters | Returns | Description |
 |------|------------|---------|-------------|
-| `discover` | — | Server info, bootstrap stub | First call: how to start a session. |
+| `discover` | — | Server info, `session_scope`, bootstrap stub | First call: how to start a session. When `session_scope` is `multi`, pass `repo` on `start_session`. |
 | `list_workflows` | — | Workflow list (`id`, `title`, `version`, `tags`) | Catalog of available workflows. |
-| `health_check` | — | Status, version, workflow count, uptime | Process health. |
+| `health_check` | — | Status, version, workflow count, uptime, `session_scope` | Process health and binding mode. |
 
 ### Session
 
 | Tool | Parameters | Returns | Description |
 |------|------------|---------|-------------|
-| `start_session` | `agent_id`, `workflow_id?`, `planning_folder?`, `context_mode?` | `session_index`, planning path, workflow info | Open or resume a top-level session (default workflow: `meta`). [State](state_management_model.md) · [Reference delivery](resource_resolution_model.md#11-reference-delivery) |
+| `start_session` | `agent_id`, `workflow_id?`, `planning_folder?`, `repo?`, `context_mode?` | `session_index`, planning path, workflow info, `session_scope`, optional `repo` / `promotion_requires_repo` | Open or resume a top-level session (default workflow: `meta`). On install multi-root pass `repo: "owner/repo"` (from user or workspace `AGENTS.md`). [State](state_management_model.md) · [Reference delivery](resource_resolution_model.md#11-reference-delivery) |
 | `dispatch_child` | `session_index`, `workflow_id`, `agent_id?`, `planning_slug?`, `context_mode?` | Child `session_index` | Start a nested workflow under the current session. [Dispatch](dispatch_model.md) |
 | `get_workflow_status` | `session_index` | Status, current/completed activities, checkpoint hint | Snapshot of where the session is. |
 | `inspect_session` | `session_index`, `view?`, `child_index?`, `variable?` | Compact projection | Read-only view of session state (usable while blocked). |

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -19,7 +19,8 @@ The rule wires natural-language requests ("start a work package", "resume the wo
 `discover` returns:
 
 - **Server name and version** — confirms which workflow server the agent is talking to.
-- **Bootstrap procedure** — the pre-session stub the agent must follow: fetch `workflow-server://schemas/workflow`, call `start_session`, then `get_workflow` and follow the returned operations bundle. Activity dispatch (`next_activity` / `get_activity`) and checkpoint discipline come from that bundle, not from the stub itself. `list_workflows` is available without a session and is typically used during meta `discover-session`, not as a required bootstrap step.
+- **`session_scope`** — `single` or `multi`. When `multi` (install multi-root), the agent must pass `repo: "owner/repo"` on `start_session` (from the user or workspace `AGENTS.md` / `CLAUDE.md`) so transient meta can promote under `engineering/<owner>/<repo>/`.
+- **Bootstrap procedure** — the pre-session stub the agent must follow: fetch `workflow-server://schemas/workflow`, bind `repo` when multi-root, call `start_session`, then `get_workflow` and follow the returned operations bundle. Activity dispatch (`next_activity` / `get_activity`) and checkpoint discipline come from that bundle, not from the stub itself. `list_workflows` is available without a session and is typically used during meta `discover-session`, not as a required bootstrap step.
 
 Because `discover` is the entry point, the procedure stays in sync with the server. You do not need to maintain a separate copy of the protocol in your IDE rules — the rule above only has to enforce "call `discover` first." Ongoing delivery policy (worker-fresh, resource `#section` vs whole file, force-full escapes) is authoritative in techniques delivered with the operations bundle after `get_workflow`.
 
@@ -41,7 +42,7 @@ After configuring the rule:
 
 1. Restart your MCP client.
 2. Ask the agent to `list available workflows`. It should call `list_workflows` (no session token required) and return the workflow inventory.
-3. Ask the agent to `start a work-package workflow`. It should first call `discover`, then complete the returned bootstrap (schema fetch → `start_session` → `get_workflow`).
+3. Ask the agent to `start a work-package workflow`. It should first call `discover`, then complete the returned bootstrap (schema fetch → multi-root `repo` if needed → `start_session` → `get_workflow`).
 
 If the agent skips `discover`, your rule has not been picked up — re-check the IDE's rule configuration.
 

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -1,10 +1,8 @@
 # Workflow Server IDE Setup
 
-This guide explains how to configure your IDE so that the agent connects to the workflow server correctly on every workflow request.
+## Bootstrap rule
 
-## Bootstrap Rule
-
-Add the following to your IDE's "always-applied" rule set (Cursor rule, Claude Code project rule, etc.):
+Add this to your IDE's always-applied rules (Cursor rule, Claude Code project rule, etc.):
 
 ```
 For any start workflow, create work package, or resume work package request, call the `discover` tool on the workflow-server MCP server to learn the bootstrap procedure. Complete the procedure before any other action.
@@ -12,48 +10,21 @@ For any start workflow, create work package, or resume work package request, cal
 If the user provides a `session_token`, pass it to subsequent workflow-server calls per their instructions.
 ```
 
-The rule wires natural-language requests ("start a work package", "resume the workflow", "begin a workflow") into the server's bootstrap procedure. The agent always calls `discover` first — which returns the server name, version, and the full bootstrap sequence — before doing anything else.
+That is enough. `discover` returns the live bootstrap steps (schema fetch → `start_session` → `get_workflow`). Do not copy the protocol into IDE rules.
 
-## What the Bootstrap Returns
+When `discover` reports `session_scope: multi`, pass `repo: "owner/repo"` on `start_session` (from the user or workspace `AGENTS.md` / `CLAUDE.md`).
 
-`discover` returns:
+## Verify
 
-- **Server name and version** — confirms which workflow server the agent is talking to.
-- **`session_scope`** — `single` or `multi`. When `multi` (install multi-root), the agent must pass `repo: "owner/repo"` on `start_session` (from the user or workspace `AGENTS.md` / `CLAUDE.md`) so transient meta can promote under `engineering/<owner>/<repo>/`.
-- **Bootstrap procedure** — the pre-session stub the agent must follow: fetch `workflow-server://schemas/workflow`, bind `repo` when multi-root, call `start_session`, then `get_workflow` and follow the returned operations bundle. Activity dispatch (`next_activity` / `get_activity`) and checkpoint discipline come from that bundle, not from the stub itself. `list_workflows` is available without a session and is typically used during meta `discover-session`, not as a required bootstrap step.
+1. Restart the MCP client.
+2. Ask to list workflows → `list_workflows`.
+3. Ask to start a work-package → `discover`, then the returned bootstrap (include `repo` when multi-root).
 
-Because `discover` is the entry point, the procedure stays in sync with the server. You do not need to maintain a separate copy of the protocol in your IDE rules — the rule above only has to enforce "call `discover` first." Ongoing delivery policy (worker-fresh, resource `#section` vs whole file, force-full escapes) is authoritative in techniques delivered with the operations bundle after `get_workflow`.
-
-## Delivery Context and Worker Parameters
-
-Two session-shaping choices affect how much content the server delivers and how it is sized. Both are decided by your execution topology.
-
-- **`context_mode` (on `start_session` / `dispatch_child`).** Declares the session's delivery context model. The default (omit, or `"fresh"`) delivers full content on every call and is correct whenever activities are dispatched to spawned workers — each worker is a fresh context that relies on the repeated delivery. Pass `context_mode: "persistent"` **only** when a single agent context executes the whole session itself (no worker spawning): already-delivered bundle, technique, and resource content then arrives as `{ delivery: "unchanged", content_hash }` references instead of being repeated, and `get_activity { bundle: "full" }` / `get_technique { full: true }` / `get_resource { full: true }` re-fetch anything that context no longer holds.
-- **`agent_id` (on `start_session` / `dispatch_child`).** Names the agent whose delivery ledger the server keys against. In a solo/persistent session use one canonical `agent_id` for the whole walk so reference delivery collapses correctly; resuming under a different `agent_id` starts that agent from an empty ledger (its first deliveries are full).
-- **`context_tokens` (REQUIRED on `get_activity`).** The worker declares its own context window in tokens on its activity-fetch entry call. The server derives an eager step-technique bundling budget from it (availability headroom × a token→char factor, both server config) and inlines the activity's ungated step-bound techniques that fit under that budget; the rest stay lazy via `get_technique`. It is per-agent and per-call — never stored on the session, never defaulted. **Omitting `context_tokens` on `get_activity` is a validation error.** `get_workflow` does no technique bundling and takes no `context_tokens`.
-
-## Schema Awareness (Optional)
-
-The server also exposes the JSON Schemas for `workflow`, `activity`, `technique`, `condition`, and `state` via an MCP resource at `workflow-server://schemas`. Agents that want to author or validate workflow definitions locally can fetch this resource on startup. See [schemas/README.md](../schemas/README.md) for the schema reference.
-
-## Verifying the Connection
-
-After configuring the rule:
-
-1. Restart your MCP client.
-2. Ask the agent to `list available workflows`. It should call `list_workflows` (no session token required) and return the workflow inventory.
-3. Ask the agent to `start a work-package workflow`. It should first call `discover`, then complete the returned bootstrap (schema fetch → multi-root `repo` if needed → `start_session` → `get_workflow`).
-
-If the agent skips `discover`, your rule has not been picked up — re-check the IDE's rule configuration.
+If the agent skips `discover`, the rule is not loaded.
 
 ## Related
 
-- [README.md](../README.md) — project overview and quick-start.
-- [setup.md](../setup.md) — install sequence (transport, init-repo, IDE rule, day-two).
-- [examples/cursor-workspace/](../examples/cursor-workspace/) — copyable Cursor multi-root workspace.
-- [http.md](../http.md) — Docker / HTTP transport only.
-- [stdio.md](../stdio.md) — local checkout / stdio transport only.
-- [Development Guide](development.md) — env vars and process flags (developers).
-- [API Reference](api-reference.md) — tool catalog (links out for depth).
-- [Site API](../site/api/tools.html) — wire descriptions generated from source.
-- [Workflow Fidelity](workflow-fidelity.md) — enforcement layers and what the bootstrap procedure protects against.
+- [setup.md](../setup.md) — install
+- [examples/cursor-workspace/](../examples/cursor-workspace/) — Cursor multi-root template
+- [http.md](../http.md) / [stdio.md](../stdio.md) — transports
+- [api-reference.md](api-reference.md) — tools (`context_mode`, `context_tokens`, schemas)

--- a/examples/cursor-workspace/.claude/rules/workflow-server.md
+++ b/examples/cursor-workspace/.claude/rules/workflow-server.md
@@ -4,4 +4,6 @@ description: Workflow server integration
 
 For any start workflow or create or resume work package request, call the `discover` tool on the workflow-server MCP server to learn the bootstrap procedure. Complete the procedure before any other action.
 
+When `discover` reports `session_scope: multi`, pass `repo` from this workspace's `AGENTS.md` on `start_session`.
+
 If the user provides a `session_token`, pass it to subsequent workflow-server calls per their instructions.

--- a/examples/cursor-workspace/.cursor/rules/workflow-server.mdc
+++ b/examples/cursor-workspace/.cursor/rules/workflow-server.mdc
@@ -6,3 +6,5 @@ alwaysApply: true
 # Workflow Server Integration
 
 For any start workflow or create or resume work package request, call the `discover` tool on the workflow-server MCP server to learn the bootstrap procedure. Complete the procedure before any other action.
+
+When `discover` reports `session_scope: multi`, pass `repo` from this workspace's `AGENTS.md` on `start_session`.

--- a/site/api/tools.html
+++ b/site/api/tools.html
@@ -106,7 +106,7 @@
       </section>
       <section class="tool" id="health_check">
         <h3><code>health_check</code></h3>
-        <p class="tool-summary">Server health: status, name, version, workflow count, uptime.</p>
+        <p class="tool-summary">Server health: status, name, version, workflow count, uptime, session_scope.</p>
         <details class="tool-details">
           <summary>Full description</summary>
           <p>Quick ping to confirm the server is up. Returns status, name, version, workflow count, and uptime.</p>

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -347,9 +347,15 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
         },
         session_index: sessionIndex,
         planning_slug: slug,
+        session_scope: sessionScope.mode,
       };
       if (state.planningFolderPath) response['planning_folder_path'] = state.planningFolderPath;
       if (sessionRoot.repo) response['repo'] = sessionRoot.repo;
+      // Fail-soft signal: multi-root transient without repo still boots, but
+      // dispatch_child promotion will fail until start_session is re-called with repo.
+      if (sessionScope.mode === 'multi' && isTransientSession && !sessionRoot.repo) {
+        response['promotion_requires_repo'] = true;
+      }
       if (state.contextMode) response['context_mode'] = state.contextMode;
       if (migrationResult.migrated) {
         response['migrated'] = true;

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -271,13 +271,20 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
     };
   }
 
-  server.tool('discover', 'Entry point — call before other tools. Returns server info and the bootstrap procedure. No session_index required.', {},
+  server.tool('discover', 'Entry point — call before other tools. Returns server info, session_scope (single|multi), and the bootstrap procedure. No session_index required. When session_scope is multi, pass repo on start_session.', {},
     withAuditLog('discover', async () => {
       const bootstrapResult = await readResourceRaw(config.workflowDir, 'meta', 'bootstrap-protocol');
+      const scope = buildSessionScope(config);
       const lines = [
         `server: ${config.serverName}`,
         `version: ${config.serverVersion}`,
+        `session_scope: ${scope.mode}`,
       ];
+      if (scope.mode === 'multi') {
+        lines.push(
+          'repo_binding: required — pass repo: "owner/repo" on start_session (from user or workspace AGENTS.md)',
+        );
+      }
       if (bootstrapResult.success) {
         lines.push('', bootstrapResult.value.content);
       }
@@ -1291,14 +1298,23 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       };
     }), traceOpts ? { ...traceOpts, excludeFromTrace: true } : undefined));
 
-  server.tool('health_check', 'Server health: status, name, version, workflow count, uptime. No session_index required.', {},
+  server.tool('health_check', 'Server health: status, name, version, workflow count, uptime, session_scope. No session_index required. session_scope multi means pass repo on start_session.', {},
     withAuditLog('health_check', async () => {
       const workflows = await listWorkflows(config.workflowDir);
+      const scope = buildSessionScope(config);
+      const payload: Record<string, unknown> = {
+        status: 'healthy',
+        server: config.serverName,
+        version: config.serverVersion,
+        workflows_available: workflows.length,
+        uptime_seconds: Math.floor(process.uptime()),
+        session_scope: scope.mode,
+      };
+      if (scope.mode === 'multi') {
+        payload['repo_binding'] = 'required_on_start_session';
+      }
       return {
-        content: [{ type: 'text' as const, text: JSON.stringify({
-          status: 'healthy', server: config.serverName, version: config.serverVersion,
-          workflows_available: workflows.length, uptime_seconds: Math.floor(process.uptime()),
-        }, null, 2) }],
+        content: [{ type: 'text' as const, text: JSON.stringify(payload, null, 2) }],
       };
     }));
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -170,10 +170,12 @@ describe('mcp-server integration', () => {
       const guide = parseToolResponse(result);
       expect(guide.server).toBeDefined();
       expect(guide.version).toBeDefined();
+      expect(guide.session_scope).toBe('single');
       expect(guide._body).toBeDefined();
       expect(typeof guide._body).toBe('string');
       expect(guide._body).toContain('start_session');
       expect(guide._body).toContain('get_workflow');
+      expect(guide._body).toMatch(/repo/i);
       expect(guide.available_workflows).toBeUndefined();
     });
   });
@@ -428,6 +430,7 @@ describe('mcp-server integration', () => {
       const health = parseToolResponse(result);
       expect(health.status).toBe('healthy');
       expect(health.workflows_available).toBeGreaterThanOrEqual(2);
+      expect(health.session_scope).toBe('single');
     });
   });
 
@@ -1483,6 +1486,8 @@ describe('mcp-server integration', () => {
       expect(response.workflow.id).toBe('meta');
       expect(response.session_index).toMatch(/^[A-Z2-7]{6}$/);
       expect(response.planning_slug).toBeDefined();
+      expect(response.session_scope).toBe('single');
+      expect(response.promotion_requires_repo).toBeUndefined();
     });
 
     it('accepts workflow_id for non-meta workflow', async () => {

--- a/tests/multi-root-bootstrap.test.ts
+++ b/tests/multi-root-bootstrap.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createServer } from '../src/server.js';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import {
+  lookupTransientRepoByFolder,
+  registerTransient,
+  createTransientFolder,
+} from '../src/utils/session/store.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseToolResponse(result: any): any {
+  const text = (result.content[0] as { type: 'text'; text: string }).text;
+  return JSON.parse(text);
+}
+
+describe('multi-root bootstrap binding', () => {
+  let client: Client;
+  let closeTransport: () => Promise<void>;
+  let installDir: string;
+  let engMulti: string;
+  let wsMulti: string;
+
+  beforeAll(async () => {
+    installDir = mkdtempSync(join(tmpdir(), 'wf-multi-boot-'));
+    engMulti = join(installDir, 'engineering');
+    wsMulti = join(installDir, 'workspace');
+    mkdirSync(join(engMulti, 'acme', 'app'), { recursive: true });
+    mkdirSync(join(wsMulti, 'acme', 'app'), { recursive: true });
+
+    const config = {
+      workflowDir: resolve(import.meta.dirname, '../workflows'),
+      schemasDir: resolve(import.meta.dirname, '../schemas'),
+      workspaceDir: wsMulti,
+      engineeringDir: engMulti,
+      installDir,
+      serverName: 'test-multi-root',
+      serverVersion: '1.0.0',
+      minCheckpointResponseSeconds: 0,
+    };
+
+    const server = createServer(config);
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+
+    client = new Client({ name: 'test-client', version: '1.0.0' }, {});
+    await client.connect(clientTransport);
+
+    closeTransport = async () => {
+      await client.close();
+      await server.close();
+    };
+  });
+
+  afterAll(async () => {
+    await closeTransport();
+    try {
+      rmSync(installDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('discover reports session_scope multi and repo_binding', async () => {
+    const result = await client.callTool({ name: 'discover', arguments: {} });
+    expect(result.isError).toBeFalsy();
+    const text = (result.content[0] as { type: 'text'; text: string }).text;
+    expect(text).toMatch(/session_scope:\s*multi/);
+    expect(text).toMatch(/repo_binding:\s*required/);
+    expect(text).toMatch(/repo:\s*"owner\/repo"/);
+  });
+
+  it('health_check reports session_scope multi', async () => {
+    const result = await client.callTool({ name: 'health_check', arguments: {} });
+    const health = parseToolResponse(result);
+    expect(health.status).toBe('healthy');
+    expect(health.session_scope).toBe('multi');
+    expect(health.repo_binding).toBe('required_on_start_session');
+  });
+
+  it('start_session without repo sets promotion_requires_repo on multi-root meta', async () => {
+    const result = await client.callTool({
+      name: 'start_session',
+      arguments: { workflow_id: 'meta', agent_id: 'orchestrator' },
+    });
+    expect(result.isError).toBeFalsy();
+    const response = parseToolResponse(result);
+    expect(response.session_scope).toBe('multi');
+    expect(response.promotion_requires_repo).toBe(true);
+    expect(response.repo).toBeUndefined();
+  });
+
+  it('dispatch_child fails without a stashed repo on multi-root', async () => {
+    const meta = await client.callTool({
+      name: 'start_session',
+      arguments: { workflow_id: 'meta', agent_id: 'orchestrator' },
+    });
+    const metaIdx = parseToolResponse(meta).session_index;
+
+    const child = await client.callTool({
+      name: 'dispatch_child',
+      arguments: {
+        session_index: metaIdx,
+        workflow_id: 'work-package',
+        agent_id: 'worker-1',
+        planning_slug: '2026-07-24-no-repo',
+      },
+    });
+    expect(child.isError).toBeTruthy();
+    const text = (child.content as { text: string }[])[0]?.text ?? '';
+    expect(text).toMatch(/cannot promote transient session without a target repo/i);
+    expect(text).toMatch(/Pass repo on start_session/i);
+  });
+
+  it('start_session with repo binds and dispatch_child promotes under engineering/owner/repo', async () => {
+    const meta = await client.callTool({
+      name: 'start_session',
+      arguments: {
+        workflow_id: 'meta',
+        agent_id: 'orchestrator',
+        repo: 'acme/app',
+      },
+    });
+    expect(meta.isError).toBeFalsy();
+    const metaResp = parseToolResponse(meta);
+    expect(metaResp.session_scope).toBe('multi');
+    expect(metaResp.repo).toBe('acme/app');
+    expect(metaResp.promotion_requires_repo).toBeUndefined();
+
+    const slug = '2026-07-24-with-repo';
+    const child = await client.callTool({
+      name: 'dispatch_child',
+      arguments: {
+        session_index: metaResp.session_index,
+        workflow_id: 'work-package',
+        agent_id: 'worker-1',
+        planning_slug: slug,
+      },
+    });
+    expect(child.isError).toBeFalsy();
+    const childResp = parseToolResponse(child);
+    expect(childResp.planning_slug).toBe(slug);
+
+    const promoted = join(engMulti, 'acme', 'app', 'artifacts', 'planning', slug);
+    expect(existsSync(join(promoted, 'session.json'))).toBe(true);
+    expect(childResp.planning_folder_path).toBe(promoted);
+
+    const stored = JSON.parse(readFileSync(join(promoted, 'session.json'), 'utf8'));
+    expect(stored.workflowId).toBe('meta');
+    expect(stored.triggeredWorkflows).toHaveLength(1);
+    expect(stored.triggeredWorkflows[0].workflowId).toBe('work-package');
+  });
+});
+
+describe('transient repo stash helpers', () => {
+  it('registerTransient stores and lookupTransientRepoByFolder returns repo', async () => {
+    const folder = await createTransientFolder();
+    try {
+      registerTransient('ABC234', folder, undefined, 'acme/app');
+      expect(lookupTransientRepoByFolder(folder)).toBe('acme/app');
+    } finally {
+      rmSync(folder, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/session-scope.test.ts
+++ b/tests/session-scope.test.ts
@@ -95,6 +95,19 @@ describe('session scope (multi-root)', () => {
     expect(root.repo).toBe('acme/app');
     expect(root.engineeringDir).toBe(resolve('/tmp/inst/engineering/acme/app'));
   });
+
+  it('resolveSessionRoot error text tells agents to pass repo from AGENTS.md', () => {
+    const scope = buildSessionScope({
+      workflowDir: '/w',
+      schemasDir: '/s',
+      workspaceDir: '/tmp/inst/workspace',
+      engineeringDir: '/tmp/inst/engineering',
+      installDir: '/tmp/inst',
+      serverName: 't',
+      serverVersion: '1',
+    });
+    expect(() => resolveSessionRoot(scope, {})).toThrow(/AGENTS\.md/);
+  });
 });
 
 describe('session multi-root FS search', () => {


### PR DESCRIPTION
## Summary
- Teach bootstrap/start_session to bind repo on install multi-root (from workspace AGENTS.md).
- Surface session_scope on discover/health_check/start_session, plus promotion_requires_repo when multi-root meta lacks a binding.
- Integration tests for multi-root promote success/failure paths.
- Workflows pin: bootstrap-protocol + start-session technique guidance.

Follow-up to #284 / issue #283: server already accepted repo; agents still failed because discover/bootstrap never required it and live failure only appeared at dispatch_child.

## Test plan
- [x] npm run typecheck
- [x] vitest multi-root-bootstrap, session-scope, mcp-server
- [ ] Redeploy local install and smoke: discover → start_session({ repo }) → dispatch_child promotes under engineering/<owner>/<repo>/