### PR TITLE
fix(workflows): derive the worktree path from the checkout, not a home directory

### DIFF
--- a/work-package/activities/README.md
+++ b/work-package/activities/README.md
@@ -10,7 +10,7 @@ For the activity-to-activity flow diagram, the feedback loops, and review-mode b
 
 ### 01. Start Work Package
 
-Initializes the work package: resolves `{repo_root}` (monorepo vs standalone), refreshes repo-root submodules and GitNexus, verifies or creates a tracker issue, materializes a dedicated git worktree at `{target_path}` (install layout: `<install-root>/worktrees/<owner>/<repo>/<wp-slug>/`; otherwise `~/projects/work/{component_name}/{wp-slug}/`), sets up the feature branch and draft PR inside that worktree, and binds the server-resolved planning folder. In review mode it instead captures the existing PR reference and checks out the PR's branch. Entry activity; leads to design-philosophy.
+Initializes the work package: resolves `{repo_root}` (monorepo vs standalone), refreshes repo-root submodules and GitNexus, verifies or creates a tracker issue, materializes a dedicated git worktree at `{target_path}` (`<checkout>/.worktrees/<wp-slug>/`), sets up the feature branch and draft PR inside that worktree, and binds the server-resolved planning folder. In review mode it instead captures the existing PR reference and checks out the PR's branch. Entry activity; leads to design-philosophy.
 
 Definition: [`01-start-work-package.yaml`](./01-start-work-package.yaml)
 

--- a/work-package/techniques/naming-conventions.md
+++ b/work-package/techniques/naming-conventions.md
@@ -41,12 +41,7 @@ Derived feature branch name `{type}/{issue_number}-{slugified-title}`. In review
 
 ### target_path
 
-Canonical feature-worktree path, distinct from `{planning_folder_path}` and from `{repo_root}`:
-
-- **Install layout** — when `{planning_folder_path}` sits under `projects/<owner>/<repo>/.engineering/artifacts/planning/<slug>`:  
-  `<install-root>/worktrees/<owner>/<repo>/<slug>/`
-- **Personal layout** (fallback):  
-  `~/projects/work/{component_name}/<slug>/`
+Canonical feature-worktree path `<checkout>/.worktrees/<slug>/`, distinct from `{planning_folder_path}` and from `{repo_root}`.
 
 ## Protocol
 
@@ -55,10 +50,7 @@ Canonical feature-worktree path, distinct from `{planning_folder_path}` and from
 3. Slugify `{issue_title}` (lowercase, dashes, max ~40 chars) for the description segment.
 4. Set `{branch_name}` to `{type}/{issue_number}-{slugified-title}` per the convention `type/issue-number-short-description`.
 5. Determine the work-package slug `{$wp_slug}` as the basename of `{planning_folder_path}` (the planning slug `YYYY-MM-DD-{initiative-name}`), so the worktree name stays aligned with the server's planning folder. In review mode, derive `{$wp_slug}` from the PR title or branch name instead.
-6. Set `{target_path}` from `{planning_folder_path}`:
-   - When `{planning_folder_path}` matches `…/projects/<owner>/<repo>/.engineering/artifacts/planning/{$wp_slug}`, take the install root as the ancestor above `projects/` and set `{target_path}` to `<install-root>/worktrees/<owner>/<repo>/{$wp_slug}/`.
-   - Otherwise set `{target_path}` to `~/projects/work/{component_name}/{$wp_slug}/`.
-   From this point on, "inside `{target_path}`" refers to this worktree (not the checkout at `{repo_root}`). Never place `{target_path}` under `{planning_folder_path}` or under `{repo_root}`.
+6. Take `{$checkout_root}` as the ancestor of `{planning_folder_path}` above `.engineering/artifacts/planning/`, and set `{target_path}` to `{$checkout_root}/.worktrees/{$wp_slug}/` — the gitignored feature-worktree directory nested in the checkout. From this point on, "inside `{target_path}`" refers to this worktree (not the checkout at `{repo_root}`). Never place `{target_path}` under `{planning_folder_path}` or under `{repo_root}`, and never anchor it to a home directory or an install root.
 
 ## Rules
 

--- a/workflow-design/techniques/derive-workflows-target-path.md
+++ b/workflow-design/techniques/derive-workflows-target-path.md
@@ -17,17 +17,18 @@ Absolute path to this session's planning folder under the server `.engineering` 
 
 ### target_path
 
-Filesystem path of the dedicated workflows worktree for this session: `~/projects/work/workflows/{basename(planning_folder_path)}/`. Distinct from `{planning_folder_path}` — never place planning artifacts under `{target_path}`.
+Filesystem path of the dedicated workflows worktree for this session: `<checkout>/.worktrees/{basename(planning_folder_path)}/`. Distinct from `{planning_folder_path}` — never place planning artifacts under `{target_path}`.
 
 ## Protocol
 
 ### 1. Extract Planning Slug
 
 - Take the basename of `{planning_folder_path}` as `{$planning_slug}` (e.g. `2026-07-18-workflow-design-universal-worktrees`)
+- Take `{$checkout_root}` as the ancestor of `{planning_folder_path}` above `.engineering/artifacts/planning/`
 
 ### 2. Compose Target Path
 
-- Set `{target_path}` to `~/projects/work/workflows/{$planning_slug}/` (expand `~` to the user's home directory when materialising)
+- Set `{target_path}` to `{$checkout_root}/.worktrees/{$planning_slug}/` — the gitignored feature-worktree directory nested in the checkout; never anchor it to a home directory or an install root
 - Do not bind work-package issue-shaped naming conventions — the planning-folder basename is the sole path segment
 
 ### 3. Path Separation


### PR DESCRIPTION
Closes #309.

## Problem

Three surfaces emitted feature-worktree paths that sat outside the worktree root the server binds and validates:

- `workflow-design/techniques/derive-workflows-target-path.md` anchored `target_path` to `~/projects/work/workflows/<slug>/`.
- `work-package/techniques/naming-conventions.md` offered two forms — a deprecated `<install-root>/worktrees/<owner>/<repo>/<slug>/` that `src/config.ts` already documents as unused for new paths, and a `~/projects/work/<component>/<slug>/` fallback.
- `work-package/activities/README.md` documented both stale forms as the expected layout.

`docs/install-projects-worktrees.md` states `<checkout>/.worktrees/<slug>/` is the **only** allowed feature worktree path, and `src/config.ts` implements it (`CHECKOUT_WORKTREES_DIR`, `workspaceDir = <checkout>/.worktrees`). A path outside the checkout is not covered by the Docker projects-root bind, so a containerised run cannot see a worktree the workflow itself created; `assertPathInsideRoot` also fails closed on it.

## Change

Derive the checkout root from `{planning_folder_path}` — the ancestor above `.engineering/artifacts/planning/` — and compose `target_path` as `<checkout>/.worktrees/<slug>/`. No home directory, no install root, and the two `work-package` branches collapse into one formula. The `work-package` activities README is restated to match.

`component_name` remains an input to `create-worktree` for locating the component git directory; it is simply no longer a path segment.

## Verification

- `check-all-refs` — 0 unresolved.
- `check-technique-template` — every technique file follows the normative template.
- `validate-workflow-yaml` — `work-package` all PASS.
- No remaining `projects/work` or `install-root>/worktrees` literals anywhere in the workflows tree.

## Note

This does not resolve the ambiguity #309 raises about where a *submodule* content tree's worktree belongs — the formula gives a flat `<checkout>/.worktrees/<slug>` with the component nested inside, which matches all 33 existing entries. Worth confirming that is the intended shape before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
