### PR TITLE
feat(install): relax path co-location to HOST_PROJECTS_ROOT + nested .worktrees

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,14 +28,16 @@ WORKFLOW_SERVER_MCP_URL=http://127.0.0.1:3000/mcp
 # Install root (default: ~/.local/share/workflow-server). Used with --repo.
 # WORKFLOW_SERVER_INSTALL_DIR=
 
-# Feature worktrees root (default when empty: $INSTALL/worktrees).
+# Projects root (preferred: ~/projects/dev). Layout:
+#   $HOST_PROJECTS_ROOT/<repo>/.engineering/
+#   $HOST_PROJECTS_ROOT/<repo>/.worktrees/<slug>/
+# HOST_PROJECTS_ROOT=
+# WORKFLOW_SERVER_ENGINEERING_DIR=
+
+# Workspace multi-root — prefer same path as HOST_PROJECTS_ROOT (nested .worktrees).
+# $INSTALL/worktrees is deprecated.
 WORKFLOW_WORKSPACE=
 # WORKTREE_ROOT=
-
-# Projects multi-root (default when empty: $INSTALL/projects). Engineering lives at
-# projects/<owner>/<repo>/.engineering.
-# WORKFLOW_SERVER_ENGINEERING_DIR=
-# HOST_PROJECTS_ROOT=
 
 # Optional process pin to one owner/repo (stdio single-tenant). Prefer passing
 # repo at start_session when using Docker multi-root + init-repo.
@@ -58,9 +60,9 @@ SCHEMAS_DIR=
 # =============================================================================
 # Docker Compose — host bind sources (paths on the machine running compose)
 # =============================================================================
-# Host binds (install.sh defaults: $INSTALL/worktrees and $INSTALL/projects)
-HOST_WORKTREE_ROOT=
+# Host binds — preferred: HOST_PROJECTS_ROOT only (nested .worktrees)
 HOST_PROJECTS_ROOT=
+# HOST_WORKTREE_ROOT=   # deprecated separate global feature-tree root
 HOST_WORKFLOWS_DIR=./workflows
 HOST_SCHEMAS_DIR=./schemas
 # Durable HMAC key on the host (install.sh default: $INSTALL/state)
@@ -72,9 +74,9 @@ HOST_PORT=3000
 # Must NOT reuse WORKFLOW_DIR / WORKFLOW_WORKSPACE from the host section above.
 # =============================================================================
 CONTAINER_INSTALL_DIR=/var/lib/workflow-server
-CONTAINER_WORKTREE_ROOT=/var/lib/workflow-server/worktrees
 CONTAINER_PROJECTS_ROOT=/var/lib/workflow-server/projects
-# Engineering multi-root coincides with projects under the install layout
+# Nested model: workspace multi-root = projects multi-root
+CONTAINER_WORKTREE_ROOT=/var/lib/workflow-server/projects
 CONTAINER_ENGINEERING_ROOT=/var/lib/workflow-server/projects
 CONTAINER_STATE_DIR=/var/lib/workflow-server/state
 CONTAINER_WORKFLOW_DIR=/app/workflows

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Dependencies
 node_modules/
 
+# Nested feature worktrees (per-checkout parent; not $INSTALL/worktrees)
+.worktrees/
+
 # Build output
 dist/
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,7 @@
-# Host worktrees + projects roots are bound RW; the server derives planning under
-# projects/<owner>/<repo>/.engineering and feature worktrees under worktrees/.
+# Host projects root is bound RW. Preferred layout:
+#   $HOST_PROJECTS_ROOT/<repo>/.engineering/  and  <repo>/.worktrees/<slug>/
+# $INSTALL/worktrees (HOST_WORKTREE_ROOT) is deprecated; omit it when using nested
+# .worktrees under the projects root (compose may still mount a legacy path if set).
 # Agents create worktrees on the host before the server writes artifacts.
 #
 # Paths are overridable via environment variables or a local `.env` file
@@ -18,8 +20,9 @@ services:
     ports:
       - "${HOST_PORT:-3000}:${PORT:-3000}"
     environment:
-      WORKTREE_ROOT: ${CONTAINER_WORKTREE_ROOT:-/var/lib/workflow-server/worktrees}
-      WORKFLOW_WORKSPACE: ${CONTAINER_WORKTREE_ROOT:-/var/lib/workflow-server/worktrees}
+      # Nested model: workspace multi-root defaults to the projects mount
+      WORKTREE_ROOT: ${CONTAINER_WORKTREE_ROOT:-${CONTAINER_PROJECTS_ROOT:-/var/lib/workflow-server/projects}}
+      WORKFLOW_WORKSPACE: ${CONTAINER_WORKTREE_ROOT:-${CONTAINER_PROJECTS_ROOT:-/var/lib/workflow-server/projects}}
       WORKFLOW_SERVER_ENGINEERING_DIR: ${CONTAINER_ENGINEERING_ROOT:-${CONTAINER_PROJECTS_ROOT:-/var/lib/workflow-server/projects}}
       WORKFLOW_SERVER_INSTALL_DIR: ${CONTAINER_INSTALL_DIR:-/var/lib/workflow-server}
       # Optional: override default planning slug (multi-root uses artifacts/planning per repo)
@@ -43,14 +46,9 @@ services:
         source: ${HOST_SCHEMAS_DIR:-./schemas}
         target: ${CONTAINER_SCHEMAS_DIR:-/app/schemas}
         read_only: true
-      # Feature worktrees root (default $INSTALL/worktrees)
+      # Projects root: checkouts + .engineering + nested .worktrees (preferred)
       - type: bind
-        source: ${HOST_WORKTREE_ROOT:-${HOME}/.local/share/workflow-server/worktrees}
-        target: ${CONTAINER_WORKTREE_ROOT:-/var/lib/workflow-server/worktrees}
-        read_only: false
-      # Projects multi-root: app clones + .engineering (default $INSTALL/projects)
-      - type: bind
-        source: ${HOST_PROJECTS_ROOT:-${HOME}/.local/share/workflow-server/projects}
+        source: ${HOST_PROJECTS_ROOT:-${HOME}/projects/dev}
         target: ${CONTAINER_PROJECTS_ROOT:-/var/lib/workflow-server/projects}
         read_only: false
       # Durable server state (HMAC secret)

--- a/docs/install-projects-worktrees.md
+++ b/docs/install-projects-worktrees.md
@@ -1,95 +1,104 @@
-# Install layout: projects + worktrees
+# Install layout: projects + nested worktrees
 
 ## Goal
 
