### PR TITLE
Land the server-side half of the git-derived host-repo binding (#348)

### DIFF
--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -49,7 +49,7 @@ Pass `session_index` from `start_session` on every authenticated workflow-server
 
 That is enough. `discover` returns the live bootstrap steps (schema fetch → bind `repo` → `start_session` → `get_workflow`). Do not copy the protocol into IDE rules.
 
-Always pass `repo: "owner/repo"` on `start_session` (from the user or workspace `AGENTS.md` / `CLAUDE.md`). Agents do not special-case server topology.
+Always pass `repo: "owner/repo"` on `start_session`, derived from git via `version-control::resolve-host-repo` — the origin remote of the outermost superproject that claims the workspace checkout. The user and the workspace `AGENTS.md` / `CLAUDE.md` are fallback sources only where that derivation yields nothing: a workspace that is not a git repo, or a host with no origin remote. Agents do not special-case server topology.
 
 ## Verify
 

--- a/scripts/binding-fidelity-triage.json
+++ b/scripts/binding-fidelity-triage.json
@@ -1317,6 +1317,13 @@
     },
     {
       "check": "read-resolution",
+      "site": "substrate-node-security-audit/techniques/write-report.md:90",
+      "detail": "{target_path} has no producer (declared id / $-local / workflow var / set-target)",
+      "verdict": "fix-later",
+      "rationale": "undeclared-seed"
+    },
+    {
+      "check": "read-resolution",
       "site": "work-package/techniques/manage-git/TECHNIQUE.md:25",
       "detail": "{display_name} has no producer (declared id / $-local / workflow var / set-target)",
       "verdict": "harmless",

--- a/src/tools/resource-tools.ts
+++ b/src/tools/resource-tools.ts
@@ -103,7 +103,7 @@ export function registerResourceTools(server: McpServer, config: ServerConfig): 
       description:
         'Start or resume the top-level workflow session. Returns `session_index`, workflow metadata, and canonical `planning_folder_path`. ' +
         'Pass `planning_folder` as an absolute path (basename = slug). ' +
-        'Always pass `repo` as owner/repo (from the user or workspace AGENTS.md) — stored on session.json#repo. ' +
+        'Always pass `repo` as owner/repo, derived from git via `version-control::resolve-host-repo` (origin remote of the outermost claiming superproject); the user or workspace AGENTS.md is a fallback only when the workspace is not a git repo or has no origin remote. Stored on session.json#repo. ' +
         'Omit planning_folder for a transient meta bootstrap. Children use `dispatch_child`, not this tool. ' +
         '`context_mode: "persistent"` is ONLY for solo (same agent context; no worker spawn); omit/`"fresh"` for disposable workers.',
       inputSchema: z

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -323,7 +323,7 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       const lines = [
         `server: ${config.serverName}`,
         `version: ${config.serverVersion}`,
-        'repo_binding: required — pass repo: "owner/repo" on start_session (from user or workspace AGENTS.md)',
+        'repo_binding: required — pass repo: "owner/repo" on start_session, derived from git via version-control::resolve-host-repo (the origin remote of the outermost superproject that claims the workspace checkout). The user or workspace AGENTS.md is a fallback only where that derivation yields nothing: a workspace that is not a git repo, or a host with no origin remote.',
       ];
       if (bootstrapResult.success) {
         lines.push('', bootstrapResult.value.content);

--- a/src/utils/session/scope.ts
+++ b/src/utils/session/scope.ts
@@ -236,7 +236,9 @@ export function resolveSessionRoot(
   if (scope.mode === 'multi') {
     throw new Error(
       'start_session: repo is required when the server is bound to a projects multi-root ' +
-        '(HOST_PROJECTS_ROOT). Pass repo: "owner/repo" (from the user or workspace AGENTS.md). ' +
+        '(HOST_PROJECTS_ROOT). Pass repo: "owner/repo" derived from git via version-control::resolve-host-repo ' +
+        '(origin remote of the outermost claiming superproject); the user or workspace AGENTS.md is a fallback ' +
+        'only when the workspace is not a git repo or has no origin remote. ' +
         'Planning lives at <repo>/.engineering/artifacts/planning/ under that root.',
     );
   }

--- a/tests/e2e/__snapshots__/corpus-sha.json
+++ b/tests/e2e/__snapshots__/corpus-sha.json
@@ -1,4 +1,4 @@
 {
-  "corpusSha": "f84fe02b12f9617f401767b9b96f329d8c13225c",
+  "corpusSha": "bd9c03dfd549aa442047aae0488f7188338feb90",
   "note": "Corpus commit the committed walk snapshots were generated against. Update it in the same commit that bumps the workflows submodule and re-baselines the walk (npm run baseline:stamp)."
 }

--- a/tests/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/tests/e2e/__snapshots__/snapshot.test.ts.snap
@@ -53,6 +53,7 @@ exports[`work-package walk snapshots (baseline) > [default] matches committed ba
       "stepsExecuted": [
         "announce-start",
         "detect-review-mode",
+        "derive-host-repo",
         "resolve-repo-root",
         "analyze-repo-with-gitnexus",
         "verify-signing-precondition",
@@ -484,6 +485,7 @@ exports[`work-package walk snapshots (baseline) > [elicitation-only] matches com
       "stepsExecuted": [
         "announce-start",
         "detect-review-mode",
+        "derive-host-repo",
         "resolve-repo-root",
         "analyze-repo-with-gitnexus",
         "verify-signing-precondition",
@@ -982,6 +984,7 @@ exports[`work-package walk snapshots (baseline) > [full-workflow] matches commit
       "stepsExecuted": [
         "announce-start",
         "detect-review-mode",
+        "derive-host-repo",
         "resolve-repo-root",
         "analyze-repo-with-gitnexus",
         "verify-signing-precondition",
@@ -1507,6 +1510,7 @@ exports[`work-package walk snapshots (baseline) > [research-only] matches commit
       "stepsExecuted": [
         "announce-start",
         "detect-review-mode",
+        "derive-host-repo",
         "resolve-repo-root",
         "analyze-repo-with-gitnexus",
         "verify-signing-precondition",
@@ -1978,6 +1982,7 @@ exports[`work-package walk snapshots (baseline) > [review-mode] matches committe
         "announce-derived-review-mode",
         "ingest-prior-feedback",
         "seed-review-mode-outcomes",
+        "derive-host-repo",
         "resolve-repo-root",
         "analyze-repo-with-gitnexus",
         "verify-signing-precondition",
@@ -2353,6 +2358,7 @@ exports[`work-package walk snapshots (baseline) > [skip-optional] matches commit
       "stepsExecuted": [
         "announce-start",
         "detect-review-mode",
+        "derive-host-repo",
         "resolve-repo-root",
         "analyze-repo-with-gitnexus",
         "verify-signing-precondition",

--- a/tests/reference-delivery.test.ts
+++ b/tests/reference-delivery.test.ts
@@ -219,11 +219,12 @@ describe('reference-not-repeat delivery (B1)', () => {
         expect(isUnchangedMarker(value), `expected marker for ${key}`).toBe(true);
       }
       expect(isUnchangedMarker(second.bundle['rules'])).toBe(true);
-      // The activity body itself is still delivered. (`work-package` declares only
-      // orchestrator-scoped `rules.workflow`, so it carries no inherited `activity_rules`
-      // block — that collapse is covered below against a workflow that declares them.)
+      // The activity body itself is still delivered. (`work-package` declares an
+      // activity-scoped rules bucket alongside its orchestrator-scoped `rules.workflow`, so
+      // `start-work-package` carries an inherited `activity_rules` block; on a byte-identical
+      // refetch that block collapses to a marker just like the technique bundle above.)
       const secondBody = parse(second.bodyText) as Record<string, unknown>;
-      expect(secondBody['activity_rules']).toBeUndefined();
+      expect(isUnchangedMarker(secondBody['activity_rules'])).toBe(true);
       expect(secondBody['id']).toBe('start-work-package');
       expect(secondBody['steps']).toBeDefined();
 


### PR DESCRIPTION
Closes #348. Both obligations #345 left in the server tree, which was outside that branch's edit surface.

## 1. Harness strings — point the repo binding at the derivation

The three strings the issue enumerates still told the caller the host repo comes from the user or the workspace `AGENTS.md` — the provenance #345 demotes to a fallback. Each now names `version-control::resolve-host-repo` and states the two conditions under which prose applies at all: a workspace that is not a git repo, or a host with no origin remote.

- `src/tools/workflow-tools.ts:326` — inside the `discover` return. The urgent one: it is the first surface an orchestrator reads and sits directly above the rewritten bootstrap body, so it contradicted the new contract before any session existed. The `repo_binding: required` prefix is preserved — `tests/multi-root-bootstrap.test.ts:68` asserts it.
- `src/tools/resource-tools.ts:106` — the `start_session` tool description.
- `src/utils/session/scope.ts:238-241` — the multi-root "repo is required" error.

Also fixed a **fourth** surface the issue does not list: `docs/ide-setup.md:52` carried the identical claim on a user-facing page. Same defect, so leaving it would have left the contradiction standing. Flagging it as beyond the three checkboxes.

## 2. Submodule bump and walk re-baseline

Pointer `f84fe02b` → `bd9c03df` (#345's merge commit, 45 files), with everything that pointer invalidates refreshed in the **same commit**, as `corpus-sha.json` and `scripts/stamp-corpus-baseline.ts` both require.

- `corpus-sha.json` stamped to the new sha
- `snapshot.test.ts.snap` — one new step, `derive-host-repo`, before `resolve-repo-root` in all six policies. That is #345 splitting the old step in two (findings register WC-1). Nothing else drifted.

The walk was confirmed red before stamping: the stamp guard fired with its named cause plus all six policy snapshots — exactly the failure the issue predicted.

## Two further failures the pointer move surfaced

Neither is in the issue; both are corpus-driven, and both had to be fixed for CI to be green at the new pointer.

**`tests/reference-delivery.test.ts`** used `work-package` as its *negative* case for the inherited `activity_rules` block, premised on it declaring only orchestrator-scoped `rules.workflow`. #345 adds a `rules.activity` bucket to `work-package`, so `start-work-package` now carries that block and collapses it to an unchanged marker on a byte-identical refetch — the server behaving correctly, and what the dedicated case directly below it already asserts. Assertion and stale comment updated.

**binding-fidelity** gained one untriaged finding: `{target_path}` at `substrate-node-security-audit/techniques/write-report.md:90` has no producer. Worth being precise, because this is not a behavioural regression. #345 renames the output `target_path` → `component_path` on both `detect-repo-type` and `select-target-component`, the corpus's only producers of that name. The audit workflow declares no `target_path` variable and binds neither technique, so its read had been resolving against those unrelated `meta` declarations all along. The rename removed the cover; it did not change how that run behaves. Verified new by running the guard at both shas — 0 untriaged at `f84fe02b`, 1 at `bd9c03df`.

Triaged `fix-later` / `undeclared-seed`, which describes this state verbatim ("the value is simply not state", so the agent improvises it at the point of use), per CLAUDE.md's direction to classify new findings rather than suppress them. **The real repair is to declare and seed the value in the corpus — a change on the `workflows` lineage, not this branch** — so it stays open as counted debt rather than silenced.

## Verification

- `tsc --noEmit` clean
- 17/17 guards pass (`scripts/check-all.ts`)
- 742 tests pass

One red test remains: `session-crypto` "surfaces actionable EACCES when dir is not writable". It fails identically on unmodified `main` under the same sandbox (`chmod` does not block writes for that uid). Pre-existing and unrelated to this change.

## Not included

The `start_session` bind-time precondition — rejecting a `repo` whose mapped directory is not a git work tree — is left untouched. The issue explicitly scopes it out as a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)