### PR TITLE
chore(scripts): baseline the detect-resume-intent binding-fidelity entries

### DIFF
--- a/scripts/binding-fidelity-baseline.json
+++ b/scripts/binding-fidelity-baseline.json
@@ -166,6 +166,11 @@
   },
   {
     "check": "dead-output",
+    "site": "meta/techniques/workflow-engine/detect-resume-intent.md",
+    "detail": "output 'resume_intent_requested' is declared but nothing outside its own file consumes it (no read, condition, binding value, remap, or same-named input)"
+  },
+  {
+    "check": "dead-output",
     "site": "meta/techniques/workflow-engine/dispatch-activity.md",
     "detail": "output 'trace_token' is declared but nothing outside its own file consumes it (no read, condition, binding value, remap, or same-named input)"
   },
@@ -623,6 +628,11 @@
     "check": "orphan-input",
     "site": "meta :: version-control::initialize-folder",
     "detail": "own input 'initiative_name' has no producer in workflow 'meta' (no step-binding entry, workflow variable, step output, or default)"
+  },
+  {
+    "check": "orphan-input",
+    "site": "meta :: workflow-engine::detect-resume-intent",
+    "detail": "own input 'user_request' has no producer in workflow 'meta' (no step-binding entry, workflow variable, step output, or default)"
   },
   {
     "check": "orphan-input",


### PR DESCRIPTION
Companion to #311. Two `check-binding-fidelity` baseline rows for the `detect-resume-intent` operation that #311 adds to the `meta` workflow.

## Why these are not defects

- **`dead-output` for `resume_intent_requested`** — the variable *is* consumed, by three `when:` gates on `discover-session`'s search steps. `collectReads` in `scripts/check-binding-fidelity.ts` recognises `{token}` interpolations, structured `condition:` variables, and step bindings; it does not parse `when:` expression strings, so a variable consumed only through an inline gate reads as dead. Switching to structured `condition:` would satisfy the guard but adopt a construct `activity.schema.json` marks LEGACY on non-checkpoint steps.
- **`orphan-input` for `user_request`** — the request text reaches the operation from the user turn rather than from an in-workflow producer. The other `meta` operations declaring the same input already carry equivalent baselined entries.

## Why a separate branch

`scripts/binding-fidelity-baseline.json` lives on `main`; #311 targets `workflows`. The two are different content trees in the same repository, so the baseline rows cannot ride that PR.

## Follow-up

The guard's blind spot to `when:` gates is the underlying issue and is tracked as deferred item X-4 in the session's planning folder. Fixing it would let the first row be dropped rather than baselined.

Verified: the file parses as valid JSON (256 entries) and `check-binding-fidelity` reports 0 NEW against the #311 worktree with these rows present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
