### PR TITLE
feat(workflow-authoring): new authoring workflow, and deprecate workflow-design (#321 S1-S4, S6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ defines the ontology and section conventions that every technique follows.
 | [`prism`](prism/) | Structural analysis through cognitive lenses — 46 prisms across 11 families, 4 pipeline modes |
 | [`prism-update`](prism-update/) | Sync the prism workflow's resources and routing with upstream agi-in-md changes |
 | [`prism-evaluate`](prism-evaluate/) | Multi-dimensional evaluation of proposals, documents, or codebases through configurable analytical dimensions mapped to prism lenses |
+| [`workflow-authoring`](workflow-authoring/) | Create, update, or audit workflow definitions — guided elicitation, one criteria walk per target, and structural gates on removals and commit |
 | [`workflow-design`](workflow-design/) | Create or update workflow definitions with guided elicitation, schema expressiveness enforcement, and convention conformance |
 
 ## Universal Techniques ([meta/techniques/](meta/techniques/))

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ defines the ontology and section conventions that every technique follows.
 | [`prism-update`](prism-update/) | Sync the prism workflow's resources and routing with upstream agi-in-md changes |
 | [`prism-evaluate`](prism-evaluate/) | Multi-dimensional evaluation of proposals, documents, or codebases through configurable analytical dimensions mapped to prism lenses |
 | [`workflow-authoring`](workflow-authoring/) | Create, update, or audit workflow definitions — guided elicitation, one criteria walk per target, and structural gates on removals and commit |
-| [`workflow-design`](workflow-design/) | Create or update workflow definitions with guided elicitation, schema expressiveness enforcement, and convention conformance |
+| [`workflow-design`](workflow-design/) | **Deprecated** — start `workflow-authoring` instead. Retained only until the sessions already in flight against it finish |
 
 ## Universal Techniques ([meta/techniques/](meta/techniques/))
 

--- a/work-package/techniques/manage-artifacts/write-artifact.md
+++ b/work-package/techniques/manage-artifacts/write-artifact.md
@@ -23,7 +23,11 @@ Artifact content to write
 
 ### target_dir
 
-*(optional, default `planning_folder_path`)* The directory the artifact is written into. Defaults to `{planning_folder_path}`; bind it to `{comprehension_dir}` when writing into the comprehension directory rather than the planning folder.
+*(optional)* The directory the artifact is written into. Defaults to `{planning_folder_path}`; bind it to `{comprehension_dir}` when writing into the comprehension directory rather than the planning folder.
+
+#### default
+
+`planning_folder_path`
 
 ## Outputs
 

--- a/workflow-authoring/README.md
+++ b/workflow-authoring/README.md
@@ -13,6 +13,7 @@ Activity `#` columns match the on-disk `NN-` file prefixes; the prefix is server
 | 01 | [**Intake and Context**](./activities/README.md#01-intake-and-context) | All | Classify create/update/review, name the target, derive the edit surface, produce the change brief and approve inventoried removals |
 | 06 | [**Scope and Draft**](./activities/README.md#06-scope-and-draft) | Create, Update | Prepare the edit worktree, enumerate and confirm the file manifest, author every file it names, align the target README and the planning artifacts |
 | 08 | [**Quality Review**](./activities/README.md#08-quality-review) | All | One criteria walk per target over its own surface and its consumer surface, plus the repository's definition guards against the tree the run edits |
+| 09 | [**Validate and Commit**](./activities/README.md#09-validate-and-commit) | All | Re-derive the findings independently, gate the disposition, re-verify scope, then commit, publish and close out |
 
 **Detailed documentation:**
 
@@ -50,11 +51,11 @@ The audit criteria this workflow applies — the anti-pattern catalog, the desig
 
 In create and update modes the workflow seeds a **planning folder** under `.engineering/artifacts/planning/`: a `README.md` from the universal [planning-readme](../meta/resources/planning-readme.md) Template under this workflow's [readme-seed](./resources/readme-seed.md) profile, plus the planning artifacts each activity persists as numbered files via [`work-package::manage-artifacts::write-artifact`](../work-package/techniques/manage-artifacts/write-artifact.md).
 
-**Create mode:** a change brief recording the design surface and any judgement left open, a confirmed scope manifest, and the enumerated definition files authored under `{target_path}`.
+**Create mode:** a change brief, a confirmed scope manifest, the enumerated definition files authored under `{target_path}`, a findings register, and — once the commit gate approves — a commit on the run's branch, a non-draft pull request against `workflows`, and a `COMPLETE.md` close-out.
 
 **Update mode:** the same, plus an impact analysis whose removals inventory has been approved, and a per-file check that no reduction reaches the tree unaccounted for.
 
-**Review mode:** no planning folder is seeded and no worktree is created; the edit-surface path is still derived, so every guard a review run invokes reads the tree the run targets.
+**Review mode:** the findings register is the run's terminal record. No planning folder is seeded, no worktree is created, nothing is committed and no close-out is written — the commit gate is mode-gated away. The edit-surface path is still derived, so every guard a review run invokes reads the tree the run targets. A review run may escalate to update mode against one narrowed target instead of closing.
 
 ---
 
@@ -68,7 +69,8 @@ workflows/workflow-authoring/
 │   ├── README.md                           # Per-activity orientation map
 │   ├── 01-intake-and-context.yaml          # Classify mode and target, derive edit surface, change brief
 │   ├── 06-scope-and-draft.yaml             # Worktree, file manifest, per-file drafting, artifact alignment
-│   └── 08-quality-review.yaml              # Per-target criteria walk, consumer surface, definition guards
+│   ├── 08-quality-review.yaml              # Per-target criteria walk, consumer surface, definition guards
+│   └── 09-validate-and-commit.yaml         # Independent re-derivation, disposition, commit, publish, close out
 ├── techniques/
 │   ├── README.md                           # Technique orientation map
 │   ├── TECHNIQUE.md                        # Shared inputs and authoring invariants
@@ -89,13 +91,21 @@ workflows/workflow-authoring/
 │       ├── reload-workflow.md
 │       ├── resolve-consumer-surface.md
 │       ├── audit-canon.md
-│       └── audit-schema-validation.md
+│       ├── audit-schema-validation.md
+│       ├── apply-audit-fixes.md
+│       ├── verify-high-findings.md
+│       ├── compile-report.md
+│       ├── scope-verification.md
+│       ├── compose-publication.md
+│       ├── commit-verification.md
+│       └── create-completion-doc.md
 └── resources/
     ├── README.md                           # Resource index and artifact-to-guide map
     ├── change-brief.md                     # Creation guide
     ├── impact-analysis.md                  # Creation guide
     ├── scope-manifest.md                   # Creation guide
     ├── findings-register.md                # Creation guide, section-delivered
+    ├── completion-artifact.md               # Creation guide, the run's terminal record
     ├── elicitation-guide.md                # Mode dimension sets and question bank
     ├── update-mode-guide.md                # Change-category vocabulary
     └── readme-seed.md                      # Progress inventory and mode map for the planning README

--- a/workflow-authoring/README.md
+++ b/workflow-authoring/README.md
@@ -12,6 +12,7 @@ Activity `#` columns match the on-disk `NN-` file prefixes; the prefix is server
 |---|----------|------|---------|
 | 01 | [**Intake and Context**](./activities/README.md#01-intake-and-context) | All | Classify create/update/review, name the target, derive the edit surface, produce the change brief and approve inventoried removals |
 | 06 | [**Scope and Draft**](./activities/README.md#06-scope-and-draft) | Create, Update | Prepare the edit worktree, enumerate and confirm the file manifest, author every file it names, align the target README and the planning artifacts |
+| 08 | [**Quality Review**](./activities/README.md#08-quality-review) | All | One criteria walk per target over its own surface and its consumer surface, plus the repository's definition guards against the tree the run edits |
 
 **Detailed documentation:**
 
@@ -66,7 +67,8 @@ workflows/workflow-authoring/
 ├── activities/
 │   ├── README.md                           # Per-activity orientation map
 │   ├── 01-intake-and-context.yaml          # Classify mode and target, derive edit surface, change brief
-│   └── 06-scope-and-draft.yaml             # Worktree, file manifest, per-file drafting, artifact alignment
+│   ├── 06-scope-and-draft.yaml             # Worktree, file manifest, per-file drafting, artifact alignment
+│   └── 08-quality-review.yaml              # Per-target criteria walk, consumer surface, definition guards
 ├── techniques/
 │   ├── README.md                           # Technique orientation map
 │   ├── TECHNIQUE.md                        # Shared inputs and authoring invariants
@@ -82,12 +84,18 @@ workflows/workflow-authoring/
 │       ├── yaml-authoring.md
 │       ├── review-drafted-file.md
 │       ├── readme-authoring.md
-│       └── verify-artifact-conforms.md
+│       ├── verify-artifact-conforms.md
+│       ├── load-known-findings.md
+│       ├── reload-workflow.md
+│       ├── resolve-consumer-surface.md
+│       ├── audit-canon.md
+│       └── audit-schema-validation.md
 └── resources/
     ├── README.md                           # Resource index and artifact-to-guide map
     ├── change-brief.md                     # Creation guide
     ├── impact-analysis.md                  # Creation guide
     ├── scope-manifest.md                   # Creation guide
+    ├── findings-register.md                # Creation guide, section-delivered
     ├── elicitation-guide.md                # Mode dimension sets and question bank
     ├── update-mode-guide.md                # Change-category vocabulary
     └── readme-seed.md                      # Progress inventory and mode map for the planning README

--- a/workflow-authoring/README.md
+++ b/workflow-authoring/README.md
@@ -11,6 +11,7 @@ Activity `#` columns match the on-disk `NN-` file prefixes; the prefix is server
 | # | Activity | Mode | Purpose |
 |---|----------|------|---------|
 | 01 | [**Intake and Context**](./activities/README.md#01-intake-and-context) | All | Classify create/update/review, name the target, derive the edit surface, produce the change brief and approve inventoried removals |
+| 06 | [**Scope and Draft**](./activities/README.md#06-scope-and-draft) | Create, Update | Prepare the edit worktree, enumerate and confirm the file manifest, author every file it names, align the target README and the planning artifacts |
 
 **Detailed documentation:**
 
@@ -48,9 +49,9 @@ The audit criteria this workflow applies — the anti-pattern catalog, the desig
 
 In create and update modes the workflow seeds a **planning folder** under `.engineering/artifacts/planning/`: a `README.md` from the universal [planning-readme](../meta/resources/planning-readme.md) Template under this workflow's [readme-seed](./resources/readme-seed.md) profile, plus the planning artifacts each activity persists as numbered files via [`work-package::manage-artifacts::write-artifact`](../work-package/techniques/manage-artifacts/write-artifact.md).
 
-**Create mode:** a change brief recording the design surface and any judgement left open.
+**Create mode:** a change brief recording the design surface and any judgement left open, a confirmed scope manifest, and the enumerated definition files authored under `{target_path}`.
 
-**Update mode:** a change brief plus an impact analysis whose removals inventory has been approved.
+**Update mode:** the same, plus an impact analysis whose removals inventory has been approved, and a per-file check that no reduction reaches the tree unaccounted for.
 
 **Review mode:** no planning folder is seeded and no worktree is created; the edit-surface path is still derived, so every guard a review run invokes reads the tree the run targets.
 
@@ -64,7 +65,8 @@ workflows/workflow-authoring/
 ├── README.md                               # This file
 ├── activities/
 │   ├── README.md                           # Per-activity orientation map
-│   └── 01-intake-and-context.yaml          # Classify mode and target, derive edit surface, change brief
+│   ├── 01-intake-and-context.yaml          # Classify mode and target, derive edit surface, change brief
+│   └── 06-scope-and-draft.yaml             # Worktree, file manifest, per-file drafting, artifact alignment
 ├── techniques/
 │   ├── README.md                           # Technique orientation map
 │   ├── TECHNIQUE.md                        # Shared inputs and authoring invariants
@@ -74,11 +76,18 @@ workflows/workflow-authoring/
 │       ├── intake-classification.md
 │       ├── elicit-change-brief.md
 │       ├── synthesize-change-brief.md
-│       └── impact-analysis.md
+│       ├── impact-analysis.md
+│       ├── derive-workflow-branch.md
+│       ├── scope-definition.md
+│       ├── yaml-authoring.md
+│       ├── review-drafted-file.md
+│       ├── readme-authoring.md
+│       └── verify-artifact-conforms.md
 └── resources/
     ├── README.md                           # Resource index and artifact-to-guide map
     ├── change-brief.md                     # Creation guide
     ├── impact-analysis.md                  # Creation guide
+    ├── scope-manifest.md                   # Creation guide
     ├── elicitation-guide.md                # Mode dimension sets and question bank
     ├── update-mode-guide.md                # Change-category vocabulary
     └── readme-seed.md                      # Progress inventory and mode map for the planning README

--- a/workflow-authoring/README.md
+++ b/workflow-authoring/README.md
@@ -1,0 +1,85 @@
+# Workflow Authoring Workflow
+
+> v1.0.0 — Guides agents through creating, updating, or reviewing workflow definitions. Intent is derived from the request first, so a gate is presented only where a real gap remains; `{headless_mode}` defaults to true, and a checkpoint declaring neither a default option nor an auto-advance interval always waits for a person. Create and update runs edit inside a dedicated `{target_path}` worktree.
+
+---
+
+## Overview
+
+Activity `#` columns match the on-disk `NN-` file prefixes; the prefix is server-computed from the filename and orders both activities and the artifacts they produce, so gaps are intentional and renumbering is not free.
+
+| # | Activity | Mode | Purpose |
+|---|----------|------|---------|
+| 01 | [**Intake and Context**](./activities/README.md#01-intake-and-context) | All | Classify create/update/review, name the target, derive the edit surface, produce the change brief and approve inventoried removals |
+
+**Detailed documentation:**
+
+- **Activities:** [activities/README.md](./activities/README.md) — the per-activity orientation map, linking the authoritative YAML.
+- **Techniques:** [techniques/README.md](./techniques/README.md) — the local operation group and the shared operations this workflow binds.
+- **Resources:** [resources/README.md](./resources/README.md) — creation guides, read-guides, and where the audit criteria live.
+
+---
+
+## Modes
+
+| Mode | Activation | Description |
+|------|------------|-------------|
+| **Create** | "create a workflow", "new workflow" | Build a new workflow from a free-form description |
+| **Update** | "update workflow", "modify workflow" | Change an existing workflow, with the removals it implies inventoried and approved |
+| **Review** | "review workflow", "audit workflow" | Audit one or more existing workflows and produce a findings register |
+
+`{operation_type}` is the sole mode state. Every mode-dependent step gates on it directly; there is no second mode flag.
+
+---
+
+## Orchestration Model
+
+Inherits the meta orchestrator/worker pattern — [workflow-orchestrator](../meta/techniques/workflow-engine/workflow-orchestrator.md) and [activity-worker](../meta/techniques/workflow-engine/activity-worker.md) via [dispatch-activity](../meta/techniques/workflow-engine/dispatch-activity.md). Engine dispatch and checkpoint mechanics are not restated here.
+
+---
+
+## Criteria
+
+The audit criteria this workflow applies — the anti-pattern catalog, the design principles, the schema construct inventory and the convention checklist — are consulted by cross-workflow reference rather than copied. They currently live in [workflow-design](../workflow-design/resources/), which this workflow depends on until that tree is retired. See [resources/README.md](./resources/README.md#criteria-homes).
+
+---
+
+## Outputs
+
+In create and update modes the workflow seeds a **planning folder** under `.engineering/artifacts/planning/`: a `README.md` from the universal [planning-readme](../meta/resources/planning-readme.md) Template under this workflow's [readme-seed](./resources/readme-seed.md) profile, plus the planning artifacts each activity persists as numbered files via [`work-package::manage-artifacts::write-artifact`](../work-package/techniques/manage-artifacts/write-artifact.md).
+
+**Create mode:** a change brief recording the design surface and any judgement left open.
+
+**Update mode:** a change brief plus an impact analysis whose removals inventory has been approved.
+
+**Review mode:** no planning folder is seeded and no worktree is created; the edit-surface path is still derived, so every guard a review run invokes reads the tree the run targets.
+
+---
+
+## File Structure
+
+```
+workflows/workflow-authoring/
+├── workflow.yaml                           # Workflow definition (variables, rules, inherited techniques)
+├── README.md                               # This file
+├── activities/
+│   ├── README.md                           # Per-activity orientation map
+│   └── 01-intake-and-context.yaml          # Classify mode and target, derive edit surface, change brief
+├── techniques/
+│   ├── README.md                           # Technique orientation map
+│   ├── TECHNIQUE.md                        # Shared inputs and authoring invariants
+│   └── workflow-definition/                # Local operation group — cross-workflow addressable
+│       ├── TECHNIQUE.md                    # Group contract
+│       ├── derive-workflows-target-path.md
+│       ├── intake-classification.md
+│       ├── elicit-change-brief.md
+│       ├── synthesize-change-brief.md
+│       └── impact-analysis.md
+└── resources/
+    ├── README.md                           # Resource index and artifact-to-guide map
+    ├── change-brief.md                     # Creation guide
+    ├── impact-analysis.md                  # Creation guide
+    ├── elicitation-guide.md                # Mode dimension sets and question bank
+    ├── update-mode-guide.md                # Change-category vocabulary
+    └── readme-seed.md                      # Progress inventory and mode map for the planning README
+```

--- a/workflow-authoring/activities/01-intake-and-context.yaml
+++ b/workflow-authoring/activities/01-intake-and-context.yaml
@@ -157,7 +157,7 @@ transitions:
           variable: review_scope_confirmed
           operator: "!="
           value: true
-  - to: __terminal__
+  - to: scope-and-draft
     isDefault: true
 outcome:
   - The run carries a classified operation type and a named target, so every later gate and step can branch on derived state rather than re-reading the request

--- a/workflow-authoring/activities/01-intake-and-context.yaml
+++ b/workflow-authoring/activities/01-intake-and-context.yaml
@@ -144,6 +144,13 @@ steps:
         effect:
           setVariable:
             removals_approved: false
+  - kind: action
+    id: clear-review-seed
+    when: update_seeded_from_review == true
+    actions:
+      - action: set
+        target: update_seeded_from_review
+        value: false
 transitions:
   - to: __terminal__
     condition:
@@ -156,6 +163,18 @@ transitions:
         - type: simple
           variable: review_scope_confirmed
           operator: "!="
+          value: true
+  - to: quality-review
+    condition:
+      type: and
+      conditions:
+        - type: simple
+          variable: operation_type
+          operator: ==
+          value: review
+        - type: simple
+          variable: review_scope_confirmed
+          operator: ==
           value: true
   - to: scope-and-draft
     isDefault: true

--- a/workflow-authoring/activities/01-intake-and-context.yaml
+++ b/workflow-authoring/activities/01-intake-and-context.yaml
@@ -1,0 +1,166 @@
+id: intake-and-context
+version: 1.0.0
+name: Intake and Context
+description: "Classify the request as create, update or review, name the target, derive the edit-surface path, and produce the change brief and the change constraints the rest of the run draws on."
+required: true
+steps:
+  - kind: action
+    id: bind-planning-folder-path
+    actions:
+      - action: set
+        target: planning_folder_path
+        message: Absolute planning folder this session writes its artifacts into, as reported in the server session summary.
+  - kind: technique
+    id: derive-target-path
+    technique: workflow-definition::derive-workflows-target-path
+  - kind: technique
+    id: classify-intake
+    technique: workflow-definition::intake-classification
+    when: update_seeded_from_review != true
+  - kind: checkpoint
+    id: design-intent-batch
+    condition:
+      type: and
+      conditions:
+        - type: simple
+          variable: intent_needs_confirmation
+          operator: ==
+          value: true
+        - type: simple
+          variable: update_seeded_from_review
+          operator: "!="
+          value: true
+    message: "Design intent needs confirmation — classified `{operation_type}` for `{workflow_id}` (mode ambiguous={operation_type_ambiguous}, change_request_clear={change_request_clear})."
+    blocking: true
+    options:
+      - id: confirm-intent
+        label: Confirm classified intent
+        description: Accept the classified mode, target, and change request as stated.
+        effect:
+          setVariable:
+            intent_needs_confirmation: false
+            review_scope_confirmed: true
+      - id: confirm-create
+        label: Create a new workflow
+        description: Correct classification to create mode.
+        effect:
+          setVariable:
+            operation_type: create
+            operation_type_ambiguous: false
+            intent_needs_confirmation: false
+      - id: confirm-update
+        label: Update an existing workflow
+        description: Correct classification to update mode.
+        effect:
+          setVariable:
+            operation_type: update
+            operation_type_ambiguous: false
+            intent_needs_confirmation: false
+      - id: wrong-review-target
+        label: Wrong review target set
+        description: Rejects the review target set; supply a corrected `target_workflow_ids` list.
+        effect:
+          setVariable:
+            review_scope_confirmed: false
+      - id: cancel-as-create
+        label: Cancel update — create new instead
+        description: Abandon the update path; flip mode to create.
+        effect:
+          setVariable:
+            operation_type: create
+            operation_type_ambiguous: false
+            intent_needs_confirmation: false
+  - kind: action
+    id: announce-wrong-target
+    when: operation_type == 'review' && review_scope_confirmed != true
+    actions:
+      - action: message
+        message: "Review target set `{target_workflow_ids}` is rejected — no audit target is confirmed for this run."
+  - kind: technique
+    id: seed-planning-readme
+    technique:
+      name: workflow-engine::create-readme
+      inputs:
+        entity_context: "entity_title={workflow_id}; entity_type={operation_type}; status=Planning"
+        seed_profile: workflow-authoring/readme-seed
+    when: operation_type != 'review'
+  - kind: technique
+    id: elicit-change-brief
+    technique: workflow-definition::elicit-change-brief
+    when: operation_type == 'create'
+  - kind: technique
+    id: synthesize-change-brief
+    technique: workflow-definition::synthesize-change-brief
+    when: operation_type == 'update'
+  - kind: technique
+    id: analyze-impact
+    technique: workflow-definition::impact-analysis
+    when: operation_type == 'update'
+  - kind: technique
+    id: persist-change-brief
+    technique:
+      name: work-package::manage-artifacts::write-artifact
+      inputs:
+        bare_filename: change-brief.md
+        artifact_content: change_brief
+      outputs:
+        written_artifact: change_brief_path
+    when: operation_type != 'review'
+  - kind: technique
+    id: persist-impact-analysis
+    technique:
+      name: work-package::manage-artifacts::write-artifact
+      inputs:
+        bare_filename: impact-analysis.md
+        artifact_content: impact_analysis
+      outputs:
+        written_artifact: impact_analysis_path
+    when: operation_type == 'update'
+  - kind: action
+    id: surface-open-judgements
+    when: open_judgements_count > 0
+    actions:
+      - action: message
+        message: "{open_judgements_count} design judgements are unresolved in the [change brief]({change_brief_path})."
+  - kind: checkpoint
+    id: impact-approved
+    condition:
+      type: simple
+      variable: removal_count
+      operator: ">"
+      value: 0
+    message: "{removal_count} content removals are inventoried in the [impact analysis]({impact_analysis_path})."
+    blocking: true
+    options:
+      - id: approve-removals
+        label: Approve the inventoried removals
+        description: Accept every removal in the inventory as intentional.
+        effect:
+          setVariable:
+            removals_approved: true
+      - id: preserve-more
+        label: Preserve content instead
+        description: Reject the inventory; the manifest must preserve the flagged content.
+        effect:
+          setVariable:
+            removals_approved: false
+transitions:
+  - to: __terminal__
+    condition:
+      type: and
+      conditions:
+        - type: simple
+          variable: operation_type
+          operator: ==
+          value: review
+        - type: simple
+          variable: review_scope_confirmed
+          operator: "!="
+          value: true
+  - to: __terminal__
+    isDefault: true
+outcome:
+  - The run carries a classified operation type and a named target, so every later gate and step can branch on derived state rather than re-reading the request
+  - The edit-surface path is derived in every mode, so a guard invoked later never falls back to a checkout the run did not touch
+  - Create and update runs hold a persisted change brief; update runs additionally hold an impact classification with an approved removals inventory
+  - A rejected review target set ends the run instead of proceeding to audit content the user declined

--- a/workflow-authoring/activities/06-scope-and-draft.yaml
+++ b/workflow-authoring/activities/06-scope-and-draft.yaml
@@ -1,0 +1,122 @@
+id: scope-and-draft
+version: 1.0.0
+name: Scope and Draft
+description: "Prepare the edit worktree, enumerate the complete file manifest, author every file the manifest names, and bring the target README and the planning artifacts into line with what was drafted."
+required: true
+steps:
+  - kind: technique
+    id: derive-workflow-branch
+    technique: workflow-definition::derive-workflow-branch
+    when: operation_type != 'review'
+  - kind: technique
+    id: ensure-worktree
+    technique:
+      name: work-package::manage-git::create-worktree
+      inputs:
+        branch_name: workflow_branch
+        create_branch: true
+        component_name: workflows
+    when: operation_type != 'review'
+  - kind: technique
+    id: define-scope
+    technique: workflow-definition::scope-definition
+    when: operation_type != 'review'
+  - kind: technique
+    id: persist-scope-manifest
+    technique:
+      name: work-package::manage-artifacts::write-artifact
+      inputs:
+        bare_filename: scope-manifest.md
+        artifact_content: scope_manifest
+      outputs:
+        written_artifact: scope_manifest_path
+    when: operation_type != 'review'
+  - kind: checkpoint
+    id: scope-confirmed#{scope_round}
+    condition:
+      type: simple
+      variable: operation_type
+      operator: "!="
+      value: review
+    message: "{file_count} files are enumerated for `{workflow_id}` ([scope manifest]({scope_manifest_path}))."
+    blocking: false
+    defaultOption: confirmed
+    autoAdvanceMs: 30000
+    options:
+      - id: confirmed
+        label: Manifest is complete and correct
+        description: Every file the change touches is enumerated, and the drafting order holds.
+        effect:
+          setVariable:
+            scope_manifest_confirmed: true
+      - id: revise
+        label: Manifest needs revising
+        description: A file is missing, misclassified or wrongly in scope; re-enumerate before drafting.
+        effect:
+          setVariable:
+            scope_manifest_confirmed: false
+          transitionTo: scope-and-draft
+  - kind: action
+    id: bump-scope-round
+    when: operation_type != 'review' && scope_manifest_confirmed != true
+    actions:
+      - action: set
+        target: scope_round
+        message: The next scope-confirmation round for this run, one higher than the round just answered.
+  - kind: loop
+    id: file-drafting-loop
+    name: File Drafting Loop
+    loopType: forEach
+    variable: current_file
+    over: scope_manifest
+    maxIterations: 50
+    when: scope_manifest_confirmed == true
+    steps:
+      - kind: technique
+        id: author-yaml
+        technique: workflow-definition::yaml-authoring
+      - kind: technique
+        id: review-file
+        technique: workflow-definition::review-drafted-file
+      - kind: checkpoint
+        id: preservation-check#{current_file.path}
+        condition:
+          type: simple
+          variable: has_unflagged_removals
+          operator: ==
+          value: true
+        message: "The draft of `{current_file.path}` removes content the [impact analysis]({impact_analysis_path}) does not account for."
+        blocking: true
+        options:
+          - id: flag-and-proceed
+            label: Removal is intentional
+            description: Record the removal against the inventory and keep the draft as written.
+            effect:
+              setVariable:
+                removal_disposition: flagged
+          - id: restore-content
+            label: Restore the content
+            description: The content must survive; re-author the file preserving it.
+            effect:
+              setVariable:
+                removal_disposition: restored
+      - kind: technique
+        id: apply-removal-disposition
+        technique: workflow-definition::yaml-authoring
+        when: has_unflagged_removals == true && removal_disposition == 'restored'
+  - kind: technique
+    id: author-workflow-readme
+    technique: workflow-definition::readme-authoring
+    when: operation_type != 'review' && scope_manifest_confirmed == true
+  - kind: technique
+    id: verify-planning-artifacts
+    technique: workflow-definition::verify-artifact-conforms
+    when: operation_type != 'review' && scope_manifest_confirmed == true
+transitions:
+  - to: __terminal__
+    isDefault: true
+outcome:
+  - Create and update runs hold a dedicated worktree on their own branch, so no edit lands in the shared library checkout
+  - The complete set of files the change touches is enumerated and confirmed before any of them is written
+  - Every enumerated file is authored against the schema its kind selects, and a reduction no inventory accounts for is surfaced for a decision rather than committed quietly
+  - The target README and the planning artifacts state what the tree actually contains

--- a/workflow-authoring/activities/06-scope-and-draft.yaml
+++ b/workflow-authoring/activities/06-scope-and-draft.yaml
@@ -113,7 +113,7 @@ steps:
     technique: workflow-definition::verify-artifact-conforms
     when: operation_type != 'review' && scope_manifest_confirmed == true
 transitions:
-  - to: __terminal__
+  - to: quality-review
     isDefault: true
 outcome:
   - Create and update runs hold a dedicated worktree on their own branch, so no edit lands in the shared library checkout

--- a/workflow-authoring/activities/08-quality-review.yaml
+++ b/workflow-authoring/activities/08-quality-review.yaml
@@ -5,6 +5,20 @@ description: "Walk every criteria home against each target's definition surface 
 required: true
 steps:
   - kind: technique
+    id: author-fixes
+    technique:
+      name: workflow-definition::yaml-authoring
+      inputs:
+        selected_findings: verified_findings
+    when: remediation_round > 0
+  - kind: technique
+    id: record-fixes
+    technique:
+      name: workflow-definition::apply-audit-fixes
+      inputs:
+        selected_findings: verified_findings
+    when: remediation_round > 0
+  - kind: technique
     id: load-known-findings
     technique: workflow-definition::load-known-findings
   - kind: technique
@@ -38,7 +52,7 @@ steps:
             target: register_sections
             message: "This target's register section appended to the sections already gathered: `{target_workflow_id}` with `{audit_findings}`, the divergences in `{coverage_ledger}`, and `{fail_count}`. Appends; never replaces a prior target's section."
 transitions:
-  - to: __terminal__
+  - to: validate-and-commit
     isDefault: true
 outcome:
   - Every criteria home is walked once per target against the working tree, so a finding is attributed to this change rather than to the catalogue it came from

--- a/workflow-authoring/activities/08-quality-review.yaml
+++ b/workflow-authoring/activities/08-quality-review.yaml
@@ -1,0 +1,47 @@
+id: quality-review
+version: 1.0.0
+name: Quality Review
+description: "Walk every criteria home against each target's definition surface in one pass, extend that walk to the references other workflows hold into the target, and run the repository's definition guards against the tree the run edits."
+required: true
+steps:
+  - kind: technique
+    id: load-known-findings
+    technique: workflow-definition::load-known-findings
+  - kind: technique
+    id: survey-reference-workflows
+    technique:
+      name: workflow-engine::list-workflows
+      outputs:
+        workflow_catalog: reference_workflows
+  - kind: loop
+    id: target-sweep-loop
+    name: Target Sweep Loop
+    loopType: forEach
+    variable: target_workflow_id
+    over: target_workflow_ids
+    maxIterations: 20
+    steps:
+      - kind: technique
+        id: rebind-target-baseline
+        technique: workflow-definition::reload-workflow
+      - kind: technique
+        id: resolve-consumer-surface
+        technique: workflow-definition::resolve-consumer-surface
+      - kind: technique
+        id: sweep-canon
+        technique: workflow-definition::audit-canon
+      - kind: technique
+        id: validate-schema
+        technique: workflow-definition::audit-schema-validation
+        actions:
+          - action: set
+            target: register_sections
+            message: "This target's register section appended to the sections already gathered: `{target_workflow_id}` with `{audit_findings}`, the divergences in `{coverage_ledger}`, and `{fail_count}`. Appends; never replaces a prior target's section."
+transitions:
+  - to: __terminal__
+    isDefault: true
+outcome:
+  - Every criteria home is walked once per target against the working tree, so a finding is attributed to this change rather than to the catalogue it came from
+  - A violation reachable only through another workflow's reference into the target is reachable, because the consumer surface is part of what the walk covers
+  - Every enumeration unit the walk could not apply is recorded with the reason, so absent coverage is visible rather than indistinguishable from a clean result
+  - The definition guards run against the tree this run edits, not against a checkout it never touched

--- a/workflow-authoring/activities/09-validate-and-commit.yaml
+++ b/workflow-authoring/activities/09-validate-and-commit.yaml
@@ -1,0 +1,202 @@
+id: validate-and-commit
+version: 1.0.0
+name: Validate and Commit
+description: "Re-derive the high-severity findings independently, persist the register, take the operator's disposition, then re-verify scope, commit, publish and close out. Terminal."
+required: true
+steps:
+  - kind: technique
+    id: verify-audit-findings
+    technique: workflow-definition::verify-high-findings
+  - kind: technique
+    id: compile-register
+    technique: workflow-definition::compile-report
+  - kind: technique
+    id: persist-register
+    technique:
+      name: work-package::manage-artifacts::write-artifact
+      inputs:
+        bare_filename: findings-register.md
+        artifact_content: findings_register
+      outputs:
+        written_artifact: report_path
+  - kind: checkpoint
+    id: review-disposition
+    condition:
+      type: simple
+      variable: operation_type
+      operator: ==
+      value: review
+    message: "{open_finding_count} findings are open across {target_workflow_ids} ([findings register]({report_path}))."
+    blocking: true
+    options:
+      - id: fix-issues
+        label: Fix the findings
+        description: Escalate to update mode against one escalated target; supply a corrected `target_workflow_ids` holding only that target.
+        effect:
+          setVariable:
+            operation_type: update
+            update_seeded_from_review: true
+          transitionTo: intake-and-context
+      - id: report-only
+        label: Close on the register
+        description: The register is the run's terminal record; make no changes.
+        effect:
+          setVariable:
+            review_closed: true
+  - kind: checkpoint
+    id: audit-disposition#{remediation_round}
+    condition:
+      type: or
+      conditions:
+        - type: simple
+          variable: has_critical_finding
+          operator: ==
+          value: true
+        - type: simple
+          variable: open_finding_count
+          operator: ">"
+          value: 0
+    message: "{open_finding_count} findings are open, critical={has_critical_finding}, blocked units={has_coverage_gap}, files failing validation={fail_count} ([findings register]({report_path}))."
+    blocking: true
+    options:
+      - id: remediate
+        label: Remediate before attesting
+        description: Return to the sweep and apply the fixes the re-derived findings prescribe.
+        effect:
+          setVariable:
+            remediation_selected: true
+          transitionTo: quality-review
+      - id: accept-and-record
+        label: Accept the findings as recorded
+        description: The open findings stand as recorded in the register; proceed to attestation.
+        effect:
+          setVariable:
+            remediation_selected: false
+            has_critical_finding: false
+  - kind: action
+    id: bump-remediation-round
+    when: remediation_selected == true
+    actions:
+      - action: set
+        target: remediation_round
+        message: The next remediation round for this run, one higher than the round just answered.
+  - kind: technique
+    id: verify-scope-manifest
+    technique: workflow-definition::scope-verification
+    when: operation_type != 'review' && remediation_selected != true && review_closed != true && update_seeded_from_review != true
+  - kind: technique
+    id: verify-planning-readme
+    technique:
+      name: workflow-engine::verify-readme-conforms
+      inputs:
+        seed_profile: workflow-authoring/readme-seed
+    when: remediation_selected != true && review_closed != true && update_seeded_from_review != true
+  - kind: checkpoint
+    id: approve-to-commit#{remediation_round}
+    condition:
+      type: and
+      conditions:
+        - type: simple
+          variable: operation_type
+          operator: "!="
+          value: review
+        - type: simple
+          variable: remediation_selected
+          operator: "!="
+          value: true
+        - type: simple
+          variable: review_closed
+          operator: "!="
+          value: true
+        - type: simple
+          variable: update_seeded_from_review
+          operator: "!="
+          value: true
+    message: "{addressed_count} of {total_count} manifest entries are delivered with {unaddressed_count} outstanding, {open_finding_count} findings open, blocked units={has_coverage_gap} ([change brief]({change_brief_path}), [scope manifest]({scope_manifest_path}), [findings register]({report_path}))."
+    blocking: true
+    options:
+      - id: approved
+        label: Approved — commit and publish
+        description: The change is complete as recorded and may be committed and published.
+        effect:
+          setVariable:
+            commit_approved: true
+      - id: return-to-draft
+        label: Return to drafting
+        description: The change is not ready; re-enter drafting to revise the files.
+        effect:
+          transitionTo: scope-and-draft
+  - kind: technique
+    id: compose-publication
+    technique: workflow-definition::compose-publication
+    when: commit_approved == true && remediation_selected != true && review_closed != true && update_seeded_from_review != true
+  - kind: technique
+    id: stage-and-commit
+    technique:
+      name: version-control::commit-regular-files
+      inputs:
+        branch: workflow_branch
+    when: commit_approved == true && remediation_selected != true && review_closed != true && update_seeded_from_review != true
+  - kind: technique
+    id: verify-commit
+    technique: workflow-definition::commit-verification
+    when: commit_approved == true && remediation_selected != true && review_closed != true && update_seeded_from_review != true
+  - kind: technique
+    id: push-branch
+    technique:
+      name: version-control::push-branch
+      inputs:
+        repo_path: target_path
+        branch: workflow_branch
+        remote_name: origin
+    when: commit_approved == true && remediation_selected != true && review_closed != true && update_seeded_from_review != true
+  - kind: technique
+    id: open-pr
+    technique:
+      name: github-cli-protocol::create-pr
+      inputs:
+        repo_path: target_path
+        branch: workflow_branch
+        base_branch: workflows
+        as_draft: false
+    when: commit_approved == true && remediation_selected != true && review_closed != true && update_seeded_from_review != true
+  - kind: technique
+    id: compose-close-out
+    technique: workflow-definition::create-completion-doc
+    when: commit_approved == true && remediation_selected != true && review_closed != true && update_seeded_from_review != true
+  - kind: technique
+    id: persist-close-out
+    technique:
+      name: work-package::manage-artifacts::write-artifact
+      inputs:
+        bare_filename: COMPLETE.md
+        artifact_content: completion_document
+    when: commit_approved == true && remediation_selected != true && review_closed != true && update_seeded_from_review != true
+  - kind: technique
+    id: remove-worktree
+    technique:
+      name: work-package::manage-git::remove-worktree
+      inputs:
+        component_name: workflows
+    when: worktree_created == true && commit_approved == true && remediation_selected != true && review_closed != true && update_seeded_from_review != true
+transitions:
+  - to: quality-review
+    condition:
+      type: and
+      conditions:
+        - type: simple
+          variable: remediation_selected
+          operator: ==
+          value: true
+        - type: simple
+          variable: remediation_round
+          operator: "<"
+          value: 3
+  - to: __terminal__
+    isDefault: true
+outcome:
+  - Every high-severity finding is re-derived independently before it drives an edit, so a finding that cannot be reproduced never reaches remediation
+  - The register is the run's durable audit record, and a review run terminates on it with nothing committed
+  - Scope is re-verified in both directions before the commit gate, not after it
+  - A remediation round leaves the worktree, the branch and the register intact, because nothing past the disposition runs until the round that resolves it
+  - A committed change is published as a non-draft pull request with a close-out that states delivery, limitations and what the run itself taught

--- a/workflow-authoring/activities/README.md
+++ b/workflow-authoring/activities/README.md
@@ -20,4 +20,12 @@ Definition: [`01-intake-and-context.yaml`](./01-intake-and-context.yaml). Leads 
 
 Prepares a dedicated worktree on the run's own branch, so no edit lands in the shared library checkout. Enumerates the complete set of files the change touches and holds that manifest at a soft gate before anything is written; revising the manifest re-enters the activity rather than continuing into drafting. Then authors each enumerated file against the schema its kind selects, and stops on any reduction the removals inventory does not account for so the operator disposes of it. Closes by bringing the target README and the planning artifacts into line with what was drafted. Skipped whole in review mode: every step is either mode-gated or gated on a manifest confirmation a review run never reaches.
 
-Definition: [`06-scope-and-draft.yaml`](./06-scope-and-draft.yaml).
+Definition: [`06-scope-and-draft.yaml`](./06-scope-and-draft.yaml). Leads to [Quality Review](#08-quality-review).
+
+---
+
+### 08. Quality Review
+
+Runs in every mode. Loads the exclusions a prior pass accepted, takes the library catalog as the reference set, then sweeps each target in scope: resolves that target's current surface and the base ref its change is measured against, resolves the references other workflows hold into it, walks every criteria home against both surfaces in a single pass, and runs the repository's definition guards against the tree the run edits. A create or update run sweeps its one target; a review run sweeps each named target in turn, accumulating a register section per target.
+
+Definition: [`08-quality-review.yaml`](./08-quality-review.yaml).

--- a/workflow-authoring/activities/README.md
+++ b/workflow-authoring/activities/README.md
@@ -28,4 +28,16 @@ Definition: [`06-scope-and-draft.yaml`](./06-scope-and-draft.yaml). Leads to [Qu
 
 Runs in every mode. Loads the exclusions a prior pass accepted, takes the library catalog as the reference set, then sweeps each target in scope: resolves that target's current surface and the base ref its change is measured against, resolves the references other workflows hold into it, walks every criteria home against both surfaces in a single pass, and runs the repository's definition guards against the tree the run edits. A create or update run sweeps its one target; a review run sweeps each named target in turn, accumulating a register section per target.
 
-Definition: [`08-quality-review.yaml`](./08-quality-review.yaml).
+On a remediation round it also applies the fixes the re-derived findings prescribe and records what changed, before sweeping again.
+
+Definition: [`08-quality-review.yaml`](./08-quality-review.yaml). Leads to [Validate and Commit](#09-validate-and-commit).
+
+---
+
+### 09. Validate and Commit
+
+Terminal. Re-derives every high-severity finding independently, refuting by default, so a finding that cannot be reproduced from the construct it cites never drives an edit. Persists the register, then takes the operator's disposition: a review run closes on the register or escalates to update mode against one narrowed target; a create or update run either remediates and returns to the sweep, or accepts the findings as recorded. Past the disposition it re-verifies scope in both directions, gates the commit, then commits, publishes a non-draft pull request, writes the close-out and tears the worktree down.
+
+Everything past the disposition is suppressed on any path that has chosen to go back, because a recorded transition does not itself move the run. A remediation round therefore leaves the worktree, the branch and the register intact for the round that resolves it.
+
+Definition: [`09-validate-and-commit.yaml`](./09-validate-and-commit.yaml). Terminal in every mode.

--- a/workflow-authoring/activities/README.md
+++ b/workflow-authoring/activities/README.md
@@ -12,4 +12,12 @@ This file is an orientation map. Authoritative definitions live in the per-activ
 
 Classifies the request as create, update or review, names the target, and derives the edit-surface path in every mode. Create and update runs seed the planning folder and produce a change brief; update runs additionally produce an impact classification and take approval for the removals it inventories. Gate 1 fires only when intent needs confirmation, and is suppressed on a run that re-enters carrying an already-decided mode. A review run whose target set the user rejects ends here rather than proceeding to audit content the user declined.
 
-Definition: [`01-intake-and-context.yaml`](./01-intake-and-context.yaml).
+Definition: [`01-intake-and-context.yaml`](./01-intake-and-context.yaml). Leads to [Scope and Draft](#06-scope-and-draft), except on a review run whose target set was rejected, which ends here.
+
+---
+
+### 06. Scope and Draft
+
+Prepares a dedicated worktree on the run's own branch, so no edit lands in the shared library checkout. Enumerates the complete set of files the change touches and holds that manifest at a soft gate before anything is written; revising the manifest re-enters the activity rather than continuing into drafting. Then authors each enumerated file against the schema its kind selects, and stops on any reduction the removals inventory does not account for so the operator disposes of it. Closes by bringing the target README and the planning artifacts into line with what was drafted. Skipped whole in review mode: every step is either mode-gated or gated on a manifest confirmation a review run never reaches.
+
+Definition: [`06-scope-and-draft.yaml`](./06-scope-and-draft.yaml).

--- a/workflow-authoring/activities/README.md
+++ b/workflow-authoring/activities/README.md
@@ -1,0 +1,15 @@
+# Workflow Authoring Activities
+
+> Part of the [Workflow Authoring Workflow](../README.md)
+
+Heading numbers match the on-disk `NN-` file prefixes. Prefixes are sparse by design: they are the server-computed artifact prefix and the activity sort key, so a gap costs nothing and a renumber renames artifacts.
+
+This file is an orientation map. Authoritative definitions live in the per-activity YAML linked from each section below.
+
+---
+
+### 01. Intake and Context
+
+Classifies the request as create, update or review, names the target, and derives the edit-surface path in every mode. Create and update runs seed the planning folder and produce a change brief; update runs additionally produce an impact classification and take approval for the removals it inventories. Gate 1 fires only when intent needs confirmation, and is suppressed on a run that re-enters carrying an already-decided mode. A review run whose target set the user rejects ends here rather than proceeding to audit content the user declined.
+
+Definition: [`01-intake-and-context.yaml`](./01-intake-and-context.yaml).

--- a/workflow-authoring/resources/README.md
+++ b/workflow-authoring/resources/README.md
@@ -14,6 +14,7 @@ Read-guides for the design surface, and **creation guides** — Template plus Ru
 | [Impact Analysis](impact-analysis.md) | Creation guide: `impact-analysis.md` |
 | [Scope Manifest](scope-manifest.md) | Creation guide: `scope-manifest.md` |
 | [Findings Register](findings-register.md) | Creation guide: `findings-register.md`, section-delivered |
+| [Close-Out](completion-artifact.md) | Creation guide: `COMPLETE.md`, the run's single terminal record |
 | [Elicitation Guide](elicitation-guide.md) | Mode dimension sets and the per-dimension question bank |
 | [Update Mode Guide](update-mode-guide.md) | Change-request category vocabulary |
 | [README Seed](readme-seed.md) | Progress inventory, classifier and mode-exclusion map for the planning-folder `README.md` |
@@ -31,6 +32,7 @@ Every bare filename this workflow persists maps to a guide that owns its Templat
 | `impact-analysis.md` | [impact-analysis](impact-analysis.md) |
 | `scope-manifest.md` | [scope-manifest](scope-manifest.md) |
 | `findings-register.md` | [findings-register](findings-register.md) |
+| `COMPLETE.md` | [completion-artifact](completion-artifact.md) |
 
 Layout authority lives in the guide, not in the protocol of the operation that persists the file.
 
@@ -57,5 +59,6 @@ Other workflows may consult this workflow's guides by resource id:
 - `workflow-authoring/impact-analysis`
 - `workflow-authoring/scope-manifest`
 - `workflow-authoring/findings-register`
+- `workflow-authoring/completion-artifact`
 - `workflow-authoring/elicitation-guide`
 - `workflow-authoring/update-mode-guide`

--- a/workflow-authoring/resources/README.md
+++ b/workflow-authoring/resources/README.md
@@ -12,6 +12,7 @@ Read-guides for the design surface, and **creation guides** — Template plus Ru
 |----------|---------|
 | [Change Brief](change-brief.md) | Creation guide: `change-brief.md` |
 | [Impact Analysis](impact-analysis.md) | Creation guide: `impact-analysis.md` |
+| [Scope Manifest](scope-manifest.md) | Creation guide: `scope-manifest.md` |
 | [Elicitation Guide](elicitation-guide.md) | Mode dimension sets and the per-dimension question bank |
 | [Update Mode Guide](update-mode-guide.md) | Change-request category vocabulary |
 | [README Seed](readme-seed.md) | Progress inventory, classifier and mode-exclusion map for the planning-folder `README.md` |
@@ -27,6 +28,7 @@ Every bare filename this workflow persists maps to a guide that owns its Templat
 | `README.md` | [planning-readme](../../meta/resources/planning-readme.md) Template plus [readme-seed](readme-seed.md) |
 | `change-brief.md` | [change-brief](change-brief.md) |
 | `impact-analysis.md` | [impact-analysis](impact-analysis.md) |
+| `scope-manifest.md` | [scope-manifest](scope-manifest.md) |
 
 Layout authority lives in the guide, not in the protocol of the operation that persists the file.
 
@@ -51,5 +53,6 @@ Other workflows may consult this workflow's guides by resource id:
 
 - `workflow-authoring/change-brief`
 - `workflow-authoring/impact-analysis`
+- `workflow-authoring/scope-manifest`
 - `workflow-authoring/elicitation-guide`
 - `workflow-authoring/update-mode-guide`

--- a/workflow-authoring/resources/README.md
+++ b/workflow-authoring/resources/README.md
@@ -13,6 +13,7 @@ Read-guides for the design surface, and **creation guides** — Template plus Ru
 | [Change Brief](change-brief.md) | Creation guide: `change-brief.md` |
 | [Impact Analysis](impact-analysis.md) | Creation guide: `impact-analysis.md` |
 | [Scope Manifest](scope-manifest.md) | Creation guide: `scope-manifest.md` |
+| [Findings Register](findings-register.md) | Creation guide: `findings-register.md`, section-delivered |
 | [Elicitation Guide](elicitation-guide.md) | Mode dimension sets and the per-dimension question bank |
 | [Update Mode Guide](update-mode-guide.md) | Change-request category vocabulary |
 | [README Seed](readme-seed.md) | Progress inventory, classifier and mode-exclusion map for the planning-folder `README.md` |
@@ -29,6 +30,7 @@ Every bare filename this workflow persists maps to a guide that owns its Templat
 | `change-brief.md` | [change-brief](change-brief.md) |
 | `impact-analysis.md` | [impact-analysis](impact-analysis.md) |
 | `scope-manifest.md` | [scope-manifest](scope-manifest.md) |
+| `findings-register.md` | [findings-register](findings-register.md) |
 
 Layout authority lives in the guide, not in the protocol of the operation that persists the file.
 
@@ -54,5 +56,6 @@ Other workflows may consult this workflow's guides by resource id:
 - `workflow-authoring/change-brief`
 - `workflow-authoring/impact-analysis`
 - `workflow-authoring/scope-manifest`
+- `workflow-authoring/findings-register`
 - `workflow-authoring/elicitation-guide`
 - `workflow-authoring/update-mode-guide`

--- a/workflow-authoring/resources/README.md
+++ b/workflow-authoring/resources/README.md
@@ -1,0 +1,55 @@
+# Workflow Authoring Resources
+
+> Part of the [Workflow Authoring Workflow](../README.md)
+
+Read-guides for the design surface, and **creation guides** — Template plus Rules — for every planning-folder artifact this workflow persists.
+
+---
+
+## Resource index
+
+| Resource | Purpose |
+|----------|---------|
+| [Change Brief](change-brief.md) | Creation guide: `change-brief.md` |
+| [Impact Analysis](impact-analysis.md) | Creation guide: `impact-analysis.md` |
+| [Elicitation Guide](elicitation-guide.md) | Mode dimension sets and the per-dimension question bank |
+| [Update Mode Guide](update-mode-guide.md) | Change-request category vocabulary |
+| [README Seed](readme-seed.md) | Progress inventory, classifier and mode-exclusion map for the planning-folder `README.md` |
+
+---
+
+## Planning artifact to guide map
+
+Every bare filename this workflow persists maps to a guide that owns its Template.
+
+| Bare filename | Guide |
+|---------------|-------|
+| `README.md` | [planning-readme](../../meta/resources/planning-readme.md) Template plus [readme-seed](readme-seed.md) |
+| `change-brief.md` | [change-brief](change-brief.md) |
+| `impact-analysis.md` | [impact-analysis](impact-analysis.md) |
+
+Layout authority lives in the guide, not in the protocol of the operation that persists the file.
+
+---
+
+## Criteria homes
+
+The audit criteria this workflow applies are not held here. They are consulted where they already live, by cross-workflow reference, so the corpus keeps one physical copy of each:
+
+- [Anti-Patterns](../../workflow-design/resources/anti-patterns.md) — specific smell instances, Detect / Do not flag / Fix
+- [Design Principles](../../workflow-design/resources/design-principles.md) — prefer / before / only after stance
+- [Schema Construct Inventory](../../workflow-design/resources/schema-construct-inventory.md) — prose-to-construct mapping tables
+- [Convention Conformance](../../workflow-design/resources/convention-conformance.md) — reference conventions against sibling workflows
+
+Fetch these by section. `anti-patterns.md` alone exceeds the per-resource eager-delivery cap, so a whole-file reference is never bundled.
+
+---
+
+## Cross-workflow access
+
+Other workflows may consult this workflow's guides by resource id:
+
+- `workflow-authoring/change-brief`
+- `workflow-authoring/impact-analysis`
+- `workflow-authoring/elicitation-guide`
+- `workflow-authoring/update-mode-guide`

--- a/workflow-authoring/resources/change-brief.md
+++ b/workflow-authoring/resources/change-brief.md
@@ -1,0 +1,70 @@
+---
+name: change-brief
+description: Creation guide for the change-brief planning artifact — purpose, dimension captures or deltas, and open design judgements.
+metadata:
+  version: 1.0.0
+  order: 10
+---
+
+# Change Brief Guide
+
+The confirmed design surface for a create or update run. Answers: what outcome is intended, what changes per design dimension, and which judgements are still open. Canonical home for purpose, change goals and open judgements ([canonical-home map](../techniques/TECHNIQUE.md#canonical-home-map)).
+
+## Template
+
+```markdown
+# Change Brief — {short title}
+
+**Workflow:** `{workflow-id}` v{version}
+**Mode:** Create | Update
+**Date:** YYYY-MM-DD
+**Change categories:** [update runs only]
+**Change request:** [one line]
+**Baseline:** [link the baseline surface on an update run]
+
+---
+
+## Purpose
+
+[2–4 sentences: the outcome a run produces, and what this session changes about it.]
+
+| Goal | Meaning |
+|------|---------|
+| … | … |
+
+**Out of scope:** [bullets]
+
+---
+
+## Dimensions
+
+[Create: one section per dimension in the create set. Update: only the dimensions that change — an unchanged dimension is absent, not reprinted.]
+
+| Dimension | This run's shape |
+|-----------|------------------|
+| … | … |
+
+---
+
+## Open judgements
+
+| # | Judgement | Why it is open | Effect if decided either way |
+|---|-----------|----------------|------------------------------|
+| 1 | … | … | … |
+
+[Omit the section when nothing is open.]
+
+---
+
+## Confirmation ask
+
+[One line: what approving this brief commits to.]
+```
+
+## Rules
+
+- **Purpose and deltas only.** An update brief carries the dimensions that change; it does not reprint the ones that do not.
+- **Tables over narrative.** A dimension gets a row, not an essay.
+- **Own facts only.** Impact classification, the file manifest and findings live in their own homes — link them, never restate their bodies ([canonical-home map](../techniques/TECHNIQUE.md#canonical-home-map)).
+- **Name every gap.** A question the run could not settle is a row in Open judgements, not a silently chosen default.
+- **Line budget:** ~120 lines for an update; a create brief may run longer but stays delta-shaped per dimension.

--- a/workflow-authoring/resources/completion-artifact.md
+++ b/workflow-authoring/resources/completion-artifact.md
@@ -1,0 +1,64 @@
+---
+name: completion-artifact
+description: Creation guide for COMPLETE.md — the run's single terminal record, with the retrospective as a section.
+metadata:
+  version: 1.0.0
+  order: 14
+---
+
+# Close-Out Guide
+
+`COMPLETE.md` is the **single terminal artifact** of a run. It answers what was delivered, what was decided, and what is left open. There is no separate retrospective document: the retrospective on the run itself is a section here.
+
+## Template
+
+~~~~markdown
+# Workflow Authoring: [workflow-id] — Complete
+
+> [Create | Update] · [date]
+
+## Summary
+
+[2–3 sentences: what was created or what changed, and why it matters.]
+
+## What Was Delivered
+
+- **Activities:** [created / modified]
+- **Techniques:** [created / modified]
+- **Resources:** [created / modified]
+- **Variables and rules:** [notable additions]
+
+[On an update run, frame each as added, modified or removed against the prior version.]
+
+## Design Decisions
+
+[Link the artifacts holding this run's decisions. Record here only a drafting-time
+decision with no other home — context, decision, rationale, alternatives — and keep it
+short.]
+
+## Scope Outcome
+
+[Exception-only against the confirmed manifest. A manifest delivered exactly is one
+line. Rows appear only for drift: a file changed that nothing planned, or an entry
+left undelivered.]
+
+## Known Limitations and Deferrals
+
+<!-- Canonical home. Other artifacts link here; this list is not duplicated elsewhere. -->
+- **[Limitation]** — [caveat about what was delivered]
+- **[Deferred]** — [reason, and what would close it]
+
+## Run Retrospective
+
+[Prioritized, specific observations about the run itself: what cost more than it
+should have, what a gate caught or missed, what would change next time. Omit the
+section when nothing rises above noise.]
+~~~~
+
+## Rules
+
+- **What Was Delivered is concrete** — name the files produced or changed, not a summary of the kind of work done.
+- **Link, don't restate.** Decisions, scope and findings live in their own homes; this stays a short close-out.
+- **Exception-only Scope Outcome.** A table whose every row passes carries no information; only drift earns rows.
+- **Omit a null section** rather than writing that it does not apply.
+- **Line budget:** ~70 lines. A longer close-out is a sign a section belongs in its own home.

--- a/workflow-authoring/resources/elicitation-guide.md
+++ b/workflow-authoring/resources/elicitation-guide.md
@@ -1,0 +1,37 @@
+---
+name: elicitation-guide
+description: Mode dimension sets and the per-dimension question bank for eliciting a workflow specification.
+metadata:
+  version: 1.0.0
+  order: 20
+---
+
+# Elicitation Guide
+
+Question bank and mode dimension sets for settling a workflow's design surface one dimension at a time.
+
+## Mode Dimension Sets
+
+| Mode | Dimensions (order) |
+|------|--------------------|
+| **Create** | purpose → activity list → activity model → checkpoints → artifacts → variables → techniques → rules |
+| **Update** | purpose → activity list → checkpoints → artifacts → rules |
+
+The update set omits activity model, variables and techniques — those are already established on the existing workflow and change only when the request says so.
+
+## Dimensions
+
+| Dimension | Capture (settle at least) | Anchor questions |
+|-----------|---------------------------|------------------|
+| **Purpose** | Workflow purpose, target domain, value proposition | What outcome does a run produce? Who triggers it, and when? What is the value over doing it ad hoc? |
+| **Activity list** | Per-activity name, one-sentence purpose, user-interaction flag, expected artifacts | What are the phases from start to finish? What does each phase produce? Which are optional or mode-specific? |
+| **Activity model** | Activities connected by transitions from an entry activity, with any branches or rework loops | Is the flow linear, or are there branches and rework loops? What is the entry activity? What are the terminal conditions? |
+| **Checkpoints** | Per-activity decision points — question, options, and per-option recorded effect | Where must a human decide? What are the options, and what does each record or where does it route? Blocking or auto-advancing? |
+| **Artifacts** | Output files each activity leaves behind, each named by its producing operation's declared artifact | What durable outputs does a run leave? Which one is a run's terminal record? |
+| **Variables** | Run state: name, type, description, default | What state must persist across activities? What gates each branch? What is each default? |
+| **Techniques** | Capability description and binding sites; reuse shared and cross-workflow operations before authoring a local one | What operations do steps perform? Does an existing shared operation already cover it? What is genuinely new? |
+| **Rules** | Cross-activity invariants with their enforcement carrier — structural (gate, condition, transition) or guidance-only | What constraints must always hold? Which can be violated by ignoring text, and so need a structural carrier? |
+
+## Minimum Viable Elicitation
+
+For a small or well-understood workflow, settle at minimum purpose, the activity list, the checkpoints and the rules. Model, artifacts, variables and techniques can usually be derived from those four with one confirmation each.

--- a/workflow-authoring/resources/findings-register.md
+++ b/workflow-authoring/resources/findings-register.md
@@ -1,0 +1,95 @@
+---
+name: findings-register
+description: Creation guide for the findings-register planning artifact — findings rows, coverage divergences, known exclusions, sources.
+metadata:
+  version: 1.0.0
+  order: 13
+---
+
+# Findings Register Guide
+
+The audit record for a run: what the criteria walk found, which enumeration units it could not walk, and which findings a prior pass already accepted. Read by later steps of the same run as much as by a person, so its sections are one row per item rather than prose. Canonical home for audit findings ([canonical-home map](../techniques/TECHNIQUE.md#canonical-home-map)).
+
+Each section below is fetched on its own. A consumer that needs the row shape does not load the skeleton, and a consumer that needs the skeleton does not load the exclusion rules.
+
+## Template
+
+~~~~markdown
+# Findings Register — `{workflow-id}`
+
+**Date:** YYYY-MM-DD · **Mode:** Create | Update | Review
+**Base ref:** `{ref}` · **Targets:** one row per target below
+
+## Summary
+
+| Severity | Open | Known |
+|----------|-----:|------:|
+| Critical | N | N |
+| High     | N | N |
+| Medium   | N | N |
+| Low      | N | N |
+
+## Findings
+
+[One section per target swept, each holding that target's findings table.]
+
+## Coverage
+
+[Divergences only. Omit the section entirely when every unit was walked.]
+
+## Known
+
+[Findings a prior pass accepted, excluded from the decision surface. Omit when empty.]
+
+## Sources
+
+[One row per input artifact consulted, label and path. Omit when none.]
+~~~~
+
+## Findings
+
+One row per finding, in severity order — Critical, then High, Medium, Low.
+
+| Column | Carries |
+|--------|---------|
+| ID | Stable within the register, so a disposition can name a row |
+| Severity | `Critical` for a schema-invalid or structurally broken construct that must not be committed, then `High`, `Medium`, `Low` |
+| Entry | The criteria entry by its kebab-case name — never a bare historic number, and never the catalogue's entry count |
+| Location | File and field, at the depth the entry's evidence sits |
+| Evidence | The construct the entry's Detect keys on, quoted or named |
+| Origin | `diff` when the violation arrived with this change, `pre-existing` when it was already there at the base ref |
+| Known | Set when a prior pass accepted this finding's key |
+| Fix | The action the entry prescribes, in one line |
+
+A row whose Evidence column cannot name a construct is not a finding and does not belong in the table.
+
+## Coverage
+
+Divergences only. A unit walked cleanly gets no row — the absence of a row is the positive result.
+
+| Column | Carries |
+|--------|---------|
+| Home | The criteria home the unit belongs to |
+| Unit | The unit's own anchor |
+| Status | `not-applicable` with the reason it does not reach this surface, or `blocked` with what prevented the walk |
+
+Only `blocked` represents missing coverage. `not-applicable` is an evidenced negative and does not.
+
+The obligation is one row per unwalked enumeration unit of each named home. The inventory of units is not restated here — it lives in the walking operation's own first phase, which is its single home.
+
+## Known
+
+One row per finding a prior pass accepted, carrying its key and where the acceptance was recorded. Excluded from the decision surface and from the Summary's Open column, counted under Known. Omit the section when nothing is excluded.
+
+## Sources
+
+One row per input artifact the register drew on, each a label and a path. A run that consulted none omits the section.
+
+## Rules
+
+- **Rows, not prose.** Every section is one row per item; a section that would read as a narrative belongs somewhere else.
+- **No aggregate scorecard is persisted.** The Summary counts severities; the full per-unit coverage scorecard stays in-session and only its divergences land here.
+- **Omit an empty section** rather than emitting it with a "none" row.
+- **Cite entries by name.** Never a bare historic designator, and never any count of the catalogue's entries.
+- **Own facts only.** Link the artifacts the register drew on; do not restate their bodies ([canonical-home map](../techniques/TECHNIQUE.md#canonical-home-map)).
+- **Line budget:** the finding rows are the length; everything around them stays inside ~60 lines.

--- a/workflow-authoring/resources/impact-analysis.md
+++ b/workflow-authoring/resources/impact-analysis.md
@@ -1,0 +1,85 @@
+---
+name: impact-analysis
+description: Creation guide for the impact-analysis planning artifact — classification, integrity verdicts, removals inventory.
+metadata:
+  version: 1.0.0
+  order: 11
+---
+
+# Impact Analysis Guide
+
+The update-mode decision surface. Answers: what is touched, is topology intact, and which removals are intentional? Canonical home for impact classification, integrity verdicts and the removals inventory ([canonical-home map](../techniques/TECHNIQUE.md#canonical-home-map)).
+
+## Template
+
+```markdown
+# Impact Analysis — {short title}
+
+**Workflow:** `{workflow-id}` v{version}
+**Mode:** Update
+**Date:** YYYY-MM-DD
+**Change source:** [link the change brief]
+**Baseline:** [link the baseline surface]
+
+---
+
+## Summary
+
+[2–3 sentences: kind of change; topology intact or not.]
+
+**Removals inventoried:** N
+
+---
+
+## 1. Impact classification
+
+### Directly modified
+
+| File | Why |
+|------|-----|
+| `path` | one line |
+
+### Possibly touched at draft time
+
+| File | Why |
+|------|-----|
+| `path` | one line |
+
+### Unaffected
+
+[One short note: counts by category. No per-file entries.]
+
+---
+
+## 2. Integrity checks
+
+| Check | Verdict |
+|-------|---------|
+| Transitions, entry activity, reachability | Pass / Fail — [one line] |
+| Technique and resource references | Pass / Fail — [one line] |
+| Variables, checkpoint effects, step gates | Pass / Fail — [one line] |
+
+---
+
+## 3. Removals inventory
+
+| # | Location | Removed | Preserved |
+|---|----------|---------|-----------|
+| 1 | `path` or gate | what drops | what stays |
+
+[Omit the section when nothing is removed.]
+
+---
+
+## Decision ask
+
+Confirm the impact scope and the inventoried removals — or preserve instead.
+```
+
+## Rules
+
+- **No per-file entries for unaffected files** — one summary note.
+- **Every material reduction** gets a removed-versus-preserved row. A reduction no row names is unapproved.
+- **Integrity is a verdict plus one line**, not a walkthrough of the check.
+- **Own facts only.** Link the change brief and the baseline; do not restate purpose or inventory ([canonical-home map](../techniques/TECHNIQUE.md#canonical-home-map)).
+- **Line budget:** ~100 lines unless the removals inventory is long, in which case its rows are the length.

--- a/workflow-authoring/resources/readme-seed.md
+++ b/workflow-authoring/resources/readme-seed.md
@@ -1,0 +1,51 @@
+---
+name: readme-seed
+description: Workflow-authoring planning-folder README seed profile — Progress inventory, classifier vocabulary, and mode-exclusion map for create-readme.
+metadata:
+  version: 1.0.0
+  order: 22
+---
+
+# Workflow Authoring README Seed
+
+Fill data for [create-readme](../../meta/techniques/workflow-engine/create-readme.md). Layout and policy live in [Planning Folder README Guide](../../meta/resources/planning-readme.md) ([Template](../../meta/resources/planning-readme.md#template)).
+
+## Classifier
+
+Header-line kind labels: `Create`, `Update`, `Review`.
+
+Lifecycle **Status** values: `Planning`, `Drafting`, `Reviewing`, `Complete`.
+
+## Links defaults
+
+| Resource | Link shape |
+|----------|------------|
+| Target workflow | `workflows/[workflow-id]/` |
+| Related workflow | `[name](../../[related]/README.md)` |
+| PR | `[#N](https://{repo_host}/{org}/{repo}/pull/N)` |
+
+## Progress inventory
+
+| # | @ | Item | Description | Estimate | Status |
+|---|---|------|-------------|----------|--------|
+| 1 | 01 | Intake and context | Mode, target, edit-surface path | 15-30m | ⬚ |
+| 2 | 01 | [Change brief](change-brief.md) | Purpose, dimension shape, open judgements | 20-40m | ⬚ |
+| 3 | 01 | [Impact analysis](impact-analysis.md) | Blast radius, integrity, removals | 20-40m | ⊘ |
+
+Initial Status icons are from [Status vocabulary](../../meta/resources/planning-readme.md#status-vocabulary). The impact-analysis row starts cancelled/N/A because only an update run produces it.
+
+## Mode exclusion map
+
+Mode key: `{operation_type}` (`create` | `update` | `review`).
+
+### Create
+
+Leave Progress Status as authored; the impact-analysis row stays cancelled/N/A.
+
+### Update
+
+Flip the impact-analysis row from cancelled/N/A to pending. Leave the other rows as authored.
+
+### Review
+
+The planning-folder README is not seeded on a review run. When one is seeded anyway, set cancelled/N/A on every row a review run does not reach.

--- a/workflow-authoring/resources/readme-seed.md
+++ b/workflow-authoring/resources/readme-seed.md
@@ -34,6 +34,9 @@ Lifecycle **Status** values: `Planning`, `Drafting`, `Reviewing`, `Complete`.
 | 4 | 06 | Scope and draft | Worktree, manifest, per-file drafting | 30-60m | ⬚ |
 | 5 | 06 | [Scope manifest](scope-manifest.md) | File-level change inventory | 15-30m | ⬚ |
 | 6 | 08 | Quality review | Criteria walk, consumer surface, guards | 30-60m | ⬚ |
+| 7 | 09 | [Findings register](findings-register.md) | Audit record, coverage, exclusions | 15-30m | ⬚ |
+| 8 | 09 | Validate and commit | Scope re-check, commit, pull request | 20-40m | ⬚ |
+| 9 | 09 | [Close-out (COMPLETE.md)](COMPLETE.md) | Delivery, limitations, retrospective | 10-20m | ⬚ |
 
 Initial Status icons are from [Status vocabulary](../../meta/resources/planning-readme.md#status-vocabulary). The impact-analysis row starts cancelled/N/A because only an update run produces it.
 
@@ -51,4 +54,4 @@ Flip the impact-analysis row from cancelled/N/A to pending. Leave the other rows
 
 ### Review
 
-The planning-folder README is not seeded on a review run. When one is seeded anyway, set cancelled/N/A on every row a review run does not reach.
+The planning-folder README is not seeded on a review run. When one is seeded anyway, keep the quality-review and findings-register rows in scope and set cancelled/N/A on every other row — a review run commits nothing and writes no close-out.

--- a/workflow-authoring/resources/readme-seed.md
+++ b/workflow-authoring/resources/readme-seed.md
@@ -31,6 +31,8 @@ Lifecycle **Status** values: `Planning`, `Drafting`, `Reviewing`, `Complete`.
 | 1 | 01 | Intake and context | Mode, target, edit-surface path | 15-30m | ⬚ |
 | 2 | 01 | [Change brief](change-brief.md) | Purpose, dimension shape, open judgements | 20-40m | ⬚ |
 | 3 | 01 | [Impact analysis](impact-analysis.md) | Blast radius, integrity, removals | 20-40m | ⊘ |
+| 4 | 06 | Scope and draft | Worktree, manifest, per-file drafting | 30-60m | ⬚ |
+| 5 | 06 | [Scope manifest](scope-manifest.md) | File-level change inventory | 15-30m | ⬚ |
 
 Initial Status icons are from [Status vocabulary](../../meta/resources/planning-readme.md#status-vocabulary). The impact-analysis row starts cancelled/N/A because only an update run produces it.
 

--- a/workflow-authoring/resources/readme-seed.md
+++ b/workflow-authoring/resources/readme-seed.md
@@ -33,6 +33,7 @@ Lifecycle **Status** values: `Planning`, `Drafting`, `Reviewing`, `Complete`.
 | 3 | 01 | [Impact analysis](impact-analysis.md) | Blast radius, integrity, removals | 20-40m | ⊘ |
 | 4 | 06 | Scope and draft | Worktree, manifest, per-file drafting | 30-60m | ⬚ |
 | 5 | 06 | [Scope manifest](scope-manifest.md) | File-level change inventory | 15-30m | ⬚ |
+| 6 | 08 | Quality review | Criteria walk, consumer surface, guards | 30-60m | ⬚ |
 
 Initial Status icons are from [Status vocabulary](../../meta/resources/planning-readme.md#status-vocabulary). The impact-analysis row starts cancelled/N/A because only an update run produces it.
 

--- a/workflow-authoring/resources/scope-manifest.md
+++ b/workflow-authoring/resources/scope-manifest.md
@@ -1,0 +1,63 @@
+---
+name: scope-manifest
+description: Creation guide for the scope-manifest planning artifact — file table, structural design, drafting order.
+metadata:
+  version: 1.0.0
+  order: 12
+---
+
+# Scope Manifest Guide
+
+The file-level decision surface for a create or update run. Answers: which files, what structural shape, and in what order are they drafted? Canonical home for the file manifest, the structural design and the drafting order ([canonical-home map](../techniques/TECHNIQUE.md#canonical-home-map)).
+
+## Template
+
+~~~~markdown
+# Scope Manifest — {short title}
+
+**Target:** `{workflow-id}` v{version} · **Mode:** Create | Update
+**Basis:** [link the change brief] · [link the impact analysis on an update run]
+**Edit surface:** `{path}` — present and on the run's branch, or not
+
+[One line: how many files are created, modified, removed.] Preserved instead of removed: [count, on an update run].
+
+---
+
+## File manifest
+
+| # | Path (under `{workflow-id}/`) | Kind | Action | One-line change |
+|---|-------------------------------|------|--------|-----------------|
+| 1 | `…` | activity \| technique \| resource \| readme \| root | create \| modify \| remove | … |
+
+**Out of scope this pass:** [bullets]
+
+---
+
+## Structural design
+
+```
+{workflow-id}/   # the tree, or an explicit "unchanged"
+├── …
+```
+
+**Flow:** [one line when the topology is unchanged; otherwise a short transition note]
+
+| Convention | This change |
+|------------|-------------|
+| … | … |
+
+---
+
+## Drafting order
+
+1. **Tier** — [one-line rationale]
+2. …
+~~~~
+
+## Rules
+
+- **The file table is the payload** — structural design and drafting order stay compact beside it.
+- **Own facts only.** Link the change brief and the impact analysis; do not restate purpose or removals ([canonical-home map](../techniques/TECHNIQUE.md#canonical-home-map)).
+- **An update may declare the layout unchanged** and must still enumerate every file it touches.
+- **No implicit files.** A file the change touches and the table does not name is out of scope for the run.
+- **Line budget:** ~80 lines unless the file table is long, in which case its rows are the length.

--- a/workflow-authoring/resources/update-mode-guide.md
+++ b/workflow-authoring/resources/update-mode-guide.md
@@ -1,0 +1,23 @@
+---
+name: update-mode-guide
+description: Change-request category vocabulary for modifying an existing workflow.
+metadata:
+  version: 1.0.0
+  order: 21
+---
+
+# Update Mode Guide
+
+Vocabulary for categorising a change request against an existing workflow.
+
+## Change Categories
+
+| Category | Meaning |
+|----------|---------|
+| **Activity** | Add, modify or remove an activity |
+| **Technique** | Add, modify or remove a technique or a binding |
+| **Resource** | Add, modify or remove a resource |
+| **Metadata** | Workflow id, title, description, tags, version or similar root fields |
+| **Structural refactor** | Transitions, decisions, variables or cross-cutting shape changes with no single-file focus |
+
+A request may span more than one category; record each that applies.

--- a/workflow-authoring/techniques/README.md
+++ b/workflow-authoring/techniques/README.md
@@ -19,6 +19,12 @@ Workflow-local operations live in the [`workflow-definition`](./workflow-definit
 | [`elicit-change-brief`](./workflow-definition/elicit-change-brief.md) | Elicit a new workflow's change brief one design dimension at a time |
 | [`synthesize-change-brief`](./workflow-definition/synthesize-change-brief.md) | Assemble an existing workflow's change brief from the dimensions that change |
 | [`impact-analysis`](./workflow-definition/impact-analysis.md) | Classify impact, check integrity and inventory removals against an existing definition |
+| [`derive-workflow-branch`](./workflow-definition/derive-workflow-branch.md) | Derive the feature branch name this run's changes are committed to |
+| [`scope-definition`](./workflow-definition/scope-definition.md) | Enumerate the complete file manifest with its structural design and drafting order |
+| [`yaml-authoring`](./workflow-definition/yaml-authoring.md) | Author one manifest entry as a schema-valid definition file |
+| [`review-drafted-file`](./workflow-definition/review-drafted-file.md) | Detect content a drafted file removes that no inventory accounts for |
+| [`readme-authoring`](./workflow-definition/readme-authoring.md) | Generate or revise the target workflow's root README |
+| [`verify-artifact-conforms`](./workflow-definition/verify-artifact-conforms.md) | Correct the planning artifacts against their own guides and the canonical-home map |
 
 ## Shared operations bound by this workflow
 
@@ -29,3 +35,4 @@ Resolved directly from the named workflow — no copy is held here.
 | [`variable-binding`](../../meta/techniques/variable-binding.md) | Declared at `workflow.techniques.activity`; inherited by every activity rather than bound per step |
 | [`workflow-engine::create-readme`](../../meta/techniques/workflow-engine/create-readme.md) | Seed the planning-folder `README.md` from the universal Template under this workflow's seed profile |
 | [`work-package::manage-artifacts`](../../work-package/techniques/manage-artifacts/TECHNIQUE.md) | `write-artifact` — the numbered planning-folder artifact write |
+| [`work-package::manage-git`](../../work-package/techniques/manage-git/TECHNIQUE.md) | `create-worktree` — materialise the run's edit worktree on its own branch |

--- a/workflow-authoring/techniques/README.md
+++ b/workflow-authoring/techniques/README.md
@@ -25,6 +25,11 @@ Workflow-local operations live in the [`workflow-definition`](./workflow-definit
 | [`review-drafted-file`](./workflow-definition/review-drafted-file.md) | Detect content a drafted file removes that no inventory accounts for |
 | [`readme-authoring`](./workflow-definition/readme-authoring.md) | Generate or revise the target workflow's root README |
 | [`verify-artifact-conforms`](./workflow-definition/verify-artifact-conforms.md) | Correct the planning artifacts against their own guides and the canonical-home map |
+| [`load-known-findings`](./workflow-definition/load-known-findings.md) | Normalise the baselines and a prior register into comparable exclusion keys |
+| [`reload-workflow`](./workflow-definition/reload-workflow.md) | Resolve one target's current definition surface and the base ref its change is measured against |
+| [`resolve-consumer-surface`](./workflow-definition/resolve-consumer-surface.md) | Resolve the references other workflows hold into a target against the files this run changed |
+| [`audit-canon`](./workflow-definition/audit-canon.md) | Walk every criteria home once against a target's surface, attributing and recording coverage |
+| [`audit-schema-validation`](./workflow-definition/audit-schema-validation.md) | Run the repository's definition guards against the tree the run edits |
 
 ## Shared operations bound by this workflow
 
@@ -34,5 +39,6 @@ Resolved directly from the named workflow — no copy is held here.
 |-----------|----------|
 | [`variable-binding`](../../meta/techniques/variable-binding.md) | Declared at `workflow.techniques.activity`; inherited by every activity rather than bound per step |
 | [`workflow-engine::create-readme`](../../meta/techniques/workflow-engine/create-readme.md) | Seed the planning-folder `README.md` from the universal Template under this workflow's seed profile |
+| [`workflow-engine::list-workflows`](../../meta/techniques/workflow-engine/list-workflows.md) | The library catalog, remapped as the reference set a conformance walk compares against |
 | [`work-package::manage-artifacts`](../../work-package/techniques/manage-artifacts/TECHNIQUE.md) | `write-artifact` — the numbered planning-folder artifact write |
 | [`work-package::manage-git`](../../work-package/techniques/manage-git/TECHNIQUE.md) | `create-worktree` — materialise the run's edit worktree on its own branch |

--- a/workflow-authoring/techniques/README.md
+++ b/workflow-authoring/techniques/README.md
@@ -1,0 +1,31 @@
+# Workflow Authoring Techniques
+
+> Part of the [Workflow Authoring Workflow](../README.md)
+
+The technique library for this workflow. Each technique is one capability an activity step binds via `step.technique`; the authoritative capability, inputs, outputs, protocol and rules live in the per-technique `.md` file. This file orients — it does not restate protocols.
+
+[`TECHNIQUE.md`](./TECHNIQUE.md) holds the inputs and authoring invariants shared by every technique here, including the canonical-home map.
+
+Workflow-local operations live in the [`workflow-definition`](./workflow-definition/TECHNIQUE.md) group, so each has a `group::operation` address that another workflow can bind without copying the file.
+
+---
+
+## Local operations
+
+| Operation | Capability |
+|-----------|------------|
+| [`derive-workflows-target-path`](./workflow-definition/derive-workflows-target-path.md) | Derive the dedicated workflows edit root from the planning-folder basename |
+| [`intake-classification`](./workflow-definition/intake-classification.md) | Classify create, update or review; land the gap flags, the target set and the baseline |
+| [`elicit-change-brief`](./workflow-definition/elicit-change-brief.md) | Elicit a new workflow's change brief one design dimension at a time |
+| [`synthesize-change-brief`](./workflow-definition/synthesize-change-brief.md) | Assemble an existing workflow's change brief from the dimensions that change |
+| [`impact-analysis`](./workflow-definition/impact-analysis.md) | Classify impact, check integrity and inventory removals against an existing definition |
+
+## Shared operations bound by this workflow
+
+Resolved directly from the named workflow — no copy is held here.
+
+| Reference | Used for |
+|-----------|----------|
+| [`variable-binding`](../../meta/techniques/variable-binding.md) | Declared at `workflow.techniques.activity`; inherited by every activity rather than bound per step |
+| [`workflow-engine::create-readme`](../../meta/techniques/workflow-engine/create-readme.md) | Seed the planning-folder `README.md` from the universal Template under this workflow's seed profile |
+| [`work-package::manage-artifacts`](../../work-package/techniques/manage-artifacts/TECHNIQUE.md) | `write-artifact` — the numbered planning-folder artifact write |

--- a/workflow-authoring/techniques/README.md
+++ b/workflow-authoring/techniques/README.md
@@ -30,6 +30,13 @@ Workflow-local operations live in the [`workflow-definition`](./workflow-definit
 | [`resolve-consumer-surface`](./workflow-definition/resolve-consumer-surface.md) | Resolve the references other workflows hold into a target against the files this run changed |
 | [`audit-canon`](./workflow-definition/audit-canon.md) | Walk every criteria home once against a target's surface, attributing and recording coverage |
 | [`audit-schema-validation`](./workflow-definition/audit-schema-validation.md) | Run the repository's definition guards against the tree the run edits |
+| [`apply-audit-fixes`](./workflow-definition/apply-audit-fixes.md) | Record what a remediation round changed, per finding, with its post-edit validation result |
+| [`verify-high-findings`](./workflow-definition/verify-high-findings.md) | Re-derive every high-severity finding independently and recalibrate severity |
+| [`compile-report`](./workflow-definition/compile-report.md) | Roll the swept targets up into the run's findings register |
+| [`scope-verification`](./workflow-definition/scope-verification.md) | Check the confirmed manifest against the change set in both directions |
+| [`compose-publication`](./workflow-definition/compose-publication.md) | Compose what to stage, the commit message, and the pull-request title and body |
+| [`commit-verification`](./workflow-definition/commit-verification.md) | Confirm the commit landed with every touched file in it |
+| [`create-completion-doc`](./workflow-definition/create-completion-doc.md) | Record the run's single terminal document, retrospective included |
 
 ## Shared operations bound by this workflow
 
@@ -41,4 +48,7 @@ Resolved directly from the named workflow — no copy is held here.
 | [`workflow-engine::create-readme`](../../meta/techniques/workflow-engine/create-readme.md) | Seed the planning-folder `README.md` from the universal Template under this workflow's seed profile |
 | [`workflow-engine::list-workflows`](../../meta/techniques/workflow-engine/list-workflows.md) | The library catalog, remapped as the reference set a conformance walk compares against |
 | [`work-package::manage-artifacts`](../../work-package/techniques/manage-artifacts/TECHNIQUE.md) | `write-artifact` — the numbered planning-folder artifact write |
-| [`work-package::manage-git`](../../work-package/techniques/manage-git/TECHNIQUE.md) | `create-worktree` — materialise the run's edit worktree on its own branch |
+| [`work-package::manage-git`](../../work-package/techniques/manage-git/TECHNIQUE.md) | `create-worktree` and `remove-worktree` — materialise and tear down the run's edit worktree |
+| [`workflow-engine::verify-readme-conforms`](../../meta/techniques/workflow-engine/verify-readme-conforms.md) | Drift-check the planning-folder `README.md` against the Template and this workflow's seed profile |
+| [`meta::version-control`](../../meta/techniques/version-control/TECHNIQUE.md) | `commit-regular-files` and `push-branch` |
+| [`meta::github-cli-protocol`](../../meta/techniques/github-cli-protocol/TECHNIQUE.md) | `create-pr` — opened non-draft, because the commit gate already approved publication |

--- a/workflow-authoring/techniques/TECHNIQUE.md
+++ b/workflow-authoring/techniques/TECHNIQUE.md
@@ -1,0 +1,46 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Shared inputs and authoring invariants for every operation in this workflow.
+
+## Inputs
+
+### user_description
+
+Free-form statement of the workflow the user wants created, changed or audited.
+
+### planning_folder_path
+
+Absolute path to this run's planning folder — the write location for every planning artifact.
+
+### target_workflow_id
+
+*(optional)* Id of the workflow this run is authoring, changing or auditing.
+
+### target_workflow_ids
+
+*(optional)* Ordered list of workflow ids in scope for this run; a single-target run carries a one-element list.
+
+## Rules
+
+### single-source-and-link
+
+Every planning fact has exactly one canonical artifact. Where a second artifact needs that fact, it carries a link to the canonical home and at most a one-line pointer, never a copy of the body.
+
+### canonical-home-map
+
+No fact category below has a second canonical home.
+
+| Fact category | Canonical home |
+|---|---|
+| Purpose, change goals, open design judgements | `change-brief.md` |
+| Impact classification, integrity verdicts, removals inventory | `impact-analysis.md` |
+| Session index — progress, links, artifact pointers | `README.md` |
+
+### apply-canon-when-authoring
+
+Author definition content against [Schema Expressiveness Anti-Patterns](../../workflow-design/resources/anti-patterns.md#schema-expressiveness-anti-patterns) and [Description Hygiene Anti-Patterns](../../workflow-design/resources/anti-patterns.md#description-hygiene-anti-patterns) as write-time constraints rather than as findings a later audit recovers. Follow each entry as written; do not restate its criteria here.

--- a/workflow-authoring/techniques/TECHNIQUE.md
+++ b/workflow-authoring/techniques/TECHNIQUE.md
@@ -33,12 +33,13 @@ Every planning fact has exactly one canonical artifact. Where a second artifact 
 
 ### canonical-home-map
 
-No fact category below has a second canonical home.
+No fact category below has a second canonical home. [verify-artifact-conforms](./workflow-definition/verify-artifact-conforms.md) enforces the map.
 
 | Fact category | Canonical home |
 |---|---|
 | Purpose, change goals, open design judgements | `change-brief.md` |
 | Impact classification, integrity verdicts, removals inventory | `impact-analysis.md` |
+| File manifest, structural design, drafting order | `scope-manifest.md` |
 | Session index — progress, links, artifact pointers | `README.md` |
 
 ### apply-canon-when-authoring

--- a/workflow-authoring/techniques/TECHNIQUE.md
+++ b/workflow-authoring/techniques/TECHNIQUE.md
@@ -41,6 +41,7 @@ No fact category below has a second canonical home. [verify-artifact-conforms](.
 | Impact classification, integrity verdicts, removals inventory | `impact-analysis.md` |
 | File manifest, structural design, drafting order | `scope-manifest.md` |
 | Audit findings, coverage divergences, accepted exclusions | `findings-register.md` |
+| Delivery, limitations, deferrals, the run's own retrospective | `COMPLETE.md` |
 | Session index — progress, links, artifact pointers | `README.md` |
 
 ### apply-canon-when-authoring

--- a/workflow-authoring/techniques/TECHNIQUE.md
+++ b/workflow-authoring/techniques/TECHNIQUE.md
@@ -40,6 +40,7 @@ No fact category below has a second canonical home. [verify-artifact-conforms](.
 | Purpose, change goals, open design judgements | `change-brief.md` |
 | Impact classification, integrity verdicts, removals inventory | `impact-analysis.md` |
 | File manifest, structural design, drafting order | `scope-manifest.md` |
+| Audit findings, coverage divergences, accepted exclusions | `findings-register.md` |
 | Session index — progress, links, artifact pointers | `README.md` |
 
 ### apply-canon-when-authoring

--- a/workflow-authoring/techniques/workflow-definition/TECHNIQUE.md
+++ b/workflow-authoring/techniques/workflow-definition/TECHNIQUE.md
@@ -1,0 +1,14 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Shared contract for the operations that classify, author and audit workflow definition files.
+
+## Rules
+
+### edit-surface-is-the-evidence
+
+Definition files are read and written under `{target_path}`. The served catalog answers from the library checkout, which can lag the branch under change, so a claim taken from it is not evidence about the files this run edits.

--- a/workflow-authoring/techniques/workflow-definition/apply-audit-fixes.md
+++ b/workflow-authoring/techniques/workflow-definition/apply-audit-fixes.md
@@ -1,0 +1,33 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Durable record of what a remediation round changed, per finding, with the post-edit validation result.
+
+## Inputs
+
+### selected_findings
+
+The findings selected for repair, each naming the file, the construct and the corrective action its criteria entry prescribes.
+
+## Outputs
+
+### fixes_applied
+
+Per-finding record of the file edited, the change made, and the schema-validation result for each affected file after the edit. An entry whose finding was resolved without an edit records that instead.
+
+## Protocol
+
+### 1. Record What Changed
+
+- For each entry in `{selected_findings}`, record the file edited, the change made, and the validation result for that file after the edit
+- Record a collateral change — anything altered that no finding named — as its own line against the finding whose fix caused it, so it is visible in the durable record rather than absorbed into it
+
+## Rules
+
+### every-change-is-in-the-record
+
+A change absent from the record is a change nobody can review. Record what actually happened, including an edit that turned out wider than its finding called for, rather than the edit the finding described.

--- a/workflow-authoring/techniques/workflow-definition/audit-canon.md
+++ b/workflow-authoring/techniques/workflow-definition/audit-canon.md
@@ -1,0 +1,89 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+One walk of every criteria home against a target's definition surface, with each finding attributed against the change and each enumeration unit's coverage recorded.
+
+## Inputs
+
+### surface_files
+
+Every definition file of the target in scope for this walk.
+
+### changed_files
+
+The subset of `{surface_files}` that differs from the run's base ref.
+
+### base_ref
+
+The git ref the change is measured against.
+
+### known_finding_keys
+
+Keys of findings already accepted or baselined, each pairing a criteria entry with a location.
+
+### consumer_surface
+
+The references other workflows hold into the target, each resolved to the file it names and marked for whether this run changed it.
+
+### reference_workflows
+
+The sibling workflows whose established conventions the target is compared against.
+
+### change_constraints
+
+*(optional)* The co-change set and the identifier-collision set for this change. Absent on a run with no impact pass behind it.
+
+## Outputs
+
+### audit_findings
+
+One entry per violation: the criteria entry by its kebab-case name, the file and field it was found in, the structural evidence satisfying that entry's Detect, the fix that entry prescribes, a severity, whether the violation arrived with `{changed_files}` or pre-existed at `{base_ref}`, and whether its key was already known. Severity is `Critical` for a schema-invalid or structurally broken construct, then `High`, `Medium`, `Low`.
+
+### coverage_ledger
+
+One row per enumeration unit walked, each carrying the unit's home, the unit's anchor, and one of three statuses. `walked` means the unit's criteria were applied to every file in scope. `not-applicable` carries the reason the unit does not reach this surface and is an evidenced negative, not a skip. `blocked` carries what prevented the walk and is the only status representing missing coverage.
+
+## Protocol
+
+### 1. Enumerate the Criteria Units
+
+- Take one enumeration unit per `##` section of each of [Design Principles](../../../workflow-design/resources/design-principles.md), [Schema Construct Inventory](../../../workflow-design/resources/schema-construct-inventory.md) and [Convention Conformance](../../../workflow-design/resources/convention-conformance.md)
+- Take the anti-pattern units from the sections below, which are that home in full. Enumerate this list rather than matching section titles by pattern: entries sit outside the family sections, and a pattern match drops them with no error, no warning and no coverage signal.
+  - [Creation Rules](../../../workflow-design/resources/anti-patterns.md#creation-rules)
+  - [Structural Anti-Patterns](../../../workflow-design/resources/anti-patterns.md#structural-anti-patterns)
+  - [Interaction Anti-Patterns](../../../workflow-design/resources/anti-patterns.md#interaction-anti-patterns)
+  - [Schema Expressiveness Anti-Patterns](../../../workflow-design/resources/anti-patterns.md#schema-expressiveness-anti-patterns)
+  - [Rule Hygiene Anti-Patterns](../../../workflow-design/resources/anti-patterns.md#rule-hygiene-anti-patterns)
+  - [Description Hygiene Anti-Patterns](../../../workflow-design/resources/anti-patterns.md#description-hygiene-anti-patterns)
+  - [Coupling Anti-Patterns](../../../workflow-design/resources/anti-patterns.md#coupling-anti-patterns)
+  - [Tool-Technique-Doc Consistency Anti-Patterns](../../../workflow-design/resources/anti-patterns.md#tool-technique-doc-consistency-anti-patterns)
+  - [Execution Anti-Patterns](../../../workflow-design/resources/anti-patterns.md#execution-anti-patterns)
+  - [Output Economy Anti-Patterns](../../../workflow-design/resources/anti-patterns.md#output-economy-anti-patterns)
+  - [Canon Hygiene Anti-Patterns](../../../workflow-design/resources/anti-patterns.md#canon-hygiene-anti-patterns)
+  - [Technique Protocol Anti-Patterns](../../../workflow-design/resources/anti-patterns.md#technique-protocol-anti-patterns)
+  - [Authoring Guidance (MR)](../../../workflow-design/resources/anti-patterns.md#authoring-guidance-mr)
+- Do not restate, summarize or number the entries a unit contains; follow each entry as written, and cite entries by their kebab-case name
+
+### 2. Walk Every Unit Against the Surface
+
+- For each unit, apply its criteria to `{surface_files}`: honour each entry's Detect, its exclusions and its Fix exactly as that entry states them
+- Take Detect from the anti-pattern and construct-inventory homes; take from the principles home only whether the authored content honours a stance, so one violation is not counted twice under two homes
+- Extend the same criteria to `{consumer_surface}` — a reference another workflow holds is part of the surface this change can break, and a violation reachable only from there is reachable
+- Compare against `{reference_workflows}` wherever a unit states its criteria relative to established sibling convention
+- When `{change_constraints}` is present, check each authored identifier against its collision set and each file against its co-change set
+- Record every violation into `{audit_findings}` and every unit's disposition into `{coverage_ledger}`, at the shapes their Output declarations state
+
+### 3. Attribute and Exclude
+
+- Attribute each finding against `{base_ref}`: a violation in a file listed in `{changed_files}` arrived with this change; one anywhere else pre-existed it
+- Mark a finding whose key appears in `{known_finding_keys}` as known and leave it out of the decision surface — recorded, not deleted, so a later pass can ask whether the acceptance still holds
+
+## Rules
+
+### structural-evidence-first
+
+A finding names the structural evidence its entry's Detect keys on — the field, shape or phrase that entry itself names — and inferred intent is never that evidence. Where an entry keys on the harness tool surface or on an authoritative bootstrap resource, the evidence is that surface read directly, not the authored claim about it. A finding that cannot point at the construct is not a finding.

--- a/workflow-authoring/techniques/workflow-definition/audit-schema-validation.md
+++ b/workflow-authoring/techniques/workflow-definition/audit-schema-validation.md
@@ -1,0 +1,47 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+The repository's definition guards run against one target, with every resolvable failure resolved.
+
+## Outputs
+
+### fail_count
+
+Number of definition files a guard rejected, counted after every resolvable failure has been resolved. Zero when the whole suite is clean against the target.
+
+## Protocol
+
+### 1. Run the Definition Guards
+
+- Each guard resolves its corpus root from `--root`, then `WORKFLOWS_DIR`, then a default relative path. Pass `--root {target_path}` so every guard reads the tree this run edits; an empty value is treated as absent and silently falls back to that default, which is a checkout the run never touched.
+- The two validators take a **positional** path and implement no `--root`:
+  - `npx tsx scripts/validate-workflow-yaml.ts {target_path}/{target_workflow_id}` — every definition file against its schema
+  - `npx tsx scripts/validate-activities.ts {target_path}` — every activity file, including resolved step-id collisions
+- The remaining guards each take `--root {target_path}`:
+  - `check-all-refs.ts` — every activity and workflow technique reference resolves through the loader
+  - `check-binding-fidelity.ts` — no new binding drift: every bound input key is declared, every read resolves to a producer, no declared output is dead, no bound op's own input is unsuppliable
+  - `check-resource-anchors.ts` — every relative resource link with an anchor resolves to a rendered heading
+  - `check-variable-model.ts` — declared defaults, existence gates and checkpoint effects are coherent with the seeded variable model
+  - `check-fragments.ts` — every fragment reference resolves, every fragment is used, and no inline body duplicates a fragment or another site
+  - `check-technique-template.ts` — every technique file follows the normative template
+  - `check-activity-technique-overlap.ts` — no activity-level technique reference duplicates a step binding
+  - `check-audience.ts` — every output declaring an agent audience carries a machine-readable artifact name
+  - `check-self-provisioned-input.ts` — no step interpolates its own set target into its own technique inputs
+  - `check-identifier-qualification.ts` — no new bare-word data identifier
+  - `check-review-mode-gating.ts` — review-reachable gates are resolvable without a person
+  - `check-stealth-isolation.ts` — no leakage path out of an isolated workflow
+
+### 2. Resolve the Failures
+
+- Record each rejection with the guard that raised it and the message it printed, then correct the definition and re-run that guard
+- A guard reporting against a committed baseline fails only on violations beyond it; a violation that is genuinely intended is recorded as a finding for disposition rather than baselined away here
+
+## Rules
+
+### guard-green-is-narrow-evidence
+
+A clean guard is evidence only for the form that guard matches. Two known blind spots stand: a resource reference in already-projected form carries no `.md` and is invisible to the anchor guard, and an unresolvable resource is skipped at delivery with no warning at all. Treat an unexplained absence in a delivered payload as a reference defect, not as an empty result.

--- a/workflow-authoring/techniques/workflow-definition/commit-verification.md
+++ b/workflow-authoring/techniques/workflow-definition/commit-verification.md
@@ -1,0 +1,15 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Confirmation that a commit on the run's edit worktree landed complete.
+
+## Protocol
+
+### 1. Verify the Commit Landed Complete
+
+- Confirm the commit exists on the branch checked out at `{target_path}`, and that every file the change created or modified is in it
+- A file the change touched and the commit omitted is the failure this check exists to catch; report it rather than committing again over it

--- a/workflow-authoring/techniques/workflow-definition/compile-report.md
+++ b/workflow-authoring/techniques/workflow-definition/compile-report.md
@@ -1,0 +1,68 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+The run's findings register, rolled up from every target swept.
+
+## Inputs
+
+### register_sections
+
+The per-target sections gathered across the sweep, each carrying a target id with its findings, its coverage divergences and its validation result.
+
+### verified_findings
+
+The recalibrated finding set, each entry marked confirmed, downgraded or withdrawn.
+
+### coverage_ledger
+
+One row per enumeration unit the walk covered, each carrying its home, its anchor and its status.
+
+### known_finding_keys
+
+Keys of findings already accepted or baselined, each pairing a criteria entry with a location.
+
+### impact_analysis_path
+
+*(optional)* Absolute path to the impact report this run produced. Absent on a run with no impact pass behind it.
+
+### fixes_applied
+
+*(optional)* The per-finding record of what a remediation round edited. Absent on a first pass.
+
+## Outputs
+
+### findings_register
+
+The register body: the severity summary, one findings section per target, the coverage divergences, the accepted exclusions and the sources consulted. Shaped by [Template](../../resources/findings-register.md#template). Read by later steps of the same run as much as by a person, so every section is one row per item rather than prose.
+
+#### artifact
+
+`findings-register.md`
+
+## Protocol
+
+### 1. Roll Up the Findings
+
+- Fold `{register_sections}` into one findings section per target, taking each row's severity, entry, location, evidence, origin and known marking from `{verified_findings}` where an entry was re-derived
+- Count the severity summary from the surviving entries, with entries keyed in `{known_finding_keys}` counted under Known rather than Open
+
+### 2. Record the Divergences and the Exclusions
+
+- Take the rows of `{coverage_ledger}` that carry `blocked` or `not-applicable` into the coverage section, and omit that section entirely when every unit was walked
+- Take the entries excluded by `{known_finding_keys}` into the known section, and omit it when nothing is excluded
+- When `{fixes_applied}` is present, record what the remediation round changed against the findings it resolved
+
+### 3. Record the Sources
+
+- Emit one sources row per input artifact the register drew on, each a label and a path, including `{impact_analysis_path}` when it is present
+- When no artifact was consulted, omit the section rather than emitting it empty
+
+## Rules
+
+### the-register-is-the-decision-surface
+
+The register carries rows a reader can act on and links to the artifacts behind them. It never embeds criteria prose, and it never restates the body of an artifact it links.

--- a/workflow-authoring/techniques/workflow-definition/compose-publication.md
+++ b/workflow-authoring/techniques/workflow-definition/compose-publication.md
@@ -1,0 +1,56 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+The publication payload for a definition change — what to stage, the commit message, and the pull-request title and body.
+
+## Inputs
+
+### scope_manifest
+
+The confirmed file manifest for this run, whose entries name every file the change touches.
+
+### change_brief
+
+The change brief for this run — purpose and the dimensions the change alters.
+
+## Outputs
+
+### paths
+
+The file paths to stage: every path `{scope_manifest}` names, resolved under the run's edit worktree, with entries the manifest records as removals included so the removal is committed rather than left in the tree.
+
+### commit_message
+
+A Conventional Commits message whose scope names the workflow the change targets and whose subject states the change in one line, taken from the brief's purpose rather than from the file list.
+
+### title
+
+Pull-request title naming the target workflow and whether the change creates or modifies it.
+
+### body
+
+Pull-request body: the change stated in a short paragraph, the manifest's entries as the file breakdown, and a link to the planning folder for the artifacts behind the change.
+
+## Protocol
+
+### 1. Resolve What to Stage
+
+- Take every entry of `{scope_manifest}` and resolve its path under the run's edit worktree into `{paths}`, keeping removal entries so the deletion is part of the commit
+
+### 2. Compose the Commit Message
+
+- Compose `{commit_message}` from the purpose in `{change_brief}`: the scope names the target workflow, and the subject states what the change does, not how many files it touched
+
+### 3. Compose the Pull-Request Payload
+
+- Compose `{title}` and `{body}`: the title names the target and the kind of change; the body states the change, breaks it down by the manifest's entries, and links the planning folder rather than restating the artifacts in it
+
+## Rules
+
+### payload-describes-the-change-not-the-diff
+
+Every field here states what the change does. A message or body assembled from the file list describes the diff a reader can already see, and says nothing about why the change exists.

--- a/workflow-authoring/techniques/workflow-definition/create-completion-doc.md
+++ b/workflow-authoring/techniques/workflow-definition/create-completion-doc.md
@@ -1,0 +1,70 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+The run's single terminal record: what was delivered, what was decided, what stays open, and what the run itself taught.
+
+## Inputs
+
+### operation_type
+
+The classified operation for the request — create, update or review.
+
+### scope_manifest
+
+The confirmed file manifest for this run, against which delivery is stated.
+
+### open_finding_count
+
+Number of findings left on the decision surface at close-out.
+
+### coverage_ledger
+
+One row per enumeration unit the criteria walk covered, each carrying its home, its anchor and its status.
+
+### removals_approved
+
+Whether the inventoried content removals were approved.
+
+## Outputs
+
+### completion_document
+
+The close-out record: what the run delivered, links to where its decisions live, the scope outcome stated as exceptions only, the limitations and deferrals it leaves behind, and the retrospective on the run itself as a section rather than a separate document. Shaped by [Template](../../resources/completion-artifact.md#template).
+
+#### artifact
+
+`COMPLETE.md`
+
+## Protocol
+
+### 1. State What Was Delivered
+
+- Name the activities, techniques, resources, variables and rules the run produced or changed, concretely — on an update run framed as added, modified or removed against the prior version
+
+### 2. Point at Where the Decisions Live
+
+- Link the artifacts holding this run's decisions and record here only a decision made during drafting that has no other home
+
+### 3. State the Scope Outcome and What Stays Open
+
+- State delivery against `{scope_manifest}` as exceptions only: a manifest delivered exactly is one line, and rows appear only for drift
+- Record the limitations and deferrals the run leaves behind, including any enumeration unit `{coverage_ledger}` shows as blocked, any finding left open by `{open_finding_count}`, and any content preserved because `{removals_approved}` was withheld
+
+### 4. Record the Retrospective on the Run
+
+- Record what the run itself taught, as a section of this document: what cost more than it should have, what a gate caught or missed, and what would change the next run
+- Omit the section when nothing rises above noise
+
+## Rules
+
+### one-terminal-document
+
+This is the run's only close-out artifact. There is no separate retrospective and no session summary beside it: a second terminal document splits the record a reader has to find.
+
+### link-rather-than-restate
+
+Delivery, links and limitations — nothing here restates an artifact it links. A close-out that reprints the decisions is the artifact that goes stale first.

--- a/workflow-authoring/techniques/workflow-definition/derive-workflow-branch.md
+++ b/workflow-authoring/techniques/workflow-definition/derive-workflow-branch.md
@@ -1,0 +1,31 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Feature branch name in the workflows repo for this run's change.
+
+## Inputs
+
+### workflow_id
+
+Id of the workflow this run authors or changes — the branch name's distinguishing segment.
+
+### operation_type
+
+The classified operation for the request — create, update or review.
+
+## Outputs
+
+### workflow_branch
+
+The feature branch this run's definition changes are committed to: `workflow/{workflow_id}`, or that name plus a short change-intent slug when the plain name already carries an unrelated change.
+
+## Protocol
+
+### 1. Derive the Branch Name
+
+- Set `{workflow_branch}` to `workflow/{workflow_id}`
+- When `{operation_type}` is `update` and a branch of that name already exists carrying a prior change, append a short change-intent slug so this run has a branch of its own

--- a/workflow-authoring/techniques/workflow-definition/derive-workflows-target-path.md
+++ b/workflow-authoring/techniques/workflow-definition/derive-workflows-target-path.md
@@ -1,0 +1,32 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Dedicated workflows edit-root path derived from the planning folder basename.
+
+## Outputs
+
+### target_path
+
+Filesystem path of this run's dedicated workflows worktree: `<checkout>/.worktrees/{basename(planning_folder_path)}/`. Its immediate children are workflow directories, so it is the value a guard's `--root` takes. Distinct from `{planning_folder_path}`, which holds planning artifacts and never holds definition files.
+
+## Protocol
+
+### 1. Extract Planning Slug
+
+- Take the basename of `{planning_folder_path}` as `{$planning_slug}` (e.g. `2026-07-18-workflow-design-universal-worktrees`)
+- Take `{$checkout_root}` as the ancestor of `{planning_folder_path}` above `.engineering/artifacts/planning/`
+
+### 2. Compose Target Path
+
+- Set `{target_path}` to `{$checkout_root}/.worktrees/{$planning_slug}/` — the gitignored feature-worktree directory nested in the checkout; never anchor it to a home directory or an install root
+- Do not bind issue-shaped naming conventions from other workflows — the planning-folder basename is the sole path segment
+
+## Rules
+
+### worktree-distinct-from-planning-folder
+
+`{target_path}` is the edit, commit and PR root; `{planning_folder_path}` is the server-owned artifact folder. Never conflate them, and never nest one inside the other.

--- a/workflow-authoring/techniques/workflow-definition/derive-workflows-target-path.md
+++ b/workflow-authoring/techniques/workflow-definition/derive-workflows-target-path.md
@@ -13,16 +13,20 @@ Dedicated workflows edit-root path derived from the planning folder basename.
 
 Filesystem path of this run's dedicated workflows worktree: `<checkout>/.worktrees/{basename(planning_folder_path)}/`. Its immediate children are workflow directories, so it is the value a guard's `--root` takes. Distinct from `{planning_folder_path}`, which holds planning artifacts and never holds definition files.
 
+### repo_root
+
+Absolute path of the checkout that contains the shared workflows library — the ancestor of `{planning_folder_path}` above its `.engineering` artifact root. The library itself is the `workflows` component under it.
+
 ## Protocol
 
 ### 1. Extract Planning Slug
 
 - Take the basename of `{planning_folder_path}` as `{$planning_slug}` (e.g. `2026-07-18-workflow-design-universal-worktrees`)
-- Take `{$checkout_root}` as the ancestor of `{planning_folder_path}` above `.engineering/artifacts/planning/`
+- Take `{repo_root}` as the ancestor of `{planning_folder_path}` above `.engineering/artifacts/planning/`
 
 ### 2. Compose Target Path
 
-- Set `{target_path}` to `{$checkout_root}/.worktrees/{$planning_slug}/` — the gitignored feature-worktree directory nested in the checkout; never anchor it to a home directory or an install root
+- Set `{target_path}` to `{repo_root}/.worktrees/{$planning_slug}/` — the gitignored feature-worktree directory nested in the checkout; never anchor it to a home directory or an install root
 - Do not bind issue-shaped naming conventions from other workflows — the planning-folder basename is the sole path segment
 
 ## Rules

--- a/workflow-authoring/techniques/workflow-definition/elicit-change-brief.md
+++ b/workflow-authoring/techniques/workflow-definition/elicit-change-brief.md
@@ -1,0 +1,45 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Change brief for a new workflow, elicited one design dimension at a time.
+
+## Outputs
+
+### change_brief
+
+The assembled change brief for a new workflow: purpose, the dimension captures the guide's create set calls for, and the judgements left open. Shaped by [Template](../../resources/change-brief.md#template).
+
+#### artifact
+
+`change-brief.md`
+
+### open_judgements_count
+
+Number of design judgements recorded as unresolved in `{change_brief}`. Zero when every dimension settled.
+
+## Protocol
+
+### 1. Select the Dimension Set
+
+- Take the create set, in its stated order, from [Mode Dimension Sets](../../resources/elicitation-guide.md#mode-dimension-sets) — do not restate or reorder the list here
+
+### 2. Capture Each Dimension
+
+- For each dimension in that order, surface the anchor questions from [Dimensions](../../resources/elicitation-guide.md#dimensions) and record the user's answers at the Capture depth that section states for the dimension
+- Omit a question already settled by an answer to an earlier dimension
+- Where an answer the user did not give would have to be invented, record the gap as an open judgement instead of choosing for them
+
+### 3. Assemble the Change Brief
+
+- Fold the captures into `{change_brief}` at the shape [Template](../../resources/change-brief.md#template) declares
+- Record each open judgement as a row of the brief's judgements table and set `{open_judgements_count}` to the number of rows
+
+## Rules
+
+### judgement-not-invention
+
+An unsettled design question is recorded as an open judgement, never resolved by picking a plausible default. A brief that reads as complete because its gaps were filled silently is worse than one that names them.

--- a/workflow-authoring/techniques/workflow-definition/impact-analysis.md
+++ b/workflow-authoring/techniques/workflow-definition/impact-analysis.md
@@ -1,0 +1,77 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Impact assessment of a proposed change against an existing workflow definition.
+
+## Inputs
+
+### change_brief
+
+The change brief for this run — purpose and the dimensions the change alters.
+
+### structural_inventory
+
+Baseline of the target's existing definition: file counts by kind, entity counts, activity ids in prefix order, and what the change touches.
+
+## Outputs
+
+### removal_count
+
+Number of distinct content removals in the inventory, counting diff-based and obsolete-file removals alike. Zero when the change is additive or string-only with no material deleted.
+
+### impact_analysis
+
+The assembled impact report: per-file classification, the integrity verdicts, and the removals inventory as removed-versus-preserved rows. Shaped by [Template](../../resources/impact-analysis.md#template).
+
+#### artifact
+
+`impact-analysis.md`
+
+## Protocol
+
+### 1. Enumerate Files
+
+- Build a full inventory of the target's files with paths and purposes: the root definition, `activities/*.yaml`, techniques (`<slug>.md` standalone, `<group>/TECHNIQUE.md` container contracts, `<group>/<op>.md` nested), `resources/*.md` and the README
+
+### 2. Classify Impact
+
+- Classify each file as unaffected, directly modified (the change explicitly affects it), indirectly affected (a side-effect such as a broken transition chain), or removed (the change makes it obsolete), with a one-line justification
+
+### 3. Check Transition Integrity
+
+- Where activities are added, removed or reordered: verify every `transitions[].to` names an existing activity id, verify `initialActivity` still names a valid activity, and verify no activity is left with no incoming transition
+
+### 4. Check Reference Integrity
+
+- Verify every `techniques[]` and `technique:` reference resolves to an existing technique file, and every resource reference to an existing resource file
+
+### 5. Check Variable Integrity
+
+- Verify every `condition.variable` in transitions, decisions, step gates and loop steps resolves to a declared variable
+- Verify every checkpoint `effect.setVariable` key resolves to a declared variable
+- Record any variable declared and never referenced
+
+### 6. Inventory Removals
+
+- Compare the planned change against the existing content and list every material removal — fewer lines, removed sections, dropped fields, obsolete files
+- Record each removal as a removed-versus-preserved pair naming what drops and what stays in that region
+- Set `{removal_count}` to the number of distinct inventoried removals
+
+### 7. Compose the Impact Report
+
+- Assemble `{impact_analysis}` from the classification, the integrity verdicts and the removals inventory, at the shape [Template](../../resources/impact-analysis.md#template) declares
+- Link the change brief for purpose and the baseline for inventory rather than restating either
+
+## Rules
+
+### content-preservation
+
+A reduction is a decision, not a side-effect of an edit. Prefer additive change, and treat a reduction that no inventory row names as unapproved regardless of how small it is.
+
+### side-effect-detection
+
+Each change class implies side-effects the change request does not state: adding an activity may need new upstream transitions, techniques or resources; removing one breaks incoming transitions and may orphan techniques; renaming an activity id breaks every transition reference and `initialActivity`; adding a checkpoint may need new variables; changing checkpoint options may invalidate downstream conditions; adding or removing a mode affects the mode variable and every gate that branches on it; changing a variable's type affects every condition comparing it.

--- a/workflow-authoring/techniques/workflow-definition/impact-analysis.md
+++ b/workflow-authoring/techniques/workflow-definition/impact-analysis.md
@@ -23,6 +23,10 @@ Baseline of the target's existing definition: file counts by kind, entity counts
 
 Number of distinct content removals in the inventory, counting diff-based and obsolete-file removals alike. Zero when the change is additive or string-only with no material deleted.
 
+### change_constraints
+
+The constraints the change surface imposes on scope: the co-change set — files that must move together for the change to stay coherent — and the identifier-collision set of names already taken in the target.
+
 ### impact_analysis
 
 The assembled impact report: per-file classification, the integrity verdicts, and the removals inventory as removed-versus-preserved rows. Shaped by [Template](../../resources/impact-analysis.md#template).
@@ -55,13 +59,17 @@ The assembled impact report: per-file classification, the integrity verdicts, an
 - Verify every checkpoint `effect.setVariable` key resolves to a declared variable
 - Record any variable declared and never referenced
 
-### 6. Inventory Removals
+### 6. Derive the Change Constraints
+
+- From the classification and the reference checks, take every set of files that must move together for the change to stay coherent, and every identifier the target already uses that a new name could collide with, as `{change_constraints}`
+
+### 7. Inventory Removals
 
 - Compare the planned change against the existing content and list every material removal — fewer lines, removed sections, dropped fields, obsolete files
 - Record each removal as a removed-versus-preserved pair naming what drops and what stays in that region
 - Set `{removal_count}` to the number of distinct inventoried removals
 
-### 7. Compose the Impact Report
+### 8. Compose the Impact Report
 
 - Assemble `{impact_analysis}` from the classification, the integrity verdicts and the removals inventory, at the shape [Template](../../resources/impact-analysis.md#template) declares
 - Link the change brief for purpose and the baseline for inventory rather than restating either

--- a/workflow-authoring/techniques/workflow-definition/intake-classification.md
+++ b/workflow-authoring/techniques/workflow-definition/intake-classification.md
@@ -1,0 +1,88 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Operation-type classification and design-intent baseline for create, update or review.
+
+## Outputs
+
+### operation_type
+
+The classified operation — sole mode state for the run:
+
+- **Review** — existing-workflow reference(s) plus an audit intent (recognition signals include "review workflow", "audit workflow", "check workflow compliance", "workflow review", "assess workflow quality", "evaluate workflow")
+- **Update** — existing-workflow reference plus a change request
+- **Create** — no existing-workflow reference
+
+### operation_type_ambiguous
+
+Boolean — true when create vs update vs review cannot be classified with certainty from the request (signals conflict or are absent); false on a clear classification.
+
+### change_request_clear
+
+Boolean — in update mode, true when the change request is specific enough to draft against without clarification; false when the request is vague or contradictory. True outside update.
+
+### intent_needs_confirmation
+
+Composite boolean — true when any of: `{operation_type_ambiguous}`; update with `{change_request_clear}` false; review with an ambiguous target set. False on the clear path.
+
+### review_scope_confirmed
+
+Boolean — true when the review target set resolves to concrete, existing workflow ids; false when review is requested against a set that cannot be resolved with certainty. False outside review.
+
+### headless_mode
+
+Boolean — default **true** (soft mid-flow gates auto-resolve); false only when `{user_description}` explicitly requests interactive soft-gate behaviour (signals include "interactive", "not headless", "with checkpoints").
+
+### workflow_id
+
+The id of the workflow being created or updated.
+
+### target_workflow_id
+
+The id of the existing workflow to modify (update), or the current audit target (review). In multi-target review this is the first id in `{target_workflow_ids}` at intake and is rebound per target; unset in create mode.
+
+### target_workflow_ids
+
+Ordered list of workflow ids in scope. One element for single-target review or for update; two or more when the request names multiple workflows. Unset in create mode.
+
+### structural_inventory
+
+Per-target baseline of the existing definition — file counts by kind, entity counts, activity ids in prefix order, and a one-line statement of what the change touches. Unset in create mode.
+
+### change_category
+
+In update mode, the categorised change request from `{user_description}`: one or more of the categories in [Change Categories](../../resources/update-mode-guide.md#change-categories). Unset otherwise.
+
+## Protocol
+
+### 1. Classify Operation
+
+- Determine `{operation_type}` per the Output criteria
+- Set `{operation_type_ambiguous}` true when classification signals conflict or are insufficient; otherwise false
+- In review mode resolve `{target_workflow_ids}` from the request and seed `{target_workflow_id}` to the first element; in update mode resolve both from the single named target; in create mode leave both unset
+- In review mode set `{review_scope_confirmed}` true when every named id resolves to an existing workflow directory, and false when no concrete id is named or the named set cannot be resolved with certainty
+
+### 2. Derive Intent Gap Flag and Headless
+
+- In update mode set `{change_request_clear}` from whether `{user_description}` states a concrete change; leave it true in create and review
+- Compute `{intent_needs_confirmation}` as true when `{operation_type_ambiguous}` is true, or update with `{change_request_clear}` false, or review with an unresolved target set; otherwise false
+- Leave `{headless_mode}` true by default; set it false only on an explicit interactive opt-out in `{user_description}`
+
+### 3. Baseline the Target Definitions
+
+- In update and review modes, enumerate each target's definition files under `{target_path}` — root definition, activity files, technique files (standalone, group index and nested), resource files and README — and derive `{structural_inventory}` from that enumeration at the shape its Output declares
+- In create mode leave `{structural_inventory}` unset
+
+### 4. Categorise the Change Request
+
+- In update mode, categorise the change `{user_description}` asks for into `{change_category}` per [Change Categories](../../resources/update-mode-guide.md#change-categories); a request spanning more than one category records each
+
+## Rules
+
+### derive-before-ask
+
+Classify mode, target and clarity from the request before asking anything. `{intent_needs_confirmation}` is the sole gap signal this operation emits; it never substitutes a guess for the flag.

--- a/workflow-authoring/techniques/workflow-definition/intake-classification.md
+++ b/workflow-authoring/techniques/workflow-definition/intake-classification.md
@@ -43,15 +43,15 @@ The id of the workflow being created or updated.
 
 ### target_workflow_id
 
-The id of the existing workflow to modify (update), or the current audit target (review). In multi-target review this is the first id in `{target_workflow_ids}` at intake and is rebound per target; unset in create mode.
+The workflow id currently in scope — the one being authored on a create run, the one being modified on an update run, or the audit target currently bound on a review run. On a multi-target review it starts as the first id in `{target_workflow_ids}` and is rebound per target.
 
 ### target_workflow_ids
 
-Ordered list of workflow ids in scope. One element for single-target review or for update; two or more when the request names multiple workflows. Unset in create mode.
+Ordered list of workflow ids in scope for this run, always holding at least one. A create or update run holds the single target; a review run holds every named audit target in request order.
 
 ### structural_inventory
 
-Per-target baseline of the existing definition — file counts by kind, entity counts, activity ids in prefix order, and a one-line statement of what the change touches. Unset in create mode.
+Per-target baseline of the existing definition — file counts by kind, entity counts, activity ids in prefix order, and a one-line statement of what the change touches. Absent on a create run, which has no existing definition.
 
 ### change_category
 
@@ -63,7 +63,7 @@ In update mode, the categorised change request from `{user_description}`: one or
 
 - Determine `{operation_type}` per the Output criteria
 - Set `{operation_type_ambiguous}` true when classification signals conflict or are insufficient; otherwise false
-- In review mode resolve `{target_workflow_ids}` from the request and seed `{target_workflow_id}` to the first element; in update mode resolve both from the single named target; in create mode leave both unset
+- In review mode resolve `{target_workflow_ids}` from the request and bind `{target_workflow_id}` to its first element; in update mode take both from the single named target; in create mode take both from the id being authored, so the list is never empty in any mode
 - In review mode set `{review_scope_confirmed}` true when every named id resolves to an existing workflow directory, and false when no concrete id is named or the named set cannot be resolved with certainty
 
 ### 2. Derive Intent Gap Flag and Headless

--- a/workflow-authoring/techniques/workflow-definition/load-known-findings.md
+++ b/workflow-authoring/techniques/workflow-definition/load-known-findings.md
@@ -1,0 +1,32 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Keys of the findings a prior pass already accepted or baselined, normalised into one comparable form.
+
+## Outputs
+
+### known_finding_keys
+
+One key per already-accepted finding, each pairing the criteria entry by its kebab-case name with the location it was recorded against, in the single form a criteria walk compares against. Empty when no baseline and no prior register carry an entry for this target.
+
+## Protocol
+
+### 1. Read the Known-Finding Sources
+
+- Read the guard baselines the repository commits under `scripts/` — binding fidelity, review-mode gating, identifier qualification and audience — taking only the entries whose location falls inside the target
+- Read the findings register a prior run of this workflow left in `{planning_folder_path}`, taking the rows it records as accepted
+
+### 2. Reduce to Comparable Keys
+
+- Reduce every entry read to a key pairing its criteria entry name with its location, discarding the shape differences between the sources so one comparison serves them all
+- Where a source names a violation class rather than a criteria entry, key it on the class and record that in the key, so a walk can tell an entry-keyed exclusion from a class-keyed one
+
+## Rules
+
+### known-is-not-absent
+
+A known finding is excluded from the decision surface, never from the record. A key that suppresses a finding must remain readable as a suppression, so a later pass can ask whether the acceptance still holds.

--- a/workflow-authoring/techniques/workflow-definition/readme-authoring.md
+++ b/workflow-authoring/techniques/workflow-definition/readme-authoring.md
@@ -1,0 +1,42 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Target workflow's root README, orienting a reader to its purpose, structure and links.
+
+## Inputs
+
+### operation_type
+
+The classified operation for the request — create, update or review.
+
+### scope_manifest
+
+The complete file manifest for this run, whose entries are the structure the README orients a reader to.
+
+## Outputs
+
+### workflow_readme
+
+The target workflow's root README: generated whole on a create run, revised in place on an update run so its activity table, modes, structure block and links match the manifest as landed.
+
+#### artifact
+
+`README.md`
+
+## Protocol
+
+### 1. Generate or Revise the README
+
+- On a create run, write `{workflow_readme}` whole
+- On an update run, revise the existing README wherever `{scope_manifest}` changes what it claims — the activity table, the mode table, the file-structure block and the links
+- Take the orientation stance from [11. Complete Documentation Structure](../../../workflow-design/resources/design-principles.md#11-complete-documentation-structure): the README points at the authoritative definitions and does not transcribe them
+
+## Rules
+
+### every-claim-re-derivable
+
+Every claim the README makes is re-derivable from the tree it ships in. A row for a construct the tree does not contain, or a count of anything, is a claim that goes stale the moment the tree moves — state the structure, never its size.

--- a/workflow-authoring/techniques/workflow-definition/reload-workflow.md
+++ b/workflow-authoring/techniques/workflow-definition/reload-workflow.md
@@ -1,0 +1,42 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Current definition surface of one target and the base ref its change is measured against.
+
+## Outputs
+
+### base_ref
+
+The git ref this run's change is measured against — the merge base between the branch under change and the workflows library's default branch.
+
+### surface_files
+
+Every definition file of the target as it stands on the branch under change: the root definition, the activity files, the technique files at every level, the resource files and the README.
+
+### changed_files
+
+The subset of `{surface_files}` that differs from `{base_ref}`. Empty when the branch has not yet touched this target, which is the ordinary case for a target under audit rather than under change.
+
+## Protocol
+
+### 1. Resolve the Base Ref
+
+- Set `{base_ref}` to the merge base between the branch checked out at `{target_path}` and the workflows library's default branch
+
+### 2. Enumerate the Definition Surface
+
+- Enumerate the target's files under `{target_path}/{target_workflow_id}` as `{surface_files}`, at every technique level — standalone, group index and nested
+
+### 3. Diff the Surface Against the Base Ref
+
+- Set `{changed_files}` to the entries of `{surface_files}` that differ from their state at `{base_ref}`
+
+## Rules
+
+### one-target-per-binding
+
+This operation resolves exactly the target `{target_workflow_id}` names. When that id is rebound across a set of targets, each binding produces the surface of its own target and nothing else — a surface carrying two targets' files cannot be attributed against a single base ref.

--- a/workflow-authoring/techniques/workflow-definition/resolve-consumer-surface.md
+++ b/workflow-authoring/techniques/workflow-definition/resolve-consumer-surface.md
@@ -1,0 +1,37 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+The references other workflows hold into one target, resolved against the files this run changed.
+
+## Inputs
+
+### changed_files
+
+The definition files of the target that differ from the run's base ref.
+
+## Outputs
+
+### consumer_surface
+
+One entry per reference another workflow holds into the target: the referencing file, the reference form it uses, the target file it resolves to, and whether that file is one this run changed. Empty when nothing outside the target references it.
+
+## Protocol
+
+### 1. Find the References Into the Target
+
+- Sweep every workflow directory other than `{target_workflow_id}` for references that resolve into it: step and activity technique binds carrying it as their leading segment, resource references qualified with it, and activity file references borrowed from it
+
+### 2. Resolve Each Reference Against the Change
+
+- For each reference, resolve the file it names inside the target and record whether that file appears in `{changed_files}`
+- A reference resolving to a changed file is a consumer this change can break, and belongs in the surface a criteria walk covers
+
+## Rules
+
+### absence-is-a-result
+
+An empty surface is a finding about reach, not a failure to look. Record that the sweep ran and found nothing rather than leaving the value unproduced, because a reader cannot tell an unproduced surface from a target nothing depends on.

--- a/workflow-authoring/techniques/workflow-definition/review-drafted-file.md
+++ b/workflow-authoring/techniques/workflow-definition/review-drafted-file.md
@@ -1,0 +1,40 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Detection of content a drafted file removes that no removals inventory accounted for.
+
+## Inputs
+
+### current_file
+
+The manifest entry just drafted — full path, action, kind and the one-line statement of its change.
+
+### yaml_file
+
+The authored file at that entry's path, as just written.
+
+### operation_type
+
+The classified operation for the request — create, update or review.
+
+### impact_analysis_path
+
+*(optional)* Absolute path to the impact report whose removals inventory the comparison is measured against. Absent on a run with no existing definition to assess, where there is nothing to compare.
+
+## Outputs
+
+### has_unflagged_removals
+
+True when `{operation_type}` is `update` and the drafted file removes material that the removals inventory does not account for; false otherwise, including whenever there is no committed content to compare against.
+
+## Protocol
+
+### 1. Compare Against Committed Content
+
+- When `{operation_type}` is `update`, diff `{yaml_file}` against the committed content at the same path and take the material it drops as the run's observed reduction
+- Read the removals inventory at `{impact_analysis_path}` and set `{has_unflagged_removals}` true for any observed reduction the inventory does not name
+- When `{operation_type}` is `create` there is no committed content and no inventory, so nothing is compared and `{has_unflagged_removals}` is false

--- a/workflow-authoring/techniques/workflow-definition/scope-definition.md
+++ b/workflow-authoring/techniques/workflow-definition/scope-definition.md
@@ -1,0 +1,68 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Complete file-level scope and structural shape for a change, as a lean manifest.
+
+## Inputs
+
+### change_brief
+
+The change brief for this run — purpose and the dimensions the change alters.
+
+### change_constraints
+
+*(optional)* The co-change set and identifier-collision set derived from an impact pass: files that must move together, and names already taken. Absent on a run with no existing definition to assess.
+
+### removals_approved
+
+Whether the inventoried content removals are approved. False means the manifest preserves the flagged content instead of removing it.
+
+## Outputs
+
+### scope_manifest
+
+The complete file manifest — one entry per file to create, modify or remove, each with its full path under the target workflow directory, its action, its kind, and a one-line statement of the change. Carries the structural design and drafting order sections alongside the table. Shaped by [Template](../../resources/scope-manifest.md#template).
+
+#### artifact
+
+`scope-manifest.md`
+
+### file_count
+
+Number of entries in `{scope_manifest}`.
+
+## Protocol
+
+### 1. Design the Folder Structure
+
+- Design the target's folder layout — the workflow directory with `activities/`, `techniques/` and `resources/` — and the file naming scheme, taking both from [Reference Conventions](../../../workflow-design/resources/convention-conformance.md#reference-conventions) rather than inventing one
+
+### 2. Enumerate the Files
+
+- Enumerate every file to create, modify or remove with its full path under `{target_path}/{workflow_id}/`: path, action, kind and a one-line statement of the change — no implicit files
+- When `{change_constraints}` is present, add every file its co-change set names, and check each new identifier against its collision set before the manifest fixes a name
+- When `{removals_approved}` is false, record the flagged content as preserved and drop the corresponding remove entries
+- Set `{file_count}` to the number of entries
+
+### 3. Assemble the Structural Design
+
+- Assemble the structural-design section the guide declares: the directory tree, or an explicit statement that the layout is unchanged; a short note wherever the transition topology changes; and a compact alignment table against the conventions — not a comparison essay
+
+### 4. Assemble the Drafting Order
+
+- Assemble the drafting-order section the guide declares: root definition, activities, techniques, resources, README, each tier with a one-line rationale
+
+### 5. Compose the Manifest
+
+- Fold the table and both sections into `{scope_manifest}` at the shape [Template](../../resources/scope-manifest.md#template) declares
+- Link the change brief and the impact classification for purpose and removals rather than restating either
+
+## Rules
+
+### no-implicit-files
+
+A file the change touches and the manifest does not name is out of scope for this run. Drafting authors what the manifest names and nothing else, so a file discovered mid-draft returns here rather than being written quietly.

--- a/workflow-authoring/techniques/workflow-definition/scope-verification.md
+++ b/workflow-authoring/techniques/workflow-definition/scope-verification.md
@@ -1,0 +1,40 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+The confirmed manifest checked in both directions against what the run actually changed.
+
+## Outputs
+
+### total_count
+
+Number of entries in the confirmed manifest.
+
+### addressed_count
+
+Number of manifest entries confirmed addressed: the file is present, the recorded action was performed, and its content matches what the entry describes.
+
+### unaddressed_count
+
+Number of manifest entries still unaddressed — `{total_count}` less `{addressed_count}`. Zero when the manifest is fully delivered.
+
+## Protocol
+
+### 1. Check Each Manifest Entry
+
+- For every entry in `{scope_manifest}`, check that the file exists, that the action it records was the action performed, and that the content matches the change the entry describes
+- Set `{total_count}`, `{addressed_count}` and `{unaddressed_count}`
+
+### 2. Check the Change Set Against the Manifest
+
+- List the files actually changed for `{target_workflow_id}` under `{target_path}` and compare that set against `{scope_manifest}` in the other direction: a file changed that no entry names is unplanned scope
+- Surface each unaddressed entry and each unplanned change with a recommended disposition, exceptions only — a manifest delivered exactly gets one line, not a table of passes
+
+## Rules
+
+### both-directions-or-neither
+
+Checking only that every entry was delivered leaves the opposite drift invisible: files changed that nothing planned. A scope check that runs one direction has not checked scope.

--- a/workflow-authoring/techniques/workflow-definition/synthesize-change-brief.md
+++ b/workflow-authoring/techniques/workflow-definition/synthesize-change-brief.md
@@ -1,0 +1,49 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Change brief for an existing workflow, covering only the dimensions the change alters.
+
+## Inputs
+
+### change_category
+
+The categorised change request — one or more of the categories in [Change Categories](../../resources/update-mode-guide.md#change-categories).
+
+### structural_inventory
+
+Baseline of the target's existing definition: file counts by kind, entity counts, activity ids in prefix order, and what the change touches.
+
+### report_path
+
+*(optional)* Absolute path to a findings register that is the change specification for this run. Empty when the change came from a user request rather than an audit.
+
+## Outputs
+
+### change_brief
+
+The assembled change brief for an existing workflow: purpose, the **changed** members of the guide's update dimension set, and the judgements left open. Unchanged dimensions are absent. Shaped by [Template](../../resources/change-brief.md#template).
+
+#### artifact
+
+`change-brief.md`
+
+### open_judgements_count
+
+Number of design judgements recorded as unresolved in `{change_brief}`. Zero when the change request settled every one.
+
+## Protocol
+
+### 1. Load the Change Sources
+
+- Load `{change_category}`, `{user_description}` and `{structural_inventory}`
+- When `{report_path}` is non-empty, load that register and treat its rows as the change specification
+
+### 2. Assemble the Changed Dimensions
+
+- From the update set in [Mode Dimension Sets](../../resources/elicitation-guide.md#mode-dimension-sets), emit only the dimensions that change against the baseline and the change sources; an unchanged dimension is absent from `{change_brief}`, not reprinted from the baseline
+- Derive each emitted dimension from the change sources and the baseline; prefer additive edits the sources name, and introduce no structural change the sources do not ask for
+- Fold the emitted dimensions into `{change_brief}` at the shape [Template](../../resources/change-brief.md#template) declares, and set `{open_judgements_count}` to the number of judgements the sources leave unresolved

--- a/workflow-authoring/techniques/workflow-definition/verify-artifact-conforms.md
+++ b/workflow-authoring/techniques/workflow-definition/verify-artifact-conforms.md
@@ -1,0 +1,34 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Planning artifacts corrected in place against the guide each one's filename maps to, and against the canonical-home map.
+
+## Protocol
+
+### 1. Enumerate the Artifacts
+
+- Enumerate every planning artifact in `{planning_folder_path}` — each `.md` except session state files — and resolve each one's guide through the artifact-to-guide map
+
+### 2. Check Each Against Its Own Guide
+
+- Check each artifact against the `## Rules` of the guide its filename maps to, and against [canonical-home-map](../TECHNIQUE.md#canonical-home-map); apply each rule by cite and do not restate its criteria here
+- An artifact carrying a fact the map homes elsewhere is a finding whether or not the fact is accurate
+
+### 3. Correct in Place
+
+- Replace a restated fact with a link to its canonical home, delete a section whose content is an absence, collapse a table whose every row passes, and condense prose over its guide's budget
+- Preserve content the user asked for explicitly, whatever the budget says
+
+### 4. Surface the Exceptions
+
+- Surface the corrections made and any finding left unfixed, exceptions only — an artifact that already conformed gets no line
+
+## Rules
+
+### guide-is-the-standard
+
+An artifact is measured against the guide its own filename maps to, never against another workflow's output-discipline map. Where no guide maps the filename, that missing mapping is the finding.

--- a/workflow-authoring/techniques/workflow-definition/verify-high-findings.md
+++ b/workflow-authoring/techniques/workflow-definition/verify-high-findings.md
@@ -1,0 +1,70 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Independent re-derivation of the high-severity findings a criteria walk produced, with severity recalibrated and the decision surface counted.
+
+## Inputs
+
+### audit_findings
+
+The findings a criteria walk produced, each carrying its criteria entry, location, evidence, severity, origin and known marking.
+
+### coverage_ledger
+
+One row per enumeration unit the walk covered, each carrying its home, its anchor and its status.
+
+## Outputs
+
+### verified_findings
+
+The recalibrated finding set: each High marked confirmed, downgraded or withdrawn with the evidence of its re-derivation, and each surviving Medium spot-confirmed. Only entries in this set are eligible to drive a fix.
+
+### open_finding_count
+
+Number of findings on the decision surface after recalibration — confirmed and downgraded entries, excluding withdrawn ones and those marked known.
+
+### has_critical_finding
+
+True when any surviving finding is `Critical` severity: a schema-invalid or structurally broken construct that must not be committed.
+
+### has_coverage_gap
+
+True when any row of `{coverage_ledger}` carries status `blocked`. Rows carrying `not-applicable` are evidenced negatives and do not set it.
+
+## Protocol
+
+### 1. Re-Derive Every High Finding
+
+- For each High-severity entry in `{audit_findings}`, re-derive the violation from the cited file and construct alone, refuting by default: it survives only when the re-derivation independently reproduces it against the construct the finding names
+- Record for each what construct was inspected and whether the violation was reproduced
+
+### 2. Recalibrate Severity
+
+- Withdraw any High the re-derivation failed to reproduce; downgrade one whose evidence supports only a lesser issue; raise severity only where the re-derivation surfaces a graver problem than the original rating
+
+### 3. Confirm the Surviving Mediums
+
+- Spot-confirm each surviving Medium: the cited construct exists and the finding class is right. This is a confirmation, not a full re-derivation.
+
+### 4. Cross-Check the Coverage and Count the Surface
+
+- Check `{coverage_ledger}` against the enumeration inventory the walking operation holds — [Enumerate the Criteria Units](./audit-canon.md#1-enumerate-the-criteria-units) — and declare no inventory here
+- Emit `{verified_findings}`, `{open_finding_count}`, `{has_critical_finding}` and `{has_coverage_gap}` at the shapes their Output declarations state
+
+## Rules
+
+### refute-by-default
+
+A High finding is confirmed only when independently re-derived from the construct it cites. An unreproduced finding is withdrawn, never carried forward on the strength of the pass that raised it.
+
+### no-originating-rationale
+
+The re-derivation reads the cited construct and nothing else. The originating pass's reasoning is not consulted — not to follow it and not to check agreement with it — because a re-derivation that has read the argument it is testing is not independent.
+
+### remediation-needs-a-re-derived-claim
+
+Do not emit a remediation instruction for a row whose claim has not been re-derived. A withdrawn or unexamined finding drives no edit, whatever its original severity said.

--- a/workflow-authoring/techniques/workflow-definition/yaml-authoring.md
+++ b/workflow-authoring/techniques/workflow-definition/yaml-authoring.md
@@ -11,7 +11,11 @@ Schema-valid definition file authored from a manifest entry.
 
 ### current_file
 
-The manifest entry to author — full path, action, kind and the one-line statement of its change. Its kind selects which schema applies: root definition, activity, or technique.
+The file to author — full path, action and kind, with a one-line statement of its change. Its kind selects which schema applies: root definition, activity, or technique.
+
+### selected_findings
+
+*(optional)* Findings whose fixes are the change to author, each naming a file, a construct and the corrective action its criteria entry prescribes. When present, these name the files to author and bound how much of each may change.
 
 ### reference_file
 
@@ -36,6 +40,7 @@ The authored file at the manifest entry's path, parsing cleanly and conforming t
 ### 3. Plan the Content
 
 - Identify which fields the content needs from the JSON schema for that kind
+- When `{selected_findings}` is present, the files to author are the ones those findings cite, and the planned change is exactly what each finding's fix prescribes
 - Map the content onto formal constructs, taking the table for its own level from [Activity-Level Constructs](../../../workflow-design/resources/schema-construct-inventory.md#activity-level-constructs-activityschemajson), [Workflow-Level Constructs](../../../workflow-design/resources/schema-construct-inventory.md#workflow-level-constructs-workflowschemajson) or [Technique-Level Constructs](../../../workflow-design/resources/schema-construct-inventory.md#technique-level-constructs-techniqueschemajson), plus [Condition Constructs](../../../workflow-design/resources/schema-construct-inventory.md#condition-constructs-conditionschemajson) wherever a gate is authored
 - Cross-check required against optional properties before drafting rather than after validation fails
 
@@ -82,3 +87,7 @@ Field order follows existing files of the same kind, per [Reference Conventions]
 ### schema-reference
 
 A root definition file declares a `$schema` field naming its schema at the same relative depth every sibling uses.
+
+### smallest-edit-that-resolves
+
+An edit authored to resolve a finding is the smallest change that resolves it. Content no finding names is preserved, and rewriting a region because it was already open is not part of the fix.

--- a/workflow-authoring/techniques/workflow-definition/yaml-authoring.md
+++ b/workflow-authoring/techniques/workflow-definition/yaml-authoring.md
@@ -1,0 +1,84 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Schema-valid definition file authored from a manifest entry.
+
+## Inputs
+
+### current_file
+
+The manifest entry to author — full path, action, kind and the one-line statement of its change. Its kind selects which schema applies: root definition, activity, or technique.
+
+### reference_file
+
+*(optional)* Path to an existing valid file of the same kind, used as the syntax reference. Absent means any valid sibling of that kind serves.
+
+## Outputs
+
+### yaml_file
+
+The authored file at the manifest entry's path, parsing cleanly and conforming to the schema its kind selects.
+
+## Protocol
+
+### 1. Read a Reference of the Same Kind
+
+- Read `{reference_file}` when supplied; otherwise read at least one existing valid file of the kind `{current_file}` names
+
+### 2. Read the Schema Field Tables
+
+- Read `schemas/README.md` for the field table, required properties and allowed values of that kind
+
+### 3. Plan the Content
+
+- Identify which fields the content needs from the JSON schema for that kind
+- Map the content onto formal constructs, taking the table for its own level from [Activity-Level Constructs](../../../workflow-design/resources/schema-construct-inventory.md#activity-level-constructs-activityschemajson), [Workflow-Level Constructs](../../../workflow-design/resources/schema-construct-inventory.md#workflow-level-constructs-workflowschemajson) or [Technique-Level Constructs](../../../workflow-design/resources/schema-construct-inventory.md#technique-level-constructs-techniqueschemajson), plus [Condition Constructs](../../../workflow-design/resources/schema-construct-inventory.md#condition-constructs-conditionschemajson) wherever a gate is authored
+- Cross-check required against optional properties before drafting rather than after validation fails
+
+### 4. Draft the Content
+
+- Write `{yaml_file}` at the path `{current_file}` names, under the Rules below
+
+### 5. Validate Against the Schema
+
+- Validate the drafted file against the JSON schema its kind selects
+
+### 6. Resolve Validation Failures
+
+- Where the parser rejects the file, compare the failing line against the same construct in the reference file and correct the syntax
+- Where the file parses but does not conform, read the schema definition for the failing field and correct the content
+- Re-validate until the file passes
+
+## Rules
+
+### block-style-arrays
+
+Declare arrays as a key followed by `-`-prefixed items on indented lines. Do not annotate an array with an item count.
+
+### block-style-mappings
+
+Prefer block style — nested objects are indented `key: value` lines. Reserve flow style for short inline values.
+
+### scalar-quoting
+
+Quote any scalar containing a colon-space, starting with a character YAML treats specially, or that would otherwise parse as a number or boolean. Prefer double quotes where the value needs escape sequences.
+
+### multi-line-scalars
+
+Use a block scalar for multi-line text — `|` to preserve newlines, `>` to fold.
+
+### version-format
+
+Versions are semantic X.Y.Z, per [Reference Conventions](../../../workflow-design/resources/convention-conformance.md#reference-conventions).
+
+### field-ordering
+
+Field order follows existing files of the same kind, per [Reference Conventions](../../../workflow-design/resources/convention-conformance.md#reference-conventions).
+
+### schema-reference
+
+A root definition file declares a `$schema` field naming its schema at the same relative depth every sibling uses.

--- a/workflow-authoring/workflow.yaml
+++ b/workflow-authoring/workflow.yaml
@@ -1,0 +1,188 @@
+$schema: ../../schemas/workflow.schema.json
+id: workflow-authoring
+version: 1.0.0
+title: Workflow Authoring Workflow
+description: Guide agents through creating, updating, or reviewing workflow definitions.
+author: m2ux
+tags:
+  - workflow-creation
+  - workflow-review
+  - workflow-authoring
+  - schema-validation
+  - design-principles
+  - elicitation
+  - conventions
+rules:
+  activity:
+    - >-
+      A correction the user makes at a gate is recorded against the fact it corrects, and every
+      later gate is answered from the corrected value — never from the value it superseded.
+    - >-
+      A checkpoint that declares neither `defaultOption` nor `autoAdvanceMs` requires a user
+      response and must never be answered on the user's behalf. When `{headless_mode}` is true,
+      a checkpoint declaring both resolves to its `defaultOption` without presentation.
+techniques:
+  activity:
+    - variable-binding
+variables:
+  - name: planning_folder_path
+    type: string
+    description: Absolute path to this workflow planning folder.
+  - name: operation_type
+    type: string
+    description: The classified operation for the request — create, update, or review.
+  - name: operation_type_ambiguous
+    type: boolean
+    description: True when intake cannot confidently classify create vs update vs review from the request alone.
+    defaultValue: false
+  - name: change_request_clear
+    type: boolean
+    description: In update mode, true when the change request is clear enough to proceed without Gate 1 clarification.
+    defaultValue: true
+  - name: intent_needs_confirmation
+    type: boolean
+    description: Composite gap flag for Gate 1 — true when mode is ambiguous, the update change request is unclear, and/or review.
+    defaultValue: false
+  - name: headless_mode
+    type: boolean
+    description: When true, soft mid-flow gates auto-resolve without presentation.
+    defaultValue: true
+  - name: open_finding_count
+    type: number
+    description: Count of open findings on the decision surface.
+    defaultValue: 0
+  - name: update_seeded_from_review
+    type: boolean
+    description: True when update mode was entered from a review-mode fix disposition.
+    defaultValue: false
+  - name: removal_count
+    type: number
+    description: Count of content removals inventoried for this change.
+    defaultValue: 0
+  - name: fail_count
+    type: number
+    description: Count of YAML files that failed schema validation.
+    defaultValue: 0
+  - name: total_count
+    type: number
+    description: Total scope-manifest items checked.
+    defaultValue: 0
+  - name: addressed_count
+    type: number
+    description: Scope-manifest items confirmed addressed.
+    defaultValue: 0
+  - name: unaddressed_count
+    type: number
+    description: Scope-manifest items still unaddressed.
+    defaultValue: 0
+  - name: change_brief_path
+    type: string
+    description: Absolute path to the persisted change-brief artifact.
+    defaultValue: ""
+  - name: impact_analysis_path
+    type: string
+    description: Absolute path to the persisted impact-analysis artifact.
+    defaultValue: ""
+  - name: scope_manifest_path
+    type: string
+    description: Absolute path to the persisted scope-manifest artifact.
+    defaultValue: ""
+  - name: report_path
+    type: string
+    description: Absolute path to the persisted findings register.
+    defaultValue: ""
+  - name: review_scope_confirmed
+    type: boolean
+    description: In review mode, whether the user confirmed the audit target set.
+    defaultValue: false
+  - name: target_workflow_id
+    type: string
+    description: The workflow id currently being authored, updated or audited.
+  - name: target_workflow_ids
+    type: array
+    description: Ordered list of workflow ids in scope for this run, one or more.
+  - name: workflow_id
+    type: string
+    description: The id of the workflow being created or updated.
+  - name: scope_manifest_confirmed
+    type: boolean
+    description: Whether the complete file manifest has been confirmed.
+    defaultValue: false
+  - name: scope_manifest
+    type: array
+    description: List of files to create, modify or remove with full paths and actions.
+  - name: current_file
+    type: object
+    description: The file currently being drafted.
+  - name: has_unflagged_removals
+    type: boolean
+    description: True when drafting detects removals absent from the impact inventory.
+    defaultValue: false
+  - name: has_critical_finding
+    type: boolean
+    description: Whether any finding is Critical severity — a schema-invalid or structurally broken construct that must not be committed.
+    defaultValue: false
+  - name: target_path
+    type: string
+    description: Worktree path for edits, builds and PR operations.
+    defaultValue: ""
+  - name: worktree_created
+    type: boolean
+    description: True when a dedicated worktree at `target_path` was created or reused by this run.
+    defaultValue: false
+  - name: workflow_branch
+    type: string
+    description: The feature branch in the workflows repo carrying this change.
+    defaultValue: ""
+  - name: pr_url
+    type: string
+    description: URL of the pull request opened for this change.
+    defaultValue: ""
+  - name: pr_number
+    type: string
+    description: Number of the pull request opened for this change.
+    defaultValue: ""
+  - name: open_judgements_count
+    type: number
+    description: Count of unresolved design judgements recorded in the change brief.
+    defaultValue: 0
+  - name: removals_approved
+    type: boolean
+    description: Whether the inventoried content removals are approved.
+    defaultValue: false
+  - name: removal_disposition
+    type: string
+    description: "Disposition of an unflagged removal — `flagged | restored`."
+    defaultValue: ""
+  - name: scope_round
+    type: number
+    description: Scope-confirmation round for this run.
+    defaultValue: 0
+  - name: remediation_round
+    type: number
+    description: Remediation round for this run.
+    defaultValue: 0
+  - name: remediation_selected
+    type: boolean
+    description: Whether the operator chose remediation over acceptance at the pre-attestation gate.
+    defaultValue: false
+  - name: commit_approved
+    type: boolean
+    description: Whether the operator approved the change for commit.
+    defaultValue: false
+  - name: review_closed
+    type: boolean
+    description: Whether a review run closed on its report with no escalation.
+    defaultValue: false
+  - name: has_coverage_gap
+    type: boolean
+    description: Whether any enumeration unit was blocked rather than walked.
+    defaultValue: false
+  - name: register_sections
+    type: array
+    description: Per-target register sections accumulated across the sweep.
+    defaultValue: []
+  - name: verified_findings
+    type: array
+    description: Findings whose claims survived independent re-derivation.
+initialActivity: intake-and-context

--- a/workflow-design/README.md
+++ b/workflow-design/README.md
@@ -1,5 +1,15 @@
 # Workflow Design Workflow
 
+> **DEPRECATED — start [`workflow-authoring`](../workflow-authoring/README.md) instead.**
+> This workflow remains only so sessions already in flight can finish, and is removed once none
+> remain. Do not start a new session against it. Its version is deliberately frozen: a bump would
+> emit a version-mismatch warning on every call for every in-flight session.
+>
+> A session already under way can be finished here. The defects the replacement exists to fix are
+> still present in this tree and are not being repaired — including two thirty-second auto-advances
+> at the commit gates that select *proceed to commit* even when files are failing schema validation.
+> Prefer finishing promptly over resuming late.
+
 > v1.30.0 — Guides agents through creating, updating, or reviewing workflow definitions. In create/update modes, accepts a free-form user description, derives intent first, reconciles assumptions in a while-loop, and batches stakeholder decisions into Gate 1 (gap-only) and Gate 2 (approve-to-commit); `{headless_mode}` defaults to true so soft mid-flow gates auto-resolve (opt out with “interactive”, “not headless”, or “with checkpoints”). Create/update edits run in a dedicated `{target_path}` worktree. In review mode, audits one or more existing workflows against the design principles and produces a compliance report.
 
 ---

--- a/workflow-design/workflow.yaml
+++ b/workflow-design/workflow.yaml
@@ -1,10 +1,14 @@
 $schema: ../../schemas/workflow.schema.json
 id: workflow-design
 version: 1.30.0
-title: Workflow Design Workflow
-description: Guide agents through creating, updating, or reviewing workflow definitions.
+title: DEPRECATED — use workflow-authoring — Workflow Design Workflow
+description: >-
+  DEPRECATED — start `workflow-authoring` instead. This workflow remains only so sessions already
+  in flight can finish; it is removed once none remain. Guide agents through creating, updating, or
+  reviewing workflow definitions.
 author: m2ux
 tags:
+  - deprecated
   - workflow-creation
   - workflow-review
   - workflow-design


### PR DESCRIPTION
## Motivation

`workflow-design` has grown to nine activities, thirty-seven techniques and seventeen output files. Six separate audit passes each read the same four rule documents and each wrote its own findings file, which is slow per run and awkward to change.

It can't be fixed in place. Thirty-two sessions are currently part-way through it, and twenty-one of them would break. The server locates an activity by its filename, so if an activity is renamed or removed, moving a session into it appears to succeed and then fails later at a confusing point. So this adds a replacement alongside the old workflow and marks the old one deprecated, to be removed once those sessions have finished.

Implements #321, steps S1–S4 and S6.

## Changes

**A new `workflow-authoring` workflow.** Four activities instead of nine, twenty-three techniques instead of thirty-seven, six output files instead of seventeen. It does the same three jobs: create a workflow, change one, or audit existing ones.

**The six audit passes become one.** They never contained any rules of their own, only pointers to the four rule documents, so merging them loses nothing. The merged pass lists the sections of the rule catalogue explicitly, because four of its entries sit outside the obvious groupings and a pattern-based sweep skips them without saying so.

**The rule documents are not copied.** The new workflow points at where they already live, so there is still one copy of each rather than two. #340 adds a test for that, since the pointer is now a real dependency between the two workflows.

**`workflow-design` is marked deprecated.** Its title, its tags, its README and the library index all say so. Nothing else about it changes, so sessions still running against it keep working. Its version number is deliberately left alone: changing it would print a mismatch warning on every call for all thirty-two.

**One shared technique is corrected.** `write-artifact` in `work-package` described an optional input in a form the checks can't read, so callers had to restate a default they should be able to omit. Description only, no behaviour change, no caller affected. It sits at the base of this branch because the new workflow needs it to pass cleanly.

All fourteen definition checks pass with no new violations at every step, and no check baseline was updated. Building this surfaced six problems in the original plan, all fixed here and each recorded with its reasoning in the planning folder.

Two sessions can no longer be advanced or closed, so they are exempted on paper rather than edited; the condition for finally deleting `workflow-design` is therefore a count of two, not zero, and is written down in `drain-log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
