### PR TITLE
fix(meta): bind create-session.repo from bag target_repo

### DIFF
--- a/meta/README.md
+++ b/meta/README.md
@@ -11,7 +11,7 @@ The meta workflow is the structural home for the orchestration logic that used t
 **Key characteristics:**
 
 - Excluded from `list_workflows` — not a user-facing workflow.
-- Bootstrap (resource [`bootstrap-protocol`](./resources/bootstrap-protocol.md)) is the pre-session stub served by `discover`: schema fetch → `start_session` → `get_workflow`. Ongoing delivery policy lives in the operations bundle ([workflow-engine](./techniques/workflow-engine/TECHNIQUE.md)). There is no separate START / RESUME branching in bootstrap — `discover-session` owns target identification and saved-session matching.
+- Bootstrap (resource [`bootstrap-protocol`](./resources/bootstrap-protocol.md)) is the pre-session stub served by `discover`: schema fetch → resolve `owner/repo` → `start_session` (with `repo`) → bag `{meta_session_index}` / `{target_repo}` → `get_workflow`. Ongoing delivery policy lives in the operations bundle ([workflow-engine](./techniques/workflow-engine/TECHNIQUE.md)). There is no separate START / RESUME branching in bootstrap — `discover-session` owns target identification and saved-session matching.
 - Universal techniques resolve for any session via the loader's workflow-local → `meta` fallback chain.
 - State persistence is server-managed (no agent-side persist/restore); on-disk shape: [`docs/state_management_model.md`](../../docs/state_management_model.md).
 
@@ -95,7 +95,7 @@ Universal techniques referenced by canonical ID (the file/folder slug).
 
 | Resource ID | Resource | Purpose |
 |-------------|----------|---------|
-| `bootstrap-protocol` | [Bootstrap Protocol](./resources/bootstrap-protocol.md) | Pre-session stub served by `discover` — schema fetch, `start_session`, `get_workflow`. Ongoing delivery policy is in the operations bundle. |
+| `bootstrap-protocol` | [Bootstrap Protocol](./resources/bootstrap-protocol.md) | Pre-session stub served by `discover` — schema fetch, bind `repo` on `start_session`, bag `{target_repo}`, `get_workflow`. Ongoing delivery policy is in the operations bundle. |
 | `session-summary-template` | [Session Summary Template](./resources/session-summary-template.md) | Skeleton for the markdown session summary composed by `generate-summary` at workflow close. |
 | `planning-readme` | [Planning Folder README Guide](./resources/planning-readme.md) | Universal Template + Progress Status policy for planning-folder `README.md`. |
 

--- a/meta/activities/01-initialize-session.yaml
+++ b/meta/activities/01-initialize-session.yaml
@@ -1,5 +1,5 @@
 id: initialize-session
-version: 6.2.0
+version: 6.3.0
 name: Initialize Session
 description: Derive the client planning slug, then dispatch the client workflow as a child of the meta session.
 required: true
@@ -19,6 +19,7 @@ steps:
         parent_session_index: meta_session_index
         workflow_id: target_workflow_id
         planning_slug: client_planning_slug
+        repo: target_repo
       outputs:
         session_index: client_session_index
 transitions:

--- a/meta/resources/README.md
+++ b/meta/resources/README.md
@@ -12,7 +12,7 @@ Tool reference content for Atlassian, GitNexus, and state management has moved i
 
 | Resource ID | Resource | Purpose |
 |-------------|----------|---------|
-| `bootstrap-protocol` | [Bootstrap Protocol](./bootstrap-protocol.md) | Pre-session stub served by `discover` — schema fetch → `start_session` → `get_workflow`; cites [start-session](../techniques/workflow-engine/start-session.md) / [workflow-engine](../techniques/workflow-engine/TECHNIQUE.md) for folder topology and delivery policy. |
+| `bootstrap-protocol` | [Bootstrap Protocol](./bootstrap-protocol.md) | Pre-session stub served by `discover` — schema fetch → bind `repo` on `start_session` → bag `{target_repo}` → `get_workflow`; cites [start-session](../techniques/workflow-engine/start-session.md) / [workflow-engine](../techniques/workflow-engine/TECHNIQUE.md) for folder topology and delivery policy. |
 | `session-summary-template` | [Session Summary Template](./session-summary-template.md) | Skeleton for the markdown session summary composed at workflow close |
 | `planning-readme` | [Planning Folder README Guide](./planning-readme.md) | Universal Template + Progress Status policy for planning-folder `README.md`; Progress inventory comes from each workflow's readme-seed profile |
 

