### PR TITLE
feat(corpus): close the binding seams #327 triaged as fix-later (#336)

### DIFF
--- a/cicd-pipeline-security-audit/techniques/execute-sub-agent.md
+++ b/cicd-pipeline-security-audit/techniques/execute-sub-agent.md
@@ -7,11 +7,21 @@ metadata:
 
 Bootstrap the workflow-server MCP from a dispatched session, load an assigned activity definition (from the activity_id passed in the spawn prompt), follow its steps sequentially with verifiable outputs, and return structured output.
 
+## Inputs
+
+### scanner_id
+
+Designator for this agent instance (e.g., 'S1', 'S2', 'V', 'M'), which also names the persisted output file.
+
 ## Outputs
 
 ### sub_agent_output
 
 Structured JSON conforming to the [sub-agent output schema](../resources/sub-agent-output-schema.md#schema).
+
+#### artifact
+
+`{scanner_id}.json`
 
 #### scanner_id
 

--- a/codebase-wiki/activities/01-confirm-scope.yaml
+++ b/codebase-wiki/activities/01-confirm-scope.yaml
@@ -24,7 +24,10 @@ steps:
         description: The wiki root or the pinned commit needs adjustment before ingest begins.
   - kind: checkpoint
     id: ingest-scope-confirmed
-    message: "Here is the ingest plan derived from the scope — the ordered list of areas to ingest. Confirm before the build pass runs."
+    message: |-
+      The ingest plan derived from the scope '{ingest_scope}' — the ordered list of areas this build pass covers:
+
+      {ingest_plan}
     blocking: true
     options:
       - id: confirmed

--- a/codebase-wiki/activities/03-lint-wiki.yaml
+++ b/codebase-wiki/activities/03-lint-wiki.yaml
@@ -14,7 +14,10 @@ steps:
       variable: lint_findings_count
       operator: ">"
       value: 0
-    message: "Lint surfaced {lint_findings_count} finding(s) — see the report above. Re-ingest to fix them, or accept and publish as-is?"
+    message: |-
+      Lint surfaced {lint_findings_count} finding(s):
+
+      {lint_findings}
     blocking: true
     options:
       - id: reingest

--- a/meta/activities/03-dispatch-client-workflow.yaml
+++ b/meta/activities/03-dispatch-client-workflow.yaml
@@ -38,14 +38,14 @@ steps:
             state: variables
       - kind: technique
         id: present-yielded-checkpoint
-        when: worker_yielded_checkpoint == true
+        when: worker_result.result_type == "checkpoint_pending"
         technique:
           name: workflow-engine::present-checkpoint-to-user
           inputs:
             session_index: client_session_index
       - kind: technique
         id: respond-yielded-checkpoint
-        when: worker_yielded_checkpoint == true
+        when: worker_result.result_type == "checkpoint_pending"
         technique:
           name: workflow-engine::respond-checkpoint
           inputs:
@@ -53,14 +53,14 @@ steps:
             checkpoint_resolution: user_selection
       - kind: technique
         id: commit-activity-artifacts
-        when: worker_yielded_checkpoint == false
+        when: worker_result.result_type == "activity_complete"
         technique:
           name: workflow-engine::commit-and-persist
           inputs:
             activity_id: current_activity
       - kind: action
         id: advance-activity
-        when: worker_yielded_checkpoint == false
+        when: worker_result.result_type == "activity_complete"
         actions:
           - action: set
             target: current_activity

--- a/ponytail/activities/05-harvest-debt-and-report.yaml
+++ b/ponytail/activities/05-harvest-debt-and-report.yaml
@@ -10,5 +10,11 @@ steps:
     id: report-gain
     technique: report-gain
     when: has_debt_markers == true
+    actions:
+      - action: message
+        message: |-
+          Honest gain from the deliberate simplifications recorded in this pass:
+
+          {gain_scoreboard}
 outcome:
   - Every deliberate simplification is recorded as trackable debt with its upgrade trigger, and the honest gain is shown

--- a/prism-audit/activities/00-scope-definition.yaml
+++ b/prism-audit/activities/00-scope-definition.yaml
@@ -24,7 +24,10 @@ steps:
     technique: summarize-scope
   - kind: checkpoint
     id: confirm-scope
-    message: Please confirm the audit scope and configuration before proceeding to prompt generation.
+    message: |-
+      The audit scope and configuration, for confirmation before prompt generation:
+
+      {scope_summary}
     options:
       - id: accept
         label: Proceed

--- a/prism-audit/activities/01-prompt-generation.yaml
+++ b/prism-audit/activities/01-prompt-generation.yaml
@@ -44,6 +44,9 @@ steps:
   - kind: technique
     id: compose-prompt
     technique: compose-audit-prompt::compose-prompt
+    actions:
+      - action: message
+        message: "Audit prompt written to {audit_prompt_path} — every prism run for this audit reads it."
   - kind: technique
     id: build-audit-scopes
     technique: compose-audit-prompt::build-audit-scopes

--- a/prism-evaluate/activities/00-scope-definition.yaml
+++ b/prism-evaluate/activities/00-scope-definition.yaml
@@ -20,7 +20,10 @@ steps:
     technique: plan-evaluation::summarize-scope
   - kind: checkpoint
     id: confirm-scope
-    message: Please confirm the evaluation scope, dimensions, and configuration before proceeding to dimension planning.
+    message: |-
+      The evaluation scope, dimensions, and configuration, for confirmation before dimension planning:
+
+      {scope_summary}
     options:
       - id: accept
         label: Proceed

--- a/prism-evaluate/activities/04-deliver-results.yaml
+++ b/prism-evaluate/activities/04-deliver-results.yaml
@@ -6,6 +6,12 @@ steps:
   - kind: technique
     id: compile-and-present
     technique: compose-evaluation-report::compile-and-present
+    actions:
+      - action: message
+        message: |-
+          Evaluation complete — {evaluation_report.core_finding}
+
+          {evaluation_metrics}
   - kind: checkpoint
     id: resolution-offer
     message: Evaluation complete. Would you like to proceed with a resolution dialogue? This will iterate through each finding, propose mitigations, and collect your decisions — producing a mitigation plan and optionally applying changes to the target.

--- a/prism-evaluate/activities/05-resolution-dialogue.yaml
+++ b/prism-evaluate/activities/05-resolution-dialogue.yaml
@@ -25,6 +25,7 @@ steps:
         actions:
           - action: set
             target: accepted_mitigations
+            value: "{finding_decision}"
             description: Append the finding's recorded decision.
       - kind: checkpoint
         id: finding-decision

--- a/prism-evaluate/techniques/compose-evaluation-report/compile-and-present.md
+++ b/prism-evaluate/techniques/compose-evaluation-report/compile-and-present.md
@@ -5,7 +5,7 @@ metadata:
 
 ## Capability
 
-Read the consolidated report to extract the flat findings list, compile the finding and run metrics, and present the metrics, core finding, recommendations, and a deliverable index listing every produced artifact with its path, organised by dimension.
+Read the consolidated report to extract the flat findings list, and compile the finding and run metrics together with a deliverable index listing every produced artifact with its path, organised by dimension.
 
 ## Outputs
 
@@ -21,4 +21,4 @@ Finding count by dimension, finding count by severity, dimensions evaluated, num
 
 - Read `{evaluation_report}` and extract `{evaluation_findings}` — each finding's ID, severity, claim, critique, and mitigation tier.
 - Compile `{evaluation_metrics}`: finding count by dimension, finding count by severity (Critical, High, Medium, Low), dimensions evaluated, number of prism runs triggered, and total analysis artifacts produced.
-- Present the results to the user: `{evaluation_metrics}`, the `{evaluation_report.core_finding}` highlight, the top-priority entries of `{evaluation_report.recommendations}`, and a deliverable index listing every produced artifact with its path — `{evaluation_report}`, `{evaluation_plan_path}`, and each dimension-specific analysis artifact in `{all_artifact_paths}` — organised by dimension.
+- Fold into `{evaluation_metrics}` a deliverable index listing every produced artifact with its path — `{evaluation_report}`, `{evaluation_plan_path}`, and each dimension-specific analysis artifact in `{all_artifact_paths}` — organised by dimension.

--- a/prism-update/activities/03-verify.yaml
+++ b/prism-update/activities/03-verify.yaml
@@ -9,7 +9,10 @@ steps:
     technique: verify-prism-consistency
   - kind: checkpoint
     id: verification-result
-    message: Verification complete. Results presented above. Proceeding in 30s unless you intervene.
+    message: |-
+      Consistency verification across resources, techniques, and documentation:
+
+      {verification_report}
     options:
       - id: accept
         label: Accept — proceed to submit

--- a/prism-update/activities/04-commit-and-submit.yaml
+++ b/prism-update/activities/04-commit-and-submit.yaml
@@ -7,5 +7,8 @@ steps:
   - kind: technique
     id: submit-update
     technique: submit-update
+    actions:
+      - action: message
+        message: "The prism update is open for review: {pull_request_url}"
 outcome:
   - The prism update is in front of a reviewer as an open pull request — ready for review and merge

--- a/prism/techniques/present-result.md
+++ b/prism/techniques/present-result.md
@@ -21,6 +21,10 @@ Filesystem path to DEFINITIVE-FINDINGS.md — the detailed companion where each 
 
 Filesystem path to RUN-MANIFEST.md — the manifest recording the run's artifacts and completion status.
 
+### run_status
+
+Completion status of the run — `complete`, `partial`, or `error` — reported alongside the artifacts so an incomplete run is never presented as a finished one.
+
 ### all_artifact_paths
 
 The accumulated artifact paths produced across the analysis run, listed for reference.
@@ -39,4 +43,4 @@ The accumulated artifact paths produced across the analysis run, listed for refe
 
 ### 3. Present Result
 
-- Present the report to the caller, including the `{report_path}`, the `{definitive_findings_path}`, the `{run_manifest_path}`, and every path in `{all_artifact_paths}` for reference.
+- Present the report to the caller, leading with the `{run_status}` and including the `{report_path}`, the `{definitive_findings_path}`, the `{run_manifest_path}`, and every path in `{all_artifact_paths}` for reference.

--- a/prism/techniques/subsystem-analysis/execute.md
+++ b/prism/techniques/subsystem-analysis/execute.md
@@ -7,6 +7,12 @@ metadata:
 
 Analyze each subsystem with its assigned prism in a fresh worker, prefixing the region with a context header naming its neighbours
 
+## Inputs
+
+### subsystem_assignments
+
+Map of subsystem to the prism assigned to analyse it.
+
 ## Outputs
 
 ### subsystem_outputs
@@ -21,5 +27,5 @@ Per-subsystem analysis outputs — one for each decomposed subsystem, produced b
 
 ### 1. Execute
 
-- For each subsystem, dispatch a fresh worker with its assigned prism, prefixing the subsystem content with a context header that names the region and its neighbours: ``# SUBSYSTEM: {code_subsystem.subsystem_name} (lines {code_subsystem.start_line}-{code_subsystem.end_line} of {code_subsystem.source_filename})`` then ``# OTHER SUBSYSTEMS: {code_subsystem.other_subsystem_names}``
+- For each subsystem, dispatch a fresh worker with the prism `{subsystem_assignments}` gives it, prefixing the subsystem content with a context header that names the region and its neighbours: ``# SUBSYSTEM: {code_subsystem.subsystem_name} (lines {code_subsystem.start_line}-{code_subsystem.end_line} of {code_subsystem.source_filename})`` then ``# OTHER SUBSYSTEMS: {code_subsystem.other_subsystem_names}``
 - Each worker writes its own `{subsystem_outputs}` entry into `{output_path}`, collecting the per-subsystem analysis outputs

--- a/remediate-vuln/activities/01-start.yaml
+++ b/remediate-vuln/activities/01-start.yaml
@@ -113,6 +113,12 @@ steps:
   - kind: technique
     id: present-security-overview
     technique: security-setup::present-security-overview
+    actions:
+      - action: message
+        message: |-
+          **Security Overview** — what this vulnerability puts at risk, in plain language
+
+          {security_overview}
   - kind: technique
     id: finalize-setup
     technique: security-setup::verify-origin-untracked

--- a/substrate-node-security-audit/activities/04-adversarial-verification.yaml
+++ b/substrate-node-security-audit/activities/04-adversarial-verification.yaml
@@ -11,7 +11,11 @@ steps:
         message: Starting adversarial verification of PASS items
   - kind: technique
     id: decompose-pass-claims
-    technique: decompose-safety-claims
+    technique:
+      name: decompose-safety-claims
+      inputs:
+        pass_items: dispatch_results
+        source_files: file_inventory
   - kind: action
     id: finalize-activity
     actions:

--- a/substrate-node-security-audit/activities/05-report-generation.yaml
+++ b/substrate-node-security-audit/activities/05-report-generation.yaml
@@ -37,8 +37,10 @@ steps:
           value: true
         message: Report generation is blocked until the merge sub-agent (M) has run and set merge_complete
       - action: validate
+        target: verification_report
         message: Report generation is blocked until every .rs file >200 lines in priority-1/2 crates has been read by at least one §3-applying sub-agent (coverage gate)
       - action: validate
+        target: reconciliation_table.unaccounted == 0
         message: Report generation is blocked until the merge reconciliation table shows zero Unaccounted findings for every agent (finding-count reconciliation gate)
   - kind: technique
     id: integrate-adversarial-results
@@ -46,12 +48,18 @@ steps:
       name: merge-findings
       inputs:
         merge_strategy: integrate
+        finding_sources: decomposition_results
+        existing_table: merge_table
   - kind: technique
     id: apply-severity
     technique: score-severity
   - kind: technique
     id: coverage-gate
-    technique: verify-sub-agent-output
+    technique:
+      name: verify-sub-agent-output
+      inputs:
+        agent_results: dispatch_results
+        expected_outputs: domain_map
   - kind: technique
     id: write-report
     condition:
@@ -69,7 +77,10 @@ steps:
           variable: merge_complete
           operator: ==
           value: true
-    technique: write-report
+    technique:
+      name: write-report
+      inputs:
+        merge_table: scored_findings
   - kind: action
     id: finalize-activity
     actions:

--- a/substrate-node-security-audit/activities/10-sub-crate-review.yaml
+++ b/substrate-node-security-audit/activities/10-sub-crate-review.yaml
@@ -27,7 +27,10 @@ steps:
     technique: verify-sub-agent-output
   - kind: technique
     id: format-output
-    technique: execute-sub-agent
+    technique:
+      name: execute-sub-agent
+      inputs:
+        step_products: "{verdict_matrix}, {invariant_table}, {storage_lifecycle}, {verification_report}"
 outcome:
   - The whole crate has been read, so no source file is silently left unreviewed
   - Every §3 checklist item has an evidence-backed verdict the orchestrator can trust without re-deriving it

--- a/substrate-node-security-audit/activities/11-sub-static-analysis.yaml
+++ b/substrate-node-security-audit/activities/11-sub-static-analysis.yaml
@@ -28,7 +28,10 @@ steps:
         output_format: "| StorageMap | Crate | insert() Sites | remove() Sites | Paired? | Cap Enforced? |"
   - kind: technique
     id: format-output
-    technique: execute-sub-agent
+    technique:
+      name: execute-sub-agent
+      inputs:
+        step_products: "{pattern_results}, {storage_lifecycle}"
 outcome:
   - The full pattern catalog has been run against the whole scope, so no static-analysis category is left unexamined
   - Each mechanical check has a decisive PASS/FAIL the orchestrator can act on without re-running it

--- a/substrate-node-security-audit/activities/12-sub-toolkit-review.yaml
+++ b/substrate-node-security-audit/activities/12-sub-toolkit-review.yaml
@@ -12,7 +12,10 @@ steps:
         checklist_source: toolkit-checklist
   - kind: technique
     id: format-output
-    technique: execute-sub-agent
+    technique:
+      name: execute-sub-agent
+      inputs:
+        step_products: "{verdict_matrix}"
 outcome:
   - Every toolkit function is reviewed against all 8 checklist items, so benign-looking helpers can no longer be skimmed past
   - State, arithmetic, and I/O bugs are surfaced per function rather than only on representative samples

--- a/substrate-node-security-audit/techniques/execute-ensemble-pass.md
+++ b/substrate-node-security-audit/techniques/execute-ensemble-pass.md
@@ -9,16 +9,6 @@ metadata:
 
 Run a second independent audit pass over the priority-1/2 components, verifying known blind spots first, and emit a second-pass findings artifact whose existence attests that the pass actually executed.
 
-## Inputs
-
-### blind_spot_items
-
-The universal blind-spot checklist items plus the target-specific items from the [target profile](../resources/target-profile.md#target-specific-ensemble-blind-spot-items).
-
-### ensemble_supplementary_files
-
-Supplementary files per the [target profile](../resources/target-profile.md#supplementary-file-assignments), ensuring blind-spot items can be mechanically verified.
-
 ## Outputs
 
 ### second_pass_findings
@@ -33,12 +23,12 @@ Findings from the second independent pass, including at least one sub-agent resu
 
 ### 1. Configure Pass
 
-- Scope the second pass to the priority-1/2 components, including `{blind_spot_items}` and `{ensemble_supplementary_files}`.
+- Scope the second pass to the priority-1/2 components, taking the supplementary files each blind-spot item needs from the [Supplementary File Assignments](../resources/target-profile.md#supplementary-file-assignments).
 - Use a different model or temperature when available; the same model with a different system prompt is acceptable.
 
 ### 2. Verify Blind Spots
 
-- Verify the universal blind-spot items first — (1) §3.1 weight accounting (non-zero `on_finalize` weight), (2) §3.3 event filtering (trace every event field independently on partial success), (3) §3.2 pagination counter (trace first-iteration behavior), (4) §2.10 serialization pairing (produce the size/serialize pairing table) — then the target-specific items from `{blind_spot_items}`, recording a CONFIRMED / REFUTED / INSUFFICIENT verdict for each.
+- Verify the universal blind-spot items first — (1) §3.1 weight accounting (non-zero `on_finalize` weight), (2) §3.3 event filtering (trace every event field independently on partial success), (3) §3.2 pagination counter (trace first-iteration behavior), (4) §2.10 serialization pairing (produce the size/serialize pairing table) — then the [Target-Specific Ensemble Blind Spot Items](../resources/target-profile.md#target-specific-ensemble-blind-spot-items), recording a CONFIRMED / REFUTED / INSUFFICIENT verdict for each.
 
 ### 3. Execute Second Pass
 

--- a/substrate-node-security-audit/techniques/execute-sub-agent.md
+++ b/substrate-node-security-audit/techniques/execute-sub-agent.md
@@ -7,11 +7,25 @@ metadata:
 
 Bootstrap the workflow-server, load an assigned activity, follow its steps sequentially, and return structured output
 
+## Inputs
+
+### agent_id
+
+Designator for this agent instance (e.g., 'a1-nto', 'b-static-analysis', 'd2-toolkit'), which also names the persisted output file.
+
+### step_products
+
+The declared products of the activity's preceding steps — the tables and verdict sets folded into the structured output.
+
 ## Outputs
 
 ### sub_agent_output
 
 Structured JSON conforming to the [Schema](../resources/sub-agent-output-schema.md#schema).
+
+#### artifact
+
+`{agent_id}.json`
 
 #### agent_id
 
@@ -63,7 +77,7 @@ observations not formal findings but for orchestrator review (optional)
 
 ### 3. Verify Output
 
-- Assemble `{sub_agent_output}` and verify it against the checks below before returning it.
+- Assemble `{sub_agent_output}` by folding every entry of `{step_products}` into its `mandatory_tables`, `checklist_coverage`, and `findings` fields, then verify it against the checks below before returning it.
 - `{sub_agent_output.steps_completed}` matches the activity's step IDs — no steps omitted.
 - Every FAIL in `{sub_agent_output.checklist_coverage}` has a corresponding finding in `{sub_agent_output.findings}`.
 - Every `{sub_agent_output.mandatory_tables}` entry is either populated or null with justification.

--- a/substrate-node-security-audit/techniques/merge-findings.md
+++ b/substrate-node-security-audit/techniques/merge-findings.md
@@ -47,17 +47,17 @@ total agent findings, total report findings, merged count, promoted count
 
 for union-merge: consensus/single-source/escalated classification per finding
 
-### reconciliation_table
-
-Per-agent finding-count reconciliation with zero Unaccounted.
-
-### calibration_crosscheck
+#### calibration_crosscheck
 
 Per-finding calibration comparison: our score, benchmark match, benchmark score, delta, action.
 
-### observation_dispositions
+#### observation_dispositions
 
 Per-observation table: source, agent, observation, disposition, finding reference.
+
+### reconciliation_table
+
+Per-agent finding-count reconciliation, carrying an `unaccounted` count that is zero when the merge is lossless.
 
 ## Protocol
 
@@ -71,7 +71,7 @@ Per-observation table: source, agent, observation, disposition, finding referenc
 
 ### 3. Elevate Observations
 
-- Review every reconnaissance lead and additional observation across `{finding_sources}`, plus every emergent vulnerability domain and reconnaissance lead in `{observation_sources}`. Each must be dispositioned as captured by an existing finding, elevated to a new finding, or not-applicable with justification, recording the `{observation_dispositions}` table. Observations describing divergent code paths, missing validation, error-path state persistence, silent error consumption, or trust boundary amplification are always security-relevant and are elevated.
+- Review every reconnaissance lead and additional observation across `{finding_sources}`, plus every emergent vulnerability domain and reconnaissance lead in `{observation_sources}`. Each must be dispositioned as captured by an existing finding, elevated to a new finding, or not-applicable with justification, recording the `{merge_table.observation_dispositions}` table. Observations describing divergent code paths, missing validation, error-path state persistence, silent error consumption, or trust boundary amplification are always security-relevant and are elevated.
 
 ### 4. Apply Strategy
 
@@ -79,11 +79,11 @@ Per-observation table: source, agent, observation, disposition, finding referenc
 
 ### 5. Score With Calibration
 
-- Score every finding using the [severity rubric](../resources/severity-rubric.md). For every finding (not just High/Critical), search the [calibration benchmarks](../resources/target-profile.md#severity-calibration-benchmark) for a matching pattern; flag a divergence of one level and treat a divergence of two or more levels as a floor at the benchmark severity. Record the `{calibration_crosscheck}` table.
+- Score every finding using the [severity rubric](../resources/severity-rubric.md). For every finding (not just High/Critical), search the [calibration benchmarks](../resources/target-profile.md#severity-calibration-benchmark) for a matching pattern; flag a divergence of one level and treat a divergence of two or more levels as a floor at the benchmark severity. Record the `{merge_table.calibration_crosscheck}` table.
 
 ### 6. Reconcile
 
-- For each agent compute Findings Submitted, In Merge Table, Explicitly Deduplicated, Elevated from Observations, and Unaccounted, recording the `{reconciliation_table}`. Unaccounted must equal zero for every agent.
+- For each agent compute Findings Submitted, In Merge Table, Explicitly Deduplicated, Elevated from Observations, and Unaccounted, recording the `{reconciliation_table}` with its `unaccounted` total. Unaccounted must equal zero for every agent.
 
 ### 7. Verify Completeness
 

--- a/substrate-node-security-audit/techniques/setup-audit-target.md
+++ b/substrate-node-security-audit/techniques/setup-audit-target.md
@@ -27,25 +27,25 @@ The target component name used to build the planning-folder name.
 
 ## Outputs
 
-### audit_target
+### target_commit
 
-Initialized target ready for analysis.
+The exact revision the target component is checked out at, recorded for reproducibility.
 
-#### confirmed_target
+### file_inventory
 
-Confirmed target component and revision
+Every in-scope source file with its line count, sorted largest first.
 
-#### dependency_scan_results
+### reference_report
 
-Dependency scan results or fallback manifest
+Path to any reference document the user supplied, recorded without being read so later phases can quarantine it.
 
-#### file_inventory
+### dependency_scan_results
 
-File inventory sorted by size
+Known-vulnerable dependency report, or the extracted dependency manifest when no scanner is available.
 
-#### reference_documents
+#### artifact
 
-Reference document paths (if any, quarantined for later phases)
+`dependency-scan.json`
 
 ### start_here
 
@@ -63,11 +63,11 @@ Session overview with audit target, commit, methodology, and artifact index.
 
 ### 2. Extract Revision
 
-- Extract the git commit hash or branch from the `{user_request}`. If not specified, default to the component's current `HEAD`. Record the exact revision for reproducibility.
+- Extract the git commit hash or branch from the `{user_request}`. If not specified, default to the component's current `HEAD`. Record the exact revision as `{target_commit}`.
 
 ### 3. Extract Reference
 
-- If the user specified any reference documents (e.g., professional audit reports, prior reviews), record their paths without loading or reading them. Set corresponding workflow variables for later phases.
+- If the user specified a reference document (e.g., a professional audit report or prior review), record its path as `{reference_report}` without loading or reading it, so later phases can quarantine it.
 
 ### 4. Checkout Revision
 
@@ -75,11 +75,12 @@ Session overview with audit target, commit, methodology, and artifact index.
 
 ### 5. Scan Dependencies
 
-- Attempt to run dependency scanning tools (e.g., `cargo audit`, `cargo deny`, `npm audit`). Save outputs to the `{planning_folder_path}`. If the scanning tools cannot be executed, fall back to manual dependency manifest extraction: extract the dependency manifest (e.g., `Cargo.lock`, `package-lock.json`) and set a flag indicating manual inspection is needed.
+- Attempt to run dependency scanning tools (e.g., `cargo audit`, `cargo deny`, `npm audit`) and record the result as `{dependency_scan_results}` in the `{planning_folder_path}`.  
+  > If the scanning tools cannot be executed, extract the dependency manifest (e.g., `Cargo.lock`, `package-lock.json`) instead and mark the result as requiring manual inspection.
 
 ### 6. Generate Inventory
 
-- Produce a sorted file inventory listing all source files with line counts, largest first. Save to the `{planning_folder_path}`. Together with the confirmed target, revision, and dependency scan results, this completes the `{audit_target}` ready for analysis.
+- Produce `{file_inventory}` listing every in-scope source file with its line count, largest first, and save it to the `{planning_folder_path}`.
 
 ### 7. Create Planning Folder
 

--- a/substrate-node-security-audit/workflow.yaml
+++ b/substrate-node-security-audit/workflow.yaml
@@ -44,6 +44,9 @@ variables:
   - name: user_request
     type: string
     description: The user's free-form request that opened this audit.
+  - name: workspace_root
+    type: string
+    description: Absolute path to the repository root the audit runs against.
   - name: target_submodule
     type: string
     description: Path to the submodule being audited (e.g., midnight-node)

--- a/work-package/activities/01-start-work-package.yaml
+++ b/work-package/activities/01-start-work-package.yaml
@@ -244,7 +244,7 @@ steps:
       value: jira
     actions:
       - action: validate
-        target: jira_cloud_id != null
+        target: cloudId != null
         message: Atlassian cloudId not set. Load the atlassian-operations technique and call getAccessibleAtlassianResources before any Jira tool.
   - kind: technique
     id: verify-github-issue
@@ -557,7 +557,10 @@ steps:
         source_material: issue details, ticket description, and any context gathered during this activity
     actions:
       - action: message
-        message: "**Problem Overview** (plain-language summary for stakeholder reference)"
+        message: |-
+          **Problem Overview** — plain-language summary for stakeholder reference
+
+          {stakeholder_overview}
   - kind: technique
     id: derive-branch-name
     technique:

--- a/work-package/activities/06-plan-prepare.yaml
+++ b/work-package/activities/06-plan-prepare.yaml
@@ -46,7 +46,10 @@ steps:
         readme_section_heading: "## Solution Overview"
     actions:
       - action: message
-        message: "**Solution Overview** (plain-language summary for stakeholder reference)"
+        message: |-
+          **Solution Overview** — plain-language summary for stakeholder reference
+
+          {stakeholder_overview}
   - kind: technique
     id: collect-assumptions
     technique:

--- a/work-package/activities/08-implement.yaml
+++ b/work-package/activities/08-implement.yaml
@@ -33,7 +33,11 @@ steps:
         technique: manage-git::artifact-commits
       - kind: technique
         id: log-provenance
-        technique: dco-provenance::append-task-row
+        technique:
+          name: dco-provenance::append-task-row
+          inputs:
+            task_id: "{current_task.id}"
+            task_description: "{current_task.description}"
       - kind: technique
         id: self-review
         technique: task-completion-review

--- a/work-package/activities/09-lean-coding-audit.yaml
+++ b/work-package/activities/09-lean-coding-audit.yaml
@@ -72,7 +72,7 @@ steps:
         id: validate-safety-floor
         actions:
           - action: validate
-            target: safety_floor
+            target: safety_floor_cleared == true
             message: Confirm the applied simplifications hold the safety floor — reject any simplification that breaches it.
       - kind: action
         id: reassess-simplification

--- a/work-package/activities/10-post-impl-review.yaml
+++ b/work-package/activities/10-post-impl-review.yaml
@@ -146,7 +146,10 @@ steps:
       value: true
   - kind: technique
     id: classify-and-route-findings
-    technique: findings-classification
+    technique:
+      name: findings-classification
+      inputs:
+        findings_to_classify: manual_diff_review_report
   - kind: checkpoint
     id: local-validation-permission
     message: Is the local environment suitable to run the project's validation suite?

--- a/work-package/activities/11-validate.yaml
+++ b/work-package/activities/11-validate.yaml
@@ -28,7 +28,10 @@ steps:
     when: project_type == 'rust-substrate' && run_local_validation == true
   - kind: technique
     id: document-failures
-    technique: findings-classification
+    technique:
+      name: findings-classification
+      inputs:
+        findings_to_classify: "{validation_results.failed_checks}"
     condition:
       type: simple
       variable: is_review_mode

--- a/work-package/activities/13-submit-for-review.yaml
+++ b/work-package/activities/13-submit-for-review.yaml
@@ -130,14 +130,6 @@ steps:
           variable: review_posted
           operator: ==
           value: true
-  - kind: technique
-    id: dco-sign-off
-    technique: dco-provenance::record-attestation
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: "!="
-      value: true
   - kind: checkpoint
     id: dco-sign-off-confirmation
     condition:
@@ -157,9 +149,23 @@ steps:
       - id: certify
         label: I certify all of the above — proceed
         description: DCO attestation recorded. Timestamp and identity logged to the [provenance log]({provenance_log_path}).
+        effect:
+          setVariable:
+            attestation_option: certify
       - id: flag-legal
         label: I have reservations — flag for legal review
         description: Document concern in the [provenance log]({provenance_log_path}) before proceeding. Consider escalating to legal or OSS program review.
+        effect:
+          setVariable:
+            attestation_option: flag-legal
+  - kind: technique
+    id: dco-sign-off
+    technique: dco-provenance::record-attestation
+    condition:
+      type: simple
+      variable: is_review_mode
+      operator: "!="
+      value: true
   - kind: technique
     id: verify-push-remote
     technique: manage-git::verify-remote-private
@@ -333,26 +339,12 @@ steps:
           variable: stealth_mode
           operator: "!="
           value: true
-        - type: simple
-          variable: squash_merge_supported
-          operator: ==
-          value: true
     actions:
       - action: message
         message: |-
           PR is ready for review. Merge strategy guidance (informational — no response needed):
 
-          **Squash merge available — use squash merge with signed commit.**
-          To get a GPG-signed + DCO-attested merge commit, merge locally:
-          ```
-          git checkout main && git pull
-          git merge --squash {branch_name}
-          git commit -s -S -m 'feat: description (#{pr_number})'
-          git push
-          ```
-          Note: GitHub web UI squash merge is not GPG-signed. Use the local flow above for a verified commit.
-
-          If squash merge is not available on this repo, branch commits land as-is — no signing required.
+          {presented_merge_guidance}
   - kind: checkpoint
     id: build-artifact-check
     condition:
@@ -423,6 +415,9 @@ steps:
   - kind: technique
     id: mark-ready
     technique: update-pr::mark-ready
+    actions:
+      - action: message
+        message: "Pull request marked ready for review — {updated_pr.pr_status}: {updated_pr.pr_url}"
     condition:
       type: and
       conditions:

--- a/work-package/activities/14-complete.yaml
+++ b/work-package/activities/14-complete.yaml
@@ -117,6 +117,12 @@ steps:
   - kind: technique
     id: select-next
     technique: conduct-retrospective::select-next
+    actions:
+      - action: message
+        message: |-
+          Hand-off for the next work package:
+
+          {next_work_package_context}
   - kind: action
     id: announce-completion
     actions:

--- a/work-package/activities/15-codebase-comprehension.yaml
+++ b/work-package/activities/15-codebase-comprehension.yaml
@@ -11,7 +11,11 @@ steps:
     technique: survey
   - kind: technique
     id: create-comprehension-artifact
-    technique: manage-artifacts::write-artifact
+    technique:
+      name: manage-artifacts::write-artifact
+      inputs:
+        artifact_content: comprehension_survey
+        target_dir: comprehension_dir
     actions:
       - action: message
         message: Comprehension artifact recorded for reference.

--- a/work-package/techniques/apply-review-fixes.md
+++ b/work-package/techniques/apply-review-fixes.md
@@ -29,12 +29,6 @@ Path to the target repository.
 
 The feature branch that receives the fix commits.
 
-## Outputs
-
-### applied_fixes
-
-One or more fix commits on `{branch_name}` that apply the selected `{review_findings}` in `{target_path}` (empty when nothing was committed).
-
 ## Protocol
 
 ### 1. Select Fixes
@@ -51,7 +45,7 @@ One or more fix commits on `{branch_name}` that apply the selected `{review_find
 
 ### 3. Commit Changes
 
-- Apply [manage-git](./manage-git/TECHNIQUE.md)::[commit-paths](./manage-git/commit-paths.md) with `{target_path}`, `{branch_name}`, the fixed source paths, and a Conventional Commits message for the fix cycle. Capture `{commit_sha}` from that Apply and emit `{applied_fixes}` as the resulting fix commit(s) on `{branch_name}` (empty when there was nothing to commit). This is the technique's final phase; no separate source commit step follows. Do not use [artifact-commits](./manage-git/artifact-commits.md) here — that op is planning-folder / engineering-repo only.
+- Apply [manage-git](./manage-git/TECHNIQUE.md)::[commit-paths](./manage-git/commit-paths.md) with `{target_path}`, `{branch_name}`, the fixed source paths, and a Conventional Commits message for the fix cycle, noting the `{commit_sha}` it returns against the findings the cycle addressed. This is the technique's final phase; no separate source commit step follows. Do not use [artifact-commits](./manage-git/artifact-commits.md) here — that op is planning-folder / engineering-repo only.
 
 
 ## Rules

--- a/work-package/techniques/assess-ticket-completeness.md
+++ b/work-package/techniques/assess-ticket-completeness.md
@@ -9,7 +9,7 @@ Tracker-ticket quality across problem, goal, scope, acceptance criteria, and use
 
 ## Inputs
 
-### ticket_details
+### issue_record
 
 Summary, description, and context of the tracker ticket being assessed (the linked issue's fields).
 
@@ -27,7 +27,7 @@ True once any identified gaps have been recorded (in the assumptions log) so the
 
 ### 1. Assess the Dimensions
 
-- Evaluate the `{ticket_details}` across five issue-quality dimensions: problem statement, goal, scope, acceptance criteria, and user stories.
+- Evaluate the `{issue_record}` across five issue-quality dimensions: problem statement, goal, scope, acceptance criteria, and user stories.
 - Judge each dimension as present and sufficient, present but weak, or missing.
 
 ### 2. Document Gaps

--- a/work-package/techniques/codebase-comprehension/survey.md
+++ b/work-package/techniques/codebase-comprehension/survey.md
@@ -31,19 +31,23 @@ Whether `{host_repo_path}` has a usable GitNexus index; selects between gitnexus
 
 ## Outputs
 
-### architecture_overview
+### comprehension_survey
+
+Initial survey of the codebase area, taking the shape and fill rules of the [Artifact Template](../../resources/codebase-comprehension.md#artifact-template).
+
+#### architecture_overview
 
 Module structure, boundaries and responsibilities, dependency relationships, and overarching patterns (layered, event-driven, actor, plugin, etc.) for the surveyed area.
 
-### key_abstractions
+#### key_abstractions
 
 Core types, traits/interfaces, and data structures forming the domain model, with type hierarchies, error-handling strategy, and state-management approach.
 
-### design_rationale
+#### design_rationale
 
 Inferred rationale for significant design choices and their trade-offs, framed as hypotheses for user validation.
 
-### domain_glossary
+#### domain_glossary
 
 Mapping of domain-specific terms to the technical modules/constructs that implement them, connected to the problem statement.
 
@@ -94,3 +98,7 @@ Mapping of domain-specific terms to the technical modules/constructs that implem
 - Map technical modules to domain concepts: what real-world problem does each subsystem solve?
 - Build a glossary of domain-specific terms found in code, comments, and documentation
 - Connect domain concepts to the problem statement to highlight relevant areas
+
+### 7. Assemble Survey
+
+- Fold the architecture overview, key abstractions, design rationale, and domain glossary into `{comprehension_survey}`, in the section order the [Artifact Template](../../resources/codebase-comprehension.md#artifact-template) defines

--- a/work-package/techniques/create-issue.md
+++ b/work-package/techniques/create-issue.md
@@ -17,9 +17,9 @@ Selected platform for issue creation (github or jira)
 
 Type of issue (feature, bug, task, enhancement, epic)
 
-### target_submodule
+### component_name
 
-Target submodule for the work package (e.g., midnight-node, midnight-ledger)
+Basename of the component the work package targets (e.g., midnight-node, midnight-ledger)
 
 ### jira_project
 
@@ -31,21 +31,13 @@ Target submodule for the work package (e.g., midnight-node, midnight-ledger)
 
 Boolean gate — `false` when step 1 verified an existing issue, otherwise `true` (a new issue must be created).
 
-### created_issue
+### issue_number
 
-Issue created on the selected platform
+Issue number of the verified or newly created issue (GitHub #N or Jira KEY-N).
 
-#### issue_number
+### issue_url
 
-Issue number (GitHub #N or Jira KEY-N)
-
-#### issue_url
-
-URL to the created issue
-
-#### jira_cloud_id
-
-Atlassian cloud ID for subsequent Jira operations (Jira only)
+URL of the verified or newly created issue.
 
 ## Protocol
 
@@ -60,9 +52,9 @@ Atlassian cloud ID for subsequent Jira operations (Jira only)
 ### 2. Create Github Issue
 
 - Runs when `{issue_platform}` is github and `{needs_issue_creation}` is true. Use attached [github-issue-creation](../resources/github-issue-creation.md) for guidance.
-- Gather title, description, and acceptance criteria from user context, scoping the issue to the `{target_submodule}` the work package targets
+- Gather title, description, and acceptance criteria from user context, scoping the issue to the `{component_name}` the work package targets
 - Map `{issue_type}` to GitHub labels using the label mapping below
-- Create the issue, then verify creation succeeded — this verified issue is the `{created_issue}`. Capture `{issue_number}` and `{issue_url}`.
+- Create the issue, then verify creation succeeded, capturing `{issue_number}` and `{issue_url}` from the verified issue.
 - GitHub label mapping: `feature->enhancement`, `bug->bug`, `task->chore`, `enhancement->enhancement`
 - If a `gh` CLI command fails (auth, permissions, or network — including the `gh issue view` verification in step 1), verify `gh` auth status and repository access, then retry or prompt the user to create the issue manually.
 
@@ -71,8 +63,8 @@ Atlassian cloud ID for subsequent Jira operations (Jira only)
 - Runs when `{issue_platform}` is jira and `{needs_issue_creation}` is true. Use attached [jira-issue-creation](../resources/jira-issue-creation.md) for guidance.
 - Obtain Atlassian cloud ID via `getAccessibleAtlassianResources` and preserve as `{$jira_cloud_id}`. This MUST be the first Jira tool call.
 - Create the issue in the `{jira_project}` chosen at the `jira-project-selection` gate; if it is unset, list available projects via `getVisibleJiraProjects` and obtain the user's project selection. Resolve available issue types for the selected project.
-- Gather summary, description, and acceptance criteria, scoping the issue to the `{target_submodule}` the work package targets. Resolve assignee account ID if specified.
-- Create the issue with mapped type using the issue-type mapping below — the resulting issue is the `{created_issue}`. Capture `{issue_number}` and `{issue_url}`.
+- Gather summary, description, and acceptance criteria, scoping the issue to the `{component_name}` the work package targets. Resolve assignee account ID if specified.
+- Create the issue with mapped type using the issue-type mapping below, capturing `{issue_number}` and `{issue_url}` from the resulting issue.
 - Jira issue type mapping: `feature->Story`, `bug->Bug`, `task->Task`, `enhancement->Story`, `epic->Epic`
 - If any Atlassian API call fails (auth, permissions, or invalid request — including the `getJiraIssue` verification in step 1), verify the cloudId and project access, and check the Jira issue type and required fields before retrying.
 

--- a/work-package/techniques/create-test-plan.md
+++ b/work-package/techniques/create-test-plan.md
@@ -9,7 +9,7 @@ Create test strategy and test plan with cases and acceptance criteria
 
 ## Inputs
 
-### plan_tasks
+### todo_tasks
 
 Atomic task breakdown with dependencies and ordering for the work package
 
@@ -31,7 +31,7 @@ Test [strategy](../resources/test-plan.md#test-plan-structure) and acceptance cr
 
 ### 2. Define Strategy
 
-- Define test strategy for the work package (unit, integration, e2e), using the `{plan_tasks}` breakdown to scope coverage to each task and its dependencies
+- Define test strategy for the work package (unit, integration, e2e), using the `{todo_tasks}` breakdown to scope coverage to each task and its dependencies
 - If `{requirements}` are not available, prompt the user to complete elicitation before continuing with test planning
 - Identify which `{requirements}` need which types of tests
 - Determine test infrastructure needs (fixtures, mocks, test doubles)

--- a/work-package/techniques/dco-provenance/record-attestation.md
+++ b/work-package/techniques/dco-provenance/record-attestation.md
@@ -9,14 +9,6 @@ Human DCO attestation recorded once per work package in `provenance-log.md`.
 
 ## Inputs
 
-### certifier_name
-
-Display name from `git config user.name`
-
-### certifier_email
-
-Email from `git config user.email`
-
 ### attestation_option
 
 One of: `certify` | `flag-legal` — the human's DCO certification selection
@@ -27,7 +19,7 @@ One of: `certify` | `flag-legal` — the human's DCO certification selection
 
 ### legal_review_note
 
-*(required only when attestation_option = flag-legal)* The concern text provided by the user
+*(optional)* The concern text provided by the user — present only when `{attestation_option}` is `flag-legal`
 
 ## Outputs
 
@@ -38,8 +30,9 @@ The updated provenance log, with the attestation section appended
 
 ## Protocol
 
-1. Append an `## Attestation` section to the `{provenance_log}` containing: ISO 8601 timestamp, certifier identity (`{certifier_name} <{certifier_email}>`), and the selected option.  
+1. Read the certifier identity from `git config user.name` and `git config user.email` at the moment of attestation, so the record carries the identity that will author the commits rather than a value captured earlier in the run.
+2. Append an `## Attestation` section to the `{provenance_log}` containing: ISO 8601 timestamp, the certifier identity as `name <email>`, and the selected option.  
    > Record the attestation only after the human has explicitly selected `certify` or `flag-legal`. The attestation is a record of a human decision; it must never be synthesised ahead of that decision.
    - If attestation is requested before the human has made an explicit `certify` or `flag-legal` selection, do not append — wait for the selection first.
    - If `provenance-log.md` does not exist at this point — meaning no task rows were appended during the work package — surface this to the user: a missing log means something went wrong during task work, so investigate the missing rows before retrying.
-2. If `attestation_option = flag-legal`, include a `Legal Review Note` field with the provided `{legal_review_note}` text.
+3. If `attestation_option = flag-legal`, include a `Legal Review Note` field with the provided `{legal_review_note}` text.

--- a/work-package/techniques/design-philosophy/TECHNIQUE.md
+++ b/work-package/techniques/design-philosophy/TECHNIQUE.md
@@ -9,7 +9,7 @@ Structured design framework — problem classification, complexity, and workflow
 
 ## Inputs
 
-### issue_details
+### issue_record
 
 Summary, description, and context from the linked issue
 

--- a/work-package/techniques/design-philosophy/classify.md
+++ b/work-package/techniques/design-philosophy/classify.md
@@ -13,7 +13,7 @@ Classify the problem as specific (cause known/unknown) or inventive (improvement
 
 The problem definition, classified into a problem type and assessed for complexity.
 
-### issue_details
+### issue_record
 
 Summary, description, and context from the linked issue, used to infer the problem type and any preliminary target symbols.
 

--- a/work-package/techniques/design-philosophy/define.md
+++ b/work-package/techniques/design-philosophy/define.md
@@ -9,7 +9,7 @@ Define a clear problem statement with system understanding, impact, success crit
 
 ## Inputs
 
-### issue_details
+### issue_record
 
 Summary, description, and context from the linked issue, reviewed to ground the problem statement.
 
@@ -27,7 +27,7 @@ A clear problem definition with system understanding, impact assessment, success
 
 ### 1. Review Context
 
-- Review `{issue_details}` and `{problem_context}`; the solution-space methodology (conventional-first, inventive principles) lives in the [design-framework](../../resources/design-framework.md#design-framework-trizics-approach) and is applied later at plan time — this operation defines the problem only
+- Review `{issue_record}` and `{problem_context}`; the solution-space methodology (conventional-first, inventive principles) lives in the [design-framework](../../resources/design-framework.md#design-framework-trizics-approach) and is applied later at plan time — this operation defines the problem only
 
 ### 2. Define Problem
 

--- a/work-package/techniques/finalize-documentation/create-complete-doc.md
+++ b/work-package/techniques/finalize-documentation/create-complete-doc.md
@@ -17,6 +17,18 @@ Path to the planning folder where the completion document is created.
 
 *(optional)* True when the run audited an external change; false or unset when it produced an implementation.
 
+### finalized_adr
+
+*(optional)* The ADR as accepted, with the implementation outcome recorded — absent when the work package created no ADR.
+
+### finalized_test_plan
+
+*(optional)* The test plan with each case linked to its test source file and line.
+
+### documented_apis
+
+*(optional)* The public APIs in the diff that the documentation pass covered.
+
 ## Outputs
 
 ### completion_document

--- a/work-package/techniques/finalize-documentation/finalize-test-plan.md
+++ b/work-package/techniques/finalize-documentation/finalize-test-plan.md
@@ -9,7 +9,7 @@ Finalize the test plan by linking each test case to its actual source location.
 
 ## Inputs
 
-### test_plan
+### test_plan_document
 
 The [test plan](../../resources/test-plan.md#test-plan-structure) artifact for this work package.
 
@@ -25,6 +25,6 @@ The work package's [test plan](../../resources/test-plan.md#test-plan-structure)
 
 ## Protocol
 
-1. Load the `{test_plan}`. If it is not found at the expected path, check `{planning_folder_path}` for alternative names.
+1. Load the `{test_plan_document}`. If it is not found at the expected path, check `{planning_folder_path}` for alternative names.
 2. Add hyperlinks to actual test source file locations per [create-test-plan](../create-test-plan.md#test-id-format)'s test-id-format rule (definition line, `**`-suffixed disabled tests) and [manage-artifacts](../manage-artifacts/TECHNIQUE.md#hyperlink-conventions).
 3. Ensure each test case references its source file and line; verify every link resolves.

--- a/work-package/techniques/implementation-analysis/TECHNIQUE.md
+++ b/work-package/techniques/implementation-analysis/TECHNIQUE.md
@@ -9,9 +9,9 @@ Current-implementation effectiveness analysis — baseline metrics, gaps, and do
 
 ## Inputs
 
-### target_submodule
+### component_name
 
-Target submodule for the work package (e.g., midnight-node, midnight-ledger)
+Basename of the component the work package targets (e.g., midnight-node, midnight-ledger)
 
 ## Outputs
 

--- a/work-package/techniques/implementation-analysis/analyze.md
+++ b/work-package/techniques/implementation-analysis/analyze.md
@@ -9,7 +9,7 @@ Effectiveness, baseline metrics, and gaps of the current implementation against 
 
 ## Inputs
 
-### target_submodule
+### component_name
 
 Target submodule for the work package, e.g. midnight-node, midnight-ledger. Used to resolve the codebase to locate and to key the GitNexus index (`gitnexus://repo/{name}/...`).
 
@@ -49,7 +49,7 @@ Gaps linked to measurable success criteria from `{requirements}`, with documente
 
 ### 2. Gitnexus First Locate
 
-- When the `{target_submodule}` codebase has a GitNexus index, apply [gitnexus-operations](../../../meta/techniques/gitnexus-operations/TECHNIQUE.md)::[query](../../../meta/techniques/gitnexus-operations/query.md)(query: `{$concept}`) to find execution flows by concept and [gitnexus-operations](../../../meta/techniques/gitnexus-operations/TECHNIQUE.md)::[context](../../../meta/techniques/gitnexus-operations/context.md)(name: `{$symbol}`) for 360-degree symbol usage (callers, callees, process membership)
+- When the `{component_name}` codebase has a GitNexus index, apply [gitnexus-operations](../../../meta/techniques/gitnexus-operations/TECHNIQUE.md)::[query](../../../meta/techniques/gitnexus-operations/query.md)(query: `{$concept}`) to find execution flows by concept and [gitnexus-operations](../../../meta/techniques/gitnexus-operations/TECHNIQUE.md)::[context](../../../meta/techniques/gitnexus-operations/context.md)(name: `{$symbol}`) for 360-degree symbol usage (callers, callees, process membership)
 - Read `gitnexus://repo/{name}/clusters` to identify functional areas and `gitnexus://repo/{name}/processes` for end-to-end flow inventory
 - Fall back to grep/Read/glob only when the codebase is not indexed or the index is stale.
 

--- a/work-package/techniques/manage-git/artifact-commits.md
+++ b/work-package/techniques/manage-git/artifact-commits.md
@@ -29,12 +29,6 @@ Engineering branch to push to
 
 Path to the product repo root (monorepo or standalone); the engineering checkout sits at or under it.
 
-## Outputs
-
-### artifact_commit
-
-The artifact commit pushed to `{branch}` on `origin` in `{eng_git_dir}`, carrying the canonical `docs(work-package): {activity_name} artifacts for {issue_key}` message and rebased onto sibling work-package commits. A side-effect op; the pushed commit is its product.
-
 ## Protocol
 
 ### 1. Commit Artifacts

--- a/work-package/techniques/manage-git/squash-merge.md
+++ b/work-package/techniques/manage-git/squash-merge.md
@@ -33,12 +33,6 @@ The feature branch whose commits are squashed onto `{default_branch}`.
 
 The pull-request number, interpolated into the merge commit subject (`(#{pr_number})`).
 
-## Outputs
-
-### squash_merge_commit
-
-A single signed, sign-off-trailered squash commit (`{type}: {commit_description} (#{pr_number})`) landed on `{default_branch}` and pushed to `origin`. A side-effect op; the merged default-branch history is its product.
-
 ## Protocol
 
 1. From `{target_path}`, check out and update the default branch: `git checkout {default_branch} && git pull`.

--- a/work-package/techniques/manage-git/sync-branch.md
+++ b/work-package/techniques/manage-git/sync-branch.md
@@ -21,13 +21,6 @@ The feature branch brought current with the default branch.
 
 The default branch (typically `main`) fetched and rebased/merged into `{branch_name}`.
 
-## Outputs
-
-### synced_branch
-
-`{branch_name}` updated to include the latest default-branch commits, with any conflicts resolved. A side-effect op; the current feature branch is its product.
-
-
 ## Protocol
 
 1. From `{target_path}`, fetch the default branch and rebase or merge it into `{branch_name}` to bring the feature branch current.

--- a/work-package/techniques/manage-git/update-repo-submodules.md
+++ b/work-package/techniques/manage-git/update-repo-submodules.md
@@ -13,12 +13,6 @@ Refresh the monorepo's submodules to their tracked remote HEADs, with locking an
 
 Path to the repo root (monorepo whose submodules are refreshed); the gate, lock, freshness sentinel, and `git submodule update` all operate inside it. The op is a no-op when this is empty or the repo root is a standalone repo with no `.gitmodules`.
 
-## Outputs
-
-### refreshed_submodules
-
-The monorepo's submodules advanced to their tracked branches' remote HEADs (or a silent skip when gated out / skip-if-recent), with the `.workflow-submodule-refresh` freshness sentinel touched on success. Pointer changes are NOT committed. A side-effect op; repo-root freshness is its product.
-
 ## Protocol
 
 ### 1. Gate and Lock

--- a/work-package/techniques/plan-prepare/plan.md
+++ b/work-package/techniques/plan-prepare/plan.md
@@ -9,10 +9,6 @@ Work-package plan artifact — task breakdown, dependencies, ordering, and recor
 
 ## Inputs
 
-### design_philosophy
-
-Design philosophy artifact with problem classification and workflow path.
-
 ### requirements
 
 Work package requirements, driving the task breakdown and success-criteria alignment.

--- a/work-package/techniques/requirements-elicitation/ask-question.md
+++ b/work-package/techniques/requirements-elicitation/ask-question.md
@@ -13,11 +13,15 @@ Single-question unit of the domain-iteration elicitation loop.
 
 The question domain for this iteration; one question is posed from it per [requirements-elicitation](../../resources/requirements-elicitation.md).
 
+### elicitation_log
+
+The record of questions asked and responses given so far, which this iteration extends.
+
 ## Outputs
 
 ### elicitation_log
 
-The record of questions asked and responses given, with this iteration's question/response appended.
+The record of questions asked and responses given, carried in from the prior iteration with this one's question and response appended.
 
 ### elicitation_complete
 

--- a/work-package/techniques/requirements-elicitation/create-document.md
+++ b/work-package/techniques/requirements-elicitation/create-document.md
@@ -21,6 +21,10 @@ The defined success criteria with verification methods, recorded into the artifa
 
 The in/out scope definitions, recorded into the artifact.
 
+### elicitation_log
+
+The record of questions asked and responses given, recorded into the artifact as the provenance of the captured requirements.
+
 ### planning_folder_path
 
 Path to the planning artifacts folder where the artifact is created.

--- a/work-package/techniques/review-code.md
+++ b/work-package/techniques/review-code.md
@@ -13,6 +13,10 @@ Rust/Substrate code review of implementation changes for architecture, error han
 
 The authored surface — the PR's changed-files set, produced canonically by `review-baseline-state`.
 
+### expected_changes
+
+*(optional)* The changes the PR was expected to make, when a review-mode baseline derived them — the yardstick the authored surface is judged against.
+
 ### project_type
 
 *(optional)* Detected project type (rust-substrate or other)

--- a/work-package/techniques/review-diff.md
+++ b/work-package/techniques/review-diff.md
@@ -17,6 +17,14 @@ Feature branch whose diff is reviewed (synced via `git pull`, parsed via `git di
 
 Folder where the change block index and manual diff review report are written
 
+### base_pr_diff
+
+*(optional)* The base↔PR diff to review, when a review-mode baseline already derived it — read in place of re-deriving the three-dot diff.
+
+### base_sha
+
+*(optional)* Commit SHA of the base branch the diff is taken against, so block citations resolve at the reviewed baseline.
+
 ### pr_number
 
 PR identifier, used to resolve the authoritative base branch via `gh pr view`

--- a/work-package/techniques/review-summary.md
+++ b/work-package/techniques/review-summary.md
@@ -13,13 +13,13 @@ Consolidated review summary in the consolidated review format.
 
 The findings gathered and classified across code review, test review, validation, and strategic review — the content the summary renders.
 
-### review_mode_resource
-
-The attached [review-mode](../resources/review-mode.md) resource. Read the whole-document skeleton from [Review Comment Template](../resources/review-mode.md#review-comment-template) and each category's findings fragment from that category's own section (e.g. [#code-review](../resources/review-mode.md#code-review), [#test-review](../resources/review-mode.md#test-review), [#strategic-review](../resources/review-mode.md#strategic-review)).
-
 ### prior_feedback_triage
 
 The triage of prior PR feedback — each prior comment dispositioned Confirmed / Refuted / Superseded — rendered as the summary's Prior Feedback Triage section.
+
+### review_ticket_ref
+
+*(optional)* The tracker ticket the reviewed PR addresses, named in the summary so the review is traceable to the work it judges.
 
 ### rating_cap
 
@@ -56,7 +56,7 @@ Every slot in `{review_summary}` whose measured size exceeds its budget in the f
 
 ### 1. Load the Format
 
-- Read the whole-document skeleton from [Review Comment Template](../resources/review-mode.md#review-comment-template) in the attached `{review_mode_resource}`. Read each category's findings fragment from that category's own section as it is populated (e.g. [#prior-feedback-triage](../resources/review-mode.md#prior-feedback-triage), [#code-review](../resources/review-mode.md#code-review), [#test-review](../resources/review-mode.md#test-review), [#documentation-review](../resources/review-mode.md#documentation-review), [#validation](../resources/review-mode.md#validation), [#branch-hygiene](../resources/review-mode.md#branch-hygiene), [#strategic-review](../resources/review-mode.md#strategic-review)).
+- Read the whole-document skeleton from [Review Comment Template](../resources/review-mode.md#review-comment-template). Read each category's findings fragment from that category's own section as it is populated (e.g. [#prior-feedback-triage](../resources/review-mode.md#prior-feedback-triage), [#code-review](../resources/review-mode.md#code-review), [#test-review](../resources/review-mode.md#test-review), [#documentation-review](../resources/review-mode.md#documentation-review), [#validation](../resources/review-mode.md#validation), [#branch-hygiene](../resources/review-mode.md#branch-hygiene), [#strategic-review](../resources/review-mode.md#strategic-review)).
 
 ### 2. Resolve the Two Refs
 

--- a/work-package/techniques/strategic-review/TECHNIQUE.md
+++ b/work-package/techniques/strategic-review/TECHNIQUE.md
@@ -47,7 +47,7 @@ Strategic review [findings](../../resources/strategic-review.md#strategic-review
 
 Architecture [summary](../../resources/architecture-summary.md#architecture-summary-artifact-template) with diagrams for stakeholders
 
-#### architecture_summary_artifact
+#### artifact
 
 `architecture-summary.md`
 

--- a/work-package/techniques/strategic-review/apply-cleanup.md
+++ b/work-package/techniques/strategic-review/apply-cleanup.md
@@ -25,12 +25,6 @@ Target repository root — restore and commit scope for source cleanup and the `
 
 The strategic review document listing the identified artifacts to remove when the user approves.
 
-## Outputs
-
-### cleanup_commit
-
-SHA of the feature-branch commit carrying the applied cleanup (identified artifacts removed when approved) and the `changes/` changelog fragment when present. Empty when there was nothing to commit.
-
 ## Protocol
 
 ### 1. Apply Cleanup

--- a/work-package/techniques/strategic-review/verify-fragment.md
+++ b/work-package/techniques/strategic-review/verify-fragment.md
@@ -13,6 +13,10 @@ Whether the work-package change fragment under the target path references the is
 
 Target repository root, checked for a `changes/` folder and the located fragment.
 
+### changes_fragment
+
+*(optional)* The changelog fragment written for this work package, when one was produced — the body checked for the issue reference.
+
 ### issue_url
 
 The full issue URL whose verbatim (or equivalent GitHub-reference) presence in the fragment body is verified.

--- a/work-package/techniques/validate-build/apply-fix.md
+++ b/work-package/techniques/validate-build/apply-fix.md
@@ -17,15 +17,12 @@ Identifier of the originally failed check
 
 Concrete fix approach to execute (file edit, `fmt-fix` invocation, dependency install, etc.)
 
-## Outputs
+### root_cause
 
-### fix_applied
-
-Boolean — true if the fix was applied; false if the fix requires user input or external action
-
+One-line statement of the root cause the fix strategy addresses, so the edit targets the cause rather than the symptom.
 
 ## Protocol
 
-1. Execute the fix per `{fix_strategy}` for the check identified by `{check_id}`: source edits go through harness Edit/Write; formatting fixes go through [cargo-operations](../../../meta/techniques/cargo-operations/TECHNIQUE.md)::[fmt-fix](../../../meta/techniques/cargo-operations/fmt-fix.md); dependency or environment fixes are surfaced to the user.
-2. Set `{fix_applied}` = true on success. Set `{fix_applied}` = false when the fix requires user input.
+1. Execute the fix per `{fix_strategy}` for the `{root_cause}` behind the check identified by `{check_id}`: source edits go through harness Edit/Write; formatting fixes go through [cargo-operations](../../../meta/techniques/cargo-operations/TECHNIQUE.md)::[fmt-fix](../../../meta/techniques/cargo-operations/fmt-fix.md); dependency or environment fixes are surfaced to the user.
+   - A fix that requires user input or external action is left unapplied; the suite re-run that follows is what reports whether the check now passes.
    - If a check keeps failing across successive analyze/fix iterations, surface the latest analysis to the user rather than looping indefinitely.

--- a/work-package/workflow.yaml
+++ b/work-package/workflow.yaml
@@ -143,6 +143,17 @@ variables:
   - name: branch_name
     type: string
     description: Feature branch name.
+  - name: default_branch
+    type: string
+    description: The repository's default branch, which feature branches sync from and merge into.
+  - name: attestation_option
+    type: string
+    description: "The human's DCO certification selection: 'certify' or 'flag-legal'."
+    defaultValue: certify
+  - name: safety_floor_cleared
+    type: boolean
+    description: Whether the applied simplifications hold the ponytail safety floor.
+    defaultValue: false
   - name: review_pr_url
     type: string
     description: URL of the PR being reviewed (review mode only).

--- a/work-packages/activities/01-scope-assessment.yaml
+++ b/work-packages/activities/01-scope-assessment.yaml
@@ -3,18 +3,15 @@ version: 1.2.0
 name: Scope Assessment
 description: Confirm multi-work-package initiative and identify work packages to be planned
 steps:
-  - kind: action
-    id: verify-preconditions
-    actions:
-      - action: validate
-        target: agents_md_read
-        message: AGENTS.md must be read before starting workflow
   - kind: technique
     id: assess-scope
     technique: assess-initiative-scope
   - kind: checkpoint
     id: scope-confirmed
-    message: I've identified N work packages. Proceed with planning?
+    message: |-
+      The initiative decomposes into {package_count} independently deliverable work packages:
+
+      {work_packages}
     options:
       - id: proceed
         label: Proceed with planning

--- a/work-packages/activities/05-prioritization.yaml
+++ b/work-packages/activities/05-prioritization.yaml
@@ -8,7 +8,10 @@ steps:
     technique: prioritize-packages
   - kind: checkpoint
     id: priority-confirmed
-    message: Here's the proposed priority order. Adjust as needed?
+    message: |-
+      The proposed execution order, with the dependency graph and per-package rationale behind it:
+
+      {priority_order}
     options:
       - id: accept
         label: Accept priority order

--- a/work-packages/activities/06-finalize-roadmap.yaml
+++ b/work-packages/activities/06-finalize-roadmap.yaml
@@ -8,7 +8,7 @@ steps:
     technique: document-roadmap
   - kind: checkpoint
     id: roadmap-complete
-    message: Roadmap complete. Ready to begin implementation?
+    message: The roadmap is complete — packages sequenced with navigation and success criteria, over an estimated span of {timeline_estimate}.
     options:
       - id: begin
         label: Begin implementation

--- a/work-packages/techniques/assess-initiative-scope.md
+++ b/work-packages/techniques/assess-initiative-scope.md
@@ -9,9 +9,9 @@ Identify and categorize work packages from a multi-package initiative descriptio
 
 ## Inputs
 
-### user_initiative_description
+### user_request
 
-Free-form description of the initiative from the user
+The user's free-form description of the initiative.
 
 ## Outputs
 
@@ -31,7 +31,7 @@ Total number of identified packages
 
 ### 1. Confirm Multi Package
 
-- Read `{user_initiative_description}` and assess whether it involves multiple distinct deliverables or a single work package  
+- Read `{user_request}` and assess whether it involves multiple distinct deliverables or a single work package  
   > If it is a single package, recommend the `work-package` workflow instead and stop.
 - If multiple packages, proceed with decomposition
 
@@ -43,11 +43,10 @@ Total number of identified packages
 - Name each package descriptively using the domain language from the user's description
 - Capture a one-sentence description for each package
 
-### 3. Present Scope
+### 3. Size and Name
 
-- Present the `{work_packages}` as a numbered table of the identified packages with name and description
-- Highlight any packages that seem too large (should be split) or too small (should be merged)  
-  > Packages should be 2-8 hours of agentic work. Larger packages should be split; smaller ones merged.
+- Assemble `{work_packages}` as a numbered table of the identified packages with name and description, and `{package_count}` as its row count
+- Split any package larger than 8 hours of agentic work along a natural boundary, and merge any smaller than 2 hours into its nearest sibling
 - Set `{initiative_name}` based on the overall theme of the packages, per the [planning-folder-template](../resources/planning-folder-template.md#folder-location)
 
 ## Rules

--- a/work-packages/techniques/document-roadmap.md
+++ b/work-packages/techniques/document-roadmap.md
@@ -64,7 +64,3 @@ Overall timeline span for the initiative, derived from phase durations
 
 - Define initiative-level success criteria (all packages complete, domain-specific criteria)
 - Reference per-package criteria from individual plan documents
-
-### 5. Present Roadmap
-
-- Present the completed `{start_here}` roadmap to the user for final review

--- a/work-packages/techniques/orchestrate-package-execution/execute-package.md
+++ b/work-packages/techniques/orchestrate-package-execution/execute-package.md
@@ -31,9 +31,9 @@ Progress indicator (e.g., '3/7 complete'), written into the updated START-HERE.m
 
 `START-HERE.md`
 
-### package_planning_paths
+#### package_planning_paths
 
-Map of package name to the child work-package's planning-folder path, captured as each child workflow completes
+Map of package name to the child work-package's planning-folder path, rendered as the planning-folder link in each status row
 
 ## Protocol
 
@@ -50,8 +50,8 @@ Map of package name to the child work-package's planning-folder path, captured a
 
 ### 3. Update Status
 
-- Capture the completed package's `{planning_folder_path}` from the child workflow's `returnedContext` and store it in `{package_planning_paths}` keyed by package name
-- Update the `START-HERE.md` status table: mark the completed package as done, add its PR link, and add a link to the package's planning-folder `README.md`
+- Capture the completed package's `{planning_folder_path}` from the child workflow's `returnedContext` as `{$package_planning_paths}`, keyed by package name
+- Update the `START-HERE.md` status table: mark the completed package as done, add its PR link, and add the package's planning-folder link from `{package_planning_paths}`
 - Recompute `{overall_progress}` to reflect the completed count
 
 ### 4. Check Remaining

--- a/work-packages/techniques/prioritize-packages.md
+++ b/work-packages/techniques/prioritize-packages.md
@@ -27,41 +27,35 @@ Ordered list of work packages by execution priority, with prioritization rationa
 
 `priority-ranking.md`
 
-### dependency_graph
+#### dependency_graph
 
-Dependency graph representation
+Dependency graph representation, showing which packages block or depend on which others
 
-### prioritization_rationale
+#### prioritization_rationale
 
-Per-package rationale for the ordering
+Per-package rationale for the ordering, with the value, risk, and effort assessments behind it
 
 ## Protocol
 
 ### 1. Analyze Dependencies
 
 - Apply the [prioritization-framework](../resources/prioritization-framework.md#step-1-dependency-graph) evaluation methodology
-- Build a dependency graph from the dependency sections of all `{package_plans}`, cross-checking against `{dependency_map}` to confirm which packages block or depend on which others
-- Perform topological sort to identify valid orderings
-- If the dependency graph contains cycles, present the cycle to the user and recommend decomposition or dependency removal
+- Build the dependency graph from the dependency sections of all `{package_plans}`, cross-checking against `{dependency_map}` to confirm which packages block or depend on which others
+- Perform topological sort to identify valid orderings  
+  > A cycle is a decomposition problem: record the cycle and the packages in it, and recommend extracting the shared component or removing the dependency.
 
 ### 2. Evaluate Criteria
 
 - For each package, assess: business value (High/Medium/Low), risk (High/Medium/Low), effort (High/Medium/Low)
 - Use the [scoring guidance](../resources/prioritization-framework.md#scoring-guidance) from the prioritization framework
-- Document the rationale for each assessment
+- Record the rationale for each assessment
 
-### 3. Propose Order
+### 3. Assemble Ranking
 
 - Apply priority ordering rules: dependency-first, then high-value/low-effort, then high-risk-early
 - Identify packages that could be parallelized (independent, no shared resources)
-- Generate the priority table with package, value, risk, effort, and rationale
+- Write `{priority_order}` as the ranking document: the priority table with package, value, risk, effort, and rationale, the dependency graph as text or a mermaid diagram, and any alternative valid sequences
 - If all packages evaluate identically on every criterion, ask the user which dimension matters most for their context to break the tie
-
-### 4. Present Prioritization
-
-- Present the `{dependency_graph}` (text or mermaid diagram)
-- Present the priority table with `{prioritization_rationale}` for the proposed order, forming `{priority_order}`
-- Note alternative orderings if multiple valid sequences exist
 
 ## Rules
 

--- a/work-packages/workflow.yaml
+++ b/work-packages/workflow.yaml
@@ -22,6 +22,9 @@ techniques:
   activity:
     - variable-binding
 variables:
+  - name: user_request
+    type: string
+    description: The user's free-form description of the initiative that opened this session.
   - name: initiative_name
     type: string
     description: Name of the overall multi-package initiative
@@ -64,12 +67,6 @@ variables:
   - name: dependency_map
     type: object
     description: Map of inter-package dependencies identified during package planning
-  - name: dependency_graph
-    type: string
-    description: Visual or structured dependency graph representation
-  - name: prioritization_rationale
-    type: string
-    description: Reasoning for the chosen priority order
   - name: roadmap_complete
     type: boolean
     description: Whether the roadmap has been finalized and approved
@@ -80,7 +77,4 @@ variables:
   - name: parent_workflow
     type: string
     description: Reference back to work-packages context when triggering work-package workflow
-  - name: package_planning_paths
-    type: object
-    description: Map of package name/index to the child work-package's planning_folder_path. Populated from returnedContext after each child workflow completes. Used to link the initiative README to each WP's independent planning folder.
 initialActivity: scope-assessment

--- a/workflow-authoring/activities/09-validate-and-commit.yaml
+++ b/workflow-authoring/activities/09-validate-and-commit.yaml
@@ -136,6 +136,8 @@ steps:
       name: version-control::commit-regular-files
       inputs:
         branch: workflow_branch
+        paths: paths
+        commit_message: commit_message
     when: commit_approved == true && remediation_selected != true && review_closed != true && update_seeded_from_review != true
   - kind: technique
     id: verify-commit
@@ -158,6 +160,8 @@ steps:
         repo_path: target_path
         branch: workflow_branch
         base_branch: workflows
+        title: title
+        body: body
         as_draft: false
     when: commit_approved == true && remediation_selected != true && review_closed != true && update_seeded_from_review != true
   - kind: technique

--- a/workflow-design/activities/06-scope-and-draft.yaml
+++ b/workflow-design/activities/06-scope-and-draft.yaml
@@ -103,7 +103,10 @@ steps:
             description: Drafting approach for this file requires revision.
       - kind: technique
         id: yaml-authoring
-        technique: yaml-authoring
+        technique:
+          name: yaml-authoring
+          inputs:
+            schema_type: "{current_file.type}"
       - kind: technique
         id: review-drafted-file
         technique: review-drafted-file

--- a/workflow-design/activities/09-validate-and-commit.yaml
+++ b/workflow-design/activities/09-validate-and-commit.yaml
@@ -205,6 +205,8 @@ steps:
         repo_path: target_path
         branch: workflow_branch
         base_branch: workflows
+        title: title
+        body: body
         as_draft: true
     condition:
       type: simple

--- a/workflow-design/activities/10-post-update-review.yaml
+++ b/workflow-design/activities/10-post-update-review.yaml
@@ -206,6 +206,8 @@ steps:
         repo_path: target_path
         branch: workflow_branch
         base_branch: workflows
+        title: title
+        body: body
         as_draft: false
     when: needs_recommit == true
   - kind: action

--- a/workflow-design/resources/anti-patterns.md
+++ b/workflow-design/resources/anti-patterns.md
@@ -1804,3 +1804,15 @@ Several techniques reach a harness capability directly because no operation owns
 **Do not flag:** A single call site — one consumer is not duplication, and inventing a wrapper against a hypothetical second is premature (`duplicate-shared-capability`). Sites that already bind or Apply a wrapping op, and the wrapper itself, where naming the tool is the point (`canonical-technique-reference`). Surfaces whose domain is the harness — engine, conduct, bootstrap and agent-entry prompts. Distinct callers of one tool for genuinely different capabilities.
 
 **Fix:** Author the operation that owns the capability, declaring its product on `## Outputs`; bind it as an activity step ahead of its consumers and let them declare that product as an input — never a Protocol `Apply` from each consumer (`pass-orchestration-in-technique`). Repoint every sideways citation at the owner. See also `no-duplicated-guidance`, `tool-contract-restated-in-protocol`.
+
+### AP-138. output-without-destination
+
+"`dependency_graph` and `prioritization_rationale` declared beside the ranking document whose sections they are"
+
+A declared output has nowhere to go, so the value exists only in the producing worker's report.
+
+**Detect:** For each `### <id>` under a technique's `## Outputs`, name where the value lands. A destination is an `#### artifact` on that entry; a step binding, output remap, gate, `validate` target, or same-named input reachable from a workflow that can bind this op; or a `{id}` interpolation in the binding activity's message or checkpoint text. Flag an entry with none — including one whose only mention is its own Protocol ("return `{id}`"), and one backed by a workflow `variables[]` slot that nothing reads. Test: name the reader; if the answer is the worker's own report, the entry is not a bind contract.
+
+**Do not flag:** An operation whose callers resolve outside the declaring tree — a shared library op, or one bound cross-workflow — where having no in-tree consumer is the expected state of a library. An output whose consumer is a sibling `#### artifact` token-template on the same technique, which resolves when the artifact contract is synthesised. A terminal activity's product that the binding activity surfaces: position at the end of the graph is not the licence, the delivery is.
+
+**Fix:** Give the value the destination it has. A file → `#### artifact` on the entry (`artifact-not-buried`, `artifact-name-is-filename`). A field of a sibling output's document → a `####` component of that output rather than a sibling `###` entry. A value a later step needs → bind it at the step and let the consumer declare it as an input. A value the run must show a human → interpolate `{id}` from the binding activity (`session-interaction-in-technique`). Where none applies the declaration is dead weight: delete it, and the variable that shadowed it. See [Output Economy](./design-principles.md#12-output-economy) and [Separate Contract from Procedure](./design-principles.md#13-separate-contract-from-procedure); the inverse smell is `technique-outputs-declared`.

--- a/workflow-design/techniques/review-draft-yaml.md
+++ b/workflow-design/techniques/review-draft-yaml.md
@@ -23,10 +23,6 @@ The classified operation — `create` or `update`.
 
 The block-indexed review table following the [Draft Attestation Guide](../resources/draft-attestation.md#template).
 
-### draft_attestation
-
-Record in the planning folder that every drafted block has been reviewed and is understood and intentional (closing line of the [draft-attestation](../resources/draft-attestation.md#template) template).
-
 ### draft_attestation_path
 
 Absolute path to the written draft-attestation artifact (includes the block-indexed review).
@@ -34,6 +30,10 @@ Absolute path to the written draft-attestation artifact (includes the block-inde
 #### artifact
 
 `draft-attestation.md`
+
+#### draft_attestation
+
+Closing line of the [draft-attestation](../resources/draft-attestation.md#template) template, recording that every drafted block has been reviewed and is understood and intentional.
 
 ## Protocol
 
@@ -48,5 +48,5 @@ Absolute path to the written draft-attestation artifact (includes the block-inde
 
 ### 3. Record Draft Attestation
 
-- Record `{draft_attestation}` in that artifact once every block is marked understood and intentional; flag any block marked for revision
+- Record `{draft_attestation_path.draft_attestation}` in that artifact once every block is marked understood and intentional; flag any block marked for revision
 - Binding-fidelity pass: for each drafted activity step that persists a planning artifact, confirm `manage-artifacts::write-artifact` (or equivalent) is a bound `steps[]` entry — not protocol-only prose — and that every technique input marked required has a producer in the same activity (or an explicit step-binding). Flag gaps for revision before attestation closes.

--- a/workflow-design/techniques/summarize-findings.md
+++ b/workflow-design/techniques/summarize-findings.md
@@ -7,6 +7,16 @@ metadata:
 
 Severity-rated summary of post-update audit findings.
 
+## Inputs
+
+### scope_drift_findings
+
+Severity-rated drift findings — files changed outside the manifest, and manifest items with no corresponding change. Empty on a clean pass.
+
+### fixes_applied
+
+*(optional)* Per-finding record of what the remediation pass edited, when one ran.
+
 ## Outputs
 
 ### findings_summary

--- a/workflow-design/techniques/yaml-authoring.md
+++ b/workflow-design/techniques/yaml-authoring.md
@@ -19,9 +19,9 @@ Which schema applies to this file — one of: workflow (`schemas/workflow.schema
 
 ## Outputs
 
-### yaml_file
+### drafted_files
 
-A syntactically valid YAML file that passes schema validation
+The set of files drafted for this workflow so far, extended with the one just written — each syntactically valid and passing schema validation for its type.
 
 ## Protocol
 
@@ -40,7 +40,7 @@ A syntactically valid YAML file that passes schema validation
 
 ### 4. Draft Content
 
-- Write `{yaml_file}` per Rules below (block arrays/mappings, scalar quoting, multi-line scalars, field ordering, version format)
+- Write the file per Rules below (block arrays/mappings, scalar quoting, multi-line scalars, field ordering, version format), adding it to `{drafted_files}`
 - Description hygiene for prose fields: [Document in Positive Present](../resources/design-principles.md#17-document-in-positive-present) and Description Hygiene anti-patterns — do not bury procedure in `description` / `outcome` / `message` / option text
 
 ### 5. Validate Against Schema


### PR DESCRIPTION
Closes the corpus half of #336. The guard, triage and test changes are a
separate PR against `main` — **merge this one first**; the server PR's triage
file is only correct against this corpus.

## What this does

Every value a technique declares now has a destination. Of the 119 `fix-later`
binding-fidelity findings #327 triaged, **78 are closed by wiring in this PR**;
the rest are closed on the server side by guard fixes and re-verdicts.

Worked as seams, not as a list, so the count fell faster than 1:1:

| Seam | Findings |
|---|---|
| `codebase-comprehension::survey` declared four outputs nothing consumed, while the next step wrote an artifact it had no content for | 4 |
| `meta`'s dispatch loop gated four steps on `worker_yielded_checkpoint`, which nothing produces — the worker envelope already carries `result_type` as its discriminant | 4 |
| `title` / `body` / `paths` / `commit_message` composed but never passed to the meta `create-pr` and `commit-regular-files` ops | 6 |
| `substrate-node-security-audit` recon products fanned out to consumers that never declared them | 20 |

Several `undeclared-seed` inputs turned out to be shadows rather than gaps:
`ticket_details` and `issue_details` are the `issue_record` their producers
already declare, `target_submodule` is `component_name`, `jira_cloud_id` is the
`cloudId` that `resolve-cloud-id` owns, `plan_tasks` is `todo_tasks`, and
`safety_floor` is `safety_floor_cleared`. Those close under **Single Source of
Truth** rather than by adding state.

Where a technique's own Outputs said *"a side-effect op; the pushed commit is
its product"*, the declaration is deleted — `artifact-commits`, `squash-merge`,
`sync-branch`, `update-repo-submodules`, `apply-review-fixes`, `apply-cleanup`,
`validate-build::apply-fix`. A contract nothing can bind is not a contract.

Delivery moved to the activities that own it, per **Keep Session Interaction in
Activities**: the `Present` phases in `prioritize-packages`,
`document-roadmap`, `assess-initiative-scope` and `compile-and-present` are
gone, and their bind sites interpolate the values instead. Both
`stakeholder-overview` messages were caption-only and now carry the summary
they announced.

## Defects found on the way, fixed here

- **DCO attestation ran before its own sign-off.** `record-attestation` was
  bound *ahead* of `dco-sign-off-confirmation`, and that checkpoint carried no
  `setVariable` effects at all — so `attestation_option` and
  `legal_review_note` were never written by anything, and the op's own rule
  ("never synthesised ahead of that decision") had nothing enforcing it. The
  checkpoint now precedes the record and carries its effects.
- **A misspelled artifact block.** `strategic-review/TECHNIQUE.md` declared
  `#### architecture_summary_artifact` where the construct is `#### artifact`,
  so the server never saw the declaration.
- **Two inert gates.** `substrate-node-security-audit`'s report-generation
  guard had two `validate` actions with a message and no `target`. They now
  name `reconciliation_table.unaccounted` and `verification_report`.

## Canon

Adds `output-without-destination` to
[anti-patterns.md](workflows/workflow-design/resources/anti-patterns.md) — the
design-time home for this smell, its four dispositions (declare the artifact,
fold into a sibling output as a `####` component, bind it, or surface it from
the binding activity), and the two carve-outs where having no consumer is what
a correct contract looks like. This is #336 R5's decision: **being the last
step of a workflow is not a licence; the delivery is.**

No wiring needed — `audit-anti-patterns` refuses to depend on the catalog's
entry count, so the walk picks it up.

## Please look at this one

`work-packages`' `verify-preconditions` step is **removed**. Its `validate`
targeted `agents_md_read`, which nothing produces, so the gate could never
pass. The `agents-md-prerequisite` workflow rule is now the single home, which
trades structure for text against **Encode Constraints as Structure**.
Restoring enforcement needs a step that actually sets the flag — this is the
only place the change reduces enforcement rather than increasing it.

## Verification

`npm run check:all` — 19/19 pass against this corpus (with the server PR's
guard applied). `binding-fidelity` reports 0 live, 0 untriaged, 0 fix-later.

## After merge

The parent repo needs the submodule bump plus both corpus stamps refreshed in
one commit: `npm run test:ci -- -u`, `npm run baseline:stamp`, and the matching
`corpusSha` in `scripts/binding-fidelity-triage.json`. Both stamps currently
read `6bc46faf` while the checkout is at `f7eb4793` — that drift pre-dates this
work and is the named cause of the 7 `tests/e2e/snapshot.test.ts` failures.

Refs #336, #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)
