### PR TITLE
fix: omit Claude template residue from Cursor kickoffs

### DIFF
--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -33,6 +33,8 @@ Then ask the agent to start a workflow. Prefer this over hand-rolling MCP config
 | `scripts/claude/` | Portable hooks + `bin/sbx` (from repo [`scripts/claude/`](../scripts/claude/)) |
 | `.claude/settings.json` | **Generated at deploy** from [settings.template.json](../examples/cursor-workspace/.claude/settings.template.json) — broad Bash/MCP allows, safety hooks; not committed from a live workspace |
 
+`settings.template.json` / `settings.example.json` stay in the repo template only — deploy does **not** copy them into the kickoff dir (and removes them on `--force` if an older deploy left them behind).
+
 `install.sh` places `deploy-cursor-workspace.sh`, `examples/cursor-workspace/`, and `scripts/claude/` under the install dir so deploy works without a full checkout.
 
 Claude settings use `__HOME__` / `__WORKSPACE__` tokens in the template; deploy expands them to absolute paths. Hook commands point at the kickoff `scripts/claude/hooks/…`. Re-run with `--force` after pulling template or hook changes.

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -31,13 +31,11 @@ Then ask the agent to start a workflow. Prefer this over hand-rolling MCP config
 | `.cursor/rules/`, `.claude/rules/` | Bootstrap / companion rules |
 | `AGENTS.md` → `CLAUDE.md` | Target checkout + `owner/repo` placeholder |
 | `scripts/claude/` | Portable hooks + `bin/sbx` (from repo [`scripts/claude/`](../scripts/claude/)) |
-| `.claude/settings.json` | **Generated at deploy** from [settings.template.json](../examples/cursor-workspace/.claude/settings.template.json) — broad Bash/MCP allows, safety hooks; not committed from a live workspace |
-
-`settings.template.json` / `settings.example.json` stay in the repo template only — deploy does **not** copy them into the kickoff dir (and removes them on `--force` if an older deploy left them behind).
+| `.claude/settings.json` | Generated at deploy from [settings.template.json](../examples/cursor-workspace/.claude/settings.template.json) |
 
 `install.sh` places `deploy-cursor-workspace.sh`, `examples/cursor-workspace/`, and `scripts/claude/` under the install dir so deploy works without a full checkout.
 
-Claude settings use `__HOME__` / `__WORKSPACE__` tokens in the template; deploy expands them to absolute paths. Hook commands point at the kickoff `scripts/claude/hooks/…`. Re-run with `--force` after pulling template or hook changes.
+Deploy expands `__HOME__` / `__WORKSPACE__` in the template. Re-run with `--force` after template or hook changes.
 
 ## Bootstrap rule (reference)
 

--- a/scripts/claude/README.md
+++ b/scripts/claude/README.md
@@ -10,7 +10,7 @@ kickoff workspace as `scripts/claude/` and writes workspace-local
 ```text
 scripts/claude/
 ├── README.md                       # this file (deployed with the tree)
-├── .gitignore                      # ignore __pycache__ / *.pyc under this tree
+├── .gitignore                      # repo packaging only (stripped at deploy)
 ├── bin/
 │   └── sbx                         # bubblewrap profile-C launcher (no net; project+/tmp RW)
 └── hooks/
@@ -31,5 +31,6 @@ scripts/claude/
 
 Project-level Claude settings for Cursor kickoffs are generated at deploy time
 from `examples/cursor-workspace/.claude/settings.template.json` into the
-workspace dir only (`~/.local/share/cursor/workspaces/<name>/.claude/settings.json`).
-Do not commit machine-local hook paths.
+workspace dir only as `.claude/settings.json`. The template and
+`settings.example.json` are **not** installed into the kickoff. Do not commit
+machine-local hook paths.

--- a/scripts/claude/README.md
+++ b/scripts/claude/README.md
@@ -9,8 +9,8 @@ kickoff workspace as `scripts/claude/` and writes workspace-local
 
 ```text
 scripts/claude/
-├── README.md                       # this file (deployed with the tree)
-├── .gitignore                      # repo packaging only (stripped at deploy)
+├── README.md
+├── .gitignore
 ├── bin/
 │   └── sbx                         # bubblewrap profile-C launcher (no net; project+/tmp RW)
 └── hooks/
@@ -29,8 +29,5 @@ scripts/claude/
 
 ## Note
 
-Project-level Claude settings for Cursor kickoffs are generated at deploy time
-from `examples/cursor-workspace/.claude/settings.template.json` into the
-workspace dir only as `.claude/settings.json`. The template and
-`settings.example.json` are **not** installed into the kickoff. Do not commit
-machine-local hook paths.
+Deploy writes `.claude/settings.json` from
+`examples/cursor-workspace/.claude/settings.template.json`.

