### PR TITLE
feat(meta,workflow-design): gate the saved-session search on stated resume intent, repair the hand-off; catalogue AP-127

### DIFF
--- a/meta/README.md
+++ b/meta/README.md
@@ -121,7 +121,7 @@ Meta itself produces no domain artefacts. Its outputs are session-state side-eff
 
 ```
 workflows/meta/
-├── workflow.yaml                            # Meta workflow definition (19 variables, 2 rules)
+├── workflow.yaml                            # Meta workflow definition
 ├── README.md                                # This file
 ├── activities/
 │   ├── 00-discover-session.yaml             # Match user request, scan saved sessions on resume intent

--- a/meta/README.md
+++ b/meta/README.md
@@ -1,6 +1,6 @@
 # Meta Workflow
 
-> v5.2.0 — Top-level lifecycle workflow for the workflow-server. Bootstrap navigates here directly. The meta session runs five activities that identify a target client workflow, match any saved session, create or resume the client session as a child of meta, resolve target_path, drive the client workflow's activity loop and mediate its checkpoint yields, and close out. Provides the universal technique repository for all client workflows.
+> v5.9.0 — Top-level lifecycle workflow for the workflow-server. Bootstrap navigates here directly. The meta session runs five activities that identify a target client workflow, match any saved session when the request states resume intent, create or resume the client session as a child of meta, resolve target_path, drive the client workflow's activity loop and mediate its checkpoint yields, and close out. Provides the universal technique repository for all client workflows.
 
 ---
 
@@ -17,7 +17,7 @@ The meta workflow is the structural home for the orchestration logic that used t
 
 | # | Activity | Role |
 |---|----------|------|
-| 00 | [**Discover Session**](./activities/README.md#00-discover-session) | Identify the target client workflow and surface any saved session to resume |
+| 00 | [**Discover Session**](./activities/README.md#00-discover-session) | Identify the target client workflow and, on stated resume intent, surface any saved session to resume |
 | 01 | [**Initialize Session**](./activities/README.md#01-initialize-session) | Give the work package a stable identity and create or resume the client session as a child of meta |
 | 02 | [**Resolve Target**](./activities/README.md#02-resolve-target) | Detect the repo structure (regular vs. submodule monorepo) and resolve `target_path` |
 | 03 | [**Dispatch Client Workflow**](./activities/README.md#03-dispatch-client-workflow) | Drive the client workflow end to end inline, mediating its checkpoints with the user |
@@ -37,7 +37,7 @@ The meta workflow is the structural home for the orchestration logic that used t
 ```mermaid
 graph TD
     startNode(["Bootstrap"]) -->|"start_session(workflow_id: meta)"| DS["00 discover-session"]
-    DS -->|"target_workflow_id, has_saved_state, is_resuming"| INI["01 initialize-session"]
+    DS -->|"target_workflow_id, resume_intent_requested, has_saved_state, is_resuming"| INI["01 initialize-session"]
     INI -->|"client_session_index, client_planning_slug"| RT["02 resolve-target"]
     RT -->|"target_path"| DSP["03 dispatch-client-workflow"]
     DSP -->|"current_activity == null"| END["04 end-workflow"]
@@ -98,6 +98,7 @@ Universal techniques referenced by canonical ID (the file/folder slug).
 | `bootstrap-protocol` | [Bootstrap Protocol](./resources/bootstrap-protocol.md) | Pre-session stub served by `discover` — schema fetch, bind `repo` on `start_session`, bag `{target_repo}`, `get_workflow`. Ongoing delivery policy is in the operations bundle. |
 | `session-summary-template` | [Session Summary Template](./resources/session-summary-template.md) | Skeleton for the markdown session summary composed by `generate-summary` at workflow close. |
 | `planning-readme` | [Planning Folder README Guide](./resources/planning-readme.md) | Universal Template + Progress Status policy for planning-folder `README.md`. |
+| `resume-intent-lexicon` | [Resume Intent Lexicon](./resources/resume-intent-lexicon.md) | Continuation-phrase vocabulary gating `discover-session`'s saved-session search. |
 
 Agent entry Protocol: [`workflow-engine::activity-worker`](./techniques/workflow-engine/activity-worker.md) and [`workflow-engine::workflow-orchestrator`](./techniques/workflow-engine/workflow-orchestrator.md); spawn stubs from [`compose-prompt`](./techniques/workflow-engine/compose-prompt.md).
 
@@ -120,10 +121,10 @@ Meta itself produces no domain artefacts. Its outputs are session-state side-eff
 
 ```
 workflows/meta/
-├── workflow.yaml                            # Meta workflow definition (16 variables, 3 rules)
+├── workflow.yaml                            # Meta workflow definition (19 variables, 2 rules)
 ├── README.md                                # This file
 ├── activities/
-│   ├── 00-discover-session.yaml             # Match user request, scan saved sessions
+│   ├── 00-discover-session.yaml             # Match user request, scan saved sessions on resume intent
 │   ├── 01-initialize-session.yaml           # Create or resume the client session
 │   ├── 02-resolve-target.yaml               # Detect repo type, set target_path
 │   ├── 03-dispatch-client-workflow.yaml     # Drive the client activity loop (while current_activity != null)
@@ -150,5 +151,6 @@ workflows/meta/
     ├── bootstrap-protocol.md                # Pre-session stub (discover)
     ├── session-summary-template.md
     ├── planning-readme.md                   # Universal planning README Template + Progress policy
+    ├── resume-intent-lexicon.md             # Continuation phrases gating the saved-session search
     └── workflow-canonical.md                # Ontology / section conventions
 ```

