### PR TITLE
fix: install deploy-cursor-workspace into local install dir

### DIFF
--- a/examples/cursor-workspace/README.md
+++ b/examples/cursor-workspace/README.md
@@ -9,9 +9,11 @@ Requires workflow-server running ([setup.md](../../setup.md), [http.md](../../ht
 a product checkout under your projects root, and `$USER` set.
 
 ```bash
-# from a workflow-server checkout
+# after install.sh (preferred)
+~/.local/share/workflow-server/deploy-cursor-workspace.sh --github=m2ux/workflow-server
+# or from a workflow-server checkout
 ./scripts/deploy-cursor-workspace.sh --github=m2ux/workflow-server
-./scripts/deploy-cursor-workspace.sh --help   # all flags
+~/.local/share/workflow-server/deploy-cursor-workspace.sh --help
 ```
 
 Writes absolute `/home/$USER/…` roots into

--- a/scripts/deploy-cursor-workspace.sh
+++ b/scripts/deploy-cursor-workspace.sh
@@ -20,8 +20,15 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-TEMPLATE_DIR="${REPO_ROOT}/examples/cursor-workspace"
+# Repo checkout: scripts/deploy-… → ../examples/cursor-workspace
+# install.sh layout: $INSTALL/deploy-… + $INSTALL/examples/cursor-workspace
+if [[ -d "${SCRIPT_DIR}/../examples/cursor-workspace" ]]; then
+  TEMPLATE_DIR="$(cd "${SCRIPT_DIR}/../examples/cursor-workspace" && pwd)"
+elif [[ -d "${SCRIPT_DIR}/examples/cursor-workspace" ]]; then
+  TEMPLATE_DIR="$(cd "${SCRIPT_DIR}/examples/cursor-workspace" && pwd)"
+else
+  TEMPLATE_DIR="${SCRIPT_DIR}/../examples/cursor-workspace"
+fi
 
 # Canonical user paths are always /home/$USER/… (see --user to override $USER).
 USER_NAME="${USER:-}"
@@ -58,7 +65,8 @@ Options:
                              (default: /home/\$USER/.local/share/cursor/workspaces)
   --mcp-url=URL              workflow-server HTTP MCP URL written into mcp.json
                              (default: http://127.0.0.1:3000/mcp)
-  --template=DIR             Template source (default: <repo>/examples/cursor-workspace)
+  --template=DIR             Template source (default: examples/cursor-workspace next to
+                             this script, or ../examples/cursor-workspace from scripts/)
   --force                    Refresh managed files in an existing workspace dir
                              (upserts required MCP servers; keeps any extras)
   --dry-run                  Print actions only

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,9 +24,11 @@ DEFAULT_REF="main"
 DEFAULT_START_NAME="start.sh"
 DEFAULT_STOP_NAME="stop.sh"
 DEFAULT_UPDATE_NAME="update-workflows.sh"
+DEFAULT_DEPLOY_CURSOR_NAME="deploy-cursor-workspace.sh"
 DEFAULT_ENV_NAME="env"
 DEFAULT_CONTAINER_NAME="workflow-server"
 DEFAULT_HOST_PORT="3000"
+DEFAULT_CURSOR_TEMPLATE_REL="examples/cursor-workspace"
 # Older helper script names — removed on upgrade when present.
 LEGACY_NAMES=(
   "run-workflow-server.sh"
@@ -76,6 +78,8 @@ LAYOUT
     ${DEFAULT_START_NAME}
     ${DEFAULT_STOP_NAME}
     ${DEFAULT_UPDATE_NAME}
+    ${DEFAULT_DEPLOY_CURSOR_NAME}
+    ${DEFAULT_CURSOR_TEMPLATE_REL}/  # template for deploy-cursor-workspace
     ${DEFAULT_ENV_NAME}               # HOST_PROJECTS_ROOT + port / name
     workflows/               # git clone -b workflows (server definitions)
     state/                   # durable HMAC key (mounted by start.sh)
@@ -92,6 +96,7 @@ AFTER INSTALL
   \$INSTALL/${DEFAULT_START_NAME} -d
   \$INSTALL/${DEFAULT_STOP_NAME}
   \$INSTALL/${DEFAULT_UPDATE_NAME}
+  \$INSTALL/${DEFAULT_DEPLOY_CURSOR_NAME} --github=owner/repo
   export WORKFLOW_SERVER_MCP_URL=http://127.0.0.1:${DEFAULT_HOST_PORT}/mcp
   curl -fsS http://127.0.0.1:${DEFAULT_HOST_PORT}/health
   curl -fsS http://127.0.0.1:${DEFAULT_HOST_PORT}/ready   # sessionKeyWritable: true
@@ -132,6 +137,46 @@ fetch_script() {
   echo "Fetching ${label} → ${dest}"
   curl -fsSL -o "$dest" "$url"
   chmod +x "$dest"
+}
+
+# Install examples/cursor-workspace next to deploy-cursor-workspace.sh.
+# Prefer GitHub codeload tarball when using the default raw base; else sparse clone.
+fetch_cursor_workspace_template() {
+  local dest="$1"
+  local tmp tarball_ok=0 src=""
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/wf-cursor-tmpl.XXXXXX")"
+
+  echo "Fetching Cursor workspace template → ${dest}"
+
+  if [[ "$RAW_BASE" == https://raw.githubusercontent.com/m2ux/workflow-server ]]; then
+    if curl -fsSL "https://codeload.github.com/m2ux/workflow-server/tar.gz/${REF}" \
+      -o "${tmp}/src.tgz" \
+      && tar -xzf "${tmp}/src.tgz" -C "$tmp" 2>/dev/null; then
+      src="$(find "$tmp" -type d -path '*/examples/cursor-workspace' 2>/dev/null | head -n 1 || true)"
+      if [[ -n "$src" && -d "$src" ]]; then
+        tarball_ok=1
+        rm -rf "$dest"
+        mkdir -p "$(dirname "$dest")"
+        cp -a "$src" "$dest"
+      fi
+    fi
+  fi
+
+  if [[ "$tarball_ok" -ne 1 ]]; then
+    echo "  (falling back to git sparse checkout from ${REPO_URL} @ ${REF})"
+    git clone -b "$REF" --depth 1 --filter=blob:none --sparse "$REPO_URL" "${tmp}/repo" \
+      || { rm -rf "$tmp"; die "failed to clone for Cursor template"; }
+    git -C "${tmp}/repo" sparse-checkout set examples/cursor-workspace \
+      || { rm -rf "$tmp"; die "failed sparse-checkout examples/cursor-workspace"; }
+    [[ -d "${tmp}/repo/examples/cursor-workspace" ]] \
+      || { rm -rf "$tmp"; die "examples/cursor-workspace missing after sparse checkout"; }
+    rm -rf "$dest"
+    mkdir -p "$(dirname "$dest")"
+    cp -a "${tmp}/repo/examples/cursor-workspace" "$dest"
+  fi
+
+  rm -rf "$tmp"
+  [[ -d "$dest" ]] || die "Cursor workspace template not installed: ${dest}"
 }
 
 while [[ $# -gt 0 ]]; do
@@ -219,11 +264,14 @@ fi
 START_PATH="${INSTALL_DIR}/${DEFAULT_START_NAME}"
 STOP_PATH="${INSTALL_DIR}/${DEFAULT_STOP_NAME}"
 UPDATE_PATH="${INSTALL_DIR}/${DEFAULT_UPDATE_NAME}"
+DEPLOY_CURSOR_PATH="${INSTALL_DIR}/${DEFAULT_DEPLOY_CURSOR_NAME}"
+CURSOR_TEMPLATE_DIR="${INSTALL_DIR}/${DEFAULT_CURSOR_TEMPLATE_REL}"
 ENV_PATH="${INSTALL_DIR}/${DEFAULT_ENV_NAME}"
 WORKFLOWS_DIR="${INSTALL_DIR}/workflows"
 START_URL="${RAW_BASE}/${REF}/scripts/start.sh"
 STOP_URL="${RAW_BASE}/${REF}/scripts/stop.sh"
 UPDATE_URL="${RAW_BASE}/${REF}/scripts/update-workflows.sh"
+DEPLOY_CURSOR_URL="${RAW_BASE}/${REF}/scripts/deploy-cursor-workspace.sh"
 
 echo "Install dir: ${INSTALL_DIR}"
 mkdir -p "$INSTALL_DIR"
@@ -238,6 +286,8 @@ fi
 fetch_script "$START_PATH" "$START_URL" "start"
 fetch_script "$STOP_PATH" "$STOP_URL" "stop"
 fetch_script "$UPDATE_PATH" "$UPDATE_URL" "update-workflows"
+fetch_script "$DEPLOY_CURSOR_PATH" "$DEPLOY_CURSOR_URL" "deploy-cursor-workspace"
+fetch_cursor_workspace_template "$CURSOR_TEMPLATE_DIR"
 
 for legacy in "${LEGACY_NAMES[@]}"; do
   legacy_path="${INSTALL_DIR}/${legacy}"
@@ -297,6 +347,10 @@ echo "  ${STOP_PATH}"
 echo
 echo "Update workflows later with:"
 echo "  ${UPDATE_PATH}"
+echo
+echo "Deploy Cursor multi-root workspace (after a product checkout exists):"
+echo "  ${DEPLOY_CURSOR_PATH} --github=owner/repo"
+echo "  Template: ${CURSOR_TEMPLATE_DIR}"
 echo
 echo "Then:"
 echo "  export WORKFLOW_SERVER_MCP_URL=http://127.0.0.1:${HOST_PORT}/mcp"

--- a/setup.md
+++ b/setup.md
@@ -48,14 +48,18 @@ Repeat **2a → 2b** for each product repo.
 **Recommended path:** deploy the [examples/cursor-workspace/](examples/cursor-workspace/) template with [`scripts/deploy-cursor-workspace.sh`](scripts/deploy-cursor-workspace.sh). That writes absolute `/home/$USER/…` multi-root paths (no `HOST_PROJECTS_ROOT` required when opening Cursor) and mirrors `~/.local/share/cursor/workspaces/workflow-server`:
 
 ```bash
-# from a workflow-server checkout ($USER must be set; needs python3)
+# after install.sh ($USER must be set; needs python3) — preferred
+~/.local/share/workflow-server/deploy-cursor-workspace.sh --github=m2ux/workflow-server
+# or from a workflow-server checkout:
 ./scripts/deploy-cursor-workspace.sh --github=m2ux/workflow-server
 # refresh an existing kickoff dir (keeps extra MCP servers):
-./scripts/deploy-cursor-workspace.sh --github=m2ux/workflow-server --force
+~/.local/share/workflow-server/deploy-cursor-workspace.sh --github=m2ux/workflow-server --force
 # preview:
-./scripts/deploy-cursor-workspace.sh --dry-run --github=m2ux/workflow-server
+~/.local/share/workflow-server/deploy-cursor-workspace.sh --dry-run --github=m2ux/workflow-server
 cursor ~/.local/share/cursor/workspaces/workflow-server/workflow-server.code-workspace
 ```
+
+`install.sh` places `deploy-cursor-workspace.sh` and `examples/cursor-workspace/` under the install dir (default `~/.local/share/workflow-server/`).
 
 | Flag | Purpose |
 |------|---------|
@@ -66,7 +70,7 @@ cursor ~/.local/share/cursor/workspaces/workflow-server/workflow-server.code-wor
 | `--force` | Refresh managed files; merge `mcp.json` without dropping other servers |
 | `--dry-run` / `--open` / `--help` | Preview, launch Cursor, full flag list |
 
-Flags: `./scripts/deploy-cursor-workspace.sh --help` · [examples/cursor-workspace/README.md](examples/cursor-workspace/README.md).
+Flags: `deploy-cursor-workspace.sh --help` · [examples/cursor-workspace/README.md](examples/cursor-workspace/README.md).
 
 The template includes MCP (`workflow-server` via `mcp-remote`), bootstrap rules, and `AGENTS.md` for `repo: "owner/repo"`.
 


### PR DESCRIPTION
## Summary
- `install.sh` did **not** ship `deploy-cursor-workspace.sh` (only `start` / `stop` / `update-workflows`).
- Fetch `deploy-cursor-workspace.sh` and the `examples/cursor-workspace` template into `$INSTALL` (default `~/.local/share/workflow-server/`).
- Deploy script resolves the template from either a repo checkout (`../examples/…`) or the install layout (`./examples/…`).
- Docs: `setup.md` §3 and the example README prefer the install-dir path.

## Test plan
- [x] `bash -n` on `install.sh` and `deploy-cursor-workspace.sh`
- [x] Local install-layout dry-run resolves template next to the script
- [x] `install.sh --install-dir=<tmp> --ref=fix/install-deploy-cursor-workspace` installs script + template
- [ ] Re-run real install and confirm `~/.local/share/workflow-server/deploy-cursor-workspace.sh` exists