### PR TITLE
fix: reject an artifact name that is not a filename (#330)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -269,7 +269,8 @@ npm run check:binding
 # Normative technique template: metadata.version-only frontmatter, no H1 title,
 # the canonical H2 set in order (Capability, Inputs, Outputs, Protocol, Rules —
 # Outputs before Protocol), snake_case entry ids (camelCase tool-parameter
-# mirrors allowed), kebab-case rule names, snake_case {$name} sigils. Hard-zero.
+# mirrors allowed), kebab-case rule names, snake_case {$name} sigils, and every
+# #### artifact body a filename the loader accepts. Hard-zero.
 npm run check:technique-template
 
 # Shared fragments (#166 B10): every rules { ref } and checkpoint ref resolves,

--- a/docs/technique-protocol-specification.md
+++ b/docs/technique-protocol-specification.md
@@ -108,6 +108,10 @@ loader rejects the singular `## Input` / `## Output` (and `## Output(s)`) varian
 - `#### <member>` is a named component of the entry (`components[member]`).
 - `#### artifact` (Outputs) is the persistence filename — a literal (`code-review.md`) or a
   `{token}`-template the worker interpolates at runtime (`{package_name}-plan.md`, the token being a snake_case symbol).
+  One filename per output: one path segment ending in an extension, with `{token}` placeholders standing where
+  literal text would. The loader rejects anything else — a technique whose artifact body is prose, several
+  names, or a declaration key is dropped with a logged warning, as a mistyped `audience` is. A technique that
+  writes several files declares one output per artifact; a name selected by a mode is one op per mode.
 - `#### audience` (Outputs) is the intended reader of the output/artifact — `human` or `agent`.
   Absent means `human`. An `agent`-audience artifact is serialized as **JSON** on disk (named under
   the same `artifactPrefix` rule as any artifact); a `human`-audience artifact is prose markdown.
@@ -480,7 +484,7 @@ The protocol-relevant rules:
   another technique only in `## Protocol` or `## Capability`, as utilisation ("use
   `cargo-operations::fmt-fix`").
 - A protocol references data by its Input/Output id. An artifact filename lives in the `#### artifact`
-  declaration (literal, `{token}`-template, or discriminator-keyed).
+  declaration (literal or `{token}`-template), one filename per output.
 - A capability or description states what a construct is; the sequence of steps and phases lives in
   `protocol[]`.
 - A protocol step is an action. A standing prohibition or invariant is a rule (§3.4) or a guard

--- a/scripts/check-technique-template.ts
+++ b/scripts/check-technique-template.ts
@@ -15,6 +15,11 @@
  *   tool parameter may be camelCase (spec §3.2 — Atlassian's `cloudId` binds natively).
  *   `###` rule names under Rules are kebab-case, optionally dot-grouped (`commit.signed`).
  * - Every `{$name}` protocol-variable binding is snake_case (spec §3.3; AP-55).
+ * - Every `#### artifact` body under Outputs is a filename the loader can accept — one path
+ *   segment with an extension, `{token}` placeholders allowed (spec §3.2). The Zod schema rejects
+ *   anything else at load, which drops the technique with a logged warning; this guard is what
+ *   makes an unfilenameable declaration read as a red test naming the file, rather than a
+ *   technique quietly missing from the corpus (#330).
  *
  * `README.md` files inside `techniques/` are navigation docs, not techniques — skipped.
  * Headings and sigils inside fenced code blocks are illustrative — skipped.
@@ -27,6 +32,7 @@ import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
 import { join, relative, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { resolveWorkflowsRoot } from './workflows-root.js';
+import { ARTIFACT_NAME_PATTERN } from '../src/schema/technique.schema.js';
 
 const DIR = fileURLToPath(new URL('.', import.meta.url));
 const ROOT = resolveWorkflowsRoot(resolve(join(DIR, '..', 'workflows')));
@@ -45,7 +51,8 @@ export interface TemplateViolation {
     | 'section-order'
     | 'entry-id-casing'
     | 'rule-name-casing'
-    | 'sigil-casing';
+    | 'sigil-casing'
+    | 'artifact-name';
   /** The offending token or the observed shape. */
   detail: string;
 }
@@ -137,6 +144,35 @@ export function lintTechniqueFile(raw: string, file: string): TemplateViolation[
   const inOrder = [...seen].sort((a, b) => CANONICAL.indexOf(a) - CANONICAL.indexOf(b));
   if (seen.join(' > ') !== inOrder.join(' > ')) {
     violations.push({ file, rule: 'section-order', detail: seen.join(' > ') });
+  }
+
+  // --- `#### artifact` bodies under Outputs name one file the loader can accept. ---
+  // `artifact` is reserved metadata only under Outputs; under Inputs the same heading is an
+  // ordinary component member, so the pass tracks which H2 it is reading.
+  const lines = annotateFences(body);
+  let inOutputs = false;
+  for (let i = 0; i < lines.length; i++) {
+    const { text, inFence } = lines[i]!;
+    if (inFence) continue;
+    const h2 = /^## (?!#)(.*)$/.exec(text);
+    if (h2) {
+      inOutputs = h2[1]!.trim() === 'Outputs';
+      continue;
+    }
+    if (!inOutputs || !/^#### artifact\s*$/i.test(text)) continue;
+    const collected: string[] = [];
+    for (let j = i + 1; j < lines.length && !/^#{1,6}\s/.test(lines[j]!.text); j++) collected.push(lines[j]!.text);
+    // Normalize as the loader does — paragraph-join the body, then strip the inline-code
+    // backticks that wrap a filename literal — so the guard tests the derived name verbatim.
+    const name = collected
+      .join('\n')
+      .split(/\r?\n\s*\r?\n/)
+      .map((p) => p.trim())
+      .filter(Boolean)
+      .join('\n\n')
+      .replace(/^`+|`+$/g, '')
+      .trim();
+    if (!ARTIFACT_NAME_PATTERN.test(name)) violations.push({ file, rule: 'artifact-name', detail: name });
   }
 
   // --- `{$name}` sigil casing (code spans included — designators are backticked). ---

--- a/src/schema/technique.schema.ts
+++ b/src/schema/technique.schema.ts
@@ -43,8 +43,22 @@ export type RulesDefinition = z.infer<typeof RulesDefinitionSchema>;
 export const OutputComponentsDefinitionSchema = z.record(z.string()).describe('Named output components: each key is a component id, value is the spec or description for that component');
 export type OutputComponentsDefinition = z.infer<typeof OutputComponentsDefinitionSchema>;
 
+/**
+ * An artifact name is a filename: one path segment ending in an extension, where a `{token}`
+ * placeholder stands wherever literal text would. Whatever an author writes here becomes the file a
+ * worker creates, so anything that cannot be a filename — prose, several names joined by `/`, a
+ * mode selector in parentheses, a YAML key — is rejected at load (the technique is dropped with a
+ * logged warning, the same treatment a mistyped `audience` gets) instead of being derived into a
+ * nonsense filename. A technique that writes several files declares one output per artifact.
+ */
+export const ARTIFACT_NAME_PATTERN = /^(?:[A-Za-z0-9._-]|\{[A-Za-z0-9._$-]+\})+\.[A-Za-z0-9]+$/;
+
+/** Rejection message for {@link ARTIFACT_NAME_PATTERN}: cause, then the conforming forms. */
+const ARTIFACT_NAME_MESSAGE =
+  'an artifact name is a single filename — one path segment ending in an extension, `{token}` placeholders allowed (`01-audit-report.md`, `{package_name}-plan.md`). Declare one output per artifact when a technique writes several files';
+
 export const OutputArtifactSchema = z.object({
-  name: z.string().describe('Artifact filename when this output is persisted. A literal (e.g. 01-audit-report.md) or a token-template with {variable} placeholders the worker interpolates from in-scope inputs/variables at runtime (e.g. {package-name}-plan.md). Declare the name here, never hardcode it in Protocol prose.'),
+  name: z.string().regex(ARTIFACT_NAME_PATTERN, ARTIFACT_NAME_MESSAGE).describe('Artifact filename when this output is persisted. A literal (e.g. 01-audit-report.md) or a token-template with {variable} placeholders the worker interpolates from in-scope inputs/variables at runtime (e.g. {package-name}-plan.md). One filename, one path segment, with an extension — a technique writing several files declares one output per artifact. Declare the name here, never hardcode it in Protocol prose.'),
   action: z.enum(['create', 'update']).default('create').optional().describe('Whether this output creates a new artifact or updates an existing one'),
 });
 export type OutputArtifact = z.infer<typeof OutputArtifactSchema>;

--- a/tests/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/tests/e2e/__snapshots__/snapshot.test.ts.snap
@@ -25,11 +25,11 @@ exports[`work-package walk snapshots (baseline) > [default] matches committed ba
       "activity": "start-work-package",
       "artifacts": [
         "prior-feedback-triage.md",
-        "name: README.md",
+        "README.md",
       ],
       "artifactsWritten": [
         "01-prior-feedback-triage.md",
-        "01-name: README.md",
+        "01-README.md",
       ],
       "checkpoints": [
         {
@@ -395,14 +395,12 @@ exports[`work-package walk snapshots (baseline) > [default] matches committed ba
         "NNNN-{decision_title}.md",
         "COMPLETE.md",
         "token-usage.md",
-        "COMPLETE.md\` (implementation) or planning-folder session \`README.md\` section (review mode)",
         "session-trace.md",
       ],
       "artifactsWritten": [
         "14-NNNN-decision_title.md",
         "14-COMPLETE.md",
         "14-token-usage.md",
-        "14-COMPLETE.md\` (implementation) or planning-folder session \`README.md\` section (review mode)",
         "14-session-trace.md",
       ],
       "checkpoints": [
@@ -458,11 +456,11 @@ exports[`work-package walk snapshots (baseline) > [elicitation-only] matches com
       "activity": "start-work-package",
       "artifacts": [
         "prior-feedback-triage.md",
-        "name: README.md",
+        "README.md",
       ],
       "artifactsWritten": [
         "01-prior-feedback-triage.md",
-        "01-name: README.md",
+        "01-README.md",
       ],
       "checkpoints": [
         {
@@ -892,14 +890,12 @@ exports[`work-package walk snapshots (baseline) > [elicitation-only] matches com
         "NNNN-{decision_title}.md",
         "COMPLETE.md",
         "token-usage.md",
-        "COMPLETE.md\` (implementation) or planning-folder session \`README.md\` section (review mode)",
         "session-trace.md",
       ],
       "artifactsWritten": [
         "14-NNNN-decision_title.md",
         "14-COMPLETE.md",
         "14-token-usage.md",
-        "14-COMPLETE.md\` (implementation) or planning-folder session \`README.md\` section (review mode)",
         "14-session-trace.md",
       ],
       "checkpoints": [
@@ -958,11 +954,11 @@ exports[`work-package walk snapshots (baseline) > [full-workflow] matches commit
       "activity": "start-work-package",
       "artifacts": [
         "prior-feedback-triage.md",
-        "name: README.md",
+        "README.md",
       ],
       "artifactsWritten": [
         "01-prior-feedback-triage.md",
-        "01-name: README.md",
+        "01-README.md",
       ],
       "checkpoints": [
         {
@@ -1420,14 +1416,12 @@ exports[`work-package walk snapshots (baseline) > [full-workflow] matches commit
         "NNNN-{decision_title}.md",
         "COMPLETE.md",
         "token-usage.md",
-        "COMPLETE.md\` (implementation) or planning-folder session \`README.md\` section (review mode)",
         "session-trace.md",
       ],
       "artifactsWritten": [
         "14-NNNN-decision_title.md",
         "14-COMPLETE.md",
         "14-token-usage.md",
-        "14-COMPLETE.md\` (implementation) or planning-folder session \`README.md\` section (review mode)",
         "14-session-trace.md",
       ],
       "checkpoints": [
@@ -1485,11 +1479,11 @@ exports[`work-package walk snapshots (baseline) > [research-only] matches commit
       "activity": "start-work-package",
       "artifacts": [
         "prior-feedback-triage.md",
-        "name: README.md",
+        "README.md",
       ],
       "artifactsWritten": [
         "01-prior-feedback-triage.md",
-        "01-name: README.md",
+        "01-README.md",
       ],
       "checkpoints": [
         {
@@ -1907,14 +1901,12 @@ exports[`work-package walk snapshots (baseline) > [research-only] matches commit
         "NNNN-{decision_title}.md",
         "COMPLETE.md",
         "token-usage.md",
-        "COMPLETE.md\` (implementation) or planning-folder session \`README.md\` section (review mode)",
         "session-trace.md",
       ],
       "artifactsWritten": [
         "14-NNNN-decision_title.md",
         "14-COMPLETE.md",
         "14-token-usage.md",
-        "14-COMPLETE.md\` (implementation) or planning-folder session \`README.md\` section (review mode)",
         "14-session-trace.md",
       ],
       "checkpoints": [
@@ -1970,11 +1962,11 @@ exports[`work-package walk snapshots (baseline) > [review-mode] matches committe
       "activity": "start-work-package",
       "artifacts": [
         "prior-feedback-triage.md",
-        "name: README.md",
+        "README.md",
       ],
       "artifactsWritten": [
         "01-prior-feedback-triage.md",
-        "01-name: README.md",
+        "01-README.md",
       ],
       "checkpoints": [],
       "manifestStatus": "valid",
@@ -2287,14 +2279,12 @@ exports[`work-package walk snapshots (baseline) > [review-mode] matches committe
         "NNNN-{decision_title}.md",
         "COMPLETE.md",
         "token-usage.md",
-        "COMPLETE.md\` (implementation) or planning-folder session \`README.md\` section (review mode)",
         "session-trace.md",
       ],
       "artifactsWritten": [
         "14-NNNN-decision_title.md",
         "14-COMPLETE.md",
         "14-token-usage.md",
-        "14-COMPLETE.md\` (implementation) or planning-folder session \`README.md\` section (review mode)",
         "14-session-trace.md",
       ],
       "checkpoints": [
@@ -2344,11 +2334,11 @@ exports[`work-package walk snapshots (baseline) > [skip-optional] matches commit
       "activity": "start-work-package",
       "artifacts": [
         "prior-feedback-triage.md",
-        "name: README.md",
+        "README.md",
       ],
       "artifactsWritten": [
         "01-prior-feedback-triage.md",
-        "01-name: README.md",
+        "01-README.md",
       ],
       "checkpoints": [
         {
@@ -2714,14 +2704,12 @@ exports[`work-package walk snapshots (baseline) > [skip-optional] matches commit
         "NNNN-{decision_title}.md",
         "COMPLETE.md",
         "token-usage.md",
-        "COMPLETE.md\` (implementation) or planning-folder session \`README.md\` section (review mode)",
         "session-trace.md",
       ],
       "artifactsWritten": [
         "14-NNNN-decision_title.md",
         "14-COMPLETE.md",
         "14-token-usage.md",
-        "14-COMPLETE.md\` (implementation) or planning-folder session \`README.md\` section (review mode)",
         "14-session-trace.md",
       ],
       "checkpoints": [

--- a/tests/schema-validation.test.ts
+++ b/tests/schema-validation.test.ts
@@ -321,6 +321,48 @@ describe('schema-validation', () => {
     });
   });
 
+  describe('OutputArtifactSchema name (#330)', () => {
+    const parse = (name: string) => OutputItemDefinitionSchema.safeParse({ id: 'out', artifact: { name } }).success;
+
+    it('accepts a literal filename and a {token}-templated one', () => {
+      expect(parse('01-audit-report.md')).toBe(true);
+      expect(parse('START-HERE.md')).toBe(true);
+      expect(parse('{package_name}-plan.md')).toBe(true);
+      expect(parse('{YYYY-MM-DD}-pr{pr_number}-review-analysis.md')).toBe(true);
+      // A `{$local}` sigil and a dotted sub-field both bind inside a placeholder.
+      expect(parse('{$page_slug}.md')).toBe(true);
+      expect(parse('subsystem-{code_subsystem.subsystem_name}.md')).toBe(true);
+    });
+
+    it('rejects prose, several names, and a YAML key written as the name', () => {
+      // The two declarations that reached a worker as filenames before this refinement.
+      expect(parse('COMPLETE.md` (implementation) or planning-folder session `README.md` section (review mode)')).toBe(false);
+      expect(parse('name: README.md')).toBe(false);
+      // Several files in one slot, with or without mode selectors.
+      expect(parse('index.md` and `log.md')).toBe(false);
+      expect(parse('reflect-l12.md` (L12 structural) / `reflect-meta.md` (claim meta-analysis)')).toBe(false);
+    });
+
+    it('rejects a name that is not one path segment with an extension', () => {
+      expect(parse('planning/notes.md')).toBe(false);
+      expect(parse('audit-report')).toBe(false);
+      expect(parse('.md')).toBe(false);
+      expect(parse('')).toBe(false);
+    });
+
+    // The refinement lives under `.strict()`, so a bad name fails the whole technique — which is
+    // what drops it at load with a logged warning, as an invalid audience does.
+    it('rejects an unfilenameable name through the strict TechniqueSchema', () => {
+      const bad = {
+        id: 't', version: '1.0.0', capability: 'Cap.',
+        outputs: [{ id: 'out', artifact: { name: 'a.md` (one mode) / `b.md` (the other)' } }],
+      };
+      expect(safeValidateTechnique(bad).success).toBe(false);
+      const good = { ...bad, outputs: [{ id: 'out', artifact: { name: 'a.md' } }] };
+      expect(safeValidateTechnique(good).success).toBe(true);
+    });
+  });
+
   describe('corpus strict-parse', () => {
     // Every definition file of every workflow must parse under the closed schemas. This is the
     // guardrail for the loader's skip-on-validation-failure behavior: a schema tightening that

--- a/tests/technique-loader.test.ts
+++ b/tests/technique-loader.test.ts
@@ -262,6 +262,29 @@ describe('technique-loader', () => {
       }
     });
 
+    // #330 — an `#### artifact` body that cannot be a filename reaches the schema refinement and
+    // drops the technique, rather than being derived into the file a worker tries to create.
+    it('rejects an `#### artifact` body that is not a filename, and loads the corrected literal', async () => {
+      const dir = join(tempDir, 'meta', 'techniques');
+      await mkdir(dir, { recursive: true });
+      const technique = (artifactBody: string) => [
+        '---', 'metadata:', '  version: 1.0.0', '---', '',
+        '## Capability', '', 'Cap.', '',
+        '## Outputs', '', '### completion_record', '', 'The close-out.', '',
+        '#### artifact', '', artifactBody, '',
+      ].join('\n');
+
+      await writeFile(join(dir, 'artifact-prose.md'), technique('`COMPLETE.md` (implementation) or session `README.md` section (review mode)'), 'utf-8');
+      expect((await readTechnique('artifact-prose', tempDir)).success).toBe(false);
+
+      await writeFile(join(dir, 'artifact-prose.md'), technique('`COMPLETE.md`'), 'utf-8');
+      const fixed = await readTechnique('artifact-prose', tempDir);
+      expect(fixed.success).toBe(true);
+      if (fixed.success) {
+        expect(fixed.value.outputs?.[0]?.artifact?.name).toBe('COMPLETE.md');
+      }
+    });
+
     it('loads a minimal flat technique with frontmatter + Capability', async () => {
       const dir = join(tempDir, 'meta', 'techniques');
       await mkdir(dir, { recursive: true });

--- a/tests/technique-template.test.ts
+++ b/tests/technique-template.test.ts
@@ -96,6 +96,32 @@ describe('technique-template guard', () => {
     expect(lintTechniqueFile(bad, 'x.md').map((v) => v.rule)).toEqual(['sigil-casing']);
   });
 
+  // #330 — the guard is what makes an unfilenameable artifact declaration red. The schema drops
+  // such a technique at load with a logged warning, which on its own reads as a missing technique.
+  it('flags an `#### artifact` body that is not a filename', () => {
+    const declare = (body: string) => CONFORMANT.replace('What was found.', `What was found.\n\n#### artifact\n\n${body}`);
+    for (const bad of [
+      '`COMPLETE.md` (implementation) or session `README.md` section (review mode)',
+      '`index.md` and `log.md`',
+      'name: README.md',
+      '`planning/notes.md`',
+    ]) {
+      expect(lintTechniqueFile(declare(bad), 'x.md').map((v) => v.rule)).toEqual(['artifact-name']);
+    }
+  });
+
+  it('accepts a literal and a {token}-templated artifact name', () => {
+    const declare = (body: string) => CONFORMANT.replace('What was found.', `What was found.\n\n#### artifact\n\n${body}`);
+    for (const ok of ['`01-audit-report.md`', '`{package_name}-plan.md`', '`{$page_slug}.md`', '`START-HERE.md`']) {
+      expect(lintTechniqueFile(declare(ok), 'x.md')).toEqual([]);
+    }
+  });
+
+  it('leaves an `#### artifact` member under Inputs alone (reserved only on Outputs)', () => {
+    const raw = CONFORMANT.replace('Where to act.', 'Where to act.\n\n#### artifact\n\nThe artifact this input points at.');
+    expect(lintTechniqueFile(raw, 'x.md')).toEqual([]);
+  });
+
   it('every technique file in the corpus follows the template', () => {
     expect(collectTemplateViolations().map((v) => `[${v.rule}] ${v.file}: ${v.detail}`)).toEqual([]);
   });


### PR DESCRIPTION
Closes #330. Server half; the fifteen corrected declarations are in #331 against `workflows`.

## 1. Load-time rejection

`OutputArtifactSchema.name` now carries `ARTIFACT_NAME_PATTERN` — one path segment ending in an extension, with `{token}` placeholders standing where literal text would:

```ts
/^(?:[A-Za-z0-9._-]|\{[A-Za-z0-9._$-]+\})+\.[A-Za-z0-9]+$/
```

It sits under the strict `TechniqueSchema`, so an unfilenameable name fails the whole technique, which drops it at load with a logged warning — the treatment a mistyped `audience` already gets, per the issue.

Applied to the corpus as it stood, the pattern accepted 101 declarations and rejected 13. Every accepted form is exercised in the tests: literals (`01-audit-report.md`, `START-HERE.md`), token-templates (`{package_name}-plan.md`), `{$local}` sigils (`{$page_slug}.md`), dotted sub-fields (`subsystem-{code_subsystem.subsystem_name}.md`), multi-placeholder names (`{YYYY-MM-DD}-pr{pr_number}-review-analysis.md`).

## 2. A red test, not a silent drop

Rejection at load, on its own, turns a bad declaration into a technique quietly missing from the corpus — the same detect-then-silence shape #327 documents. So `check-technique-template` gains an `artifact-name` rule reading the raw markdown over the same exported pattern, and reports the file plus the offending text:

```
[artifact-name] work-package/techniques/conduct-retrospective/retrospective.md: COMPLETE.md` (implementation) or planning-folder session `README.md` section (review mode)
```

That guard is **hard-zero with no baseline file** — deliberately, since the issue is about a baseline absorbing this class. It already backs a corpus test (`tests/technique-template.test.ts`), so `npm test` fails on a new bad declaration. Run standalone it produced exactly the worklist the issue predicted: 13 by the loader-derived text, plus the 2 backtick-less literals the issue counts separately.

The guard tracks which H2 it is reading, because `artifact` is reserved metadata only under `## Outputs` — under `## Inputs` the same heading is an ordinary component member, and that case is covered.

## 3. Re-baseline

Both garbage entries leave `artifactsWritten`, and `01-name: README.md` becomes `01-README.md`. All six work-package policy walks differ by exactly those edits and nothing else:

```
-         "name: README.md",
+         "README.md",
-         "01-name: README.md",
+         "01-README.md",
-         "COMPLETE.md` (implementation) or planning-folder session `README.md` section (review mode)",
-         "14-COMPLETE.md` (implementation) or planning-folder session `README.md` section (review mode)",
```

## Verification

`npx tsc --noEmit` clean. Full suite: 715 passed, 1 failed — `session-crypto` "surfaces actionable EACCES", which expects `EACCES` writing to `/` and gets `ENOENT` under the read-only bind mount of my sandbox. It fails identically on an unmodified `origin/main` checkout, so it is environmental, not from this change.

All twelve corpus guards pass against the paired corpus branch. `check-binding-fidelity` reports 0 new drift, and 6 further baselined violations retired by the declaration cleanup (33 stale total, 27 of which were already stale at `origin/main` — left alone rather than folded into this diff). The `review-mode-gating` baseline is likewise stale by 1 at `origin/main`, unrelated.

## Merge order

The pointer in this branch targets #331's branch tip so the snapshot baseline here is self-consistent. Merge #331 into `workflows` first, then re-bump the pointer to that merged commit — the pattern `8c66b63f` used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
