### PR TITLE
test(workflow-authoring): criteria-delivery detector and session census (#321 S5)

### DIFF
--- a/scripts/count-workflow-sessions.ts
+++ b/scripts/count-workflow-sessions.ts
@@ -1,0 +1,127 @@
+#!/usr/bin/env npx tsx
+/**
+ * Session census for a workflow id — the retirement trigger for a drain-to-zero migration.
+ *
+ * A deletion decision hangs on this count, so it is a committed script rather than a shell
+ * one-liner: the number has to be reproducible, and the one thing it must get right is easy to
+ * get wrong. **Child sessions are embedded in the parent's `session.json` under
+ * `triggeredWorkflows[i].state`, not written as separate files.** A flat glob over
+ * `planning/*(/)session.json` therefore counts only orchestrator sessions and undercounts badly —
+ * a `meta` session that dispatched a client workflow carries that workflow's whole state nested
+ * inside it, at any depth, because a child may itself dispatch.
+ *
+ * Counts every state in the tree whose `workflowId` matches, optionally filtered by `status`.
+ *
+ * Run:
+ *   npx tsx scripts/count-workflow-sessions.ts --workflow workflow-design --status running --list
+ *
+ * Options:
+ *   --workflow <id>   workflow id to count (required)
+ *   --status <status> only count states in this status (repeatable; omit for all)
+ *   --list            print the planning folder, nesting depth and currentActivity of each match
+ *   --root <dir>      planning root to walk (default: <repo>/.engineering/artifacts/planning)
+ */
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const DIR = fileURLToPath(new URL('.', import.meta.url));
+const DEFAULT_ROOT = resolve(join(DIR, '..', '.engineering', 'artifacts', 'planning'));
+
+export interface SessionMatch {
+  /** Planning folder holding the `session.json` this state was found in. */
+  folder: string;
+  /** 0 for the file's own top-level state, 1 for a directly triggered child, and so on. */
+  depth: number;
+  workflowId: string;
+  status: string;
+  currentActivity: string;
+  workflowVersion: string;
+}
+
+/** A state node as the census reads it — only the fields the count and the listing need. */
+interface StateNode {
+  workflowId?: unknown;
+  status?: unknown;
+  currentActivity?: unknown;
+  workflowVersion?: unknown;
+  triggeredWorkflows?: unknown;
+}
+
+const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+
+/**
+ * Walk one session file's state tree, emitting every node whose workflowId matches.
+ * Recursion is unbounded in depth because a triggered child may itself trigger.
+ */
+function walkState(node: StateNode, folder: string, depth: number, workflowId: string, out: SessionMatch[]): void {
+  if (str(node.workflowId) === workflowId) {
+    out.push({
+      folder,
+      depth,
+      workflowId,
+      status: str(node.status),
+      currentActivity: str(node.currentActivity),
+      workflowVersion: str(node.workflowVersion),
+    });
+  }
+  const triggered = node.triggeredWorkflows;
+  if (!Array.isArray(triggered)) return;
+  for (const ref of triggered) {
+    if (!ref || typeof ref !== 'object') continue;
+    // The nested state is optional on the ref: a child dispatched but never persisted carries
+    // none, and a ref without one contributes no state to the census.
+    const state = (ref as { state?: unknown }).state;
+    if (state && typeof state === 'object') walkState(state as StateNode, folder, depth + 1, workflowId, out);
+  }
+}
+
+export function collectSessions(workflowId: string, statuses: string[] = [], root: string = DEFAULT_ROOT): SessionMatch[] {
+  if (!existsSync(root)) return [];
+  const matches: SessionMatch[] = [];
+  for (const entry of readdirSync(root)) {
+    const folder = join(root, entry);
+    if (!statSync(folder).isDirectory()) continue;
+    const file = join(folder, 'session.json');
+    if (!existsSync(file)) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(file, 'utf-8'));
+    } catch {
+      // An unreadable session file is reported, not skipped silently: a census that quietly
+      // drops a file can report zero while a session still exists.
+      matches.push({ folder, depth: 0, workflowId, status: 'unreadable', currentActivity: '', workflowVersion: '' });
+      continue;
+    }
+    if (parsed && typeof parsed === 'object') walkState(parsed as StateNode, folder, 0, workflowId, matches);
+  }
+  return statuses.length === 0 ? matches : matches.filter(m => statuses.includes(m.status) || m.status === 'unreadable');
+}
+
+function flagValues(argv: string[], flag: string): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === flag && argv[i + 1]) out.push(argv[i + 1]!);
+  }
+  return out;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  const argv = process.argv.slice(2);
+  const workflowId = flagValues(argv, '--workflow')[0];
+  if (!workflowId) {
+    console.error('usage: count-workflow-sessions.ts --workflow <id> [--status <status>]... [--list] [--root <dir>]');
+    process.exit(2);
+  }
+  const statuses = flagValues(argv, '--status');
+  const root = flagValues(argv, '--root')[0] ?? DEFAULT_ROOT;
+  const matches = collectSessions(workflowId, statuses, root);
+  const label = statuses.length ? ` (${statuses.join(', ')})` : '';
+  console.log(`${workflowId}${label}: ${matches.length}`);
+  if (argv.includes('--list')) {
+    for (const m of matches) {
+      const nesting = m.depth === 0 ? 'top-level' : `nested depth ${m.depth}`;
+      console.log(`  ${m.folder}  [${nesting}]  v${m.workflowVersion}  ${m.status}  @ ${m.currentActivity || '(none)'}`);
+    }
+  }
+}