--- a/meta/activities/00-discover-session.yaml
+++ b/meta/activities/00-discover-session.yaml
@@ -1,10 +1,8 @@
 id: discover-session
-version: 7.2.1
+version: 7.3.0
 name: Discover Session
-description: Identify the target workflow and search for an existing client session to resume.
+description: Identify the target workflow and, on stated resume intent, search for an existing client session to resume.
 required: true
-rules:
-  - Match identifying context against saved sessions even when the user said 'start' — surface saved state via the resume-session checkpoint
 steps:
   - kind: technique
     id: list-available-workflows
@@ -34,17 +32,26 @@ steps:
           setVariable:
             workflow_match_ambiguous: false
   - kind: technique
+    id: detect-resume-intent
+    technique: workflow-engine::detect-resume-intent
+  - kind: technique
     id: extract-context
     technique: workflow-engine::extract-identifying-context
+    when: resume_intent_requested == true
   - kind: technique
     id: scan-planning-folders
     technique: workflow-engine::scan-saved-sessions
+    when: resume_intent_requested == true
   - kind: technique
     id: match-session
     technique: workflow-engine::match-saved-session
+    when: resume_intent_requested == true
   - kind: action
     id: record-match
-    when: has_saved_state == true
+    condition:
+      type: simple
+      variable: matched_session
+      operator: exists
     actions:
       - action: set
         target: has_saved_state
@@ -76,7 +83,10 @@ steps:
             has_saved_state: false
   - kind: action
     id: record-no-match
-    when: has_saved_state == false
+    condition:
+      type: simple
+      variable: matched_session
+      operator: notExists
     actions:
       - action: set
         target: has_saved_state
@@ -86,4 +96,4 @@ transitions:
     isDefault: true
 outcome:
   - Target workflow identified (and confirmed by user if ambiguous)
-  - Existing saved session matched and resume decision captured, or no session found
+  - Saved session matched and resume decision captured on stated resume intent; no search performed otherwise

--- a/meta/activities/01-initialize-session.yaml
+++ b/meta/activities/01-initialize-session.yaml
@@ -1,7 +1,7 @@
 id: initialize-session
-version: 6.3.0
+version: 6.4.0
 name: Initialize Session
-description: Derive the client planning slug, then dispatch the client workflow as a child of the meta session.
+description: Bind the client planning slug for the run's mode, then dispatch the client workflow as a child of the meta session.
 required: true
 steps:
   - kind: technique
@@ -11,6 +11,14 @@ steps:
       outputs:
         planning_slug: client_planning_slug
     when: is_resuming == false
+  - kind: action
+    id: adopt-saved-planning-slug
+    actions:
+      - action: set
+        target: client_planning_slug
+        value: "{saved_planning_slug}"
+        description: Carry the matched session's slug into the dispatch slug so the server targets the existing planning folder.
+    when: is_resuming == true
   - kind: technique
     id: start-or-resume-session
     technique:

--- a/meta/activities/README.md
+++ b/meta/activities/README.md
@@ -12,7 +12,7 @@ The authoritative definition of each activity — its steps, technique bindings,
 
 ### 00. Discover Session
 
-Identifies the target workflow and looks for an existing client session to resume. It matches the user request against the workflow catalog, extracts the request's identifying context (ticket, branch, PR, work-package name), and scans planning folders so saved progress can be surfaced — even when the user said "start". It can surface a workflow-selection checkpoint (when the match is ambiguous) and a resume-session checkpoint (when saved state is found). Leads to [Initialize Session](#01-initialize-session).
+Identifies the target workflow and, when the request states resume intent, looks for an existing client session to resume. It matches the user request against the workflow catalog and detects resume intent against the [resume-intent lexicon](../resources/resume-intent-lexicon.md); on stated intent it then extracts the request's identifying context (ticket, branch, PR, work-package name) and scans planning folders so saved progress can be surfaced. A request stating a fresh start skips that search. It can surface a workflow-selection checkpoint (when the match is ambiguous) and a resume-session checkpoint (when saved state is found). Leads to [Initialize Session](#01-initialize-session).
 
 Definition: [`00-discover-session.yaml`](./00-discover-session.yaml)
 

--- a/meta/activities/README.md
+++ b/meta/activities/README.md
@@ -2,7 +2,7 @@
 
 > Part of the [Meta Workflow](../README.md)
 
-Five sequential activities that run inside the meta session: identify the target client workflow and any saved session, create or resume the client session, resolve target_path, drive the client workflow's activity loop inline and mediate its yielded checkpoints, and close out the session.
+Five sequential activities that run inside the meta session: identify the target client workflow and, on stated resume intent, any saved session, create or resume the client session, resolve target_path, drive the client workflow's activity loop inline and mediate its yielded checkpoints, and close out the session.
 
 Borrowable mid-phase orchestration pattern activities live under [`patterns/`](./patterns/README.md) and are **not** part of this lifecycle list.
 
@@ -20,7 +20,7 @@ Definition: [`00-discover-session.yaml`](./00-discover-session.yaml)
 
 ### 01. Initialize Session
 