-Every managed product repo under the workflow-server install root gets a **main/default-branch checkout** used as the git reference for feature worktrees. Engineering planning lives in that checkout’s **`.engineering` submodule** (initialized on init). Feature worktrees stay in a **sibling** install tree. Global workflow **definitions** remain a separate install clone.
+Product **source checkouts** live under a configurable **`HOST_PROJECTS_ROOT`**
+(not necessarily under `$INSTALL`). Every project uses the same shape. Feature
+worktrees live **only** in a gitignored **`.worktrees/`** directory inside that
+checkout. Workflow **definitions** remain a separate clone under `$INSTALL/workflows`.
 
-## Layout
+`$INSTALL/worktrees/` is **deprecated** and must not be used for new feature trees.
+
+## Preferred layout (Layer A / external projects root)
 
 ```text
-$INSTALL/   # default: ~/.local/share/workflow-server
-├── env
+$HOST_PROJECTS_ROOT/                 # e.g. ~/projects/dev  (from $INSTALL/env)
+├── <repo>/                          # basename only — not owner/repo
+│   ├── .engineering/                # submodule / planning root (when present)
+│   └── .worktrees/
+│       └── <wp-slug>/               # feature worktree of this checkout
+└── workflow-server/                 # same class as any other project
+    ├── .engineering/
+    └── .worktrees/<slug>/
+
+$INSTALL/                            # default: ~/.local/share/workflow-server
+├── env                              # HOST_PROJECTS_ROOT=…  (no HOST_WORKTREE_ROOT)
 ├── state/
-├── start.sh  stop.sh  update-workflows.sh  init-repo.sh
-├── workflows/                         # definitions branch (server WORKFLOW_DIR)
-├── projects/
-│   └── <owner>/<repo>/                # full app clone @ default branch
-│       └── .engineering/              # submodule (or materialised eng) — planning root
-└── worktrees/
-    └── <owner>/<repo>/
-        └── <wp-slug>/                 # git worktree of projects checkout (feature branch)
+├── start.sh  stop.sh  update-workflows.sh
+└── workflows/                       # definitions branch (server WORKFLOW_DIR)
 ```
 
 | Path | Role |
 |------|------|
-| `$INSTALL/projects/<o>/<r>/` | `repo_root` — primary checkout; base for `git worktree add` |
-| `$INSTALL/projects/<o>/<r>/.engineering/` | Session / planning root (`artifacts/planning/…`) |
-| `$INSTALL/worktrees/<o>/<r>/<slug>/` | Feature edit worktrees |
+| `$HOST_PROJECTS_ROOT/<repo>/` | Checkout / `repo_root` — primary source |
+| `$HOST_PROJECTS_ROOT/<repo>/.engineering/` | Planning root (`artifacts/planning/…`) |
+| `$HOST_PROJECTS_ROOT/<repo>/.worktrees/<slug>/` | **Only** allowed feature worktree path |
 | `$INSTALL/workflows/` | Workflow YAML library for the server (not per-product) |
+
+Uniform formula:
+
+```text
+checkout    = $HOST_PROJECTS_ROOT / <repo>
+planning    = checkout / .engineering / …
+target_path = checkout / .worktrees / <slug>
+```
+
+## Deprecated install co-location
+
+Older installs used `$INSTALL/projects/<owner>/<repo>` and `$INSTALL/worktrees/<owner>/<repo>`.
+Do **not** create new trees there. Operators may delete `$INSTALL/worktrees` after
+migrating feature worktrees under each checkout’s `.worktrees/`.
+
+| Deprecated | Prefer |
+|------------|--------|
+| `$INSTALL/projects/<o>/<r>/` | `$HOST_PROJECTS_ROOT/<repo>/` |
+| `$INSTALL/worktrees/<o>/<r>/<slug>/` | `$HOST_PROJECTS_ROOT/<repo>/.worktrees/<slug>/` |
+| `HOST_WORKTREE_ROOT` as a global feature-tree root | Nested `.worktrees/` only |
 
 ## Lifecycle
 
 ### install.sh
 
-- Create empty `projects/`, `worktrees/`, `state/`.
-- Clone global `workflows/` on the `workflows` branch.
-- Write `env`: `HOST_PROJECTS_ROOT`, `HOST_WORKTREE_ROOT`, install dir, port, container name.
-- Do not clone a single top-level project without `owner/repo`.
-
-### init-repo.sh owner/repo
-
-1. Clone/ensure `$INSTALL/projects/<o>/<r>` on `--branch=NAME` when set, otherwise the remote default branch (**no** bulk submodule init).
-2. Materialise engineering at `projects/<o>/<r>/.engineering`:
-   - Prefer `git submodule update --init -- .engineering` when listed in `.gitmodules`.
-   - Else existing resolution (`--engineering-branch` / eng branch clone into `.engineering`, or in-tree extract).
-3. `mkdir -p $INSTALL/worktrees/<o>/<r>/`.
-
-### update-workflows.sh
-
-1. Ff-only update global `$INSTALL/workflows`.
-2. For each `$INSTALL/projects/*/*` git checkout: fetch + ff default branch; refresh `.engineering` when it is a git/submodule checkout (dirty / `--force` policy aligned with workflows).
+- Create `state/`; clone global `workflows/` on the `workflows` branch.
+- Write `env` with **`HOST_PROJECTS_ROOT`** (default may still be `$INSTALL/projects`
+  for greenfield installs that have not opted out).
+- **Do not** require or default a separate `$INSTALL/worktrees` root when using
+  nested worktrees. If `HOST_WORKTREE_ROOT` is unset, start.sh treats the
+  projects root as the bind that covers nested `.worktrees/`.
+- Optional `--projects-root=PATH` → external root (e.g. `~/projects/dev`).
 
 ### start.sh (Docker)
 
-- Mount `projects/` RW, `worktrees/` RW, `workflows/` RO, `state/` RW.
-- `WORKTREE_ROOT` / workspace multi-root → `$INSTALL/worktrees`.
-- `WORKFLOW_SERVER_ENGINEERING_DIR` multi-root → `$INSTALL/projects` (per-repo eng = `projects/<o>/<r>/.engineering`).
+- Mount `HOST_PROJECTS_ROOT` RW (covers checkouts, `.engineering`, nested `.worktrees`).
+- Mount `workflows/` RO, `state/` RW.
+- If `HOST_WORKTREE_ROOT` is set and differs from projects root, mount it as well
+  (legacy). Prefer leaving it unset.
+- `WORKFLOW_SERVER_ENGINEERING_DIR` → projects multi-root base inside the container.
 