--- a/scripts/deploy-cursor-workspace.sh
+++ b/scripts/deploy-cursor-workspace.sh
@@ -90,7 +90,7 @@ Required MCP servers written into mcp.json (workflows depend on these):
 Claude baseline (workspace-local only):
   copies scripts/claude/ → <workspace>/scripts/claude/
   writes .claude/settings.json from settings.template.json
-  (hook paths + \$HOME permissions expanded; not committed)
+  (hook paths + \$HOME permissions expanded; template/example not installed)
 
 Path substitution (all MCP servers — command and args):
   \${HOME}  \$HOME  __USER_HOME__  /home/<name>/…  → \$HOME/…
@@ -285,9 +285,12 @@ log "  MCP URL           : ${MCP_URL}"
 log "  claude scripts    : ${CLAUDE_SCRIPTS_DIR:-"(none)"}"
 log "  claude settings   : ${CLAUDE_SETTINGS_TEMPLATE}"
 
-# --- copy template rules / skills (preserve extra local files) ----------------
+# --- copy template rules / skills (runtime only; preserve extra local files) --
+# settings.template.json / settings.example.json stay in the repo template only.
+# Live kickoff gets the rendered .claude/settings.json further below.
 if [[ "$DRY_RUN" -eq 1 ]]; then
   log "copy template rules/skills → ${DEST_DIR}"
+  log "omit settings.template.json / settings.example.json from destination"
 else
   mkdir -p "${DEST_DIR}/.cursor/rules" "${DEST_DIR}/.claude/rules"
 
@@ -297,15 +300,12 @@ else
   if [[ -d "${TEMPLATE_DIR}/.claude/rules" ]]; then
     cp -a "${TEMPLATE_DIR}/.claude/rules/." "${DEST_DIR}/.claude/rules/"
   fi
-  if [[ -f "${TEMPLATE_DIR}/.claude/settings.template.json" ]]; then
-    cp -a "${TEMPLATE_DIR}/.claude/settings.template.json" \
-      "${DEST_DIR}/.claude/settings.template.json"
-  fi
-  if [[ -f "${TEMPLATE_DIR}/.claude/settings.example.json" ]]; then
-    cp -a "${TEMPLATE_DIR}/.claude/settings.example.json" \
-      "${DEST_DIR}/.claude/settings.example.json"
-  fi
-  if [[ -d "${TEMPLATE_DIR}/.cursor/skills" ]]; then
+  # Drop packaging leftovers from older deploys (template is never a runtime file).
+  rm -f \
+    "${DEST_DIR}/.claude/settings.template.json" \
+    "${DEST_DIR}/.claude/settings.example.json"
+  if [[ -d "${TEMPLATE_DIR}/.cursor/skills" ]] \
+    && compgen -G "${TEMPLATE_DIR}/.cursor/skills/*" >/dev/null; then
     mkdir -p "${DEST_DIR}/.cursor/skills"
     cp -a "${TEMPLATE_DIR}/.cursor/skills/." "${DEST_DIR}/.cursor/skills/"
   fi
@@ -319,6 +319,10 @@ if [[ -n "$CLAUDE_SCRIPTS_DIR" && -d "$CLAUDE_SCRIPTS_DIR" ]]; then
     mkdir -p "${DEST_DIR}/scripts"
     rm -rf "${DEST_DIR}/scripts/claude"
     cp -a "${CLAUDE_SCRIPTS_DIR}" "${DEST_DIR}/scripts/claude"
+    # Packaging-only / VCS noise — not needed in a live kickoff.
+    rm -f "${DEST_DIR}/scripts/claude/.gitignore"
+    find "${DEST_DIR}/scripts/claude" -type d -name '__pycache__' -prune -exec rm -rf {} + 2>/dev/null || true
+    find "${DEST_DIR}/scripts/claude" -type f -name '*.pyc' -delete 2>/dev/null || true
     # Ensure hook + sbx executables stay runnable after copy.
     find "${DEST_DIR}/scripts/claude" -type f \( -name '*.py' -o -name 'sbx' -o -name '*.cjs' \) \
       -exec chmod a+x {} + 2>/dev/null || true

--- a/scripts/deploy-cursor-workspace.sh
+++ b/scripts/deploy-cursor-workspace.sh
@@ -90,7 +90,6 @@ Required MCP servers written into mcp.json (workflows depend on these):
 Claude baseline (workspace-local only):
   copies scripts/claude/ → <workspace>/scripts/claude/
   writes .claude/settings.json from settings.template.json
-  (hook paths + \$HOME permissions expanded; template/example not installed)
 
 Path substitution (all MCP servers — command and args):
   \${HOME}  \$HOME  __USER_HOME__  /home/<name>/…  → \$HOME/…