--- a/meta/resources/bootstrap-protocol.md
+++ b/meta/resources/bootstrap-protocol.md
@@ -11,10 +11,12 @@ IMPORTANT: YOU *MUST* *ALWAYS* EXECUTE ALL OF THESE STEPS
 
    - Orchestrators need only the workflow schema. Activity and technique schemas are worker-side and load on demand.
 
-2. `start_session { workflow_id: "meta", agent_id: "orchestrator" }`. Save the returned `session_index` (6-character base32). The server creates or rebinds `session.json` + `.session-token` under the planning folder; no agent-side state writes are required.
+2. Resolve the target repository as `owner/repo` from the workspace `AGENTS.md` or `CLAUDE.md`, or from the user. Use only a repository the user or workspace identifies.
+
+3. `start_session { workflow_id: "meta", agent_id: "orchestrator", repo }` per [start-session](../techniques/workflow-engine/start-session.md). Save the returned `session_index` (6-character base32) as bag `{meta_session_index}`. Record `{repo}` as bag `{target_repo}` (response echo when present, otherwise the value passed). The server creates or rebinds `session.json` + `.session-token` under the planning folder; no agent-side state writes are required.
 
    - Planning-folder targeting (`planning_folder` absolute-or-omit, response `planning_folder_path`) and `context_mode` topology follow [start-session](../techniques/workflow-engine/start-session.md) (and [dispatch-topology](../techniques/workflow-engine/TECHNIQUE.md#dispatch-topology) for disposable workers).
 
-3. `get_workflow { session_index }`. The response carries the workflow's resolved operations bundle ahead of the workflow definition (separated by `\n\n---\n\n`). Follow the operations and rules in the bundle — ongoing delivery policy lives there ([workflow-engine](../techniques/workflow-engine/TECHNIQUE.md)).
+4. `get_workflow { session_index }`. The response carries the workflow's resolved operations bundle ahead of the workflow definition (separated by `\n\n---\n\n`). Follow the operations and rules in the bundle — ongoing delivery policy lives there ([workflow-engine](../techniques/workflow-engine/TECHNIQUE.md)).
 
    - Pass `session_index` on every subsequent authenticated tool call ([session-index-passes-on-each-call](../techniques/workflow-engine/TECHNIQUE.md#session-index-passes-on-each-call)).

--- a/meta/techniques/workflow-engine/create-session.md
+++ b/meta/techniques/workflow-engine/create-session.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.3.0
+  version: 1.4.0
 ---
 
 ## Capability
@@ -21,6 +21,10 @@ Target client workflow id (e.g., `work-package`).
 
 The work-package planning slug — `YYYY-MM-DD-{initiative_name}`. Names the planning folder the server materialises under its workspace `.engineering` root. Omit when no slug has been derived; the server then falls back to `YYYY-MM-DD-<workflow_id>`.
 
+### repo
+
+Target repository as `owner/repo` (or GitHub URL).
+
 ## Outputs
 
 ### session_index
@@ -33,6 +37,6 @@ The canonical absolute path of the planning folder, as resolved by the server un
 
 ## Protocol
 
-1. Call `dispatch_child { session_index: {parent_session_index}, workflow_id: {workflow_id}, agent_id: 'orchestrator', planning_slug: {client_planning_slug} }`; capture `{session_index}` and `{planning_folder_path}` (server-resolved; do not compose the path). Child session embed under the parent follows the `dispatch_child` response / [handle-sub-workflow](./handle-sub-workflow.md).
+1. Call `dispatch_child { session_index: {parent_session_index}, workflow_id: {workflow_id}, agent_id: 'orchestrator', planning_slug: {client_planning_slug}, repo: {repo} }`; capture `{session_index}` and `{planning_folder_path}` (server-resolved; do not compose the path). Child session embed under the parent follows the `dispatch_child` response / [handle-sub-workflow](./handle-sub-workflow.md).
 
    Omit `context_mode` (or `"fresh"`) per [dispatch-topology](./TECHNIQUE.md#dispatch-topology) / [workers-need-full-delivery](./dispatch-activity.md#workers-need-full-delivery).

--- a/meta/techniques/workflow-engine/start-session.md
+++ b/meta/techniques/workflow-engine/start-session.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -17,13 +17,17 @@ Optional. Fresh-session workflow id (default `meta`). Ignored on resume.
 
 Optional. Absolute path whose basename is the planning slug. Omit for a transient meta bootstrap when the slug is not yet known.
 
+### repo
+
+Target repository as `owner/repo` (or GitHub URL). Identified by the user or the workspace `AGENTS.md` / `CLAUDE.md`. Also accepted implicitly when `planning_folder` already sits under `…/<owner>/<repo>/…`.
+
 ### agent_id
 
 Agent identity stored on the session (default `orchestrator`).
 
 ### context_mode
 
-Optional. Omit or pass `"fresh"`. Client sessions use per-activity disposable workers (workers-need-full-delivery).
+Optional. Omit or pass `"fresh"`. Client sessions use per-activity disposable workers ([dispatch-activity](./dispatch-activity.md)::workers-need-full-delivery).
 
 ## Outputs
 
@@ -35,10 +39,15 @@ Stable 6-character base32 index for every subsequent authenticated tool call.
 
 Canonical absolute planning folder path as resolved by the server.
 
+### repo
+
+Bound target repository as `owner/repo`.
+
 ## Protocol
 
-1. Call `start_session` with `{workflow_id}`, `{agent_id}`, and optional `{planning_folder}` per the [bootstrap protocol](../../resources/bootstrap-protocol.md). Omit `context_mode` (or pass `"fresh"`).
-2. Save `{session_index}` and `{planning_folder_path}` from the response. Do not compose or reconcile the planning path yourself.
+1. Call `start_session` with `{workflow_id}`, `{agent_id}`, `{repo}`, and optional `{planning_folder}`, per the [bootstrap protocol](../../resources/bootstrap-protocol.md). Omit `context_mode` (or pass `"fresh"`).
+   > `{repo}` is required on every call, including transient meta when `{planning_folder}` is omitted.
+2. Save `{session_index}` and `{planning_folder_path}` from the response. Record `{repo}` as bag `{target_repo}` (response echo when present, otherwise the value passed). Do not compose or reconcile the planning path yourself.
 3. Call `get_workflow { session_index }` and follow the returned operations bundle. After summarization, re-fetch with the escapes in `workflow-engine.force-full-after-summarization`.
 
 ## Rules

--- a/meta/workflow.yaml
+++ b/meta/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: meta
-version: 5.7.0
+version: 5.8.0
 title: Meta Workflow
 description: Top-level lifecycle workflow that orchestrates client workflow sessions. Excluded from list_workflows — bootstrap navigates here directly.
 author: m2ux
@@ -32,6 +32,9 @@ variables:
   - name: meta_session_index
     type: string
     description: 6-character base32 session_index of the meta session itself — read by initialize-session and passed as parent_session_index when create-session creates the client session
+  - name: target_repo
+    type: string
+    description: Target GitHub owner/repo for this run (from user or workspace AGENTS.md)
   - name: target_workflow_outcomes
     type: string
     description: The client workflow's declared outcomes, read by verify-outcomes during end-workflow close-out


### PR DESCRIPTION
## Summary

- Meta bag `target_repo` set at bootstrap / `start_session`
- `initialize-session` binds `create-session.repo` ← `target_repo`
- `dispatch_child` receives `repo` from the bag before durable parent `session.json` exists
- Single channel: variable bag + technique binding (no activity-worker Prior-state dual path)

## Test plan

- [ ] Bootstrap meta with `repo` → bag has `target_repo`
- [ ] `initialize-session` → `dispatch_child` with bound `repo` succeeds
- [ ] Activity-worker prompt has no Prior-state block