-## Server multi-root
-
-| Role | Path |
-|------|------|
-| Multi-root eng base | `$INSTALL/projects` |
-| Per-repo planning | `$INSTALL/projects/<o>/<r>/.engineering/artifacts/planning/` |
-| Feature worktree parent | `$INSTALL/worktrees/<o>/<r>/` |
-
-`start_session({ repo: "owner/repo" })` selects the per-repo engineering checkout under `projects/`.
-
-## Agent bindings
-
-| Variable | Value |
-|----------|--------|
-| `repo_root` | `$INSTALL/projects/<o>/<r>` |
-| Planning | via server under `…/.engineering/artifacts/planning/` |
-| `target_path` | `$INSTALL/worktrees/<o>/<r>/<wp-slug>/` |
+### Feature worktrees (agents)
 
 ```bash
-git -C "$INSTALL/projects/acme/app" worktree add -b "$branch" \
-  "$INSTALL/worktrees/acme/app/$slug" "origin/$default_branch"
+git -C "$HOST_PROJECTS_ROOT/my-app" worktree add -b "$branch" \
+  "$HOST_PROJECTS_ROOT/my-app/.worktrees/$slug" "origin/$default_branch"
 ```
+
+Ensure `.worktrees/` is listed in the project’s `.gitignore`.
 
 ## Cursor example roots
 
+Four navigation roots (see `examples/cursor-workspace/`):
+
 ```text
-kickoff/
-$INSTALL/projects/<owner>/<repo>
-$INSTALL/worktrees/<owner>/<repo>
+kickoff/                                      # rules + MCP
+$HOST_PROJECTS_ROOT/<repo>                    # project
+$HOST_PROJECTS_ROOT/<repo>/.engineering       # planning
+$HOST_PROJECTS_ROOT/<repo>/.worktrees         # feature trees
 ```
 
 ## Success criteria
 
-- `init-repo o/r` yields projects main checkout, `.engineering` planning root, and worktrees parent.
-- Sessions plan under `projects/…/.engineering/artifacts/planning/`.
-- Feature worktrees only under `worktrees/…`, created from `projects/…`.
+- Checkouts live under `HOST_PROJECTS_ROOT/<repo>` (basename layout).
+- Sessions plan under `<repo>/.engineering/artifacts/planning/` when eng is present.
+- Feature worktrees **only** under `<repo>/.worktrees/<slug>/`.
+- No new paths under `$INSTALL/worktrees`.
 - Global `$INSTALL/workflows` still serves definitions.
-- Product `workflows` submodule not required at init.

--- a/examples/cursor-workspace/AGENTS.md
+++ b/examples/cursor-workspace/AGENTS.md
@@ -1,11 +1,35 @@
 # Target repository
 
-The GitHub repo this Cursor workspace is bound to is:
+## Filesystem checkout (navigation)
+
+Projects live under `HOST_PROJECTS_ROOT` (see `$INSTALL/env`, default example
+`~/projects/dev`). The checkout for this workspace is the **repo basename**:
+
+```
+workflow-server
+```
+
+Full path: `$HOST_PROJECTS_ROOT/workflow-server`  
+(example absolute: `/home/mike1/projects/dev/workflow-server`)
+
+Same layout for every project — no special case for workflow-server:
+
+```text
+$HOST_PROJECTS_ROOT/<repo>/
+$HOST_PROJECTS_ROOT/<repo>/.engineering/       # planning / eng submodule
+$HOST_PROJECTS_ROOT/<repo>/.worktrees/<slug>/  # feature worktrees only
+```
+
+`$INSTALL/worktrees` and `$INSTALL/projects` are **not** used for source or
+feature trees.
+
+## Session identity (`start_session`)
+
+If the agent needs a GitHub `owner/repo` for `start_session` / `session.json#repo`,
+set it here (orthogonal to the filesystem path above):
 
 ```
 owner/repo
 ```
 
-Replace with your project (for example `m2ux/workflow-server`). Agents should always pass this
-value as `repo` on `start_session` (stored on `session.json#repo`). Install multi-root uses
-`$INSTALL/projects` + `$INSTALL/worktrees`.
+Replace with your project (for example `m2ux/workflow-server`).

--- a/examples/cursor-workspace/README.md
+++ b/examples/cursor-workspace/README.md
@@ -1,18 +1,20 @@
 # Example Cursor workspace (workflow kick-off)
 
 Minimal multi-root Cursor workspace you can copy and open to drive
-workflow-server sessions against a target `owner/repo`.
+workflow-server sessions against a project checkout under `HOST_PROJECTS_ROOT`.
 
 It mirrors a typical layout under `~/.local/share/cursor/workspaces/<name>/`:
 agent rules, MCP client config, and a `.code-workspace` that mounts the
-install-root **projects** and **worktrees** trees next to this folder.
+**project**, **`.engineering`**, and local **`.worktrees`** roots for easy
+navigation.
 
 ## Prerequisites
 
 1. Install and start workflow-server ([setup.md](../../setup.md), [http.md](../../http.md)).
