### PR TITLE
fix(dispatch_child): accept repo for multi-root promotion

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -33,7 +33,7 @@ Most tools take a `session_index` from `start_session`. Bootstrap tools do not. 
 | Tool | Parameters | Returns | Description |
 |------|------------|---------|-------------|
 | `start_session` | `agent_id`, `workflow_id?`, `planning_folder?`, `repo?`, `context_mode?` | `session_index`, planning path, workflow info, `session_scope`, optional `repo` / `promotion_requires_repo` | Open or resume a top-level session (default workflow: `meta`). On install multi-root pass `repo: "owner/repo"` (from user or workspace `AGENTS.md`). [State](state_management_model.md) · [Reference delivery](resource_resolution_model.md#11-reference-delivery) |
-| `dispatch_child` | `session_index`, `workflow_id`, `agent_id?`, `planning_slug?`, `context_mode?` | Child `session_index` | Start a nested workflow under the current session. [Dispatch](dispatch_model.md) |
+| `dispatch_child` | `session_index`, `workflow_id`, `agent_id?`, `planning_slug?`, `repo?`, `context_mode?` | Child `session_index` | Start a nested workflow under the current session. On multi-root, `repo` promotes a transient parent when `start_session` omitted it. [Dispatch](dispatch_model.md) |
 | `get_workflow_status` | `session_index` | Status, current/completed activities, checkpoint hint | Snapshot of where the session is. |
 | `inspect_session` | `session_index`, `view?`, `child_index?`, `variable?` | Compact projection | Read-only view of session state (usable while blocked). |
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -32,8 +32,8 @@ Most tools take a `session_index` from `start_session`. Bootstrap tools do not. 
 
 | Tool | Parameters | Returns | Description |
 |------|------------|---------|-------------|
-| `start_session` | `agent_id`, `workflow_id?`, `planning_folder?`, `repo?`, `context_mode?` | `session_index`, planning path, workflow info, `session_scope`, optional `repo` / `promotion_requires_repo` | Open or resume a top-level session (default workflow: `meta`). On install multi-root pass `repo: "owner/repo"` (from user or workspace `AGENTS.md`). [State](state_management_model.md) · [Reference delivery](resource_resolution_model.md#11-reference-delivery) |
-| `dispatch_child` | `session_index`, `workflow_id`, `agent_id?`, `planning_slug?`, `repo?`, `context_mode?` | Child `session_index` | Start a nested workflow under the current session. On multi-root, `repo` promotes a transient parent when `start_session` omitted it. [Dispatch](dispatch_model.md) |
+| `start_session` | `agent_id`, `workflow_id?`, `planning_folder?`, `repo?`, `context_mode?` | `session_index`, planning path, workflow info, `session_scope`, optional `repo` / `promotion_requires_repo` | Open or resume a top-level session (default workflow: `meta`). On install multi-root pass `repo: "owner/repo"` — written to `session.json#repo` (single source of truth for promotion). [State](state_management_model.md) · [Reference delivery](resource_resolution_model.md#11-reference-delivery) |
+| `dispatch_child` | `session_index`, `workflow_id`, `agent_id?`, `planning_slug?`, `repo?`, `context_mode?` | Child `session_index` | Start a nested workflow under the current session. Promotion reads only `session.repo`; optional `repo` binds if missing (must match if set). [Dispatch](dispatch_model.md) |
 | `get_workflow_status` | `session_index` | Status, current/completed activities, checkpoint hint | Snapshot of where the session is. |
 | `inspect_session` | `session_index`, `view?`, `child_index?`, `variable?` | Compact projection | Read-only view of session state (usable while blocked). |
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -24,16 +24,16 @@ Most tools take a `session_index` from `start_session`. Bootstrap tools do not. 
 
 | Tool | Parameters | Returns | Description |
 |------|------------|---------|-------------|
-| `discover` | — | Server info, `session_scope`, bootstrap stub | First call: how to start a session. When `session_scope` is `multi`, pass `repo` on `start_session`. |
+| `discover` | — | Server info, bootstrap stub | First call: how to start a session. Always pass `repo` on `start_session`. |
 | `list_workflows` | — | Workflow list (`id`, `title`, `version`, `tags`) | Catalog of available workflows. |
-| `health_check` | — | Status, version, workflow count, uptime, `session_scope` | Process health and binding mode. |
+| `health_check` | — | Status, version, workflow count, uptime | Process health. |
 
 ### Session
 
 | Tool | Parameters | Returns | Description |
 |------|------------|---------|-------------|
-| `start_session` | `agent_id`, `workflow_id?`, `planning_folder?`, `repo?`, `context_mode?` | `session_index`, planning path, workflow info, `session_scope`, optional `repo` / `promotion_requires_repo` | Open or resume a top-level session (default workflow: `meta`). On install multi-root pass `repo: "owner/repo"` — written to `session.json#repo` (single source of truth for promotion). [State](state_management_model.md) · [Reference delivery](resource_resolution_model.md#11-reference-delivery) |
-| `dispatch_child` | `session_index`, `workflow_id`, `agent_id?`, `planning_slug?`, `repo?`, `context_mode?` | Child `session_index` | Start a nested workflow under the current session. Promotion reads only `session.repo`; optional `repo` binds if missing (must match if set). [Dispatch](dispatch_model.md) |
+| `start_session` | `agent_id`, `workflow_id?`, `planning_folder?`, `repo?`, `context_mode?` | `session_index`, planning path, workflow info, optional `repo` | Open or resume a top-level session (default workflow: `meta`). Always pass `repo: "owner/repo"` — written to `session.json#repo`. [State](state_management_model.md) · [Reference delivery](resource_resolution_model.md#11-reference-delivery) |
+| `dispatch_child` | `session_index`, `workflow_id`, `agent_id?`, `planning_slug?`, `repo?`, `context_mode?` | Child `session_index` | Start a nested workflow under the current session. Uses `session.repo`; optional `repo` binds if missing (must match if set). [Dispatch](dispatch_model.md) |
 | `get_workflow_status` | `session_index` | Status, current/completed activities, checkpoint hint | Snapshot of where the session is. |
 | `inspect_session` | `session_index`, `view?`, `child_index?`, `variable?` | Compact projection | Read-only view of session state (usable while blocked). |
 

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -10,15 +10,15 @@ For any start workflow, create work package, or resume work package request, cal
 If the user provides a `session_token`, pass it to subsequent workflow-server calls per their instructions.
 ```
 
-That is enough. `discover` returns the live bootstrap steps (schema fetch → `start_session` → `get_workflow`). Do not copy the protocol into IDE rules.
+That is enough. `discover` returns the live bootstrap steps (schema fetch → bind `repo` → `start_session` → `get_workflow`). Do not copy the protocol into IDE rules.
 
-When `discover` reports `session_scope: multi`, pass `repo: "owner/repo"` on `start_session` (from the user or workspace `AGENTS.md` / `CLAUDE.md`).
+Always pass `repo: "owner/repo"` on `start_session` (from the user or workspace `AGENTS.md` / `CLAUDE.md`). Agents do not special-case server topology.
 
 ## Verify
 
 1. Restart the MCP client.
 2. Ask to list workflows → `list_workflows`.
-3. Ask to start a work-package → `discover`, then the returned bootstrap (include `repo` when multi-root).
+3. Ask to start a work-package → `discover`, then the returned bootstrap (always include `repo`).
 
 If the agent skips `discover`, the rule is not loaded.
 

--- a/examples/cursor-workspace/.claude/rules/workflow-server.md
+++ b/examples/cursor-workspace/.claude/rules/workflow-server.md
@@ -4,6 +4,6 @@ description: Workflow server integration
 
 For any start workflow or create or resume work package request, call the `discover` tool on the workflow-server MCP server to learn the bootstrap procedure. Complete the procedure before any other action.
 
-When `discover` reports `session_scope: multi`, pass `repo` from this workspace's `AGENTS.md` on `start_session`.
+Always pass `repo` from this workspace's `AGENTS.md` on `start_session`.
 
 If the user provides a `session_token`, pass it to subsequent workflow-server calls per their instructions.

--- a/examples/cursor-workspace/.cursor/rules/workflow-server.mdc
+++ b/examples/cursor-workspace/.cursor/rules/workflow-server.mdc
@@ -7,4 +7,4 @@ alwaysApply: true
 
 For any start workflow or create or resume work package request, call the `discover` tool on the workflow-server MCP server to learn the bootstrap procedure. Complete the procedure before any other action.
 
-When `discover` reports `session_scope: multi`, pass `repo` from this workspace's `AGENTS.md` on `start_session`.
+Always pass `repo` from this workspace's `AGENTS.md` on `start_session`.

--- a/examples/cursor-workspace/AGENTS.md
+++ b/examples/cursor-workspace/AGENTS.md
@@ -6,6 +6,5 @@ The GitHub repo this Cursor workspace is bound to is:
 owner/repo
 ```
 
-Replace with your project (for example `m2ux/workflow-server`). Agents should pass this
-value as `repo` on `start_session` when the workflow-server is bound to an install
-multi-root (`$INSTALL/engineering` + `$INSTALL/workspace`).
+Replace with your project (for example `m2ux/workflow-server`). Agents should always pass this
+value as `repo` on `start_session` (stored on `session.json#repo`).

--- a/examples/cursor-workspace/README.md
+++ b/examples/cursor-workspace/README.md
@@ -37,7 +37,7 @@ examples/cursor-workspace/
 
 | Path | Role |
 |------|------|
-| `AGENTS.md` | Declares the target `owner/repo`. Pass that value as `repo` on `start_session` when the server uses install multi-root. |
+| `AGENTS.md` | Declares the target `owner/repo`. Always pass that value as `repo` on `start_session`. |
 | `workflow-server.code-workspace` | Opens three roots: this folder, `$INSTALL/engineering/<owner>/<repo>`, and `$INSTALL/workspace/<owner>/<repo>`. |
 | `.cursor/mcp.json` | Connects Cursor to the running HTTP server via `npx mcp-remote`. |
 | `.cursor/rules/*.mdc` | Always-applied IDE rules (bootstrap + optional concept-rag). |

--- a/schemas/session-file.schema.json
+++ b/schemas/session-file.schema.json
@@ -294,6 +294,11 @@
         "planningFolderPath": {
           "type": "string"
         },
+        "repo": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Target owner/repo bound on this session (install multi-root single source of truth for promotion)."
+        },
         "contextMode": {
           "type": "string",
           "enum": [

--- a/site/api/tools.html
+++ b/site/api/tools.html
@@ -198,6 +198,7 @@
           <tr><td><code>workflow_id</code></td><td><code>string</code></td><td>yes</td><td>Workflow id to run or dispatch (for example, <code>work-package</code>).</td></tr>
           <tr><td><code>agent_id</code></td><td><code>string</code></td><td>no</td><td>Label for this agent in the session trace. Default: <code>&quot;worker&quot;</code></td></tr>
           <tr><td><code>planning_slug</code></td><td><code>string</code></td><td>no</td><td>Slug for the promoted planning folder when dispatching from a meta bootstrap session. Ignored if the parent already has a persistent folder.</td></tr>
+          <tr><td><code>repo</code></td><td><code>string</code></td><td>no</td><td>Optional. Target owner/repo (or github URL). Used when promoting a transient multi-root parent; overrides any repo stashed at start_session. Pass from worker prior-state / AGENTS.md when start_session omitted it.</td></tr>
           <tr><td><code>context_mode</code></td><td><code>&quot;persistent&quot; | &quot;fresh&quot;</code></td><td>no</td><td><code>persistent</code>: reuse earlier deliveries when one agent keeps full context. <code>fresh</code> (default): always return full content.</td></tr>
           </tbody>
         </table>

--- a/src/schema/session.schema.ts
+++ b/src/schema/session.schema.ts
@@ -134,11 +134,10 @@ const SessionFileBaseSchema = z.object({
   planningFolderPath: z.string().optional(),
 
   /**
-   * Target repository as `owner/repo` when this session is bound to a checkout
-   * under an install multi-root (or pinned for diagnostics on single-root).
-   * Single source of truth for promotion and planning path resolution —
-   * agents do not special-case multi vs single; they read/write this field
-   * via start_session / dispatch_child bind. Optional for back-compat.
+   * Target repository as `owner/repo`. Single source of truth for promotion
+   * and planning path resolution. Agents always bind this via start_session
+   * / dispatch_child (bind-if-missing); they do not special-case server
+   * topology. Optional only for back-compat with older session files.
    */
   repo: z.string().min(1).optional(),
 
@@ -272,7 +271,7 @@ export function createInitialSessionFile(args: {
   agentId: string;
   parentSession?: SessionFile;
   planningFolderPath?: string;
-  /** Target owner/repo bound on this session (install multi-root). */
+  /** Target owner/repo bound on this session (session.json SSOT). */
   repo?: string;
   contextMode?: 'persistent' | 'fresh';
   variables?: Record<string, unknown>;

--- a/src/schema/session.schema.ts
+++ b/src/schema/session.schema.ts
@@ -134,6 +134,15 @@ const SessionFileBaseSchema = z.object({
   planningFolderPath: z.string().optional(),
 
   /**
+   * Target repository as `owner/repo` when this session is bound to a checkout
+   * under an install multi-root (or pinned for diagnostics on single-root).
+   * Single source of truth for promotion and planning path resolution —
+   * agents do not special-case multi vs single; they read/write this field
+   * via start_session / dispatch_child bind. Optional for back-compat.
+   */
+  repo: z.string().min(1).optional(),
+
+  /**
    * Declared context model for payload delivery. `persistent` opts the
    * session into reference-not-repeat delivery: composed bundle content and
    * technique payloads already delivered to this session+agent are replaced
@@ -182,6 +191,7 @@ export interface SessionFile {
   triggeredWorkflows: EmbeddedSessionRef[];
   parentSession?: SessionFile;
   planningFolderPath?: string;
+  repo?: string;
   contextMode?: 'persistent' | 'fresh';
   deliveredContent?: Record<string, Record<string, string>>;
 }
@@ -262,6 +272,8 @@ export function createInitialSessionFile(args: {
   agentId: string;
   parentSession?: SessionFile;
   planningFolderPath?: string;
+  /** Target owner/repo bound on this session (install multi-root). */
+  repo?: string;
   contextMode?: 'persistent' | 'fresh';
   variables?: Record<string, unknown>;
 }): SessionFile {
@@ -297,6 +309,30 @@ export function createInitialSessionFile(args: {
   };
   if (args.parentSession) file.parentSession = args.parentSession;
   if (args.planningFolderPath) file.planningFolderPath = args.planningFolderPath;
+  if (args.repo) file.repo = args.repo;
   if (args.contextMode) file.contextMode = args.contextMode;
   return file;
+}
+
+/**
+ * Bind `owner/repo` onto a session. Idempotent when the session already has
+ * the same repo; rejects a conflicting rebind. Empty/undefined input is a no-op.
+ */
+export function bindSessionRepo(
+  state: SessionFile,
+  repoRaw: string | undefined,
+  normalize: (raw: string) => string,
+): SessionFile {
+  const trimmed = repoRaw?.trim();
+  if (!trimmed) return state;
+  const repo = normalize(trimmed);
+  if (state.repo) {
+    if (state.repo !== repo) {
+      throw new Error(
+        `session already bound to repo '${state.repo}'; cannot rebind to '${repo}'`,
+      );
+    }
+    return state;
+  }
+  return { ...state, repo };
 }

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -374,16 +374,18 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
       description:
         'Dispatch a child workflow under the parent session. Returns the child `session_index` and canonical `planning_folder_path`. ' +
         'Transient meta parents are promoted to a workspace planning folder first (optional `planning_slug`). ' +
+        'On install multi-root, pass `repo` here if it was not bound on start_session (workers often have owner/repo from the dispatch prompt). ' +
         'Never set `context_mode: "persistent"` on disposable-worker children — workers need fresh/full delivery.',
       inputSchema: z.object({
         ...sessionIndexParam,
         workflow_id: z.string().describe('Child workflow id (e.g. "work-package").'),
         agent_id: z.string().default('worker').describe('Child agent_id (default "worker").'),
         planning_slug: z.string().optional().describe('Optional. Promotion slug when the parent is a transient meta bootstrap. Ignored if the parent is already persistent.'),
+        repo: z.string().optional().describe('Optional. Target owner/repo (or github URL). Used when promoting a transient multi-root parent; overrides any repo stashed at start_session. Pass from worker prior-state / AGENTS.md when start_session omitted it.'),
         context_mode: z.enum(['persistent', 'fresh']).optional().describe('Optional. Child delivery mode. "persistent" ONLY for solo child walks; omit/"fresh" for disposable workers.'),
       }).strict(),
     },
-    withAuditLog('dispatch_child', withSessionStoreErrors(async ({ session_index, workflow_id, agent_id, planning_slug, context_mode }) => {
+    withAuditLog('dispatch_child', withSessionStoreErrors(async ({ session_index, workflow_id, agent_id, planning_slug, repo, context_mode }) => {
       const loadOpts = await sessionLoadOpts();
       const loaded = await loadSessionForTool(planningRootDir, session_index, loadOpts);
       const parentFolder = loaded.folderAbsPath;
@@ -422,17 +424,20 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
           planning_slug
           ?? lookupTransientSlugByFolder(parentFolder)
           ?? `${new Date().toISOString().slice(0, 10)}-${workflow_id}`;
-        // Promote into the repo checkout recorded at start_session (multi-root),
-        // or the process single engineering root. Parent folder path is tmp —
-        // use stashed repo + session scope, not dirname(parent).
+        // Promote into the repo checkout for multi-root. Precedence:
+        //   1. explicit `repo` on this call (initialize-session workers often
+        //      learn owner/repo after start_session and pass it here)
+        //   2. repo stashed on the transient folder at start_session
+        // Parent folder path is tmp — never derive owner/repo from dirname(parent).
         const promoteRoot = (() => {
           const stashedRepo = lookupTransientRepoByFolder(parentFolder);
+          const repoHint = repo?.trim() || stashedRepo;
           try {
-            return resolveSessionRoot(sessionScope, { repo: stashedRepo });
+            return resolveSessionRoot(sessionScope, { repo: repoHint });
           } catch (err) {
             throw new Error(
               `dispatch_child: cannot promote transient session without a target repo. ` +
-                `Pass repo on start_session when the server uses an install multi-root. ` +
+                `Pass repo on dispatch_child (or on start_session) when the server uses an install multi-root. ` +
                 `(${err instanceof Error ? err.message : String(err)})`,
             );
           }

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { ServerConfig } from '../config.js';
+import { normalizeRepoPath, type ServerConfig } from '../config.js';
 import { withAuditLog } from '../logging.js';
 
 import { loadWorkflow, loadWorkflowWithDiagnostics, getActivity } from '../loaders/workflow-loader.js';
@@ -28,7 +28,6 @@ import {
   registerTransient,
   lookupTransientBySlug,
   lookupTransientSlugByFolder,
-  lookupTransientRepoByFolder,
   isTransientFolder,
   redirectTransientToWorkspace,
   computeEmbeddedSessionIndex,
@@ -38,6 +37,7 @@ import {
 } from '../utils/session/index.js';
 import {
   createInitialSessionFile,
+  bindSessionRepo,
   safeValidateSessionFile,
   parentChainDepth,
   PARENT_CHAIN_DEPTH_WARN_THRESHOLD,
@@ -257,30 +257,52 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
         sessionIndex = state.sessionIndex;
         // Silently re-stamp planningFolderPath if it is missing or stale (the
         // folder was moved/renamed within the planning root since the last
-        // recorded value), update agentId if it differs, and adopt a supplied
-        // context_mode. One persist if any changed.
+        // recorded value), update agentId if it differs, adopt a supplied
+        // context_mode, and bind repo onto session.json when provided.
+        // One persist if any changed. Repo is the durable multi-root binding
+        // (not a process-local stash).
         const pathDrift = canonicalFolder !== undefined && state.planningFolderPath !== canonicalFolder;
         const agentDrift = state.agentId !== agent_id;
         const modeDrift = context_mode !== undefined && state.contextMode !== context_mode;
+        let nextState = state;
         if (pathDrift || agentDrift || modeDrift) {
-          state = {
-            ...state,
+          nextState = {
+            ...nextState,
             ...(agentDrift ? { agentId: agent_id } : {}),
             ...(pathDrift ? { planningFolderPath: canonicalFolder } : {}),
             ...(modeDrift ? { contextMode: context_mode } : {}),
           };
+        }
+        const repoBindRaw = repo?.trim() || sessionRoot.repo;
+        if (repoBindRaw) {
+          try {
+            nextState = bindSessionRepo(nextState, repoBindRaw, normalizeRepoPath);
+          } catch (err) {
+            throw new Error(
+              `start_session: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        }
+        if (nextState !== state) {
+          state = nextState;
           await writeSessionFile(folder, state);
         }
       } else {
         // Fresh top-level session — no parent. Children are dispatched via
         // dispatch_child after start_session returns the index.
         sessionIndex = await computeSessionIndex(folder);
+        const boundRepo = (() => {
+          const raw = repo?.trim() || sessionRoot.repo;
+          if (!raw) return undefined;
+          return normalizeRepoPath(raw);
+        })();
         const newState = createInitialSessionFile({
           sessionIndex,
           workflowId: effectiveWorkflowId,
           workflowVersion: effectiveWorkflowVersion,
           agentId: agent_id,
           ...(canonicalFolder ? { planningFolderPath: canonicalFolder } : {}),
+          ...(boundRepo ? { repo: boundRepo } : {}),
           ...(context_mode ? { contextMode: context_mode } : {}),
           // B7 (#166): seed declared defaults into the fresh bag. Conditional
           // on the pre-load succeeding — its failure is only surfaced further
@@ -298,13 +320,13 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
         // a slug-keyed entry for them would never be hit by a future lookup,
         // and leaving it out lets `lookupTransientSlugByFolder` return
         // undefined for the synthetic case (which dispatch_child relies on to
-        // fall through to the dated workflow-id folder name).
+        // fall through to the dated workflow-id folder name). Repo lives on
+        // session.json, not the process-local registry.
         if (isTransientSession) {
           registerTransient(
             sessionIndex,
             folder,
             slugIsSynthetic ? undefined : slug,
-            sessionRoot.repo,
           );
         }
       }
@@ -350,10 +372,12 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
         session_scope: sessionScope.mode,
       };
       if (state.planningFolderPath) response['planning_folder_path'] = state.planningFolderPath;
-      if (sessionRoot.repo) response['repo'] = sessionRoot.repo;
-      // Fail-soft signal: multi-root transient without repo still boots, but
-      // dispatch_child promotion will fail until start_session is re-called with repo.
-      if (sessionScope.mode === 'multi' && isTransientSession && !sessionRoot.repo) {
+      // Echo the durable session binding (session.json#repo), not a path-only hint.
+      if (state.repo) response['repo'] = state.repo;
+      // Fail-soft signal: multi-root transient without session.repo still boots, but
+      // dispatch_child promotion needs repo bound on the session (start_session or
+      // dispatch_child) before promote.
+      if (sessionScope.mode === 'multi' && isTransientSession && !state.repo) {
         response['promotion_requires_repo'] = true;
       }
       if (state.contextMode) response['context_mode'] = state.contextMode;
@@ -374,14 +398,14 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
       description:
         'Dispatch a child workflow under the parent session. Returns the child `session_index` and canonical `planning_folder_path`. ' +
         'Transient meta parents are promoted to a workspace planning folder first (optional `planning_slug`). ' +
-        'On install multi-root, pass `repo` here if it was not bound on start_session (workers often have owner/repo from the dispatch prompt). ' +
+        'On install multi-root, ensure `session.repo` is bound (pass `repo` here if start_session did not); promotion reads only session.json. ' +
         'Never set `context_mode: "persistent"` on disposable-worker children — workers need fresh/full delivery.',
       inputSchema: z.object({
         ...sessionIndexParam,
         workflow_id: z.string().describe('Child workflow id (e.g. "work-package").'),
         agent_id: z.string().default('worker').describe('Child agent_id (default "worker").'),
         planning_slug: z.string().optional().describe('Optional. Promotion slug when the parent is a transient meta bootstrap. Ignored if the parent is already persistent.'),
-        repo: z.string().optional().describe('Optional. Target owner/repo (or github URL). Used when promoting a transient multi-root parent; overrides any repo stashed at start_session. Pass from worker prior-state / AGENTS.md when start_session omitted it.'),
+        repo: z.string().optional().describe('Optional. Bind owner/repo onto the parent session when missing (must match if already set). Used for multi-root promotion; session.json is the source of truth.'),
         context_mode: z.enum(['persistent', 'fresh']).optional().describe('Optional. Child delivery mode. "persistent" ONLY for solo child walks; omit/"fresh" for disposable workers.'),
       }).strict(),
     },
@@ -397,6 +421,24 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
       const effectiveWorkflowVersion = wfResult.value.version ?? '';
 
       const triggeredAt = new Date().toISOString();
+
+      // Bind-if-missing on the parent session. session.json#repo is the single
+      // source of truth for multi-root promotion; dispatch_child.repo never
+      // overrides a prior bind.
+      let parentState = loaded.state;
+      if (repo?.trim()) {
+        try {
+          parentState = bindSessionRepo(parentState, repo, normalizeRepoPath);
+        } catch (err) {
+          throw new Error(
+            `dispatch_child: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+        if (parentState !== loaded.state && !parentIsTransient) {
+          // Durable parent: persist bind before embedding the child.
+          await writeSessionFile(parentFolder, parentState);
+        }
+      }
 
       if (parentIsTransient) {
         // Transient parent (meta-bootstrap) — promote the parent's state onto
@@ -424,20 +466,14 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
           planning_slug
           ?? lookupTransientSlugByFolder(parentFolder)
           ?? `${new Date().toISOString().slice(0, 10)}-${workflow_id}`;
-        // Promote into the repo checkout for multi-root. Precedence:
-        //   1. explicit `repo` on this call (initialize-session workers often
-        //      learn owner/repo after start_session and pass it here)
-        //   2. repo stashed on the transient folder at start_session
-        // Parent folder path is tmp — never derive owner/repo from dirname(parent).
+        // Promote using session.json#repo only (bound above if dispatch passed repo).
         const promoteRoot = (() => {
-          const stashedRepo = lookupTransientRepoByFolder(parentFolder);
-          const repoHint = repo?.trim() || stashedRepo;
           try {
-            return resolveSessionRoot(sessionScope, { repo: repoHint });
+            return resolveSessionRoot(sessionScope, { repo: parentState.repo });
           } catch (err) {
             throw new Error(
-              `dispatch_child: cannot promote transient session without a target repo. ` +
-                `Pass repo on dispatch_child (or on start_session) when the server uses an install multi-root. ` +
+              `dispatch_child: cannot promote transient session without session.repo. ` +
+                `Bind repo on start_session or pass repo on dispatch_child when the server uses an install multi-root. ` +
                 `(${err instanceof Error ? err.message : String(err)})`,
             );
           }
@@ -456,10 +492,11 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
           workflowId: workflow_id,
           workflowVersion: effectiveWorkflowVersion,
           agentId: agent_id,
+          ...(parentState.repo ? { repo: parentState.repo } : {}),
           ...(context_mode ? { contextMode: context_mode } : {}),
           variables: seedDefaults(wfResult.value.variables),
         });
-        const parentNext = advanceSession(loaded.state, (draft) => {
+        const parentNext = advanceSession(parentState, (draft) => {
           draft.triggeredWorkflows.push({
             workflowId: workflow_id,
             sessionIndex: childSessionIndex,
@@ -489,7 +526,9 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
       // triggeredWorkflows[N].state. The child's sessionIndex is derived
       // from the top folder + jsonPath so it stays stable as long as the
       // array index doesn't shift (triggeredWorkflows is append-only).
-      const newArrayIndex = loaded.state.triggeredWorkflows.length;
+      // Use parentState (may include a just-bound repo) rather than the
+      // pre-bind loaded.state snapshot.
+      const newArrayIndex = parentState.triggeredWorkflows.length;
       const childJsonPath = [...loaded.jsonPath, 'triggeredWorkflows', newArrayIndex, 'state'];
       const childSessionIndex = await computeEmbeddedSessionIndex(parentFolder, childJsonPath);
       const childInitial = createInitialSessionFile({
@@ -497,10 +536,11 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
         workflowId: workflow_id,
         workflowVersion: effectiveWorkflowVersion,
         agentId: agent_id,
+        ...(parentState.repo ? { repo: parentState.repo } : {}),
         ...(context_mode ? { contextMode: context_mode } : {}),
         variables: seedDefaults(wfResult.value.variables),
       });
-      const parentNext = advanceSession(loaded.state, (draft) => {
+      const parentNext = advanceSession(parentState, (draft) => {
         draft.triggeredWorkflows.push({
           workflowId: workflow_id,
           sessionIndex: childSessionIndex,

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -100,14 +100,14 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
       description:
         'Start or resume the top-level workflow session. Returns `session_index`, workflow metadata, and canonical `planning_folder_path`. ' +
         'Pass `planning_folder` as an absolute path (basename = slug). ' +
-        'When the server is bound to an install multi-root, pass `repo` as owner/repo (from the user or workspace AGENTS.md) so planning lands under engineering/<owner>/<repo>/artifacts/planning/. ' +
+        'Always pass `repo` as owner/repo (from the user or workspace AGENTS.md) — stored on session.json#repo. ' +
         'Omit planning_folder for a transient meta bootstrap. Children use `dispatch_child`, not this tool. ' +
         '`context_mode: "persistent"` is ONLY for solo (same agent context; no worker spawn); omit/`"fresh"` for disposable workers.',
       inputSchema: z
         .object({
           workflow_id: z.string().optional().describe('Optional. Fresh-session workflow id (default "meta"). Ignored on resume.'),
           planning_folder: z.string().optional().describe('Optional. Absolute path; basename is the planning slug. Bare/relative paths rejected. Omit for transient meta bootstrap.'),
-          repo: z.string().optional().describe('Optional. Target owner/repo (or github URL). Required on install multi-root when creating a non-transient session; also accepted from planning_folder under engineering/<owner>/<repo>/….'),
+          repo: z.string().optional().describe('Target owner/repo (or github URL). Always pass when known; written to session.json#repo. Also accepted from planning_folder under …/<owner>/<repo>/….'),
           agent_id: z.string().default('orchestrator').describe('Agent identity stored on the session (default "orchestrator"). Use one canonical id for solo persistent walks.'),
           context_mode: z.enum(['persistent', 'fresh']).optional().describe('Optional. "persistent" = reference delivery; ONLY for solo (same agent retains payloads). Omit/"fresh" for disposable workers. Resume overwrites recorded mode.'),
         })
@@ -369,16 +369,14 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
         },
         session_index: sessionIndex,
         planning_slug: slug,
-        session_scope: sessionScope.mode,
       };
       if (state.planningFolderPath) response['planning_folder_path'] = state.planningFolderPath;
       // Echo the durable session binding (session.json#repo), not a path-only hint.
       if (state.repo) response['repo'] = state.repo;
-      // Fail-soft signal: multi-root transient without session.repo still boots, but
-      // dispatch_child promotion needs repo bound on the session (start_session or
-      // dispatch_child) before promote.
-      if (sessionScope.mode === 'multi' && isTransientSession && !state.repo) {
-        response['promotion_requires_repo'] = true;
+      // Fail-soft: transient without session.repo still boots; bind via start_session
+      // or dispatch_child before promote / durable path resolution needs it.
+      if (isTransientSession && !state.repo) {
+        response['repo_unbound'] = true;
       }
       if (state.contextMode) response['context_mode'] = state.contextMode;
       if (migrationResult.migrated) {
@@ -398,14 +396,14 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
       description:
         'Dispatch a child workflow under the parent session. Returns the child `session_index` and canonical `planning_folder_path`. ' +
         'Transient meta parents are promoted to a workspace planning folder first (optional `planning_slug`). ' +
-        'On install multi-root, ensure `session.repo` is bound (pass `repo` here if start_session did not); promotion reads only session.json. ' +
+        'Ensure `session.repo` is bound (pass `repo` here if start_session did not); path resolution reads only session.json. ' +
         'Never set `context_mode: "persistent"` on disposable-worker children — workers need fresh/full delivery.',
       inputSchema: z.object({
         ...sessionIndexParam,
         workflow_id: z.string().describe('Child workflow id (e.g. "work-package").'),
         agent_id: z.string().default('worker').describe('Child agent_id (default "worker").'),
         planning_slug: z.string().optional().describe('Optional. Promotion slug when the parent is a transient meta bootstrap. Ignored if the parent is already persistent.'),
-        repo: z.string().optional().describe('Optional. Bind owner/repo onto the parent session when missing (must match if already set). Used for multi-root promotion; session.json is the source of truth.'),
+        repo: z.string().optional().describe('Bind owner/repo onto the parent session when missing (must match if already set). session.json#repo is the source of truth.'),
         context_mode: z.enum(['persistent', 'fresh']).optional().describe('Optional. Child delivery mode. "persistent" ONLY for solo child walks; omit/"fresh" for disposable workers.'),
       }).strict(),
     },
@@ -423,8 +421,8 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
       const triggeredAt = new Date().toISOString();
 
       // Bind-if-missing on the parent session. session.json#repo is the single
-      // source of truth for multi-root promotion; dispatch_child.repo never
-      // overrides a prior bind.
+      // source of truth for path resolution / promotion; dispatch_child.repo
+      // never overrides a prior bind.
       let parentState = loaded.state;
       if (repo?.trim()) {
         try {
@@ -473,7 +471,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
           } catch (err) {
             throw new Error(
               `dispatch_child: cannot promote transient session without session.repo. ` +
-                `Bind repo on start_session or pass repo on dispatch_child when the server uses an install multi-root. ` +
+                `Bind repo on start_session or pass repo on dispatch_child. ` +
                 `(${err instanceof Error ? err.message : String(err)})`,
             );
           }

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -274,20 +274,14 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
     };
   }
 
-  server.tool('discover', 'Entry point — call before other tools. Returns server info, session_scope (single|multi), and the bootstrap procedure. No session_index required. When session_scope is multi, pass repo on start_session.', {},
+  server.tool('discover', 'Entry point — call before other tools. Returns server info and the bootstrap procedure. No session_index required. Always pass repo on start_session.', {},
     withAuditLog('discover', async () => {
       const bootstrapResult = await readResourceRaw(config.workflowDir, 'meta', 'bootstrap-protocol');
-      const scope = buildSessionScope(config);
       const lines = [
         `server: ${config.serverName}`,
         `version: ${config.serverVersion}`,
-        `session_scope: ${scope.mode}`,
+        'repo_binding: required — pass repo: "owner/repo" on start_session (from user or workspace AGENTS.md)',
       ];
-      if (scope.mode === 'multi') {
-        lines.push(
-          'repo_binding: required — pass repo: "owner/repo" on start_session (from user or workspace AGENTS.md)',
-        );
-      }
       if (bootstrapResult.success) {
         lines.push('', bootstrapResult.value.content);
       }
@@ -1301,21 +1295,17 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       };
     }), traceOpts ? { ...traceOpts, excludeFromTrace: true } : undefined));
 
-  server.tool('health_check', 'Server health: status, name, version, workflow count, uptime, session_scope. No session_index required. session_scope multi means pass repo on start_session.', {},
+  server.tool('health_check', 'Server health: status, name, version, workflow count, uptime. No session_index required.', {},
     withAuditLog('health_check', async () => {
       const workflows = await listWorkflows(config.workflowDir);
-      const scope = buildSessionScope(config);
       const payload: Record<string, unknown> = {
         status: 'healthy',
         server: config.serverName,
         version: config.serverVersion,
         workflows_available: workflows.length,
         uptime_seconds: Math.floor(process.uptime()),
-        session_scope: scope.mode,
+        repo_binding: 'required_on_start_session',
       };
-      if (scope.mode === 'multi') {
-        payload['repo_binding'] = 'required_on_start_session';
-      }
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(payload, null, 2) }],
       };

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -144,7 +144,7 @@ const HISTORY_MILESTONE_TYPES = new Set([
 
 /** Identity projection: the stable header fields identifying the session. */
 export function projectIdentity(s: SessionFile): Record<string, unknown> {
-  return {
+  const out: Record<string, unknown> = {
     workflowId: s.workflowId,
     workflowVersion: s.workflowVersion,
     sessionIndex: s.sessionIndex,
@@ -155,6 +155,9 @@ export function projectIdentity(s: SessionFile): Record<string, unknown> {
     startedAt: s.startedAt,
     seq: s.seq,
   };
+  if (s.repo) out['repo'] = s.repo;
+  if (s.planningFolderPath) out['planningFolderPath'] = s.planningFolderPath;
+  return out;
 }
 
 /** Checkpoint projection: each response reduced to option, timestamp, and any variables it set. */

--- a/src/utils/session/store.ts
+++ b/src/utils/session/store.ts
@@ -692,8 +692,6 @@ export async function ensurePlanningFolder(
 const TRANSIENT_DIR_PREFIX = 'workflow-server-transient-';
 const transientFolderByIndex = new Map<string, string>();
 const transientFolderBySlug = new Map<string, string>();
-/** Optional owner/repo attached at start_session for multi-root promotion. */
-const transientRepoByFolder = new Map<string, string>();
 
 /** Create a fresh transient planning folder under `os.tmpdir()`. */
 export async function createTransientFolder(): Promise<string> {
@@ -707,16 +705,9 @@ export function registerTransient(
   sessionIndex: string,
   folder: string,
   slug?: string,
-  repo?: string,
 ): void {
   transientFolderByIndex.set(sessionIndex, folder);
   if (slug) transientFolderBySlug.set(slug, folder);
-  if (repo) transientRepoByFolder.set(folder, repo);
-}
-
-/** Repo hint recorded for a transient folder at start_session (multi-root). */
-export function lookupTransientRepoByFolder(folder: string): string | undefined {
-  return transientRepoByFolder.get(folder);
 }
 
 /** Look up a transient folder by the slug it was registered under. */
@@ -760,9 +751,6 @@ export async function redirectTransientToWorkspace(
   for (const [slug, f] of transientFolderBySlug.entries()) {
     if (f === oldFolder) transientFolderBySlug.delete(slug);
   }
-  const repo = transientRepoByFolder.get(oldFolder);
-  transientRepoByFolder.delete(oldFolder);
-  if (repo) transientRepoByFolder.set(newFolder, repo);
   try {
     await rm(oldFolder, { recursive: true, force: true });
   } catch {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -170,13 +170,14 @@ describe('mcp-server integration', () => {
       const guide = parseToolResponse(result);
       expect(guide.server).toBeDefined();
       expect(guide.version).toBeDefined();
-      expect(guide.session_scope).toBe('single');
+      expect(guide.repo_binding).toMatch(/required/);
       expect(guide._body).toBeDefined();
       expect(typeof guide._body).toBe('string');
       expect(guide._body).toContain('start_session');
       expect(guide._body).toContain('get_workflow');
       expect(guide._body).toMatch(/repo/i);
       expect(guide.available_workflows).toBeUndefined();
+      expect(guide.session_scope).toBeUndefined();
     });
   });
 
@@ -430,7 +431,8 @@ describe('mcp-server integration', () => {
       const health = parseToolResponse(result);
       expect(health.status).toBe('healthy');
       expect(health.workflows_available).toBeGreaterThanOrEqual(2);
-      expect(health.session_scope).toBe('single');
+      expect(health.repo_binding).toBe('required_on_start_session');
+      expect(health.session_scope).toBeUndefined();
     });
   });
 
@@ -1486,8 +1488,9 @@ describe('mcp-server integration', () => {
       expect(response.workflow.id).toBe('meta');
       expect(response.session_index).toMatch(/^[A-Z2-7]{6}$/);
       expect(response.planning_slug).toBeDefined();
-      expect(response.session_scope).toBe('single');
-      expect(response.promotion_requires_repo).toBeUndefined();
+      expect(response.session_scope).toBeUndefined();
+      // Fresh meta without repo is unbound until bind; agents should pass repo always.
+      expect(response.repo_unbound).toBe(true);
     });
 
     it('accepts workflow_id for non-meta workflow', async () => {

--- a/tests/multi-root-bootstrap.test.ts
+++ b/tests/multi-root-bootstrap.test.ts
@@ -93,7 +93,7 @@ describe('multi-root bootstrap binding', () => {
     expect(response.repo).toBeUndefined();
   });
 
-  it('dispatch_child fails without a stashed repo on multi-root', async () => {
+  it('dispatch_child fails without a stashed or explicit repo on multi-root', async () => {
     const meta = await client.callTool({
       name: 'start_session',
       arguments: { workflow_id: 'meta', agent_id: 'orchestrator' },
@@ -112,7 +112,39 @@ describe('multi-root bootstrap binding', () => {
     expect(child.isError).toBeTruthy();
     const text = (child.content as { text: string }[])[0]?.text ?? '';
     expect(text).toMatch(/cannot promote transient session without a target repo/i);
-    expect(text).toMatch(/Pass repo on start_session/i);
+    expect(text).toMatch(/Pass repo on dispatch_child/i);
+  });
+
+  it('dispatch_child accepts repo when start_session omitted it (worker path)', async () => {
+    // Mirrors initialize-session: orchestrator started multi-root meta without
+    // repo; the activity worker has owner/repo from prior-state / prompt and
+    // must be able to pass it on dispatch_child.
+    const meta = await client.callTool({
+      name: 'start_session',
+      arguments: { workflow_id: 'meta', agent_id: 'orchestrator' },
+    });
+    expect(meta.isError).toBeFalsy();
+    const metaResp = parseToolResponse(meta);
+    expect(metaResp.promotion_requires_repo).toBe(true);
+
+    const slug = '2026-07-24-worker-repo';
+    const child = await client.callTool({
+      name: 'dispatch_child',
+      arguments: {
+        session_index: metaResp.session_index,
+        workflow_id: 'work-package',
+        agent_id: 'worker-1',
+        planning_slug: slug,
+        repo: 'acme/app',
+      },
+    });
+    expect(child.isError).toBeFalsy();
+    const childResp = parseToolResponse(child);
+    expect(childResp.planning_slug).toBe(slug);
+
+    const promoted = join(engMulti, 'acme', 'app', 'artifacts', 'planning', slug);
+    expect(existsSync(join(promoted, 'session.json'))).toBe(true);
+    expect(childResp.planning_folder_path).toBe(promoted);
   });
 
   it('start_session with repo binds and dispatch_child promotes under engineering/owner/repo', async () => {

--- a/tests/multi-root-bootstrap.test.ts
+++ b/tests/multi-root-bootstrap.test.ts
@@ -5,11 +5,6 @@ import { createServer } from '../src/server.js';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import {
-  lookupTransientRepoByFolder,
-  registerTransient,
-  createTransientFolder,
-} from '../src/utils/session/store.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function parseToolResponse(result: any): any {
@@ -93,7 +88,7 @@ describe('multi-root bootstrap binding', () => {
     expect(response.repo).toBeUndefined();
   });
 
-  it('dispatch_child fails without a stashed or explicit repo on multi-root', async () => {
+  it('dispatch_child fails without session.repo on multi-root', async () => {
     const meta = await client.callTool({
       name: 'start_session',
       arguments: { workflow_id: 'meta', agent_id: 'orchestrator' },
@@ -111,14 +106,14 @@ describe('multi-root bootstrap binding', () => {
     });
     expect(child.isError).toBeTruthy();
     const text = (child.content as { text: string }[])[0]?.text ?? '';
-    expect(text).toMatch(/cannot promote transient session without a target repo/i);
-    expect(text).toMatch(/Pass repo on dispatch_child/i);
+    expect(text).toMatch(/cannot promote transient session without session\.repo/i);
+    expect(text).toMatch(/Bind repo on start_session or pass repo on dispatch_child/i);
   });
 
-  it('dispatch_child accepts repo when start_session omitted it (worker path)', async () => {
+  it('dispatch_child binds repo onto session.json when start_session omitted it', async () => {
     // Mirrors initialize-session: orchestrator started multi-root meta without
     // repo; the activity worker has owner/repo from prior-state / prompt and
-    // must be able to pass it on dispatch_child.
+    // binds it on dispatch_child. session.json is the source of truth.
     const meta = await client.callTool({
       name: 'start_session',
       arguments: { workflow_id: 'meta', agent_id: 'orchestrator' },
@@ -145,9 +140,13 @@ describe('multi-root bootstrap binding', () => {
     const promoted = join(engMulti, 'acme', 'app', 'artifacts', 'planning', slug);
     expect(existsSync(join(promoted, 'session.json'))).toBe(true);
     expect(childResp.planning_folder_path).toBe(promoted);
+
+    const stored = JSON.parse(readFileSync(join(promoted, 'session.json'), 'utf8'));
+    expect(stored.repo).toBe('acme/app');
+    expect(stored.triggeredWorkflows[0].state.repo).toBe('acme/app');
   });
 
-  it('start_session with repo binds and dispatch_child promotes under engineering/owner/repo', async () => {
+  it('start_session with repo binds session.json and dispatch_child promotes under engineering/owner/repo', async () => {
     const meta = await client.callTool({
       name: 'start_session',
       arguments: {
@@ -182,19 +181,36 @@ describe('multi-root bootstrap binding', () => {
 
     const stored = JSON.parse(readFileSync(join(promoted, 'session.json'), 'utf8'));
     expect(stored.workflowId).toBe('meta');
+    expect(stored.repo).toBe('acme/app');
     expect(stored.triggeredWorkflows).toHaveLength(1);
     expect(stored.triggeredWorkflows[0].workflowId).toBe('work-package');
+    expect(stored.triggeredWorkflows[0].state.repo).toBe('acme/app');
   });
-});
 
-describe('transient repo stash helpers', () => {
-  it('registerTransient stores and lookupTransientRepoByFolder returns repo', async () => {
-    const folder = await createTransientFolder();
-    try {
-      registerTransient('ABC234', folder, undefined, 'acme/app');
-      expect(lookupTransientRepoByFolder(folder)).toBe('acme/app');
-    } finally {
-      rmSync(folder, { recursive: true, force: true });
-    }
+  it('dispatch_child rejects repo that conflicts with session.repo', async () => {
+    const meta = await client.callTool({
+      name: 'start_session',
+      arguments: {
+        workflow_id: 'meta',
+        agent_id: 'orchestrator',
+        repo: 'acme/app',
+      },
+    });
+    const metaIdx = parseToolResponse(meta).session_index;
+
+    const child = await client.callTool({
+      name: 'dispatch_child',
+      arguments: {
+        session_index: metaIdx,
+        workflow_id: 'work-package',
+        agent_id: 'worker-1',
+        planning_slug: '2026-07-24-conflict',
+        repo: 'other/repo',
+      },
+    });
+    expect(child.isError).toBeTruthy();
+    const text = (child.content as { text: string }[])[0]?.text ?? '';
+    expect(text).toMatch(/already bound to repo 'acme\/app'/i);
+    expect(text).toMatch(/cannot rebind to 'other\/repo'/i);
   });
 });

--- a/tests/multi-root-bootstrap.test.ts
+++ b/tests/multi-root-bootstrap.test.ts
@@ -12,7 +12,7 @@ function parseToolResponse(result: any): any {
   return JSON.parse(text);
 }
 
-describe('multi-root bootstrap binding', () => {
+describe('session.repo bootstrap binding', () => {
   let client: Client;
   let closeTransport: () => Promise<void>;
   let installDir: string;
@@ -59,36 +59,37 @@ describe('multi-root bootstrap binding', () => {
     }
   });
 
-  it('discover reports session_scope multi and repo_binding', async () => {
+  it('discover always requires repo_binding (no session_scope branching)', async () => {
     const result = await client.callTool({ name: 'discover', arguments: {} });
     expect(result.isError).toBeFalsy();
     const text = (result.content[0] as { type: 'text'; text: string }).text;
-    expect(text).toMatch(/session_scope:\s*multi/);
     expect(text).toMatch(/repo_binding:\s*required/);
     expect(text).toMatch(/repo:\s*"owner\/repo"/);
+    expect(text).not.toMatch(/session_scope:/);
   });
 
-  it('health_check reports session_scope multi', async () => {
+  it('health_check always reports repo_binding required', async () => {
     const result = await client.callTool({ name: 'health_check', arguments: {} });
     const health = parseToolResponse(result);
     expect(health.status).toBe('healthy');
-    expect(health.session_scope).toBe('multi');
     expect(health.repo_binding).toBe('required_on_start_session');
+    expect(health.session_scope).toBeUndefined();
   });
 
-  it('start_session without repo sets promotion_requires_repo on multi-root meta', async () => {
+  it('start_session without repo sets repo_unbound on transient meta', async () => {
     const result = await client.callTool({
       name: 'start_session',
       arguments: { workflow_id: 'meta', agent_id: 'orchestrator' },
     });
     expect(result.isError).toBeFalsy();
     const response = parseToolResponse(result);
-    expect(response.session_scope).toBe('multi');
-    expect(response.promotion_requires_repo).toBe(true);
+    expect(response.repo_unbound).toBe(true);
     expect(response.repo).toBeUndefined();
+    expect(response.session_scope).toBeUndefined();
+    expect(response.promotion_requires_repo).toBeUndefined();
   });
 
-  it('dispatch_child fails without session.repo on multi-root', async () => {
+  it('dispatch_child fails without session.repo', async () => {
     const meta = await client.callTool({
       name: 'start_session',
       arguments: { workflow_id: 'meta', agent_id: 'orchestrator' },
@@ -111,16 +112,13 @@ describe('multi-root bootstrap binding', () => {
   });
 
   it('dispatch_child binds repo onto session.json when start_session omitted it', async () => {
-    // Mirrors initialize-session: orchestrator started multi-root meta without
-    // repo; the activity worker has owner/repo from prior-state / prompt and
-    // binds it on dispatch_child. session.json is the source of truth.
     const meta = await client.callTool({
       name: 'start_session',
       arguments: { workflow_id: 'meta', agent_id: 'orchestrator' },
     });
     expect(meta.isError).toBeFalsy();
     const metaResp = parseToolResponse(meta);
-    expect(metaResp.promotion_requires_repo).toBe(true);
+    expect(metaResp.repo_unbound).toBe(true);
 
     const slug = '2026-07-24-worker-repo';
     const child = await client.callTool({
@@ -157,9 +155,8 @@ describe('multi-root bootstrap binding', () => {
     });
     expect(meta.isError).toBeFalsy();
     const metaResp = parseToolResponse(meta);
-    expect(metaResp.session_scope).toBe('multi');
     expect(metaResp.repo).toBe('acme/app');
-    expect(metaResp.promotion_requires_repo).toBeUndefined();
+    expect(metaResp.repo_unbound).toBeUndefined();
 
     const slug = '2026-07-24-with-repo';
     const child = await client.callTool({

--- a/tests/session-schema.test.ts
+++ b/tests/session-schema.test.ts
@@ -4,6 +4,7 @@ import {
   safeValidateSessionFile,
   validateSessionFile,
   createInitialSessionFile,
+  bindSessionRepo,
   parentChainDepth,
   PARENT_CHAIN_DEPTH_WARN_THRESHOLD,
   type SessionFile,
@@ -272,6 +273,59 @@ describe('SessionFile schema', () => {
         agentId: 'worker',
       });
       expect(file.parentSession).toBeUndefined();
+    });
+
+    it('includes optional repo when provided', () => {
+      const file = createInitialSessionFile({
+        sessionIndex: VALID_INDEX,
+        workflowId: 'meta',
+        workflowVersion: '5.0.0',
+        agentId: 'orchestrator',
+        repo: 'acme/app',
+      });
+      expect(file.repo).toBe('acme/app');
+      expect(safeValidateSessionFile(file).success).toBe(true);
+    });
+  });
+
+  describe('bindSessionRepo', () => {
+    const identity = (s: string) => s;
+
+    it('binds repo when missing', () => {
+      const file = createInitialSessionFile({
+        sessionIndex: VALID_INDEX,
+        workflowId: 'meta',
+        workflowVersion: '5.0.0',
+        agentId: 'orchestrator',
+      });
+      const next = bindSessionRepo(file, 'acme/app', identity);
+      expect(next.repo).toBe('acme/app');
+      expect(file.repo).toBeUndefined();
+    });
+
+    it('is idempotent for the same repo', () => {
+      const file = createInitialSessionFile({
+        sessionIndex: VALID_INDEX,
+        workflowId: 'meta',
+        workflowVersion: '5.0.0',
+        agentId: 'orchestrator',
+        repo: 'acme/app',
+      });
+      const next = bindSessionRepo(file, 'acme/app', identity);
+      expect(next).toBe(file);
+    });
+
+    it('rejects a conflicting rebind', () => {
+      const file = createInitialSessionFile({
+        sessionIndex: VALID_INDEX,
+        workflowId: 'meta',
+        workflowVersion: '5.0.0',
+        agentId: 'orchestrator',
+        repo: 'acme/app',
+      });
+      expect(() => bindSessionRepo(file, 'other/repo', identity)).toThrow(
+        /already bound to repo 'acme\/app'/,
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- Add optional `repo` on `dispatch_child` so initialize-session workers can promote multi-root meta when `start_session` omitted the binding.
- Explicit `repo` overrides any stash from `start_session`.
- Bump workflows pin: `create-session` documents passing `repo` from prior-state / dispatch prompt / AGENTS.md.
- Test: meta without repo + `dispatch_child({ repo })` promotes under `engineering/<owner>/<repo>/`.

Follow-up to #285: workers already receive Target Github repo in the prompt but had no schema-legal place to put it at promote time.

## Test plan
- [x] npm run typecheck
- [x] vitest multi-root-bootstrap
- [ ] Redeploy install; worker dispatch_child with repo succeeds