### PR TITLE
fix(meta): name the agent primitives these hosts actually expose

### DIFF
--- a/meta/techniques/harness-compat/TECHNIQUE.md
+++ b/meta/techniques/harness-compat/TECHNIQUE.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 3.3.0
+  version: 3.4.0
 ---
 
 ## Capability
@@ -11,7 +11,7 @@ Abstract sub-agent dispatch operations — harness-independent vocabulary for sp
 
 ### harness_kind
 
-Identifier of the harness in use. Selects which harness-specific technique file supplies invocation details via resolve-harness-operation.
+Identifier of the harness in use.
 
 ## Rules
 
@@ -28,6 +28,10 @@ CRITICAL: every dispatch operation in this technique MUST be blocking-equivalent
 - Fire-and-forget dispatch with no completion wait is forbidden — that path silently drops checkpoint delivery.
 
 Harness-specific technique files document how each host expresses blocking-equivalent wait; this rule states only the contract.
+
+### harness-kind-from-host-surface
+
+`{harness_kind}` has no session-state producer — no workflow variable holds it and no step sets it. The executing agent determines it from its own host surface, the only place the fact is observable.
 
 ### index-in-prompt
 

--- a/meta/techniques/harness-compat/claude-code.md
+++ b/meta/techniques/harness-compat/claude-code.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 2.0.0
 ---
 
 ## Capability
@@ -11,16 +11,15 @@ Harness-specific invoke details for `harness_kind: claude-code`. Catalogue of al
 
 ### spawn
 
-- Invoke `Task(subagent_type=<type>, description={description}, prompt={composed_prompt})`. Same primitive across CLI, IDE extensions (VSCode), and the web app.
-- Omit `run_in_background` or set it false when the host true-blocks.
+- Invoke `Agent(subagent_type=<type>, description={description}, prompt={composed_prompt}, run_in_background=false)`. Same primitive across CLI, IDE extensions (VSCode), and the web app.
+- Set `run_in_background` false explicitly. Omitting it dispatches in the background, which forfeits the blocking-equivalent wait [foreground-always](./TECHNIQUE.md#foreground-always) requires.
 
 ### resume
 
-- Invoke `Task(resume={agent_id})`. Preserves the agent's context window.
+- Invoke `SendMessage(<agent id or name>, {composed_prompt})`. Preserves the agent's context window; a fresh `Agent` call would start over instead.
 - Include `{session_index}` in the prompt ([index-in-prompt](./TECHNIQUE.md#index-in-prompt)).
-- Omit `run_in_background` or set it false when the host true-blocks.
 
 ### concurrent
 
-- Emit multiple `Task` calls in a single response turn; the harness executes them in parallel.
-- Wait until every Task yields or completes before treating the batch as finished.
+- Emit multiple `Agent` calls in a single response turn; the harness executes them in parallel.
+- Wait until every agent yields or completes before treating the batch as finished.

--- a/meta/techniques/harness-compat/cursor.md
+++ b/meta/techniques/harness-compat/cursor.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 2.0.0
 ---
 
 ## Capability
@@ -11,17 +11,16 @@ Harness-specific invoke details for `harness_kind: cursor`. Catalogue of alterna
 
 ### spawn
 
-- Invoke `Task(subagent_type=<type>, description={description}, prompt={composed_prompt})`. Cursor wraps the Claude Code Task primitive across CLI, IDE, and web.
-- Prefer omitting `run_in_background` (or false) when the host true-blocks.
-- When the host only supports async Task, async dispatch is allowed **only if** the caller waits on the Cursor completion notification before continuing — that wait is blocking-equivalent under [foreground-always](./TECHNIQUE.md#foreground-always).
+- Invoke `Agent(subagent_type=<type>, description={description}, prompt={composed_prompt}, run_in_background=false)`. Cursor wraps the Claude Code agent primitive across CLI, IDE, and web.
+- Set `run_in_background` false explicitly. Omitting it dispatches in the background, which forfeits the blocking-equivalent wait [foreground-always](./TECHNIQUE.md#foreground-always) requires.
+- Background dispatch is allowed **only if** the caller waits on the Cursor completion notification before continuing — that wait is blocking-equivalent under [foreground-always](./TECHNIQUE.md#foreground-always).
 
 ### resume
 
-- Invoke `Task(resume={agent_id})`. Preserves the agent's context window.
+- Invoke `SendMessage(<agent id or name>, {composed_prompt})`. Preserves the agent's context window; a fresh `Agent` call would start over instead.
 - Include `{session_index}` in the prompt ([index-in-prompt](./TECHNIQUE.md#index-in-prompt)).
-- Prefer omitting `run_in_background` (or false) when the host true-blocks; async resume plus completion notification is allowed when the host cannot true-block.
 
 ### concurrent
 
-- Emit multiple `Task` calls in a single response turn; the harness executes them in parallel.
-- Wait until every Task yields or completes (true block, or async batch + completion notifications) before treating the batch as finished.
+- Emit multiple `Agent` calls in a single response turn; the harness executes them in parallel.
+- Wait until every agent yields or completes (synchronous dispatch, or background batch plus completion notifications) before treating the batch as finished.


### PR DESCRIPTION
## Problem

The `claude-code` and `cursor` invoke catalogues name `Task` — a tool neither host exposes. Read off the live surface: spawning is the **`Agent`** tool, resuming a spawned agent is **`SendMessage`**, and only `TaskOutput` / `TaskStop` carry the old name. A second `Agent` call starts a fresh context rather than continuing the one the `resume` slice exists to preserve.

The `run_in_background` guidance had inverted with the same rename:

> Omit `run_in_background` or set it false when the host true-blocks.

That was correct when omitting the flag meant foreground. On the live surface **omitting it dispatches in the background**, so the rule as written produces exactly the dispatch-with-no-completion-wait that [`foreground-always`](../blob/workflows/meta/techniques/harness-compat/TECHNIQUE.md) forbids.

Both defects predate the #272 host split — the prose came through it verbatim from the pre-split inline branch, and went stale in place when the hosts renamed the primitive.

Separately, `{harness_kind}` read as though something upstream bound it. No workflow variable holds it, no step sets it, and it appears nowhere in `src/`.

## Change

| File | Change |
|---|---|
| `claude-code.md` | `Task(...)` → `Agent(...)` with `run_in_background=false` explicit; `Task(resume=…)` → `SendMessage`; concurrent emits multiple `Agent` calls |
| `cursor.md` | Same, keeping Cursor's completion-notification wait as the blocking-equivalent path |
| `TECHNIQUE.md` | New `harness-kind-from-host-surface` rule; input description reduced to its bind contract |

`cline.md` and `generic.md` are untouched — their invocations belong to hosts whose surfaces are not readable from here, and `generic` names no tool at all.

## Verification

- `npm run check:all` — 18/18 guards pass
- Full suite green: 762 passed, 1 skipped file (the single `session-crypto` EACCES failure is a bubblewrap artifact and passes unsandboxed)
- Delivery probe over `CORE_ORCHESTRATOR_TECHNIQUES`: 0 unresolved refs; all three `spawn` / `resume` / `concurrent` slices arrive namespaced per harness with no collisions

## Depends on

Pairs with the parent-side delivery fix (`fix/harness-dispatch-delivery`) — until that lands, these files still reach no orchestrator. A `chore(corpus)` pointer bump after this merges is the third piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