--- a/tests/workflow-authoring-delivery.test.ts
+++ b/tests/workflow-authoring-delivery.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createServer } from '../src/server.js';
+import { loadResourceDelivery } from '../src/utils/resource-delivery.js';
+import { resolveWorkflowsRoot } from '../scripts/workflows-root.js';
+import { join, resolve } from 'node:path';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { parse } from 'yaml';
+
+/**
+ * Delivery regression guard for `workflow-authoring`'s criteria bundle.
+ *
+ * `workflow-authoring` cites its four criteria homes cross-workflow into `workflow-design`
+ * rather than copying them, so the corpus holds one physical copy of a 154 KB canon. That makes
+ * the citation a live dependency between two trees, and the failure mode is silent: an
+ * unresolvable resource is skipped in the eager loop with a bare `continue` and no warning
+ * (`src/tools/workflow-tools.ts`), and `check-resource-anchors` cannot see a reference in
+ * already-projected form because its pattern requires a `.md#` target. So deleting or moving
+ * `workflow-design/resources/` empties the bundle with every guard still green.
+ *
+ * This test is the detector. It asserts, over the MCP wire against the served corpus, that:
+ *
+ *   1. `quality-review` delivers exactly the eager-eligible step techniques. `collectUngated`
+ *      skips on `when`/`condition` before recursing into a loop and pushes only `kind: technique`
+ *      steps carrying an `id`, so the set is a structural consequence of the authored gates —
+ *      adding a gate to a swept step silently drops it from the bundle.
+ *   2. Every criteria home reaches the worker as a resource reference, each anti-pattern unit
+ *      carrying its `#section` anchor. `anti-patterns.md` is larger than the per-resource eager
+ *      cap, so a whole-file reference can never be bundled and would be skipped without warning;
+ *      per-section anchors are what keep each unit reachable at all.
+ *   3. Every delivered reference resolves. This is the assertion that fails the moment
+ *      `workflow-design`'s resources move, which is what makes it safe to retire that tree.
+ *
+ * The suite is conditional on `workflow-authoring` being present in the resolved workflows root,
+ * because the tree lands on the `workflows` branch before the submodule pointer moves. Point it
+ * at the branch with `WORKFLOWS_DIR` in that window; once the submodule carries the tree the
+ * suite runs unconditionally. The condition is on presence of the tree, never on the assertions:
+ * a present tree with a broken bundle fails.
+ */
+
+const WORKFLOWS_ROOT = resolveWorkflowsRoot(resolve(join(import.meta.dirname, '..', 'workflows')));
+const TREE_PRESENT = existsSync(join(WORKFLOWS_ROOT, 'workflow-authoring', 'workflow.yaml'));
+
+/**
+ * The eager-eligible step ids of `quality-review`, in document order. Every one is a
+ * `kind: technique` step carrying an `id` and no `when`/`condition`, at top level or inside the
+ * ungated sweep loop. The two remediation steps are gated and the loop container is recursed
+ * into rather than pushed, so neither appears.
+ */
+const EAGER_STEP_IDS = [
+  'load-known-findings',
+  'survey-reference-workflows',
+  'rebind-target-baseline',
+  'resolve-consumer-surface',
+  'sweep-canon',
+  'validate-schema',
+];
+
+/**
+ * Every `##` section of the anti-pattern home, which is that home in full. Four entries sit
+ * outside the family sections, so a walk that matches titles by pattern drops them — the walking
+ * operation enumerates this list for the same reason, and this is the assertion that the
+ * enumeration survives delivery.
+ */
+const ANTI_PATTERN_SECTIONS = [
+  'creation-rules',
+  'structural-anti-patterns',
+  'interaction-anti-patterns',
+  'schema-expressiveness-anti-patterns',
+  'rule-hygiene-anti-patterns',
+  'description-hygiene-anti-patterns',
+  'coupling-anti-patterns',
+  'tool-technique-doc-consistency-anti-patterns',
+  'execution-anti-patterns',
+  'output-economy-anti-patterns',
+  'canon-hygiene-anti-patterns',
+  'technique-protocol-anti-patterns',
+  'authoring-guidance-mr',
+];
+
+/** The criteria references `quality-review` must deliver, in the qualified form get_resource takes. */
+const CRITERIA_IDS = [
+  ...ANTI_PATTERN_SECTIONS.map(s => `workflow-design/anti-patterns#${s}`),
+  'workflow-design/design-principles',
+  'workflow-design/schema-construct-inventory',
+  'workflow-design/convention-conformance',
+];
+
+describe.skipIf(!TREE_PRESENT)(`workflow-authoring criteria delivery (workflows root: ${WORKFLOWS_ROOT})`, () => {
+  let client: Client;
+  let closeTransport: () => Promise<void>;
+  let workspaceDir: string;
+  let sessionIndex: string;
+  let ops: Record<string, unknown>;
+  let meta: Record<string, unknown>;
+
+  beforeAll(async () => {
+    workspaceDir = mkdtempSync(join(tmpdir(), 'wf-authoring-delivery-'));
+    const server = createServer({
+      workflowDir: WORKFLOWS_ROOT,
+      schemasDir: join(import.meta.dirname, '../schemas'),
+      workspaceDir,
+      serverName: 'test-workflow-server',
+      serverVersion: '1.0.0',
+      minCheckpointResponseSeconds: 0,
+    });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    client = new Client({ name: 'test-client', version: '1.0.0' }, {});
+    await client.connect(clientTransport);
+    closeTransport = async () => { await client.close(); await server.close(); };
+
+    const started = await client.callTool({
+      name: 'start_session',
+      arguments: {
+        workflow_id: 'workflow-authoring',
+        agent_id: 'orchestrator',
+        planning_folder: join(workspaceDir, '.engineering/artifacts/planning/delivery-probe'),
+      },
+    }) as { isError?: boolean; content?: Array<{ text: string }> };
+    expect(started.isError).toBeFalsy();
+    sessionIndex = (JSON.parse(started.content![0]!.text) as { session_index: string }).session_index;
+
+    const entered = await client.callTool({
+      name: 'next_activity',
+      arguments: { session_index: sessionIndex, activity_id: 'quality-review' },
+    }) as { isError?: boolean };
+    expect(entered.isError).toBeFalsy();
+
+    const delivered = await client.callTool({
+      name: 'get_activity',
+      arguments: { session_index: sessionIndex, context_tokens: 200_000 },
+    }) as { isError?: boolean; content?: Array<{ text: string }>; _meta?: Record<string, unknown> };
+    expect(delivered.isError).toBeFalsy();
+    ops = parse(delivered.content![0]!.text.split('\n\n---\n\n')[0]!) as Record<string, unknown>;
+    meta = delivered._meta ?? {};
+  });
+
+  afterAll(async () => {
+    await closeTransport?.();
+    try { rmSync(workspaceDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('delivers exactly the eager-eligible step techniques', () => {
+    const stepTechniques = ops['step_techniques'] as Record<string, unknown> | undefined;
+    expect(stepTechniques).toBeDefined();
+    expect(Object.keys(stepTechniques!).sort()).toEqual([...EAGER_STEP_IDS].sort());
+  });
+
+  it('delivers every criteria home as a resource reference', () => {
+    // A fresh worker runs in full delivery mode, which ships resource ids and no bodies. The
+    // ids are the contract: the worker fetches the units it reads with get_resource.
+    const refs = (meta['resource_refs'] as string[] | undefined) ?? [];
+    expect(refs.length).toBeGreaterThan(0);
+    expect(CRITERIA_IDS.filter(id => !refs.includes(id))).toEqual([]);
+  });
+
+  it('addresses every anti-pattern unit by section, never as a whole file', () => {
+    const refs = (meta['resource_refs'] as string[] | undefined) ?? [];
+    const antiPatternRefs = refs.filter(r => r.startsWith('workflow-design/anti-patterns'));
+    expect(antiPatternRefs.length).toBeGreaterThan(0);
+    expect(antiPatternRefs.filter(r => !r.includes('#'))).toEqual([]);
+  });
+
+  it('resolves every delivered reference, so no criteria unit is silently absent', async () => {
+    const refs = (meta['resource_refs'] as string[] | undefined) ?? [];
+    const unresolved: string[] = [];
+    for (const id of refs) {
+      const loaded = await loadResourceDelivery(WORKFLOWS_ROOT, 'workflow-authoring', id, sessionIndex);
+      if (!loaded.success) unresolved.push(`${id} — ${loaded.error.message}`);
+    }
+    expect(unresolved).toEqual([]);
+  });
+
+  it('keeps every criteria unit inside the per-resource eager cap', async () => {
+    // The whole anti-pattern file exceeds the cap, so an oversized unit would be skipped in the
+    // eager loop with no warning. Fetching by section is what keeps each unit deliverable.
+    const oversized: string[] = [];
+    for (const id of CRITERIA_IDS) {
+      const loaded = await loadResourceDelivery(WORKFLOWS_ROOT, 'workflow-authoring', id, sessionIndex);
+      if (loaded.success && loaded.value.content.length > 80_000) {
+        oversized.push(`${id} — ${loaded.value.content.length} chars`);
+      }
+    }
+    expect(oversized).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Motivation

Two problems, both about being able to delete `workflow-design` safely.

**The new authoring workflow in #339 doesn't copy the four rule documents; it points at where they already live in `workflow-design`.** So that workflow can't be deleted until nothing needs it any more, and if it is deleted early nothing complains. The documents simply stop arriving, and every existing check still passes: an unreadable document is skipped without a warning, the link checker can't see references in the form the server rewrites them to, and the biggest rule file is over the size limit for automatic delivery anyway, so a whole-file reference would be dropped silently too.

**Deciding when it's safe also means counting how many sessions are still running against it, and the obvious way to count gets the wrong answer.** A session started by another workflow is stored inside that parent's file rather than in one of its own. Counting files says 5. The real number is 32.

Implements #321, step S5. Companion to #339.

## Changes

**A test that checks the rule documents actually arrive.** It starts a real session, asks for the audit activity the way a worker would, and confirms the expected techniques are delivered, that all four rule documents are referenced, that the big one is referenced section by section rather than whole, that every reference can actually be read, and that each piece is under the delivery size limit.

I checked the test works by breaking the thing it's meant to catch. With one rule file moved aside, four of the five checks still passed and only "every reference can be read" failed. The references are still delivered, because they come from the technique text and get rewritten whether or not the target exists. That is exactly the silent failure, and why reading is checked separately from referencing.

The test is skipped while the new workflow isn't in the served library yet, since it lands on the `workflows` branch before the submodule pointer moves. To run it in the meantime:

```
WORKFLOWS_DIR=/path/to/workflows-branch npx vitest run tests/workflow-authoring-delivery.test.ts
```

It becomes an always-on check once the submodule carries the new workflow. **Sequence that after #339 merges.**

**A script that counts sessions properly**, by looking inside parent sessions at any depth. It also identifies the two sessions that can no longer be advanced or closed, which is what the deletion condition has to exempt.

`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