@@ -285,12 +284,9 @@ log "  MCP URL           : ${MCP_URL}"
 log "  claude scripts    : ${CLAUDE_SCRIPTS_DIR:-"(none)"}"
 log "  claude settings   : ${CLAUDE_SETTINGS_TEMPLATE}"
 
-# --- copy template rules / skills (runtime only; preserve extra local files) --
-# settings.template.json / settings.example.json stay in the repo template only.
-# Live kickoff gets the rendered .claude/settings.json further below.
+# --- copy template rules / skills (preserve extra local files) ----------------
 if [[ "$DRY_RUN" -eq 1 ]]; then
   log "copy template rules/skills → ${DEST_DIR}"
-  log "omit settings.template.json / settings.example.json from destination"
 else
   mkdir -p "${DEST_DIR}/.cursor/rules" "${DEST_DIR}/.claude/rules"
 
@@ -300,7 +296,6 @@ else
   if [[ -d "${TEMPLATE_DIR}/.claude/rules" ]]; then
     cp -a "${TEMPLATE_DIR}/.claude/rules/." "${DEST_DIR}/.claude/rules/"
   fi
-  # Drop packaging leftovers from older deploys (template is never a runtime file).
   rm -f \
     "${DEST_DIR}/.claude/settings.template.json" \
     "${DEST_DIR}/.claude/settings.example.json"
@@ -319,11 +314,9 @@ if [[ -n "$CLAUDE_SCRIPTS_DIR" && -d "$CLAUDE_SCRIPTS_DIR" ]]; then
     mkdir -p "${DEST_DIR}/scripts"
     rm -rf "${DEST_DIR}/scripts/claude"
     cp -a "${CLAUDE_SCRIPTS_DIR}" "${DEST_DIR}/scripts/claude"
-    # Packaging-only / VCS noise — not needed in a live kickoff.
     rm -f "${DEST_DIR}/scripts/claude/.gitignore"
     find "${DEST_DIR}/scripts/claude" -type d -name '__pycache__' -prune -exec rm -rf {} + 2>/dev/null || true
     find "${DEST_DIR}/scripts/claude" -type f -name '*.pyc' -delete 2>/dev/null || true
-    # Ensure hook + sbx executables stay runnable after copy.
     find "${DEST_DIR}/scripts/claude" -type f \( -name '*.py' -o -name 'sbx' -o -name '*.cjs' \) \
       -exec chmod a+x {} + 2>/dev/null || true
   fi

--- a/setup.md
+++ b/setup.md
@@ -77,7 +77,7 @@ Deploy installs:
 - MCP (`concept-rag`, `atlassian`, `gitnexus`, `workflow-server` via `mcp-remote`)
 - Bootstrap rules and `AGENTS.md` / `CLAUDE.md` for `repo: "owner/repo"`
 - Multi-root `.code-workspace` with absolute `$HOME/…` paths
-- **Claude baseline (kickoff only):** `scripts/claude/` + generated `.claude/settings.json` (rendered from `settings.template.json`; template/example files are not installed)
+- **Claude baseline (kickoff only):** `scripts/claude/` + generated `.claude/settings.json`
 
 ## 4. Update Workflows
 

--- a/setup.md
+++ b/setup.md
@@ -77,7 +77,7 @@ Deploy installs:
 - MCP (`concept-rag`, `atlassian`, `gitnexus`, `workflow-server` via `mcp-remote`)
 - Bootstrap rules and `AGENTS.md` / `CLAUDE.md` for `repo: "owner/repo"`
 - Multi-root `.code-workspace` with absolute `$HOME/…` paths
-- **Claude baseline (kickoff only):** `scripts/claude/` + generated `.claude/settings.json` (from `settings.template.json`; not part of the product checkout)
+- **Claude baseline (kickoff only):** `scripts/claude/` + generated `.claude/settings.json` (rendered from `settings.template.json`; template/example files are not installed)
 
 ## 4. Update Workflows
 


### PR DESCRIPTION
## Summary
- Stop copying `settings.template.json` / `settings.example.json` into live kickoff workspaces; only the rendered `.claude/settings.json` is installed.
- On deploy/refresh, remove those files if an older deploy left them behind.
- Strip packaging-only `scripts/claude/.gitignore` (and any `__pycache__` / `*.pyc`) from the installed hooks tree.
- Document the runtime-only install surface in setup / ide-setup / Claude scripts README.

## Test plan
- [x] `bash -n scripts/deploy-cursor-workspace.sh`
- [x] Fresh deploy into temp dir: `.claude/` contains only `rules/` + `settings.json`
- [x] Seeded leftovers (`settings.template.json`, `settings.example.json`, `.gitignore`) removed on `--force`
- [x] Generated `settings.json` expands `__HOME__` / `__WORKSPACE__` tokens
- [ ] Re-run deploy against an existing kickoff with `--force` and confirm UI no longer shows template/example files