### PR TITLE
fix(work-package,meta): clear the three corpus guard violations

### DIFF
--- a/meta/techniques/workflow-engine/workflow-orchestrator.md
+++ b/meta/techniques/workflow-engine/workflow-orchestrator.md
@@ -57,4 +57,4 @@ Honor [no-get-activity-from-orchestrator](./dispatch-activity.md#no-get-activity
 
 ### resolve-trace-at-close-out
 
-At client finalize / retrospective close-out, honor [resolve-trace-at-close-out](./dispatch-activity.md#resolve-trace-at-close-out) (mid-run accumulate via [accumulate-trace-tokens](./dispatch-activity.md#accumulate-trace-tokens)).
+At client finalize / retrospective close-out, honor [resolve-trace-at-close-out](./dispatch-activity.md#resolve-trace-at-close-out), which owns both halves of the contract — the mid-run accumulate and the close-out resolve.

--- a/work-package/activities/02-design-philosophy.yaml
+++ b/work-package/activities/02-design-philosophy.yaml
@@ -92,7 +92,7 @@ steps:
       name: analyse-challenge::run-loop
       inputs:
         concern_kind: assumptions
-        analyse: review-assumptions::reconcile
+        analyse_technique: review-assumptions::reconcile
         challenge_perspectives: '["stakeholder-gap", "rejected-paths", "evidence-strength"]'
         convergence_flag: has_resolvable_assumptions
         residue_flag: has_open_assumptions

--- a/work-package/activities/04-research.yaml
+++ b/work-package/activities/04-research.yaml
@@ -69,7 +69,7 @@ steps:
       name: analyse-challenge::run-loop
       inputs:
         concern_kind: assumptions
-        analyse: review-assumptions::reconcile
+        analyse_technique: review-assumptions::reconcile
         challenge_perspectives: '["stakeholder-gap", "rejected-paths", "evidence-strength"]'
         convergence_flag: has_resolvable_assumptions
         residue_flag: has_open_assumptions
@@ -179,22 +179,7 @@ steps:
             assembly_mode: interview
       - kind: checkpoint
         id: research-assumption-decision#{current_assumption.id}
-        message: "Assumption {current_assumption.id}: {current_assumption.statement}. Resolve now or defer."
-        blocking: true
-        options:
-          - id: resolve-inline
-            label: Resolve now
-            description: Provide resolution for this assumption
-            effect:
-              setVariable:
-                assumption_resolved_inline: true
-          - id: defer-to-stakeholder
-            label: Defer to stakeholder review
-            description: Queue this assumption for stakeholder review
-            effect:
-              setVariable:
-                assumption_deferred: true
-                has_deferred_assumptions: true
+        ref: assumption-decision
       - kind: technique
         id: record-response
         technique: review-assumptions::record

--- a/work-package/activities/05-implementation-analysis.yaml
+++ b/work-package/activities/05-implementation-analysis.yaml
@@ -35,7 +35,7 @@ steps:
       name: analyse-challenge::run-loop
       inputs:
         concern_kind: assumptions
-        analyse: review-assumptions::reconcile
+        analyse_technique: review-assumptions::reconcile
         challenge_perspectives: '["stakeholder-gap", "rejected-paths", "evidence-strength"]'
         convergence_flag: has_resolvable_assumptions
         residue_flag: has_open_assumptions
@@ -101,22 +101,7 @@ steps:
             assembly_mode: interview
       - kind: checkpoint
         id: analysis-assumption-decision#{current_assumption.id}
-        message: "Assumption {current_assumption.id}: {current_assumption.statement}. Resolve now or defer."
-        blocking: true
-        options:
-          - id: resolve-inline
-            label: Resolve now
-            description: Provide resolution for this assumption
-            effect:
-              setVariable:
-                assumption_resolved_inline: true
-          - id: defer-to-stakeholder
-            label: Defer to stakeholder review
-            description: Queue this assumption for stakeholder review
-            effect:
-              setVariable:
-                assumption_deferred: true
-                has_deferred_assumptions: true
+        ref: assumption-decision
       - kind: technique
         id: record-response
         technique: review-assumptions::record

--- a/work-package/activities/06-plan-prepare.yaml
+++ b/work-package/activities/06-plan-prepare.yaml
@@ -62,7 +62,7 @@ steps:
       name: analyse-challenge::run-loop
       inputs:
         concern_kind: assumptions
-        analyse: review-assumptions::reconcile
+        analyse_technique: review-assumptions::reconcile
         challenge_perspectives: '["stakeholder-gap", "rejected-paths", "evidence-strength"]'
         convergence_flag: has_resolvable_assumptions
         residue_flag: has_open_assumptions

--- a/work-package/activities/07-assumptions-review.yaml
+++ b/work-package/activities/07-assumptions-review.yaml
@@ -15,7 +15,7 @@ steps:
       name: analyse-challenge::run-loop
       inputs:
         concern_kind: assumptions
-        analyse: review-assumptions::reconcile
+        analyse_technique: review-assumptions::reconcile
         challenge_perspectives: '["stakeholder-gap", "rejected-paths", "evidence-strength"]'
         convergence_flag: has_resolvable_assumptions
         residue_flag: has_open_assumptions

--- a/work-package/activities/08-implement.yaml
+++ b/work-package/activities/08-implement.yaml
@@ -67,7 +67,7 @@ steps:
       name: analyse-challenge::run-loop
       inputs:
         concern_kind: assumptions
-        analyse: review-assumptions::reconcile
+        analyse_technique: review-assumptions::reconcile
         challenge_perspectives: '["stakeholder-gap", "rejected-paths", "evidence-strength"]'
         convergence_flag: has_resolvable_assumptions
         residue_flag: has_open_assumptions
@@ -125,22 +125,7 @@ steps:
             assembly_mode: interview
       - kind: checkpoint
         id: implementation-assumption-decision#{current_assumption.id}
-        message: "Assumption {current_assumption.id}: {current_assumption.statement}. Resolve now or defer."
-        blocking: true
-        options:
-          - id: resolve-inline
-            label: Resolve now
-            description: Provide resolution for this assumption
-            effect:
-              setVariable:
-                assumption_resolved_inline: true
-          - id: defer-to-stakeholder
-            label: Defer to stakeholder review
-            description: Queue this assumption for stakeholder review
-            effect:
-              setVariable:
-                assumption_deferred: true
-                has_deferred_assumptions: true
+        ref: assumption-decision
       - kind: technique
         id: record-response
         technique: review-assumptions::record

--- a/work-package/activities/15-codebase-comprehension.yaml
+++ b/work-package/activities/15-codebase-comprehension.yaml
@@ -40,7 +40,7 @@ steps:
           name: analyse-challenge::run-loop
           inputs:
             concern_kind: open_questions
-            analyse: codebase-comprehension::deep-dive
+            analyse_technique: codebase-comprehension::deep-dive
             challenge_perspectives: '["pedagogy", "rejected-paths"]'
             convergence_flag: needs_comprehension
             residue_flag: has_open_questions

--- a/work-package/techniques/analyse-challenge/TECHNIQUE.md
+++ b/work-package/techniques/analyse-challenge/TECHNIQUE.md
@@ -13,7 +13,7 @@ Parameterized analyse–challenge–combine loop that drives agent-resolvable co
 
 Domain of the open set this binding addresses (e.g. `assumptions`, `open_questions`).
 
-### analyse
+### analyse_technique
 
 Technique path invoked each iteration to deepen or resolve agent-resolvable items (e.g. `review-assumptions::reconcile`, `codebase-comprehension::deep-dive`).
 

--- a/work-package/techniques/analyse-challenge/run-loop.md
+++ b/work-package/techniques/analyse-challenge/run-loop.md
@@ -13,7 +13,7 @@ Parameterized analyse–challenge–combine iterations until agent-resolvable co
 
 Domain of the open set (e.g. `assumptions`, `open_questions`).
 
-### analyse
+### analyse_technique
 
 Technique path to invoke for the analyse phase each iteration (supplied via `step.technique.inputs`).
 
@@ -68,13 +68,13 @@ The bound residue variable after combine.
 ### 1. Resolve Binding Defaults
 
 - Resolve `{convergence_flag}` and `{residue_flag}` bag names from explicit inputs or from `{concern_kind}` defaults above
-- Confirm `{analyse}` is a callable technique path; surface a binding gap if missing
+- Confirm `{analyse_technique}` is a callable technique path; surface a binding gap if missing
 
 ### 2. Iterate (or Single Pass)
 
 - When `{iteration_mode}` is `once`, run one analyse → challenge → combine cycle and proceed to handoff.
 - When `{iteration_mode}` is `until_converged` (default), repeat while the bag variable named by `{convergence_flag}` is true (or on the first pass when the flag is unset and open concerns exist):
-  1. **Analyse** — invoke the bound `{analyse}` technique with forwarded context (`{assumptions_log}`, `{target_path}`, `{comprehension_artifact}` as applicable). When `{concern_kind}` is `open_questions` and `{analyse}` is `codebase-comprehension::deep-dive`, follow with [revise-questions](../codebase-comprehension/revise-questions.md) so Open Questions and `{needs_comprehension}` / `{has_open_questions}` stay current. Analyse updates the concern set and may set the convergence flag true when more agent-resolvable work remains.
+  1. **Analyse** — invoke the bound `{analyse_technique}` technique with forwarded context (`{assumptions_log}`, `{target_path}`, `{comprehension_artifact}` as applicable). When `{concern_kind}` is `open_questions` and `{analyse_technique}` is `codebase-comprehension::deep-dive`, follow with [revise-questions](../codebase-comprehension/revise-questions.md) so Open Questions and `{needs_comprehension}` / `{has_open_questions}` stay current. Analyse updates the concern set and may set the convergence flag true when more agent-resolvable work remains.
   2. **Challenge** — invoke [challenge](./challenge.md) with `{challenge_perspectives}` and the current concern set / log. Challenge fans out adversarially via scatter-gather and returns per-perspective findings without writing shared bag flags itself.
   3. **Combine** — invoke [combine](./combine.md) to merge challenge findings into the concern set, resolve or reclassify items, and set `{convergence_flag}` / `{residue_flag}` (and `{residue_collection}` when bound).
 - Exit when `{convergence_flag}` is false after combine (`until_converged`), or after the single pass (`once`). An empty open set yields `{residue_flag}` false.

--- a/work-package/techniques/manage-git/restore-paths-from-ref.md
+++ b/work-package/techniques/manage-git/restore-paths-from-ref.md
@@ -21,7 +21,7 @@ Git ref to restore from (default branch name, merge-base SHA, or other commit-is
 
 Array of repository-relative paths to restore from `{base_ref}`.
 
-### interactive
+### interactive_restore
 
 *(optional)* When true, use interactive hunk restore (`checkout -p`) per path. When false or unbound, restore each path whole from `{base_ref}`.
 
@@ -43,7 +43,7 @@ Paths successfully restored from `{base_ref}` and staged in `{target_path}`. Emp
 ### 2. Restore
 
 - For each path in `{paths}`:
-  - When `{interactive}` is true: `git -C {target_path} checkout -p {base_ref} -- {path}` (agent/user selects hunks).
+  - When `{interactive_restore}` is true: `git -C {target_path} checkout -p {base_ref} -- {path}` (agent/user selects hunks).
   - Otherwise: `git -C {target_path} checkout {base_ref} -- {path}`.
 - Skip paths that do not exist at `{base_ref}` (record and continue); do not invent content.
 

--- a/work-package/techniques/review-assumptions/interview.md
+++ b/work-package/techniques/review-assumptions/interview.md
@@ -25,7 +25,7 @@ The assumptions [log](../../resources/assumptions-review.md#assumptions-log-temp
 
 ### assumption_review_presentation
 
-Structured judgement-augmentation context for decision, shaped like the [Open Assumptions](../../resources/assumptions-review.md#open-assumptions) entry fields (decision space, non-resolvability rationale, technical context, agent's position, reversibility) plus a link to the assumptions log.
+Structured judgement-augmentation context for decision, shaped like the Open Assumptions entry fields of the [assumptions log template](../../resources/assumptions-review.md#assumptions-log-template) (decision space, non-resolvability rationale, technical context, agent's position, reversibility) plus a link to the assumptions log.
 
 
 ## Protocol

--- a/work-package/techniques/review-assumptions/reconcile.md
+++ b/work-package/techniques/review-assumptions/reconcile.md
@@ -123,7 +123,7 @@ Convergence is reached when no open assumption in the log — including assumpti
 
 ### handoff-to-residue
 
-After convergence, set `{has_resolvable_assumptions}` false and `{has_open_assumptions}` from the irreducible open set. When bound as `{analyse}` inside [analyse-challenge](../analyse-challenge/TECHNIQUE.md), [challenge](../analyse-challenge/challenge.md) / [combine](../analyse-challenge/combine.md) may further shrink that set before the activity gates [interview](./interview.md) on `{has_open_assumptions}`.
+After convergence, set `{has_resolvable_assumptions}` false and `{has_open_assumptions}` from the irreducible open set. When bound as `{analyse_technique}` inside [analyse-challenge](../analyse-challenge/TECHNIQUE.md), [challenge](../analyse-challenge/challenge.md) / [combine](../analyse-challenge/combine.md) may further shrink that set before the activity gates [interview](./interview.md) on `{has_open_assumptions}`.
 
 | Element | Source |
 |---------|--------|

--- a/work-package/techniques/review-test-suite.md
+++ b/work-package/techniques/review-test-suite.md
@@ -25,7 +25,7 @@ Folder where the test suite review report is written
 
 ### test_suite_review_report
 
-Test suite review [report](../resources/test-suite-review.md#test-suite-review-report-template) documenting quality assessment
+Test suite review [report](../resources/test-suite-review.md#report-template) documenting quality assessment
 
 #### artifact
 

--- a/work-package/techniques/strategic-review/apply-cleanup.md
+++ b/work-package/techniques/strategic-review/apply-cleanup.md
@@ -37,7 +37,7 @@ SHA of the feature-branch commit carrying the applied cleanup (identified artifa
 
 - Apply cleanup (removing identified artifacts) when the user approves.
 - Use the edit tool for targeted in-place cleanup modifications.
-- When whole files or hunks should match the base again, resolve `{base_ref}` (bound value, else the PR base / default branch as in [review-scope](./review-scope.md)) and Apply [manage-git](../manage-git/TECHNIQUE.md)::[restore-paths-from-ref](../manage-git/restore-paths-from-ref.md) with `{target_path}`, `{base_ref}`, the paths to restore, and `{interactive}` true only when hunk-selective restore is required; keep `{restored_paths}` for the commit phase.
+- When whole files or hunks should match the base again, resolve `{base_ref}` (bound value, else the PR base / default branch as in [review-scope](./review-scope.md)) and Apply [manage-git](../manage-git/TECHNIQUE.md)::[restore-paths-from-ref](../manage-git/restore-paths-from-ref.md) with `{target_path}`, `{base_ref}`, the paths to restore, and `{interactive_restore}` true only when hunk-selective restore is required; keep `{restored_paths}` for the commit phase.
 
 ### 2. Commit Changes
 

--- a/work-package/workflow.yaml
+++ b/work-package/workflow.yaml
@@ -65,6 +65,23 @@ fragments:
           effect:
             setVariable:
               needs_individual_interview: true
+    assumption-decision:
+      message: "Assumption {current_assumption.id}: {current_assumption.statement}. Resolve now or defer."
+      blocking: true
+      options:
+        - id: resolve-inline
+          label: Resolve now
+          description: Provide resolution for this assumption
+          effect:
+            setVariable:
+              assumption_resolved_inline: true
+        - id: defer-to-stakeholder
+          label: Defer to stakeholder review
+          description: Queue this assumption for stakeholder review
+          effect:
+            setVariable:
+              assumption_deferred: true
+              has_deferred_assumptions: true
 techniques:
   activity:
     - variable-binding


### PR DESCRIPTION
Clears the three corpus guards that have been red in the committed corpus. Each is a real defect, not a stale guard — verified by running each guard against a pristine checkout of the submodule pointer as well as the branch tip.

### `resource-anchors` — 3 broken `.md#anchor` links

Two pointed at headings that exist only **inside a fenced ```markdown template block**, so they are not rendered headings; both now address the enclosing real section:

| Link | Was | Now |
|---|---|---|
| `review-assumptions/interview.md` | `assumptions-review.md#open-assumptions` | `#assumptions-log-template` |
| `review-test-suite.md` | `test-suite-review.md#test-suite-review-report-template` | `#report-template` |

The third named `accumulate-trace-tokens` on `dispatch-activity`, a rule merged into `resolve-trace-at-close-out`. That rule's body already states both halves of the contract ("This operation owns the accumulate half…"), so the dangling parenthetical is removed rather than re-pointed.

### `identifier-qualification` (AP-60 sub-rule 3) — 2 bare single-word I/O ids

```
analyse     -> analyse_technique     (analyse-challenge::TECHNIQUE + run-loop; 7 activity bind sites)
interactive -> interactive_restore   (manage-git::restore-paths-from-ref)
```

Neither qualifies for `EXEMPT_DATA_IDS`: `analyse` is a verb naming a technique path (not a plural item-noun, tool-param mirror, or `_type`/`_mode`/`kind` discriminator), and `interactive` mirrors no external tool parameter — git spells it `-p`/`--patch`. Both new names are ≥2-word noun phrases with the head noun last, matching the sibling convention in the same signatures (`challenge_perspectives`, `convergence_flag`, `residue_flag`).

`npm run check:binding` is clean for both after the rename, including the `{interactive}` read in `strategic-review/apply-cleanup.md` that a first pass missed.

### `fragments` — one checkpoint body inlined at 3 sites

The `assumption-decision` checkpoint was authored inline in `04-research`, `05-implementation-analysis` and `08-implement` (16 identical lines each). It is now declared once under `fragments.checkpoints` and imported by `ref` at each site, following the existing `assumption-interview` precedent. **Each step keeps its own local `id`**, so no checkpoint id changes and no session-state key moves.

### Verification

- All three guards clean, plus `validate-workflow-yaml` and `check:binding`
- The `work-package` walk snapshots are **unchanged** by these edits — verified byte-identical against a pristine corpus checkout, so this branch is decoupled from the server-side baseline update

### Sequencing

Merge this first. The server-side companion PR leaves the submodule pointer untouched, so its three guard-test failures (pre-existing on `main`) clear once this lands and the pointer is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
