### PR TITLE
fix(corpus): consume the verification verdicts nothing read (#327)

### DIFF
--- a/remediate-vuln/activities/01-start.yaml
+++ b/remediate-vuln/activities/01-start.yaml
@@ -66,6 +66,10 @@ steps:
   - kind: technique
     id: configure-sec-vuln-remote
     technique: security-setup::configure-security-remote
+    actions:
+      - action: validate
+        target: security_remote_configured != false
+        message: "The 'security' remote is not registered against the private fork inside {target_path}. Add it with git remote add security {private_fork_url} and re-run."
   - kind: checkpoint
     id: confirm-security-remote
     message: "CRITICAL: Isolation check. Confirm that the 'security' remote is configured and points to a PRIVATE repository. Is 'git remote -v' output correct for 'security'?"
@@ -112,6 +116,10 @@ steps:
   - kind: technique
     id: finalize-setup
     technique: security-setup::verify-origin-untracked
+    actions:
+      - action: validate
+        target: origin_untracked != false
+        message: "The current branch in {target_path} still tracks an upstream on origin, so a push could reach the public remote. Run git branch --unset-upstream in {target_path} and re-run."
   - kind: action
     id: announce-completion
     actions:

--- a/work-package/activities/01-start-work-package.yaml
+++ b/work-package/activities/01-start-work-package.yaml
@@ -205,8 +205,9 @@ steps:
           operator: "!="
           value: true
         - type: simple
-          variable: issue_number
-          operator: notExists
+          variable: issue_present
+          operator: ==
+          value: false
     message: No GitHub or Jira issue is associated with this work package. Select how to proceed.
     options:
       - id: provide-existing
@@ -590,6 +591,10 @@ steps:
   - kind: technique
     id: check-branch
     technique: manage-git::verify-feature-branch
+    actions:
+      - action: validate
+        target: on_feature_branch != false
+        message: "The worktree at {target_path} is on a default branch, not a feature branch, so subsequent commits would land there. Check out {branch_name} in {target_path} and re-run."
   - kind: technique
     id: check-pr
     technique:

--- a/work-package/activities/02-design-philosophy.yaml
+++ b/work-package/activities/02-design-philosophy.yaml
@@ -108,10 +108,16 @@ steps:
   - kind: checkpoint
     id: ticket-completeness
     condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
+      type: and
+      conditions:
+        - type: simple
+          variable: is_review_mode
+          operator: ==
+          value: true
+        - type: simple
+          variable: ticket_gaps_documented
+          operator: ==
+          value: true
     message: Ticket completeness gaps were identified. Select whether to refactor the ticket or proceed with gaps noted.
     blocking: false
     defaultOption: proceed-with-gaps
@@ -125,11 +131,10 @@ steps:
             ticket_refactor_needed: true
       - id: proceed-with-gaps
         label: Proceed with gaps noted
-        description: Document gaps in the [assumptions log]({assumptions_log}) and continue review with gaps as tracked findings
+        description: Continue review with the recorded gaps as tracked findings in the [assumptions log]({assumptions_log})
         effect:
           setVariable:
             ticket_refactor_needed: false
-            ticket_gaps_documented: true
       - id: no-gaps
         label: Ticket is complete
         description: No significant gaps were found

--- a/work-package/techniques/assess-ticket-completeness.md
+++ b/work-package/techniques/assess-ticket-completeness.md
@@ -21,12 +21,7 @@ Summary, description, and context of the tracker ticket being assessed (the link
 
 ### ticket_gaps_documented
 
-True once any identified gaps have been recorded (in the assumptions log) so they persist as tracked findings.
-
-### ticket_refactor_needed
-
-True when the user elects to refactor the ticket to address the identified gaps; false when they choose to proceed with gaps noted or the ticket is complete.
-
+True once any identified gaps have been recorded (in the assumptions log) so they persist as tracked findings; false when every dimension is present and sufficient.
 
 ## Protocol
 
@@ -38,10 +33,5 @@ True when the user elects to refactor the ticket to address the identified gaps;
 ### 2. Document Gaps
 
 - For each dimension that is weak or missing, record the gap concisely as a tracked finding in `{assumptions_log}`.
-- Set `{ticket_gaps_documented}` once the gaps are recorded.
+- Set `{ticket_gaps_documented}` true once gaps are recorded, false when every dimension is present and sufficient.
 - Documented gaps are persistent findings, not ephemeral status text — they live in the assumptions log so review can proceed with them visible regardless of whether the ticket is refactored.
-
-### 3. Emit Gaps for Activity Decision
-
-- Emit the documented gaps as bindable output for the binding activity to surface (refactor vs proceed-with-gaps).
-- `{ticket_refactor_needed}` is set from the activity checkpoint effect: true to refactor, false to proceed with gaps noted or when no significant gaps were found.

--- a/work-package/techniques/requirements-elicitation/discuss.md
+++ b/work-package/techniques/requirements-elicitation/discuss.md
@@ -19,10 +19,6 @@ Prompt the user for the stakeholder discussion transcript before agent-led elici
 
 The transcript or summary captured from the user, or absent when the user skips.
 
-### has_stakeholder_input
-
-Boolean gate — true iff a transcript was provided, false when stakeholder discussion was skipped.
-
 ## Protocol
 
 ### 1. Prompt Transcript

--- a/work-package/workflow.yaml
+++ b/work-package/workflow.yaml
@@ -215,6 +215,10 @@ variables:
     type: boolean
     description: True while submit-for-review is waiting for reviewer feedback.
     defaultValue: false
+  - name: issue_present
+    type: boolean
+    description: Whether the user supplied an issue reference for this work package.
+    defaultValue: false
   - name: needs_issue_creation
     type: boolean
     description: Whether a new issue needs to be created.


### PR DESCRIPTION
Follow-on to #333 (merged). Corpus half of the #327 R3 burn-down; the server half is #334.

## The class

The #327 triage put 10 findings in a class called `verification-result-unconsumed`: **an operation returns a verdict, and no gate, condition, or validate target reads it.** The check runs and its answer is discarded, leaving the constraint carried by prose rather than structure — [Encode Constraints as Structure](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/design-principles.md#9-encode-constraints-as-structure).

All 10 are now closed. Eight are fixed here; one was a guard blind spot (a `when:` expression was not counted as consumption — fixed in #334) and one was misclassified by the predicate-name heuristic.

## Enforce the verdict where a human confirmation was standing in for it

Three verifications computed a boolean and threw it away, with a blocking checkpoint asking a human the question the machine had already answered:

| Site | Verdict | What was resting on the human |
|---|---|---|
| `remediate-vuln` `configure-security-remote` | `security_remote_configured` | *"CRITICAL: Isolation check. Confirm that the 'security' remote points to a PRIVATE repository. Is `git remote -v` output correct?"* |
| `remediate-vuln` `verify-origin-untracked` | `origin_untracked` | nothing at all — a branch still tracking `origin` could reach the public remote |
| `work-package` `verify-feature-branch` | `on_feature_branch` | nothing — a failed branch creation would let later commits land on the default branch |

Each binding step now carries a `validate` action on its own verdict, matching the idiom already at `12-strategic-review` and `04-isolated-fan-out`. The human confirmations stay; they are no longer the only thing standing between a stealth run and a public remote.

## Consume the verdict in the gate that was using a parallel probe

- **`issue-verification`** gated on `issue_number notExists` while `issue-reference-detection` declares `issue_present` for exactly that question — two expressions of one fact ([Single Source of Truth](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/design-principles.md#14-single-source-of-truth)). The gate now reads the declared verdict. `issue_present` is declared with `defaultValue: false` so an unproduced verdict fails *safe* and the gate still fires — without that, swapping `notExists` for `== false` would have created a gate that can never fire, the #324 A2 defect all over again. The walk snapshots caught it.

- **`ticket-completeness`** fired on `is_review_mode` alone, so every review run was asked *"Ticket completeness gaps were identified — refactor or proceed?"* whether or not the assessment found any — and then auto-advanced a consequential default on that spurious prompt. It now also gates on `ticket_gaps_documented`, so the question is asked only when there are gaps.

## Remove outputs the checkpoint owns, not the technique

- `assess-ticket-completeness` declared `ticket_refactor_needed`, and its own Outputs prose said the value *"is set from the activity checkpoint effect"* — a technique claiming a value it does not produce. Dropped, along with the Protocol bullet describing the gate that consumes it ([Keep Orchestration in Structure](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/design-principles.md#20-keep-orchestration-in-structure)).
- `discuss` declared `has_stakeholder_input`, which the `stakeholder-transcript` checkpoint writes. Dropped.
- The duplicate `ticket_gaps_documented: true` write on the `proceed-with-gaps` effect is gone: the assessment op is the single writer.

**Noted, not fixed:** `discuss`'s Capability is *"Prompt the user for the stakeholder discussion transcript… offering a skip path"* and its Protocol is *"Prompt user for…"*, *"Offer skip option…"* — session interaction inside a technique that the very next checkpoint already performs ([Keep Session Interaction in Activities](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/design-principles.md#24-keep-session-interaction-in-activities)). Removing the technique is a larger design decision than this change; left for its own.

## Verification

`npm run check:all` — 17/17 guards pass, 0 unmeasured. `binding-fidelity`: 195 findings, 70 harmless, 125 fix-later, **0 live, 0 untriaged, 0 stale** — the `verification-result-unconsumed` class is empty. Full vitest suite green (738 passed).

One walk snapshot moves: the review-mode walk no longer presents `ticket-completeness`, which is the point — no gaps were documented in that walk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