-2. Deploy engineering into the target project and run `init-repo.sh owner/repo`
-   ([setup.md §2](../../setup.md)).
-3. HTTP MCP listening at `http://127.0.0.1:3000/mcp` (or change
+2. Set `HOST_PROJECTS_ROOT` in `$INSTALL/env` (example: `~/projects/dev`).
+3. Have a checkout at `$HOST_PROJECTS_ROOT/<repo>` with optional `.engineering`
+   and a gitignored `.worktrees/` directory (create empty if missing).
+4. HTTP MCP listening at `http://127.0.0.1:3000/mcp` (or change
    [`.cursor/mcp.json`](.cursor/mcp.json)).
 
 ## Layout
@@ -20,9 +22,9 @@ install-root **projects** and **worktrees** trees next to this folder.
 ```text
 examples/cursor-workspace/
 ├── README.md                         # this file
-├── AGENTS.md                         # target owner/repo hint for start_session
+├── AGENTS.md                         # checkout basename + optional owner/repo
 ├── CLAUDE.md -> AGENTS.md            # Claude Code reads the same hint
-├── workflow-server.code-workspace    # multi-root: this dir + projects + worktrees
+├── workflow-server.code-workspace    # four roots: kickoff + project + eng + worktrees
 ├── .cursor/
 │   ├── mcp.json                      # mcp-remote → workflow-server HTTP
 │   └── rules/
@@ -37,8 +39,8 @@ examples/cursor-workspace/
 
 | Path | Role |
 |------|------|
-| `AGENTS.md` | Declares the target `owner/repo`. Always pass that value as `repo` on `start_session`. |
-| `workflow-server.code-workspace` | Opens three roots: this folder, `$INSTALL/projects/<owner>/<repo>`, and `$INSTALL/worktrees/<owner>/<repo>`. |
+| `AGENTS.md` | Declares the checkout basename under `HOST_PROJECTS_ROOT` and optional GitHub `owner/repo` for `start_session`. |
+| `workflow-server.code-workspace` | Opens four roots: this folder, `$HOST_PROJECTS_ROOT/<repo>`, `<repo>/.engineering`, and `<repo>/.worktrees`. |
 | `.cursor/mcp.json` | Connects Cursor to the running HTTP server via `npx mcp-remote`. |
 | `.cursor/rules/*.mdc` | Always-applied IDE rules (bootstrap + optional concept-rag). |
 | `.claude/rules/*` | Same rules for Claude Code. |
@@ -54,23 +56,26 @@ cp -a examples/cursor-workspace \
 
 cd ~/.local/share/cursor/workspaces/my-project
 
-# 2. Point AGENTS.md at your repo
-#    e.g. m2ux/workflow-server
+# 2. Point AGENTS.md at your checkout basename (and optional owner/repo)
 
 # 3. Fix multi-root paths in the .code-workspace file.
 #    Defaults assume:
-#      this folder  → ~/.local/share/cursor/workspaces/<name>/
-#      install dir  → ~/.local/share/workflow-server/
-#    so relative paths ../../../.local/share/workflow-server/{projects,worktrees}/owner/repo
-#    resolve correctly. Replace owner/repo with your slug.
+#      this folder         → ~/.local/share/cursor/workspaces/<name>/
+#      HOST_PROJECTS_ROOT  → ~/projects/dev
+#    so relative paths ../../../projects/dev/<repo>{,/.engineering,/.worktrees}
+#    resolve correctly. Replace workflow-server with your <repo> basename.
+#    Prefer absolute paths if your layout differs.
 
-# 4. Open in Cursor
+# 4. Ensure local worktree parent exists (gitignored on the project)
+mkdir -p "$HOST_PROJECTS_ROOT/<repo>/.worktrees"
+
+# 5. Open in Cursor
 cursor workflow-server.code-workspace
 # or: File → Open Workspace from File…
 ```
 
 Then ask the agent to start a workflow. It should call `discover`, then
-`start_session` with `repo` from `AGENTS.md`.
+`start_session` with identity from `AGENTS.md`.
 
 ## Path assumptions
 
@@ -78,20 +83,37 @@ Relative folder paths in `workflow-server.code-workspace` are written for:
 
 | Root | Default absolute path |
 |------|------------------------|
-| This workspace | `~/.local/share/cursor/workspaces/<name>/` |
-| Projects (reference + `.engineering`) | `~/.local/share/workflow-server/projects/<owner>/<repo>/` |
-| Feature worktrees | `~/.local/share/workflow-server/worktrees/<owner>/<repo>/` |
+| This workspace (kickoff) | `~/.local/share/cursor/workspaces/<name>/` |
+| Project | `~/projects/dev/<repo>/` (`HOST_PROJECTS_ROOT/<repo>`) |
+| Engineering | `~/projects/dev/<repo>/.engineering/` |
+| Feature worktrees | `~/projects/dev/<repo>/.worktrees/` |
 
-Planning sessions live under `projects/<owner>/<repo>/.engineering/artifacts/planning/`.
-Feature branches are created as git worktrees under `worktrees/<owner>/<repo>/<slug>/`,
-based off the projects checkout.
+Uniform formula (every project, including workflow-server):
 
-If your install dir or cursor share path differs, edit the two non-`./` folder
-entries (or use absolute paths).
+```text
+checkout    = $HOST_PROJECTS_ROOT / <repo>
+planning    = checkout / .engineering / …
+target_path = checkout / .worktrees / <slug>
+```
+
+**Deprecated — do not use for source or feature trees:**
+
+- `$INSTALL/projects/…`
+- `$INSTALL/worktrees/…`
+
+Workflow **definitions** may still live under `$INSTALL/workflows` (server catalog).
+That is not the product source checkout.
+
+If a project has no `.engineering` yet, materialise or init the eng submodule
+before the engineering workspace root will resolve. Create an empty
+`.worktrees/` directory (gitignored) so the worktrees root always resolves.
+
+If your `HOST_PROJECTS_ROOT` or cursor share path differs, edit the three
+non-`./` folder entries (or use absolute paths).
 
 ## Related
 
-- [setup.md](../../setup.md) — install, init-repo, IDE rule
+- [setup.md](../../setup.md) — install, IDE rule
 - [docs/install-projects-worktrees.md](../../docs/install-projects-worktrees.md) — layout plan
 - [docs/ide-setup.md](../../docs/ide-setup.md) — bootstrap rule text
 - [http.md](../../http.md) — Docker / HTTP MCP URL

--- a/examples/cursor-workspace/workflow-server.code-workspace
+++ b/examples/cursor-workspace/workflow-server.code-workspace
@@ -5,12 +5,16 @@
       "path": "./"
     },
     {
-      "name": "📦 source",
-      "path": "../../../.local/share/workflow-server/projects/owner/repo"
+      "name": "📦 project",
+      "path": "../../../projects/dev/workflow-server"
+    },
+    {
+      "name": "📦 engineering",
+      "path": "../../../projects/dev/workflow-server/.engineering"
     },
     {
       "name": "📦 worktrees",
-      "path": "../../../.local/share/workflow-server/worktrees/owner/repo"
+      "path": "../../../projects/dev/workflow-server/.worktrees"
     }
   ],
   "settings": {}

--- a/scripts/init-local-env.sh
+++ b/scripts/init-local-env.sh
@@ -99,14 +99,15 @@ ensure_dir() {
 }
 
 INSTALL_DEFAULT="$(expand_path "$INSTALL_DEFAULT")"
-if [[ -z "$WORKTREE_DEFAULT" ]]; then
-  WORKTREE_DEFAULT="${INSTALL_DEFAULT}/worktrees"
-fi
 if [[ -z "$PROJECTS_DEFAULT" ]]; then
   PROJECTS_DEFAULT="${INSTALL_DEFAULT}/projects"
 fi
-WORKTREE_DEFAULT="$(expand_path "$WORKTREE_DEFAULT")"
 PROJECTS_DEFAULT="$(expand_path "$PROJECTS_DEFAULT")"
+# Nested .worktrees under projects root; do not default to $INSTALL/worktrees.
+if [[ -z "$WORKTREE_DEFAULT" ]]; then
+  WORKTREE_DEFAULT="${PROJECTS_DEFAULT}"
+fi
+WORKTREE_DEFAULT="$(expand_path "$WORKTREE_DEFAULT")"
 STATE_DIR="${INSTALL_DEFAULT}/state"
 
 # Prefer checkout workflows/schemas when present (dev compose from repo root).
@@ -122,8 +123,10 @@ else
 fi
 
 ensure_dir "$INSTALL_DEFAULT" "install dir"
-ensure_dir "$WORKTREE_DEFAULT" "worktrees root"
 ensure_dir "$PROJECTS_DEFAULT" "projects root"
+if [[ "$WORKTREE_DEFAULT" != "$PROJECTS_DEFAULT" ]]; then
+  ensure_dir "$WORKTREE_DEFAULT" "legacy worktrees root"
+fi
 ensure_dir "$STATE_DIR" "state dir (HMAC key)"
 
 upsert WORKFLOW_SERVER_MCP_URL "http://127.0.0.1:3000/mcp"
@@ -133,14 +136,22 @@ upsert WORKTREE_ROOT "${WORKTREE_DEFAULT}"
 upsert WORKFLOW_SERVER_ENGINEERING_DIR "${PROJECTS_DEFAULT}"
 upsert WORKFLOW_DIR "${WORKFLOWS_ABS}"
 upsert SCHEMAS_DIR "${SCHEMAS_ABS}"
-upsert HOST_WORKTREE_ROOT "${WORKTREE_DEFAULT}"
 upsert HOST_PROJECTS_ROOT "${PROJECTS_DEFAULT}"
+if [[ "$WORKTREE_DEFAULT" != "$PROJECTS_DEFAULT" ]]; then
+  upsert HOST_WORKTREE_ROOT "${WORKTREE_DEFAULT}"
+fi
 upsert HOST_STATE_DIR "${STATE_DIR}"
 upsert HOST_WORKFLOWS_DIR "${WORKFLOWS_ABS}"
 upsert HOST_SCHEMAS_DIR "${SCHEMAS_ABS}"
 upsert HOST_PORT "3000"
 upsert CONTAINER_INSTALL_DIR "/var/lib/workflow-server"
-upsert CONTAINER_WORKTREE_ROOT "/var/lib/workflow-server/worktrees"
+# Nested model: workspace multi-root coincides with projects multi-root
+if [[ "$WORKTREE_DEFAULT" == "$PROJECTS_DEFAULT" ]]; then
+  upsert CONTAINER_WORKTREE_ROOT "/var/lib/workflow-server/projects"
+else
+  upsert CONTAINER_WORKTREE_ROOT "/var/lib/workflow-server/worktrees"
+  upsert HOST_WORKTREE_ROOT "${WORKTREE_DEFAULT}"
+fi
 upsert CONTAINER_PROJECTS_ROOT "/var/lib/workflow-server/projects"
 upsert CONTAINER_ENGINEERING_ROOT "/var/lib/workflow-server/projects"
 upsert CONTAINER_STATE_DIR "/var/lib/workflow-server/state"
@@ -165,8 +176,12 @@ fi
 
 echo "Wrote local env → ${ENV_FILE}"
 echo "  WORKFLOW_SERVER_INSTALL_DIR=${INSTALL_DEFAULT}"
-echo "  HOST_WORKTREE_ROOT=${WORKTREE_DEFAULT}"
 echo "  HOST_PROJECTS_ROOT=${PROJECTS_DEFAULT}"
+if [[ "$WORKTREE_DEFAULT" == "$PROJECTS_DEFAULT" ]]; then
+  echo "  worktrees: nested under HOST_PROJECTS_ROOT/<repo>/.worktrees/"
+else
+  echo "  HOST_WORKTREE_ROOT=${WORKTREE_DEFAULT}  (legacy)"
+fi
 echo "  HOST_STATE_DIR=${STATE_DIR}"
 echo "  WORKFLOW_DIR=${WORKFLOWS_ABS}"
 if [[ -n "$REPO_DEFAULT" ]]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,13 +5,14 @@
 #
 #   bash <(curl -fsSL …/install.sh) --worktree-root=~/projects/work
 #
-# Writes $INSTALL/env so start.sh needs no path args. Creates projects/ and
-# worktrees/ under the install root (per-repo checkouts via init-repo.sh).
+# Writes $INSTALL/env so start.sh needs no path args. Creates a projects root
+# (default $INSTALL/projects, or --projects-root for an external tree such as
+# ~/projects/dev). Feature worktrees live under each checkout's .worktrees/
+# (gitignored). $INSTALL/worktrees is deprecated.
 #
 # Then:
 #   ~/.local/share/workflow-server/start.sh -d
 #   ~/.local/share/workflow-server/stop.sh
-#   ~/.local/share/workflow-server/init-repo.sh owner/repo
 #
 # Needs: curl, git
 set -euo pipefail
@@ -36,7 +37,8 @@ LEGACY_NAMES=(
 )
 
 INSTALL_DIR="${WORKFLOW_SERVER_INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
-# Optional override; when unset, defaults to $INSTALL/worktrees after abs_path.
+# Optional legacy override. Prefer nested {checkout}/.worktrees/ under HOST_PROJECTS_ROOT.
+# When unset, env omits HOST_WORKTREE_ROOT and start.sh binds projects root only.
 HOST_WORKTREE_ROOT="${HOST_WORKTREE_ROOT:-${WORKFLOW_WORKSPACE:-}}"
 HOST_PROJECTS_ROOT="${HOST_PROJECTS_ROOT:-}"
 REPO_URL="${WORKFLOW_SERVER_REPO_URL:-$DEFAULT_REPO_URL}"
@@ -48,19 +50,21 @@ HOST_PORT="${HOST_PORT:-$DEFAULT_HOST_PORT}"
 usage() {
   cat <<EOF
 Install workflow-server under a local data dir: fetch helper scripts, clone
-workflows data, create projects/ + worktrees/ roots, and write a persistent
-env file. Does not start Docker.
+workflows data, ensure a projects root, and write a persistent env file.
+Does not start Docker.
 
 USAGE
   install.sh [options]
 
 OPTIONS
   --install-dir=PATH       Install root (default: ${DEFAULT_INSTALL_DIR})
-  --worktree-root=PATH     Feature worktree parent root
-                           (default: \$INSTALL/worktrees)
-                           Persisted to \$INSTALL/${DEFAULT_ENV_NAME} for start.sh
-  --projects-root=PATH       Per-repo main checkout root
-                           (default: \$INSTALL/projects)
+  --projects-root=PATH     Project checkouts root
+                           (default: \$INSTALL/projects; prefer e.g. ~/projects/dev)
+                           Checkouts are \$HOST_PROJECTS_ROOT/<repo>/ with nested
+                           .engineering/ and .worktrees/<slug>/
+  --worktree-root=PATH     DEPRECATED global feature-tree root. Prefer nested
+                           .worktrees/ under each checkout. When unset, omitted
+                           from env (start.sh mounts projects root only).
   --repo-url=URL           Git remote for workflows branch (default: GitHub m2ux)
   --ref=REF                Branch/tag for helper scripts raw URL (default: ${DEFAULT_REF})
   --name=NAME              Container name persisted for start/stop (default: ${DEFAULT_CONTAINER_NAME})
@@ -73,21 +77,21 @@ LAYOUT
     ${DEFAULT_STOP_NAME}
     ${DEFAULT_UPDATE_NAME}
     ${DEFAULT_INIT_REPO_NAME}
-    ${DEFAULT_ENV_NAME}               # persistent paths / ports for start + stop
+    ${DEFAULT_ENV_NAME}               # HOST_PROJECTS_ROOT + port / name
     workflows/               # git clone -b workflows (server definitions)
-    projects/                # per-repo main checkouts (init-repo.sh)
-      <owner>/<repo>/        #   app @ default branch
-      <owner>/<repo>/.engineering/  # eng submodule / materialised planning
-    worktrees/               # per-repo feature worktree parents (init-repo.sh)
     state/                   # durable HMAC key (mounted by start.sh)
 
-  Per-repo paths are created by init-repo.sh owner/repo.
+  \$HOST_PROJECTS_ROOT/               # from env; not necessarily under \$INSTALL
+    <repo>/                          # basename checkout
+      .engineering/                  # planning submodule when present
+      .worktrees/<slug>/             # feature worktrees only (gitignored)
+
+  \$INSTALL/worktrees/ is deprecated — do not use for new feature trees.
 
 AFTER INSTALL
   \$INSTALL/${DEFAULT_START_NAME} -d
   \$INSTALL/${DEFAULT_STOP_NAME}
   \$INSTALL/${DEFAULT_UPDATE_NAME}
-  \$INSTALL/${DEFAULT_INIT_REPO_NAME} owner/repo
   export WORKFLOW_SERVER_MCP_URL=http://127.0.0.1:${DEFAULT_HOST_PORT}/mcp
   curl -fsS http://127.0.0.1:${DEFAULT_HOST_PORT}/health
   curl -fsS http://127.0.0.1:${DEFAULT_HOST_PORT}/ready   # sessionKeyWritable: true
@@ -202,14 +206,15 @@ need curl
 need git
 
 INSTALL_DIR=$(abs_path "$INSTALL_DIR")
-if [[ -z "$HOST_WORKTREE_ROOT" ]]; then
-  HOST_WORKTREE_ROOT="${INSTALL_DIR}/worktrees"
-fi
 if [[ -z "$HOST_PROJECTS_ROOT" ]]; then
   HOST_PROJECTS_ROOT="${INSTALL_DIR}/projects"
 fi
-HOST_WORKTREE_ROOT=$(abs_path "$HOST_WORKTREE_ROOT")
 HOST_PROJECTS_ROOT=$(abs_path "$HOST_PROJECTS_ROOT")
+# Legacy only: when explicitly set, keep a separate global worktree root.
+# Nested .worktrees/ under HOST_PROJECTS_ROOT is the preferred model.
+if [[ -n "$HOST_WORKTREE_ROOT" ]]; then
+  HOST_WORKTREE_ROOT=$(abs_path "$HOST_WORKTREE_ROOT")
+fi
 
 START_PATH="${INSTALL_DIR}/${DEFAULT_START_NAME}"
 STOP_PATH="${INSTALL_DIR}/${DEFAULT_STOP_NAME}"
@@ -227,8 +232,11 @@ mkdir -p "$INSTALL_DIR"
 STATE_DIR="${INSTALL_DIR}/state"
 ensure_dir "$STATE_DIR" "state dir (HMAC key)"
 
-ensure_dir "$HOST_WORKTREE_ROOT" "worktrees root"
 ensure_dir "$HOST_PROJECTS_ROOT" "projects root"
+if [[ -n "$HOST_WORKTREE_ROOT" ]]; then
+  echo "warning: HOST_WORKTREE_ROOT is deprecated; prefer nested .worktrees/ under each checkout" >&2
+  ensure_dir "$HOST_WORKTREE_ROOT" "legacy worktrees root"
+fi
 
 fetch_script "$START_PATH" "$START_URL" "start"
 fetch_script "$STOP_PATH" "$STOP_URL" "stop"
@@ -253,25 +261,34 @@ else
 fi
 
 # Persistent config for start.sh / stop.sh (no path args needed at runtime).
-# Engineering multi-root is $HOST_PROJECTS_ROOT (per-repo eng under
-# projects/<owner>/<repo>/.engineering).
-cat >"$ENV_PATH" <<EOF
+# Feature trees: $HOST_PROJECTS_ROOT/<repo>/.worktrees/<slug>/
+# HOST_WORKTREE_ROOT is only written when explicitly set (legacy).
+{
+  cat <<EOF
 # Generated by install.sh — used by start.sh / stop.sh
 # Edit and re-run start, or re-run install with new flags.
-HOST_WORKTREE_ROOT=${HOST_WORKTREE_ROOT}
+# Feature worktrees: \$HOST_PROJECTS_ROOT/<repo>/.worktrees/<slug>/ (not \$INSTALL/worktrees)
 HOST_PROJECTS_ROOT=${HOST_PROJECTS_ROOT}
 HOST_PORT=${HOST_PORT}
 WORKFLOW_SERVER_CONTAINER_NAME=${CONTAINER_NAME}
 WORKFLOW_SERVER_INSTALL_DIR=${INSTALL_DIR}
 EOF
+  if [[ -n "$HOST_WORKTREE_ROOT" ]]; then
+    echo "HOST_WORKTREE_ROOT=${HOST_WORKTREE_ROOT}"
+  fi
+} >"$ENV_PATH"
 echo "Wrote env → ${ENV_PATH}"
 
 echo
 echo "Install complete."
 echo "  Install dir  : ${INSTALL_DIR}"
 echo "  Workflows    : ${WORKFLOWS_DIR}"
-echo "  Projects     : ${HOST_PROJECTS_ROOT}  (per-repo main + .engineering)"
-echo "  Worktrees    : ${HOST_WORKTREE_ROOT}"
+echo "  Projects     : ${HOST_PROJECTS_ROOT}  (<repo>/ + .engineering + .worktrees)"
+if [[ -n "$HOST_WORKTREE_ROOT" ]]; then
+  echo "  Worktrees    : ${HOST_WORKTREE_ROOT}  (legacy global root — deprecated)"
+else
+  echo "  Worktrees    : nested under each checkout (.worktrees/)"
+fi
 echo "  State        : ${STATE_DIR}  (HMAC key; mounted by start.sh)"
 echo "  Env          : ${ENV_PATH}"
 echo
@@ -279,10 +296,7 @@ echo "Start / stop (paths come from env — no flags required):"
 echo "  ${START_PATH} -d"
 echo "  ${STOP_PATH}"
 echo
-echo "Init a repo (projects main + .engineering + worktrees parent):"
-echo "  ${INIT_REPO_PATH} owner/repo"
-echo
-echo "Update workflows + project checkouts later with:"
+echo "Update workflows later with:"
 echo "  ${UPDATE_PATH}"
 echo
 echo "Then:"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -30,8 +30,9 @@ DEFAULT_SCHEMAS_TARGET="/app/schemas"
 DEFAULT_TRANSPORT="http"
 DEFAULT_BIND_HOST="0.0.0.0"
 DEFAULT_INSTALL_DIR="${XDG_DATA_HOME:-${HOME}/.local/share}/workflow-server"
-DEFAULT_HOST_WORKTREE_ROOT="${DEFAULT_INSTALL_DIR}/worktrees"
+# Nested .worktrees/ under HOST_PROJECTS_ROOT is preferred; $INSTALL/worktrees is deprecated.
 DEFAULT_HOST_PROJECTS_ROOT="${DEFAULT_INSTALL_DIR}/projects"
+DEFAULT_HOST_WORKTREE_ROOT=""
 DEFAULT_ENV_NAME="env"
 
 # Directory containing this script (install dir when installed as start.sh).
@@ -123,16 +124,17 @@ DEFAULT INSTALL DIR
   ${DEFAULT_INSTALL_DIR}
   (or directory containing this script when installed as start.sh)
 
-DEFAULT WORKTREES ROOT
-  ${DEFAULT_HOST_WORKTREE_ROOT}  (set at install with --worktree-root; persisted in env)
-
 DEFAULT PROJECTS ROOT
-  ${DEFAULT_HOST_PROJECTS_ROOT}  (per-repo main + .engineering; multi-root eng base)
+  ${DEFAULT_HOST_PROJECTS_ROOT}  (\$HOST_PROJECTS_ROOT/<repo>/ + .engineering + .worktrees)
+
+FEATURE WORKTREES
+  Nested only: \$HOST_PROJECTS_ROOT/<repo>/.worktrees/<slug>/
+  \$INSTALL/worktrees and HOST_WORKTREE_ROOT are deprecated.
 
 OPTIONS (optional overrides — prefer re-running install to change paths)
   --install-dir=PATH        Install root (workflows under \$INSTALL/workflows)
-  --worktree-root=PATH      One-off host feature worktrees root (RW)
-  --projects-root=PATH      One-off host projects multi-root (RW)
+  --projects-root=PATH      One-off host projects root (RW; covers nested .worktrees)
+  --worktree-root=PATH      DEPRECATED separate feature-tree root (RW)
   --workflows-dir=PATH      One-off host workflows directory (RO)
   --schemas-dir=PATH        Host schemas directory (RO); optional
   --image=REF               Full image (default: ${DEFAULT_IMAGE_REPO}:${DEFAULT_TAG})
@@ -277,16 +279,16 @@ if [[ -z "$LOADED_ENV_FILE" && -f "${INSTALL_DIR}/${DEFAULT_ENV_NAME}" ]]; then
 fi
 
 # Path resolution (CLI > install/process env already in shell > defaults):
-if [[ "$WORKTREE_SET" -eq 0 ]]; then
-  if [[ -z "$HOST_WORKTREE_ROOT" ]]; then
-    HOST_WORKTREE_ROOT="${INSTALL_DIR}/worktrees"
-  fi
-fi
-
 if [[ "$PROJECTS_SET" -eq 0 ]]; then
   if [[ -z "$HOST_PROJECTS_ROOT" ]]; then
     HOST_PROJECTS_ROOT="${INSTALL_DIR}/projects"
   fi
+fi
+
+# Nested .worktrees under projects root is preferred. Only keep a separate
+# HOST_WORKTREE_ROOT when the operator set it explicitly (CLI or env).
+if [[ "$WORKTREE_SET" -eq 0 && -z "$HOST_WORKTREE_ROOT" ]]; then
+  HOST_WORKTREE_ROOT=""
 fi
 
 if [[ "$WORKFLOWS_SET" -eq 0 ]]; then
@@ -303,19 +305,28 @@ HOST_STATE_DIR="${HOST_STATE_DIR:-${INSTALL_DIR}/state}"
 command -v docker >/dev/null 2>&1 || die "docker not found on PATH"
 
 # Resolve + create roots before bind-mount (must exist for docker -v).
-HOST_WORKTREE_ROOT="$(abs_path "$HOST_WORKTREE_ROOT")"
-if [[ ! -d "$HOST_WORKTREE_ROOT" ]]; then
-  echo "Creating worktrees root: ${HOST_WORKTREE_ROOT}"
-  mkdir -p "$HOST_WORKTREE_ROOT" || die "failed to create worktrees root: ${HOST_WORKTREE_ROOT}"
-fi
-[[ -d "$HOST_WORKTREE_ROOT" ]] || die "worktrees root is not a directory: ${HOST_WORKTREE_ROOT}"
-
 HOST_PROJECTS_ROOT="$(abs_path "$HOST_PROJECTS_ROOT")"
 if [[ ! -d "$HOST_PROJECTS_ROOT" ]]; then
   echo "Creating projects root: ${HOST_PROJECTS_ROOT}"
   mkdir -p "$HOST_PROJECTS_ROOT" || die "failed to create projects root: ${HOST_PROJECTS_ROOT}"
 fi
 [[ -d "$HOST_PROJECTS_ROOT" ]] || die "projects root is not a directory: ${HOST_PROJECTS_ROOT}"
+
+# When no separate worktree root is configured, reuse projects root so nested
+# <repo>/.worktrees/ is covered by the same bind mount.
+if [[ -z "$HOST_WORKTREE_ROOT" ]]; then
+  HOST_WORKTREE_ROOT="$HOST_PROJECTS_ROOT"
+elif [[ "$(abs_path "$HOST_WORKTREE_ROOT")" == "$(abs_path "${INSTALL_DIR}/worktrees")" ]]; then
+  echo "warning: HOST_WORKTREE_ROOT=${HOST_WORKTREE_ROOT} is deprecated; using nested .worktrees under projects root" >&2
+  HOST_WORKTREE_ROOT="$HOST_PROJECTS_ROOT"
+else
+  HOST_WORKTREE_ROOT="$(abs_path "$HOST_WORKTREE_ROOT")"
+  if [[ ! -d "$HOST_WORKTREE_ROOT" ]]; then
+    echo "Creating legacy worktrees root: ${HOST_WORKTREE_ROOT}"
+    mkdir -p "$HOST_WORKTREE_ROOT" || die "failed to create worktrees root: ${HOST_WORKTREE_ROOT}"
+  fi
+  [[ -d "$HOST_WORKTREE_ROOT" ]] || die "worktrees root is not a directory: ${HOST_WORKTREE_ROOT}"
+fi
 
 if [[ ! -d "$HOST_WORKFLOWS_DIR" ]]; then
   die "workflows directory not found: ${HOST_WORKFLOWS_DIR}
@@ -386,6 +397,12 @@ DOCKER_RUN+=(-p "${HOST_PORT}:${CONTAINER_PORT}")
 
 # Align container eng multi-root with projects mount target
 CONTAINER_ENGINEERING_ROOT="${CONTAINER_PROJECTS_ROOT}"
+# Nested .worktrees: one host root → same container path for workspace + projects
+NESTED_WORKTREES=0
+if [[ "$HOST_WORKTREE_ROOT" == "$HOST_PROJECTS_ROOT" ]]; then
+  NESTED_WORKTREES=1
+  CONTAINER_WORKTREE_ROOT="${CONTAINER_PROJECTS_ROOT}"
+fi
 
 DOCKER_RUN+=(-e "WORKTREE_ROOT=${CONTAINER_WORKTREE_ROOT}")
 DOCKER_RUN+=(-e "WORKFLOW_WORKSPACE=${CONTAINER_WORKTREE_ROOT}")
@@ -411,8 +428,10 @@ if [[ -n "$ENV_FILE" ]]; then
   DOCKER_RUN+=(--env-file "$ENV_FILE")
 fi
 
-DOCKER_RUN+=(-v "${HOST_WORKTREE_ROOT}:${CONTAINER_WORKTREE_ROOT}")
 DOCKER_RUN+=(-v "${HOST_PROJECTS_ROOT}:${CONTAINER_PROJECTS_ROOT}")
+if [[ "$NESTED_WORKTREES" -eq 0 ]]; then
+  DOCKER_RUN+=(-v "${HOST_WORKTREE_ROOT}:${CONTAINER_WORKTREE_ROOT}")
+fi
 DOCKER_RUN+=(-v "${HOST_WORKFLOWS_DIR}:${CONTAINER_WORKFLOW_DIR}:ro")
 if [[ -n "$HOST_SCHEMAS_DIR" ]]; then
   DOCKER_RUN+=(-v "${HOST_SCHEMAS_DIR}:${CONTAINER_SCHEMAS_DIR}:ro")
@@ -426,8 +445,12 @@ DOCKER_RUN+=("$FULL_IMAGE")
 echo "Install  : ${INSTALL_DIR}"
 [[ -n "$LOADED_ENV_FILE" ]] && echo "Env file : ${LOADED_ENV_FILE}"
 echo "Starting ${FULL_IMAGE}"
-echo "  worktrees  : ${HOST_WORKTREE_ROOT} → ${CONTAINER_WORKTREE_ROOT} (rw)"
-echo "  projects   : ${HOST_PROJECTS_ROOT} → ${CONTAINER_PROJECTS_ROOT} (rw; eng multi-root)"
+echo "  projects   : ${HOST_PROJECTS_ROOT} → ${CONTAINER_PROJECTS_ROOT} (rw; eng + nested .worktrees)"
+if [[ "$NESTED_WORKTREES" -eq 0 ]]; then
+  echo "  worktrees  : ${HOST_WORKTREE_ROOT} → ${CONTAINER_WORKTREE_ROOT} (rw; legacy separate root)"
+else
+  echo "  worktrees  : nested under projects (<repo>/.worktrees/)"
+fi
 echo "  workflows  : ${HOST_WORKFLOWS_DIR} → ${CONTAINER_WORKFLOW_DIR} (ro)"
 if [[ -n "$HOST_SCHEMAS_DIR" ]]; then
   echo "  schemas    : ${HOST_SCHEMAS_DIR} → ${CONTAINER_SCHEMAS_DIR} (ro)"


### PR DESCRIPTION
## Summary

- Prefer external **`HOST_PROJECTS_ROOT`** (e.g. `~/projects/dev/<repo>`) for source checkouts; every project is uniform (including workflow-server).
- Feature worktrees **only** under `{checkout}/.worktrees/<slug>/` (gitignored). **`$INSTALL/worktrees` and `HOST_WORKTREE_ROOT` are deprecated.**
- `install.sh` / `start.sh` / compose / `.env.example`: omit separate worktree root by default; bind projects root once so nested `.worktrees/` is covered.
- Cursor example: four navigation roots — kickoff, project, `.engineering`, `.worktrees`.
- Docs: `docs/install-projects-worktrees.md` updated for the nested layout.

## Operator follow-up (local, not in this PR)

```bash
# $INSTALL/env
HOST_PROJECTS_ROOT=/home/mike1/projects/dev
# remove HOST_WORKTREE_ROOT
mkdir -p "$HOST_PROJECTS_ROOT"/*/.worktrees
# reinstall or copy scripts/start.sh into $INSTALL and restart container
```

## Test plan

- [ ] `install.sh --projects-root=~/projects/dev` writes env without `HOST_WORKTREE_ROOT`
- [ ] `start.sh -d` mounts only projects + workflows + state; log says nested `.worktrees`
- [ ] Open `examples/cursor-workspace/workflow-server.code-workspace` paths resolve under `~/projects/dev/<repo>`
- [ ] Create a feature worktree under `$HOST_PROJECTS_ROOT/<repo>/.worktrees/<slug>`
- [ ] Confirm no new paths under `$INSTALL/worktrees`