-Gives the work package a stable, work-item-derived identity, then creates or resumes the client session as a child of the meta session. The slug is derived from the work item before dispatch so the server reuses it on every resume instead of a date-stamped fallback. The server owns folder creation and returns the canonical `planning_folder_path`; on resume it restores prior variables automatically, so there is no agent-side restore. Leads to [Resolve Target](#02-resolve-target).
+Gives the work package a stable, work-item-derived identity, then creates or resumes the client session as a child of the meta session. A fresh run derives the slug from the work item before dispatch so the server reuses it on every resume instead of a date-stamped fallback; a resuming run carries the matched session's slug through instead, so dispatch targets the existing planning folder. The server owns folder creation and returns the canonical `planning_folder_path`; on resume it restores prior variables automatically, so there is no agent-side restore. Leads to [Resolve Target](#02-resolve-target).
 
 Definition: [`01-initialize-session.yaml`](./01-initialize-session.yaml)
 

--- a/meta/resources/README.md
+++ b/meta/resources/README.md
@@ -15,6 +15,7 @@ Tool reference content for Atlassian, GitNexus, and state management has moved i
 | `bootstrap-protocol` | [Bootstrap Protocol](./bootstrap-protocol.md) | Pre-session stub served by `discover` — schema fetch → bind `repo` on `start_session` → bag `{target_repo}` → `get_workflow`; cites [start-session](../techniques/workflow-engine/start-session.md) / [workflow-engine](../techniques/workflow-engine/TECHNIQUE.md) for folder topology and delivery policy. |
 | `session-summary-template` | [Session Summary Template](./session-summary-template.md) | Skeleton for the markdown session summary composed at workflow close |
 | `planning-readme` | [Planning Folder README Guide](./planning-readme.md) | Universal Template + Progress Status policy for planning-folder `README.md`; Progress inventory comes from each workflow's readme-seed profile |
+| `resume-intent-lexicon` | [Resume Intent Lexicon](./resume-intent-lexicon.md) | Continuation-phrase vocabulary and negative cases matched by [detect-resume-intent](../techniques/workflow-engine/detect-resume-intent.md) to gate the saved-session search |
 
 ### Removed
 

--- a/meta/resources/resume-intent-lexicon.md
+++ b/meta/resources/resume-intent-lexicon.md
@@ -1,0 +1,33 @@
+---
+name: resume-intent-lexicon
+description: Continuation-phrase vocabulary that marks a user request as stating resume intent, with the negative cases that mark a fresh start.
+---
+
+# Resume Intent Lexicon
+
+The closed vocabulary that separates a request stating resume intent from one stating a fresh start.
+
+## Affirmative phrases
+
+| Family | Phrases |
+|--------|---------|
+| Resume | `resume`, `resuming` |
+| Continue | `continue`, `continuing`, `carry on`, `keep going` |
+| Return | `go back to`, `back to`, `return to` |
+| Prior work | `pick up`, `pick up where`, `where I left off`, `where we left off`, `finish off`, `wrap up` |
+| Existing session | `the existing session`, `my previous session`, `the session from`, `that work package again` |
+
+## Negative cases
+
+These state a fresh start and do not match, including when a work item is named alongside them:
+
+`start`, `start a new`, `begin`, `create`, `new work package`, `kick off`, `set up`, `from scratch`.
+
+A bare work-item reference — an issue number, Jira key, branch name, or PR number with no continuation phrase — is a fresh start.
+
+## Matching
+
+- Match case-insensitively on whole words, so `restart` and `discontinue` do not match `start` or `continue`.
+- A negative case alongside an affirmative phrase resolves affirmative: `start where we left off` states resume intent.
+- Multi-word phrases match with any run of whitespace between words.
+- Treat the table as the closed vocabulary; a synonym outside it is a fresh start until this resource lists it.

--- a/meta/techniques/workflow-engine/detect-resume-intent.md
+++ b/meta/techniques/workflow-engine/detect-resume-intent.md
@@ -1,0 +1,25 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Whether a user request states intent to carry on prior work.
+
+## Inputs
+
+### user_request
+
+User's free-form request.
+
+## Outputs
+
+### resume_intent_requested
+
+True when the request states intent to carry on prior work, false otherwise.
+
+## Protocol
+
+1. Match `{user_request}` against the affirmative phrases in [resume-intent-lexicon](../../resources/resume-intent-lexicon.md), applying that resource's matching rule and its negative cases.
+2. Return `{resume_intent_requested}` true on a match and false otherwise.

--- a/meta/techniques/workflow-engine/detect-resume-intent.md
+++ b/meta/techniques/workflow-engine/detect-resume-intent.md
@@ -21,5 +21,4 @@ True when the request states intent to carry on prior work, false otherwise.
 
 ## Protocol
 
-1. Match `{user_request}` against the affirmative phrases in [resume-intent-lexicon](../../resources/resume-intent-lexicon.md), applying that resource's matching rule and its negative cases.
-2. Return `{resume_intent_requested}` true on a match and false otherwise.
+1. Match `{user_request}` against the affirmative phrases in [resume-intent-lexicon](../../resources/resume-intent-lexicon.md), applying that resource's matching rule and its negative cases, and emit `{resume_intent_requested}`.

--- a/meta/techniques/workflow-engine/scan-saved-sessions.md
+++ b/meta/techniques/workflow-engine/scan-saved-sessions.md
@@ -17,11 +17,11 @@ Workflow ID to filter candidates by.
 
 ### saved_session_candidates
 
-Array of `{ planning_slug, sessionIndex, savedAt, variables }` entries recording a session for `{target_workflow_id}`; `sessionIndex`, `savedAt`, and `variables` come from the matching client record.
+Array of `{ planning_slug, sessionIndex, savedAt, variables }` entries, one per planning folder recording a session for `{target_workflow_id}`.
 
 ## Protocol
 
 1. List directories under `.engineering/artifacts/planning/`.
 2. For each directory, read its `session.json` (the server-managed state file) and capture the directory name as the `planning_slug`. Skip a directory holding no `session.json`.
-3. Treat a directory as a candidate when `{target_workflow_id}` equals either the top-level `workflowId`, or the `workflowId` of any entry in the top-level `triggeredWorkflows[]`. A meta-orchestrated run records the client workflow at the nested depth and `meta` at the top level, so both arms are needed to reach every session-bearing folder.
+3. Treat a directory as a candidate when `{target_workflow_id}` equals either the top-level `workflowId`, or the `workflowId` of any entry in the top-level `triggeredWorkflows[]`.
 4. Return as `{saved_session_candidates}` one entry per candidate directory, taking `sessionIndex`, `savedAt`, and `variables` from the matching `triggeredWorkflows[]` entry's `state` when the nested arm matched, and from the top level when the top-level arm matched.

--- a/meta/techniques/workflow-engine/scan-saved-sessions.md
+++ b/meta/techniques/workflow-engine/scan-saved-sessions.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -17,10 +17,11 @@ Workflow ID to filter candidates by.
 
 ### saved_session_candidates
 
-Array of `{ planning_slug, sessionIndex, savedAt, variables }` entries whose `workflowId` matches
+Array of `{ planning_slug, sessionIndex, savedAt, variables }` entries recording a session for `{target_workflow_id}`; `sessionIndex`, `savedAt`, and `variables` come from the matching client record.
 
 ## Protocol
 
 1. List directories under `.engineering/artifacts/planning/`.
-2. For each directory, read its `session.json` (the server-managed state file) and capture the directory name as the `planning_slug`.
-3. Return as `{saved_session_candidates}` the entries whose `workflowId` equals `{target_workflow_id}`.
+2. For each directory, read its `session.json` (the server-managed state file) and capture the directory name as the `planning_slug`. Skip a directory holding no `session.json`.
+3. Treat a directory as a candidate when `{target_workflow_id}` equals either the top-level `workflowId`, or the `workflowId` of any entry in the top-level `triggeredWorkflows[]`. A meta-orchestrated run records the client workflow at the nested depth and `meta` at the top level, so both arms are needed to reach every session-bearing folder.
+4. Return as `{saved_session_candidates}` one entry per candidate directory, taking `sessionIndex`, `savedAt`, and `variables` from the matching `triggeredWorkflows[]` entry's `state` when the nested arm matched, and from the top level when the top-level arm matched.

--- a/meta/workflow.yaml
+++ b/meta/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: meta
-version: 5.9.0
+version: 5.10.0
 title: Meta Workflow
 description: Top-level lifecycle workflow that orchestrates client workflow sessions. Excluded from list_workflows — bootstrap navigates here directly.
 author: m2ux
@@ -58,7 +58,7 @@ variables:
     defaultValue: false
   - name: saved_planning_slug
     type: string
-    description: Planning slug of the matched saved client session (set by discover-session when has_saved_state) — passed to start_session to resume the existing session.json
+    description: Planning slug of the matched saved client session.
   - name: is_resuming
     type: boolean
     description: Whether the user chose to resume the matched saved session

--- a/meta/workflow.yaml
+++ b/meta/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: meta
-version: 5.8.0
+version: 5.9.0
 title: Meta Workflow
 description: Top-level lifecycle workflow that orchestrates client workflow sessions. Excluded from list_workflows — bootstrap navigates here directly.
 author: m2ux
@@ -47,6 +47,10 @@ variables:
   - name: workflow_match_ambiguous
     type: boolean
     description: Whether the user request matched multiple workflows — gates the workflow-selection checkpoint in discover-session
+    defaultValue: false
+  - name: resume_intent_requested
+    type: boolean
+    description: Whether the user's request states intent to resume or continue prior work
     defaultValue: false
   - name: has_saved_state
     type: boolean

--- a/work-package/activities/README.md
+++ b/work-package/activities/README.md
@@ -10,7 +10,7 @@ For the activity-to-activity flow diagram, the feedback loops, and review-mode b
 
 ### 01. Start Work Package
 
-Initializes the work package: resolves `{repo_root}` (monorepo vs standalone), refreshes repo-root submodules and GitNexus, verifies or creates a tracker issue, materializes a dedicated git worktree at `{target_path}` (install layout: `<install-root>/worktrees/<owner>/<repo>/<wp-slug>/`; otherwise `~/projects/work/{component_name}/{wp-slug}/`), sets up the feature branch and draft PR inside that worktree, and binds the server-resolved planning folder. In review mode it instead captures the existing PR reference and checks out the PR's branch. Entry activity; leads to design-philosophy.
+Initializes the work package: resolves `{repo_root}` (monorepo vs standalone), refreshes repo-root submodules and GitNexus, verifies or creates a tracker issue, materializes a dedicated git worktree at `{target_path}` (`<checkout>/.worktrees/<wp-slug>/`), sets up the feature branch and draft PR inside that worktree, and binds the server-resolved planning folder. In review mode it instead captures the existing PR reference and checks out the PR's branch. Entry activity; leads to design-philosophy.
 
 Definition: [`01-start-work-package.yaml`](./01-start-work-package.yaml)
 

--- a/work-package/techniques/naming-conventions.md
+++ b/work-package/techniques/naming-conventions.md
@@ -41,12 +41,7 @@ Derived feature branch name `{type}/{issue_number}-{slugified-title}`. In review
 
 ### target_path
 
-Canonical feature-worktree path, distinct from `{planning_folder_path}` and from `{repo_root}`:
-
-- **Install layout** — when `{planning_folder_path}` sits under `projects/<owner>/<repo>/.engineering/artifacts/planning/<slug>`:  
-  `<install-root>/worktrees/<owner>/<repo>/<slug>/`
-- **Personal layout** (fallback):  
-  `~/projects/work/{component_name}/<slug>/`
+Canonical feature-worktree path `<checkout>/.worktrees/<slug>/`, distinct from `{planning_folder_path}` and from `{repo_root}`.
 
 ## Protocol
 
@@ -55,10 +50,7 @@ Canonical feature-worktree path, distinct from `{planning_folder_path}` and from
 3. Slugify `{issue_title}` (lowercase, dashes, max ~40 chars) for the description segment.
 4. Set `{branch_name}` to `{type}/{issue_number}-{slugified-title}` per the convention `type/issue-number-short-description`.
 5. Determine the work-package slug `{$wp_slug}` as the basename of `{planning_folder_path}` (the planning slug `YYYY-MM-DD-{initiative-name}`), so the worktree name stays aligned with the server's planning folder. In review mode, derive `{$wp_slug}` from the PR title or branch name instead.
-6. Set `{target_path}` from `{planning_folder_path}`:
-   - When `{planning_folder_path}` matches `…/projects/<owner>/<repo>/.engineering/artifacts/planning/{$wp_slug}`, take the install root as the ancestor above `projects/` and set `{target_path}` to `<install-root>/worktrees/<owner>/<repo>/{$wp_slug}/`.
-   - Otherwise set `{target_path}` to `~/projects/work/{component_name}/{$wp_slug}/`.
-   From this point on, "inside `{target_path}`" refers to this worktree (not the checkout at `{repo_root}`). Never place `{target_path}` under `{planning_folder_path}` or under `{repo_root}`.
+6. Take `{$checkout_root}` as the ancestor of `{planning_folder_path}` above `.engineering/artifacts/planning/`, and set `{target_path}` to `{$checkout_root}/.worktrees/{$wp_slug}/` — the gitignored feature-worktree directory nested in the checkout. From this point on, "inside `{target_path}`" refers to this worktree (not the checkout at `{repo_root}`). Never place `{target_path}` under `{planning_folder_path}` or under `{repo_root}`, and never anchor it to a home directory or an install root.
 
 ## Rules
 

--- a/workflow-design/resources/anti-patterns.md
+++ b/workflow-design/resources/anti-patterns.md
@@ -1675,13 +1675,13 @@ A second how-to (README section, resource, or technique Protocol) that duplicate
 
 ### AP-127. bag-value-as-literal
 
-"Set `{target_path}` to `~/projects/work/workflows/{$planning_slug}/`" / "push the branch to `workflows`" / "the audit covers all eight design dimensions"
+"push the branch to `workflows`" / "the audit covers all eight design dimensions"
 
 A concrete value is written out where a declared variable or technique input already holds it, so the declaration and the literal drift apart and the content pins one deployment, session, or mode.
 
-**Detect:** Cross-reference literals in workflow, activity, technique, and resource content against the workflow's `variables[]` and the enclosing technique's `## Inputs` / `## Outputs`. Flag a verbatim value — path root, branch or remote name, identifier, count, enum member, host — where a declared slot carries that same meaning and `{name}` belongs. Two signals must coincide: the slot's declared `description` names the thing the literal denotes, and the literal is the operative value rather than the slot's shape illustration. Bare literals with no declared slot are in scope only when the value varies by deployment, session, or mode; a fixed constant is not this smell.
+**Detect:** Cross-reference literals in workflow, activity, technique, and resource content against the workflow's `variables[]` and the enclosing technique's `## Inputs` / `## Outputs`. Flag a verbatim value — path root, branch or remote name, identifier, count, enum member, host — where a declared slot carries that same meaning and `{name}` belongs. Two signals must coincide: the slot's declared `description` names the thing the literal denotes, and the literal is the operative value rather than the slot's shape illustration.
 
-**Do not flag:** The declaration itself (`defaultValue`, an enum or shape hint inside the slot's own `description`); Template and example fences that show a resolved shape by design; planning-folder artifacts recording one session's resolved values; exemplar lines in a catalogue entry. Host-specific absolute paths and checkout roots are `worktree-root-placeholders`; state tracked in prose with no variable at all is `variable-for-approval`; a literal duplicating state a declared variable already derives is `no-derived-state-shadow`.
+**Do not flag:** The declaration itself (`defaultValue`, an enum or shape hint inside the slot's own `description`); Template and example fences that show a resolved shape by design; planning-folder artifacts recording one session's resolved values; exemplar lines in a catalogue entry. A literal with no declared slot carrying its meaning is out of scope here — a path literal repeated across sites is `factor-repeated-paths`, host-specific absolute paths and checkout roots are `worktree-root-placeholders`, state tracked in prose with no variable at all is `variable-for-approval`, and a literal duplicating state a declared variable already derives is `no-derived-state-shadow`.
 
-**Fix:** Replace the literal with `{name}` for the declared slot. When no slot exists and the value varies, declare the variable with its `type` (and `defaultValue` only where one value is genuinely universal), then reference it. Leave exactly one home for the value — the declaration.
+**Fix:** Replace the literal with `{name}` for the declared slot. Leave exactly one home for the value — the declaration.
 

--- a/workflow-design/resources/anti-patterns.md
+++ b/workflow-design/resources/anti-patterns.md
@@ -1673,3 +1673,15 @@ A second how-to (README section, resource, or technique Protocol) that duplicate
 
 **Fix:** Rewrite to one line naming the value; delete producer, consumer, gate, and layout tails.
 
+### AP-127. bag-value-as-literal
+
+"Set `{target_path}` to `~/projects/work/workflows/{$planning_slug}/`" / "push the branch to `workflows`" / "the audit covers all eight design dimensions"
+
+A concrete value is written out where a declared variable or technique input already holds it, so the declaration and the literal drift apart and the content pins one deployment, session, or mode.
+
+**Detect:** Cross-reference literals in workflow, activity, technique, and resource content against the workflow's `variables[]` and the enclosing technique's `## Inputs` / `## Outputs`. Flag a verbatim value — path root, branch or remote name, identifier, count, enum member, host — where a declared slot carries that same meaning and `{name}` belongs. Two signals must coincide: the slot's declared `description` names the thing the literal denotes, and the literal is the operative value rather than the slot's shape illustration. Bare literals with no declared slot are in scope only when the value varies by deployment, session, or mode; a fixed constant is not this smell.
+
+**Do not flag:** The declaration itself (`defaultValue`, an enum or shape hint inside the slot's own `description`); Template and example fences that show a resolved shape by design; planning-folder artifacts recording one session's resolved values; exemplar lines in a catalogue entry. Host-specific absolute paths and checkout roots are `worktree-root-placeholders`; state tracked in prose with no variable at all is `variable-for-approval`; a literal duplicating state a declared variable already derives is `no-derived-state-shadow`.
+
+**Fix:** Replace the literal with `{name}` for the declared slot. When no slot exists and the value varies, declare the variable with its `type` (and `defaultValue` only where one value is genuinely universal), then reference it. Leave exactly one home for the value — the declaration.
+

--- a/workflow-design/techniques/derive-workflows-target-path.md
+++ b/workflow-design/techniques/derive-workflows-target-path.md
@@ -17,17 +17,18 @@ Absolute path to this session's planning folder under the server `.engineering` 
 
 ### target_path
 
-Filesystem path of the dedicated workflows worktree for this session: `~/projects/work/workflows/{basename(planning_folder_path)}/`. Distinct from `{planning_folder_path}` — never place planning artifacts under `{target_path}`.
+Filesystem path of the dedicated workflows worktree for this session: `<checkout>/.worktrees/{basename(planning_folder_path)}/`. Distinct from `{planning_folder_path}` — never place planning artifacts under `{target_path}`.
 
 ## Protocol
 
 ### 1. Extract Planning Slug
 
 - Take the basename of `{planning_folder_path}` as `{$planning_slug}` (e.g. `2026-07-18-workflow-design-universal-worktrees`)
+- Take `{$checkout_root}` as the ancestor of `{planning_folder_path}` above `.engineering/artifacts/planning/`
 
 ### 2. Compose Target Path
 
-- Set `{target_path}` to `~/projects/work/workflows/{$planning_slug}/` (expand `~` to the user's home directory when materialising)
+- Set `{target_path}` to `{$checkout_root}/.worktrees/{$planning_slug}/` — the gitignored feature-worktree directory nested in the checkout; never anchor it to a home directory or an install root
 - Do not bind work-package issue-shaped naming conventions — the planning-folder basename is the sole path segment
 
 ### 3. Path Separation

--- a/workflow-design/workflow.yaml
+++ b/workflow-design/workflow.yaml
@@ -233,7 +233,7 @@ variables:
     defaultValue: false
   - name: design_dimensions
     type: array
-    description: The ordered design dimensions to elicit in requirements-refinement, set per mode by derive-design-dimensions (create elicits all eight.
+    description: The ordered design dimensions to elicit for this run's mode.
   - name: target_path
     type: string
     description: Feature worktree path for edits, builds, and PR ops (not repo_root).


### PR DESCRIPTION
Closes #309.

## Summary

Four changes ride this branch. The first is the design session's subject; the others were added on request during validation.

### 1. `meta` — gate the saved-session search on stated resume intent (v5.8.0 → v5.10.0)

`discover-session` paid an unconditional saved-session search on every run: it walked every planning folder (131 today) and parsed each `session.json` before the user's request was acted on. The cost grew with every recorded session, and the search almost never paid off — since mid-July, saved sessions record the client workflow at a nested depth, so the top-level-only filter could match at most 10 of 51 session-bearing folders.

- **Gate the search.** A new `workflow-engine::detect-resume-intent` operation sets the declared boolean `resume_intent_requested`; the `extract-context` / `scan-planning-folders` / `match-session` trio now carries `when: resume_intent_requested == true`. A plain "start" request skips the scan entirely.
- **Name the vocabulary.** The continuation phrases and their negative cases live in a cited resource, `resources/resume-intent-lexicon.md`, so the vocabulary can widen without touching the operation.
- **Repair the search itself,** so it can find something when it does run: `scan-saved-sessions` now treats a folder as a candidate when the target workflow id matches either the top-level `workflowId` or any `triggeredWorkflows[]` entry, taking `sessionIndex` / `savedAt` / `variables` from whichever arm matched; and `record-match` / `record-no-match` are gated on `matched_session` `exists` / `notExists` instead of on `has_saved_state`, the very fact they were supposed to establish (the old gate could never fire from its `false` default).
- **Repair the hand-off the gate feeds.** `initialize-session` derived the planning slug only on a fresh run (`when: is_resuming == false`) yet passed the same `client_planning_slug` to `create-session` either way, while the `saved_planning_slug` that `discover-session` records had no reader anywhere in `meta/`. A resuming run therefore dispatched with no slug and could not target the saved planning folder. A complementary `adopt-saved-planning-slug` step now carries the matched slug through, so the two arms are exhaustive. Without this, gating the search correctly would still not produce a working resume.

Detection is deliberately its own operation rather than a second output on `extract-identifying-context`, which keeps that contract unchanged. Four intentional removals are inventoried in the planning folder's impact analysis (§3): the inverting activity rule, the self-referential `record-match` gate, the top-level-only filter, and the "even when the user said 'start'" orientation restatement.

Lifecycle topology is untouched — only the internal step sequences of `discover-session` and `initialize-session` change.

### 2. `workflow-design` — catalogue AP-127 `bag-value-as-literal`

A new anti-pattern entry for the smell of a concrete value written out where a **declared** variable or technique input already holds it, so the declaration and the literal drift apart and the content pins one deployment, session, or mode. **Detect** cross-references literals in workflow, activity, technique, and resource content against the workflow's `variables[]` and the enclosing technique's `## Inputs` / `## Outputs`, requiring two signals to coincide: the declared slot's `description` names what the literal denotes, and the literal is the operative value rather than the slot's shape illustration.

The entry is scoped to exactly the declared-slot test its name carries. A literal with no declared slot carrying its meaning is out of scope, and the **Do not flag** carve-outs route it to the neighbouring entry that owns it: a path literal repeated across sites to `factor-repeated-paths`, host-specific absolute paths and checkout roots to `worktree-root-placeholders`, prose-tracked state with no variable at all to `variable-for-approval`, and a literal duplicating state a declared variable already derives to `no-derived-state-shadow`.

This entry is the general declared-slot case, filed off the review that produced #309.

### 3. `workflow-design` — fix a live AP-127 / AP-126 instance

`workflow-design/workflow.yaml`'s `design_dimensions.description` carried a hard-coded count of the slot's own cardinality, a producer tail, and an unclosed parenthesis. It now reads as one line naming the value. `meta`'s `saved_planning_slug` description is corrected the same way.

### 4. `workflow-design` + `work-package` — derive the worktree path from the checkout (#309)

Three surfaces emitted feature-worktree paths outside the worktree root the server binds and validates: `derive-workflows-target-path.md` anchored `target_path` to `~/projects/work/workflows/<slug>/`, `naming-conventions.md` offered a deprecated `<install-root>/worktrees/<owner>/<repo>/<slug>/` alongside a `~/projects/work/<component>/<slug>/` fallback, and `work-package/activities/README.md` documented both stale forms.

`docs/install-projects-worktrees.md` states `<checkout>/.worktrees/<slug>/` is the only allowed feature worktree path, and `src/config.ts` implements it (`CHECKOUT_WORKTREES_DIR`, `workspaceDir = <checkout>/.worktrees`). A path outside the checkout is not covered by the Docker projects-root bind, so a containerised run cannot see a worktree the workflow itself created, and `assertPathInsideRoot` fails closed on it.

All three now derive the checkout root from `{planning_folder_path}` — the ancestor above `.engineering/artifacts/planning/` — and compose `<checkout>/.worktrees/<slug>/`. The two `work-package` branches collapse into one formula. `component_name` remains an input to `create-worktree` for locating the component git directory; it is no longer a path segment. No `projects/work` or `install-root>/worktrees` literals remain in the tree.

This does not settle the ambiguity #309 raises about where a *submodule* content tree's worktree belongs — the formula gives a flat `<checkout>/.worktrees/<slug>` with the component nested inside, matching all 33 existing entries. Worth confirming that is the intended shape before merge.

## Scope manifest (14 files)

Paths are relative to `meta/` unless prefixed.

| # | Path | Type | Action | Change |
|---|------|------|--------|--------|
| 1 | `workflow.yaml` | workflow | modify | Declare boolean `resume_intent_requested` (`defaultValue: false`); one-line `saved_planning_slug` description; version → 5.10.0 |
| 2 | `activities/00-discover-session.yaml` | activity | modify | Add `detect-resume-intent`, gate the search trio, derive `has_saved_state` from `matched_session`, delete the inverting activity rule |
| 3 | `techniques/workflow-engine/detect-resume-intent.md` | technique | create | New operation — input `user_request`, output `resume_intent_requested` |
| 4 | `techniques/workflow-engine/scan-saved-sessions.md` | technique | modify | Candidate filter reads the client workflow id at its recorded nesting depth |
| 5 | `resources/resume-intent-lexicon.md` | resource | create | Continuation-phrase vocabulary and negative cases |
| 6 | `resources/README.md` | readme | modify | Resource Index gains the lexicon row |
| 7 | `activities/README.md` | readme | modify | `00. Discover Session` states the intent precondition; `01. Initialize Session` states both slug arms |
| 8 | `README.md` | readme | modify | Header version, activity-table role, flow-legend edge label, file tree |
| 9 | `activities/01-initialize-session.yaml` | activity | modify | Add `adopt-saved-planning-slug` so a resuming run binds `client_planning_slug` from `saved_planning_slug` |
| 10 | `../workflow-design/resources/anti-patterns.md` | resource | modify | Append `### AP-127. bag-value-as-literal` |
| 11 | `../workflow-design/workflow.yaml` | workflow | modify | `design_dimensions.description` to one line |
| 12 | `../workflow-design/techniques/derive-workflows-target-path.md` | technique | modify | Derive `<checkout>/.worktrees/<slug>/` instead of a home-anchored path |
| 13 | `../work-package/techniques/naming-conventions.md` | technique | modify | Collapse the two path branches into the checkout-derived formula |
| 14 | `../work-package/activities/README.md` | readme | modify | Restate the worktree layout to match |

Rows 1-8 are the design session's original manifest. Row 9 repairs the resume hand-off; rows 10-11 are the requested `workflow-design` additions; rows 12-14 are the #309 fix.

## Commits

| Commit | Change |
|--------|--------|
| `73cbfe78` | The `meta` conditional-resume change — the original 8-item scope manifest |
| `aea417ec` | AP-127 `bag-value-as-literal`, added on request |
| `8bdc8f0c` | Post-update-review remediation — six Low findings, no behaviour change |
| `ea998ae1` | Resume hand-off repair, plus two one-line variable descriptions |
| `e5abc5b5` | Checkout-derived worktree paths (#309) |

## Validation

- `validate-workflow-yaml` — `meta` (6 files) and `workflow-design` (10 files) all PASS; no unanchored protocol references across either technique tree.
- `check-all-refs` — 0 unresolved across all workflows.
- `check-variable-model` — OK; defaults, gates and `setVariable` effects coherent with the seeded model after the hand-off repair.
- `check-binding-fidelity` — 0 NEW. Two entries were expected and are non-defects: `dead-output` for `resume_intent_requested` (consumed by three `when:` gates, which the guard does not parse) and `orphan-input` for `user_request` (ambient caller-supplied context, matching the existing baselined entries for the other `meta` ops that declare it). `when:` is kept because the schema marks structured `condition:` LEGACY on non-checkpoint steps. Both baseline rows landed on the `main`-based branch `chore/binding-fidelity-baseline-resume-intent` (`728e5dae`), since `scripts/binding-fidelity-baseline.json` lives on `main` and cannot ride this branch.
- `check-audience` — 0 NEW.
- `check-technique-template` — every technique file follows the normative template.
- `check-resource-anchors` — unchanged at the 3 pre-existing breaks (`dispatch-activity.md#accumulate-trace-tokens` from `workflow-orchestrator.md`, `assumptions-review.md#open-assumptions`, `test-suite-review.md#test-suite-review-report-template`); no regressions.
- Scope-manifest verification — 8/8 of the original items addressed; the manifest was then extended to the 11 rows above.
- Post-update review — two audit passes over the committed source. The first raised six Low findings, all remediated in `8bdc8f0c`; the second raised one Low finding (a third occurrence of the pre-change phrasing in `meta/activities/README.md` that no earlier artifact had examined), also remediated. Both closed at 0 open findings, with no Critical, High or Medium at any point after the pre-commit Critical was fixed.

## Planning artifacts

Session folder (in the `.engineering` submodule): `.engineering/artifacts/planning/2026-07-27-conditional-session-resume/`

`README.md` (session index) · `03-design-specification.md` · `04-assumptions-log.md` · `06-impact-analysis.md` (removals inventory) · `07-scope-manifest.md` · `09-file-review-note.md` (binding-fidelity assessment) · `10-draft-attestation.md` · `08-*-findings.md` (quality-review satellites) · `10-post-update-review.md` and `10-*-findings.md` (post-update audit) · `11-follow-ups.md` · `05-deferred-items.md`

## Related issues

- #309 — worktree path hard-coded to `~/projects/work/`, bypassing the `.worktrees/` install layout. Closed by change 4 above. The review behind it also prompted AP-127; under AP-127's declared-slot scope that specific literal is `worktree-root-placeholders` territory.
- #310 — GitNexus use optimisation and index caveats. Filed from this session; **not** closed by this PR.
- #313 — the two `check-binding-fidelity` baseline rows. Separate only because `scripts/binding-fidelity-baseline.json` lives on `main`, which has no counterpart on this branch; it cannot be folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
