### PR TITLE
fix: stop deploy.sh committing to the caller's branch, make it idempotent

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -48,11 +48,23 @@ fi
 TEMP_DIRS_TO_CLEAN=()
 
 cleanup() {
-    for dir in "${TEMP_DIRS_TO_CLEAN[@]}"; do
+    local dir
+    for dir in ${TEMP_DIRS_TO_CLEAN[@]+"${TEMP_DIRS_TO_CLEAN[@]}"}; do
         if [[ -d "$dir" ]]; then
             rm -rf "$dir"
         fi
     done
+}
+
+# Drop one path from the cleanup list so it survives exit.
+unschedule_cleanup() {
+    local keep="$1"
+    local remaining=()
+    local dir
+    for dir in ${TEMP_DIRS_TO_CLEAN[@]+"${TEMP_DIRS_TO_CLEAN[@]}"}; do
+        [[ "$dir" == "$keep" ]] || remaining+=("$dir")
+    done
+    TEMP_DIRS_TO_CLEAN=(${remaining[@]+"${remaining[@]}"})
 }
 
 trap cleanup EXIT
@@ -65,11 +77,29 @@ timed_git() {
     timeout "$NETWORK_TIMEOUT" git "$@"
 }
 
+# Exact ref match. A substring grep over ls-remote output would treat
+# 'engineering-old' as a hit for 'engineering' and skip branch creation.
+remote_branch_exists() {
+    local repo_url="$1"
+    local branch="$2"
+    timeout "$NETWORK_TIMEOUT" git ls-remote --exit-code --heads \
+        "$repo_url" "refs/heads/$branch" >/dev/null 2>&1
+}
+
 verify_push_access() {
     local remote_url="$1"
     local branch="$2"
-    if ! timeout "$NETWORK_TIMEOUT" git push --dry-run "$remote_url" "$branch" >/dev/null 2>&1; then
+    local output
+
+    if ! git rev-parse --verify --quiet "refs/heads/$branch" >/dev/null; then
+        echo "[FAIL] Local branch '$branch' does not exist in $(pwd)"
+        echo "       (the branch was never created, or the script is in the wrong directory)"
+        return 1
+    fi
+
+    if ! output="$(timeout "$NETWORK_TIMEOUT" git push --dry-run "$remote_url" "$branch" 2>&1)"; then
         echo "[FAIL] No push access to $remote_url (branch: $branch)"
+        echo "$output" | sed 's/^/       /'
         return 1
     fi
     return 0
@@ -139,13 +169,19 @@ create_engineering_structure() {
     local target_dir="$1"
     
     echo "  Creating directory structure..."
-    
-    mkdir -p "$target_dir/artifacts/adr"
-    mkdir -p "$target_dir/artifacts/planning"
-    mkdir -p "$target_dir/artifacts/reviews"
-    mkdir -p "$target_dir/artifacts/templates"
-    mkdir -p "$target_dir/scripts"
-    
+
+    local dir
+    # .gitkeep is required, not cosmetic: git does not track empty directories,
+    # so without it the artifacts tree is absent for every consumer that clones
+    # the branch as a submodule.
+    for dir in artifacts/adr artifacts/planning artifacts/reviews \
+               artifacts/templates scripts; do
+        mkdir -p "$target_dir/$dir"
+        if [ -z "$(ls -A "$target_dir/$dir" 2>/dev/null)" ]; then
+            touch "$target_dir/$dir/.gitkeep"
+        fi
+    done
+
     if [ ! -f "$target_dir/README.md" ]; then
         cat > "$target_dir/README.md" << EOF
 # Engineering
@@ -259,8 +295,14 @@ EOF
 ensure_history_branch() {
     local repo_url="$1"
     local branch_name="$2"
-    
-    if timed_git ls-remote --heads "$repo_url" "$branch_name" 2>/dev/null | grep -q "$branch_name"; then
+
+    # Restore the CALLER's directory, not REPO_ROOT: this is called from inside
+    # the temporary orphan-branch worktree, and returning to REPO_ROOT would make
+    # every subsequent command operate on the wrong branch.
+    local caller_dir
+    caller_dir="$(pwd)"
+
+    if remote_branch_exists "$repo_url" "$branch_name"; then
         echo "  [PASS] History branch '$branch_name' exists"
         return 0
     fi
@@ -292,19 +334,115 @@ EOF
     
     if ! verify_push_access "$repo_url" "$branch_name"; then
         echo "  [WARN] Cannot push to $repo_url — check repo permissions"
-        cd "$REPO_ROOT"
+        cd "$caller_dir"
         return 1
     fi
-    
+
     if timed_git push -u origin "$branch_name" 2>/dev/null; then
         echo "  [PASS] Created and pushed branch '$branch_name'"
     else
         echo "  [WARN] Failed to push branch '$branch_name' — check repo permissions"
-        cd "$REPO_ROOT"
+        cd "$caller_dir"
         return 1
     fi
-    
-    cd "$REPO_ROOT"
+
+    cd "$caller_dir"
+    return 0
+}
+
+# =============================================================================
+# Submodule Helpers (idempotent)
+# =============================================================================
+
+# True when PATH is already registered as a submodule pointing at URL#BRANCH,
+# with a gitlink present in the index. Anything short of that is "not matching"
+# and gets rebuilt rather than patched.
+submodule_matches() {
+    local path="$1"
+    local url="$2"
+    local branch="$3"
+    local cur_url cur_branch
+
+    [ -f .gitmodules ] || return 1
+
+    cur_url="$(git config -f .gitmodules --get "submodule.$path.url" 2>/dev/null || echo "")"
+    cur_branch="$(git config -f .gitmodules --get "submodule.$path.branch" 2>/dev/null || echo "")"
+
+    [ "$cur_url" = "$url" ] || return 1
+    [ "$cur_branch" = "$branch" ] || return 1
+    git ls-files --stage -- "$path" 2>/dev/null | grep -q '^160000 ' || return 1
+
+    return 0
+}
+
+# Erase every trace of a submodule at PATH so that 'git submodule add' sees a
+# clean slate: working tree, index gitlink, .gitmodules stanza, .git/config
+# stanza, and the cached git directory. Leaving any one of these behind is what
+# makes a naive re-run fail with "already exists in the index" or "a git
+# directory for 'x' is found locally".
+purge_submodule() {
+    local path="$1"
+    local common_dir
+
+    git submodule deinit -f -- "$path" >/dev/null 2>&1 || true
+    git rm -rf --cached -- "$path" >/dev/null 2>&1 || true
+    rm -rf "$path"
+
+    git config -f .gitmodules --remove-section "submodule.$path" >/dev/null 2>&1 || true
+    git config --remove-section "submodule.$path" >/dev/null 2>&1 || true
+
+    # Submodule git dirs live under the COMMON dir, so this is also correct when
+    # called from inside a linked worktree.
+    common_dir="$(git rev-parse --git-common-dir)"
+    case "$common_dir" in
+        /*) ;;
+        *) common_dir="$(pwd)/$common_dir" ;;
+    esac
+    rm -rf "$common_dir/modules/$path"
+
+    # An empty .gitmodules would otherwise get staged as a stray file.
+    if [ -f .gitmodules ] && [ ! -s .gitmodules ]; then
+        rm -f .gitmodules
+        git rm -f --cached .gitmodules >/dev/null 2>&1 || true
+    fi
+}
+
+# Idempotent 'git submodule add'. Re-running is a no-op when the submodule is
+# already registered correctly; a mismatched or half-removed one is purged and
+# re-added. Never aborts the script — a missing private repo yields a warning.
+ensure_submodule() {
+    local path="$1"
+    local url="$2"
+    local branch="$3"
+    local label="${4:-$path}"
+
+    if submodule_matches "$path" "$url" "$branch"; then
+        if [ -e "$path/.git" ]; then
+            echo "[PASS] $label already present (branch: $branch)"
+        else
+            echo "  $label registered but not checked out — initializing..."
+            if timed_git submodule update --init -- "$path" >/dev/null 2>&1; then
+                echo "[PASS] $label (branch: $branch)"
+            else
+                echo "[WARN] $label registered but checkout failed"
+                return 1
+            fi
+        fi
+    else
+        purge_submodule "$path"
+        if timed_git submodule add --force -b "$branch" "$url" "$path" >/dev/null 2>&1; then
+            echo "[PASS] $label (branch: $branch)"
+        else
+            echo "[WARN] $label skipped (private repo, or branch '$branch' not found)"
+            purge_submodule "$path"
+            return 1
+        fi
+    fi
+
+    # 'submodule add -b' can leave the working tree detached; pin it to the branch.
+    if [ -e "$path/.git" ]; then
+        ( cd "$path" && git checkout "$branch" >/dev/null 2>&1 ) || true
+    fi
     return 0
 }
 
@@ -369,27 +507,36 @@ fi
 # Main
 # =============================================================================
 
+# Existing artifacts are snapshotted, not deleted. Teardown of .engineering/ is
+# left to ensure_submodule, which only purges when the existing registration
+# does not already match what we are about to create — so a repeat run of an
+# already-deployed project touches nothing.
 MIGRATION_BACKUP=""
-if [ -d "$ENGINEERING_DIR" ]; then
-    if [ -d "$ENGINEERING_DIR/artifacts" ] && [ -n "$(find "$ENGINEERING_DIR/artifacts" -type f 2>/dev/null | head -1)" ]; then
-        MIGRATION_BACKUP="${ENGINEERING_DIR}_migration_$$"
-        echo "Found existing artifacts to migrate..."
-        echo "  Backing up to: $MIGRATION_BACKUP"
-        cp -r "$ENGINEERING_DIR" "$MIGRATION_BACKUP"
-        TEMP_DIRS_TO_CLEAN+=("$MIGRATION_BACKUP")
-        echo "  [PASS] Backup complete ($(find "$MIGRATION_BACKUP/artifacts" -type f 2>/dev/null | wc -l) files)"
-    fi
-    echo "Removing existing .engineering/..."
-    rm -rf "$ENGINEERING_DIR"
+if [ -d "$ENGINEERING_DIR/artifacts" ] && [ -n "$(find "$ENGINEERING_DIR/artifacts" -type f 2>/dev/null | head -1)" ]; then
+    MIGRATION_BACKUP="${ENGINEERING_DIR}_migration_$$"
+    echo "Found existing artifacts to preserve..."
+    echo "  Backing up to: $MIGRATION_BACKUP"
+    cp -r "$ENGINEERING_DIR" "$MIGRATION_BACKUP"
+    TEMP_DIRS_TO_CLEAN+=("$MIGRATION_BACKUP")
+    echo "  [PASS] Backup complete ($(find "$MIGRATION_BACKUP/artifacts" -type f 2>/dev/null | wc -l) files)"
 fi
 
 migrate_existing_data() {
     local target_dir="$1"
-    
+    local caller_dir
+    caller_dir="$(pwd)"
+
     if [ -z "$MIGRATION_BACKUP" ] || [ ! -d "$MIGRATION_BACKUP" ]; then
         return 0
     fi
-    
+
+    if [ ! -d "$target_dir" ]; then
+        echo "[WARN] $target_dir missing — preserved artifacts left at:"
+        echo "       $MIGRATION_BACKUP"
+        unschedule_cleanup "$MIGRATION_BACKUP"
+        return 0
+    fi
+
     echo ""
     echo "Migrating existing artifacts..."
     
@@ -409,15 +556,18 @@ migrate_existing_data() {
             git add -A
             git commit -m "docs: migrate existing engineering artifacts" 2>/dev/null || true
             echo "  [PASS] Committed migrated data"
-            
+
             if timed_git push origin HEAD 2>/dev/null; then
                 echo "  [PASS] Pushed migrated data to remote"
             else
                 echo "  [WARN] Push failed or timed out — run 'git push' manually in .engineering/"
             fi
+        else
+            echo "  [PASS] Nothing to migrate — content already present"
         fi
     fi
-    
+
+    cd "$caller_dir"
     echo "  [PASS] Cleaned up migration backup"
 }
 
@@ -432,34 +582,43 @@ if [ "$DEPLOY_MODE" = "in-branch" ]; then
     create_engineering_structure "$ENGINEERING_DIR"
     
     echo ""
-    echo "Setting up submodule repos..."
+    echo "Setting up nested repos..."
     cd "$ENGINEERING_DIR"
-    
-    if [ ! -d "workflows/.git" ]; then
-        rm -rf workflows 2>/dev/null || true
-        if timed_git clone -b workflows "https://github.com/m2ux/workflow-server.git" workflows 2>/dev/null; then
-            echo "[PASS] workflows (workflows branch)"
-        else
-            echo "[WARN] workflows skipped"
+
+    # Plain clones, not submodules, in this mode. An existing clone is refreshed
+    # in place; only a non-repo leftover directory is discarded.
+    ensure_clone() {
+        local path="$1"
+        local url="$2"
+        local branch="$3"
+
+        if [ -e "$path/.git" ]; then
+            echo "[PASS] $path already present — refreshing"
+            ( cd "$path" \
+                && timed_git fetch origin "$branch" >/dev/null 2>&1 \
+                && git checkout "$branch" >/dev/null 2>&1 \
+                && timed_git pull --ff-only origin "$branch" >/dev/null 2>&1 ) || \
+                echo "[WARN] $path refresh failed — leaving existing checkout as-is"
+            return 0
         fi
-    else
-        echo "[PASS] workflows exists"
-    fi
-    
+
+        rm -rf "$path"
+        if timed_git clone --single-branch --branch "$branch" "$url" "$path" >/dev/null 2>&1; then
+            echo "[PASS] $path (branch: $branch)"
+        else
+            echo "[WARN] $path skipped (private repo, or branch '$branch' not found)"
+            rm -rf "$path"
+            return 1
+        fi
+    }
+
+    ensure_clone "workflows" "https://github.com/m2ux/workflow-server.git" "workflows" || true
+
     if [ "$SKIP_HISTORY" = false ]; then
-        if [ ! -d "history/.git" ]; then
-            rm -rf history 2>/dev/null || true
-            ensure_history_branch "$HISTORY_REPO" "$PROJECT_NAME"
-            if timed_git clone --single-branch --branch "$PROJECT_NAME" "$HISTORY_REPO" history 2>/dev/null; then
-                echo "[PASS] history (branch: $PROJECT_NAME)"
-            else
-                echo "[WARN] history skipped (private or branch not found)"
-            fi
-        else
-            echo "[PASS] history exists"
-        fi
+        ensure_history_branch "$HISTORY_REPO" "$PROJECT_NAME" || true
+        ensure_clone "history" "$HISTORY_REPO" "$PROJECT_NAME" || true
     fi
-    
+
     cd "$REPO_ROOT"
     
     echo ""
@@ -496,7 +655,7 @@ else
     fi
     echo ""
     
-    if timed_git ls-remote --heads "$TARGET_REPO" "$TARGET_BRANCH" 2>/dev/null | grep -q "$TARGET_BRANCH"; then
+    if remote_branch_exists "$TARGET_REPO" "$TARGET_BRANCH"; then
         echo "[PASS] Branch '$TARGET_BRANCH' found"
     else
         echo "Branch '$TARGET_BRANCH' not found. Creating..."
@@ -514,35 +673,57 @@ else
         else
             WORKTREE_DIR="${REPO_ROOT}_engineering_tmp"
             TEMP_DIRS_TO_CLEAN+=("$WORKTREE_DIR")
-            git worktree add --detach "$WORKTREE_DIR" 2>/dev/null || true
+            # Drop any stale registration or directory from a previous aborted
+            # run, otherwise 'worktree add' fails and we would fall through onto
+            # the live branch.
+            git worktree remove --force "$WORKTREE_DIR" >/dev/null 2>&1 || true
+            rm -rf "$WORKTREE_DIR"
+            git worktree prune
+            if ! git worktree add --detach "$WORKTREE_DIR"; then
+                echo "[FAIL] Could not create temporary worktree at $WORKTREE_DIR"
+                exit 1
+            fi
             cd "$WORKTREE_DIR"
         fi
         
-        git checkout --orphan "$TARGET_BRANCH"
-        git rm -rf . 2>/dev/null || true
-        
+        # The remote branch is absent, but a local one may survive from an
+        # aborted run. Reuse it rather than failing on "branch already exists";
+        # create_engineering_structure below tops up whatever it is missing.
+        if git show-ref --verify --quiet "refs/heads/$TARGET_BRANCH"; then
+            echo "  Reusing existing local branch '$TARGET_BRANCH'"
+            git checkout "$TARGET_BRANCH"
+        else
+            git checkout --orphan "$TARGET_BRANCH"
+            git rm -rf . 2>/dev/null || true
+        fi
+
         create_engineering_structure "."
-        
-        timed_git submodule add -b workflows "https://github.com/m2ux/workflow-server.git" workflows 2>/dev/null || true
-        if [ -d "workflows" ]; then
-            cd workflows
-            git checkout workflows 2>/dev/null || true
-            cd ..
-        fi
-        
+
+        ensure_submodule "workflows" \
+            "https://github.com/m2ux/workflow-server.git" "workflows" || true
+
         if [ "$SKIP_HISTORY" = false ]; then
-            ensure_history_branch "$HISTORY_REPO" "$PROJECT_NAME"
-            timed_git submodule add -b "$PROJECT_NAME" "$HISTORY_REPO" history 2>/dev/null || true
-            if [ -d "history" ]; then
-                cd history
-                git checkout "$PROJECT_NAME" 2>/dev/null || true
-                cd ..
-            fi
+            ensure_history_branch "$HISTORY_REPO" "$PROJECT_NAME" || true
+            ensure_submodule "history" "$HISTORY_REPO" "$PROJECT_NAME" || true
         fi
-        
+
+
+        # Guard against any helper having changed directory out from under us:
+        # committing here on the wrong branch would pollute the project branch.
+        CURRENT_BRANCH="$(git symbolic-ref --short -q HEAD || echo "")"
+        if [ "$CURRENT_BRANCH" != "$TARGET_BRANCH" ]; then
+            echo "[FAIL] Expected to be on '$TARGET_BRANCH' in $(pwd), but HEAD is '$CURRENT_BRANCH'"
+            echo "       Aborting before committing to the wrong branch."
+            exit 1
+        fi
+
         git add .
-        git commit -m "docs: initialize $TARGET_BRANCH engineering branch"
-        
+        if [ -n "$(git status --porcelain)" ]; then
+            git commit -m "docs: initialize $TARGET_BRANCH engineering branch"
+        else
+            echo "  Branch content already up to date — nothing to commit"
+        fi
+
         if ! verify_push_access "$TARGET_REPO" "$TARGET_BRANCH"; then
             echo "[FAIL] Cannot push to $TARGET_REPO"
             exit 1
@@ -563,32 +744,34 @@ else
     echo ""
     echo "Adding .engineering submodule..."
     cd "$REPO_ROOT"
-    git submodule add -b "$TARGET_BRANCH" "$TARGET_REPO" .engineering
-    echo "[PASS] Added .engineering submodule (branch: $TARGET_BRANCH)"
-    
+    if ! ensure_submodule ".engineering" "$TARGET_REPO" "$TARGET_BRANCH"; then
+        echo "[FAIL] Could not register .engineering submodule"
+        exit 1
+    fi
+
     echo ""
     echo "Initializing nested submodules..."
-    cd "$ENGINEERING_DIR"
-    
-    if [ -f .gitmodules ]; then
-        if timed_git submodule update --init workflows 2>/dev/null; then
+    if [ -f "$ENGINEERING_DIR/.gitmodules" ]; then
+        cd "$ENGINEERING_DIR"
+
+        if timed_git submodule update --init -- workflows >/dev/null 2>&1; then
             echo "[PASS] workflows"
         else
             echo "[WARN] workflows skipped"
         fi
-        
+
         if [ "$SKIP_HISTORY" = false ]; then
-            if timed_git submodule update --init history 2>/dev/null; then
-                cd history
-                git checkout "$PROJECT_NAME" 2>/dev/null || true
-                cd ..
+            if timed_git submodule update --init -- history >/dev/null 2>&1; then
+                ( cd history && git checkout "$PROJECT_NAME" >/dev/null 2>&1 ) || true
                 echo "[PASS] history (branch: $PROJECT_NAME)"
             else
                 echo "[WARN] history skipped (private or branch not found)"
             fi
         fi
+    else
+        echo "  No nested submodules declared"
     fi
-    
+
     cd "$REPO_ROOT"
     
     migrate_existing_data "$ENGINEERING_DIR"


### PR DESCRIPTION
## Problem

`scripts/deploy.sh` could commit to the caller's branch instead of the engineering branch, and reported the resulting failure as a permissions error.

`ensure_history_branch()` ended with an unconditional `cd "$REPO_ROOT"`, but it is called from *inside* the temporary orphan-branch worktree. When the history branch does not yet exist the function takes its create-and-push path, and on return the script is back in the project root. Everything after that call then operates on the project branch:

- the `history` submodule is added to the wrong branch
- `git add . && git commit` produces a stray commit on the caller's branch
- the push-access check runs against a local `engineering` branch that was never created

Observed on a first-time deploy, where it left a `docs: initialize engineering engineering branch` commit on `main` (sweeping in an untracked `deploy.sh`) and reported:

```
[FAIL] No push access to git@github.com:m2ux/caliper.git (branch: engineering)
[FAIL] Cannot push to git@github.com:m2ux/caliper.git
```

The real error was `error: src refspec engineering does not match any`. `verify_push_access` discarded git's stderr, so a missing local ref was indistinguishable from a genuine permissions problem. Push access was never the issue.

Only projects whose history branch does not already exist hit this — on a repeat deploy the function early-returns before the `cd`, which is why it did not show up sooner.

## Correctness fixes

- `ensure_history_branch` and `migrate_existing_data` restore the **caller's** directory, not `REPO_ROOT`.
- `verify_push_access` checks the local ref exists first, and prints git's actual stderr.
- Assert `HEAD` is on the target branch before committing the orphan branch — a backstop against this whole class of bug.
- Fail hard when the temporary worktree cannot be created. The previous `|| true` let the script fall through onto the live branch.
- Match remote branches on the full `refs/heads/` ref via `ls-remote --exit-code`. The old substring grep treated `engineering-old` as a hit for `engineering` and skipped branch creation.

## Idempotence over existing submodules and paths

Re-running the script failed outright: `rm -rf .engineering` removed the working tree but left the index gitlink, the `.gitmodules` stanza, the `.git/config` stanza, and the cached `.git/modules` directory behind, so the next `git submodule add` aborted with *"already exists in the index"*.

Three helpers replace the ad-hoc handling:

| Helper | Role |
| --- | --- |
| `submodule_matches` | Is this path already registered at the expected URL **and** branch, with a `160000` gitlink in the index? |
| `purge_submodule` | Clears all five pieces of submodule state, resolving the module cache through `--git-common-dir` so it is correct inside a linked worktree too |
| `ensure_submodule` | No-op when already correct; purge-and-re-add when mismatched or half-removed; warn rather than abort on failure |

All four submodule call sites route through `ensure_submodule`. Related:

- `.engineering` is no longer deleted unconditionally — teardown is deferred to `ensure_submodule`, which only purges on mismatch.
- An existing local orphan branch is reused rather than failing on *"branch already exists"*, and the commit is skipped when the tree is already current.
- In-branch mode refreshes an existing clone via `ensure_clone`. The old `[ ! -d workflows/.git ]` guard was dead code — the directory had just been deleted.
- Stale `_engineering_tmp` directories and worktree registrations are cleared before `worktree add`.

## Also

Seed the `artifacts/` subdirectories with `.gitkeep`. Git does not track empty directories, so the structure documented in the generated `README.md` was **absent for every consumer** that cloned the engineering branch as a submodule.

## Verification

Ran the script three times against the same project (`--orphan`, local mode). Runs 2 and 3 were true no-ops:

- no git state change; gitlink unchanged
- existing artifacts preserved (backed up, compared, restored, reported as already current)
- no leftover temp directories or worktree registrations
- `bash -n` clean

Deployment and a subsequent artifact migration were exercised end to end on a real project. No changes to any other script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
