### PR TITLE
fix: session metrics minutes + post-exit revise

### DIFF
--- a/meta/activities/04-end-workflow.yaml
+++ b/meta/activities/04-end-workflow.yaml
@@ -1,5 +1,5 @@
 id: end-workflow
-version: 4.4.0
+version: 4.5.0
 name: End Workflow
 description: Close out the client workflow.
 required: true
@@ -7,6 +7,20 @@ steps:
   - kind: technique
     id: read-session
     technique: workflow-engine::read-session
+  - kind: technique
+    id: revise-session-metrics
+    technique: workflow-engine::revise-session-metrics
+    condition:
+      type: and
+      conditions:
+        - type: simple
+          variable: client_workflow_completed
+          operator: ==
+          value: true
+        - type: simple
+          variable: planning_folder_path
+          operator: "!="
+          value: ""
   - kind: technique
     id: verify-outcomes
     technique:
@@ -44,4 +58,5 @@ steps:
         message: Workflow session closed
 outcome:
   - The user can decide whether the work is truly done — every target outcome is shown as met or flagged as a gap to address
+  - Session-trace and token-usage artifacts include the client terminal activity after that activity has exited
   - The completed session can be resumed or audited later because its final state is durably preserved

--- a/meta/techniques/workflow-engine/revise-session-metrics.md
+++ b/meta/techniques/workflow-engine/revise-session-metrics.md
@@ -1,0 +1,72 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Rewrite the client planning folder's session-trace and token-usage artifacts from the full client session ledger after that workflow has finished — including the terminal activity's own dispatch.
+
+## Inputs
+
+### planning_folder_path
+
+Absolute path to the client planning folder holding `token-usage.md` and `session-trace.md`.
+
+### client_session_index
+
+*(optional)* Client session index when the durable history lives on a child session rather than the meta session file alone.
+
+### trace_tokens
+
+*(optional)* Opaque client-run trace tokens for dispatch reconciliation when present.
+
+## Outputs
+
+### token_usage_document
+
+Updated sole cost home under the planning folder (`*token-usage.md`).
+
+### session_trace_document
+
+Updated lean mechanical trace under the planning folder (`*session-trace.md`).
+
+## Protocol
+
+### 1. Read the full client ledger
+
+- Read rolled-up `activity_usage` from the **client** session after its terminal activity has exited and the orchestrator has had its chance to `record_usage` for that dispatch ([account-every-dispatch](./dispatch-activity.md#account-every-dispatch)).
+- Include every activity that ran, including the terminal activity and any failed or partial dispatches that left a ledger row.
+- When the ledger is empty, leave existing artifacts untouched and stop — do not fabricate figures.
+
+### 2. Re-render token usage
+
+- Find-or-update the existing `token-usage.md` (same prefix the client close-out minted) with:
+  - Per-activity table: activity id, dispatch/ledger counts, tool uses, **Duration (min)** (`min = duration_ms / 60000`, one decimal), subagent tokens (or input/output when those fields exist), model, `priceTableVersion`, cost (`unknown` when unpriced).
+  - Per-workflow totals: token sum, wall-duration sum in minutes, cost.
+  - `usage_coverage`: ledger entry count, actual fresh-dispatch count, unaccounted remainder. When remainder > 0, label totals a **floor**.
+  - Estimate-not-bill caveat.
+- Do not mint a second prefix.
+
+### 3. Re-render session trace
+
+- Find-or-update the existing `session-trace.md` from the same ledger — mechanical only (dispatches, tool calls, durations in minutes, errors, `vw` clusters). Cost by one link to token-usage; no token figures restated.
+- When a successful terminal dispatch left no ledger row, record that gap in mechanical notes and in `usage_coverage`. Wall-clock from durable `activity_dispatched`/`activity_entered` to `activity_exited` may appear as an **unpriced duration note** only when both timestamps exist — never as invented tokens.
+
+### 4. Refresh the README cost line
+
+- Update the planning-folder README token-use summary line to match the revised totals. When usage is absent, omit the line.
+
+## Rules
+
+### after-client-exit
+
+Runs only after the client terminal activity has exited. A write inside that activity cannot see its own dispatch figure.
+
+### authoritative-over-draft
+
+When both an in-client-close-out draft and this revision exist, this revision is authoritative. Find-or-update in place.
+
+### no-fabrication
+
+No invented token or cost cells. Unledgered wall-clock is a mechanical note only.

--- a/work-package/resources/session-trace.md
+++ b/work-package/resources/session-trace.md
@@ -2,7 +2,7 @@
 name: session-trace
 description: Creation-guide for the lean mechanical session-trace artifact written at close-out.
 metadata:
-  version: 1.1.0
+  version: 1.1.1
 ---
 
 
@@ -21,9 +21,9 @@ Cost: [token-usage.md](NN-token-usage.md) — the run's sole cost home.
 
 ## Per-activity summary
 
-| Activity | Dispatches | Tool calls | Duration (ms) | Errors | `vw` clusters |
-|----------|------------|------------|---------------|--------|---------------|
-| {activity_id} | N | N | total/ms | count + sample `err` | summary when present |
+| Activity | Dispatches | Tool calls | Duration (min) | Errors | `vw` clusters |
+|----------|------------|------------|----------------|--------|---------------|
+| {activity_id} | N | N | total/min | count + sample `err` | summary when present |
 
 <!-- Omit empty metric rows. Prefer compact tables over narrative. -->
 
@@ -33,6 +33,7 @@ Cost: [token-usage.md](NN-token-usage.md) — the run's sole cost home.
 ## Rules
 
 - **Mechanical only** — dispatches, tool calls, durations, errors and `vw` clusters. No token counts, no cost figures, no per-activity spend: the trace and the cost artifact read the same ledger, so a figure restated here turns one wrong ledger into two disagreeing artifacts.
+- **Duration in minutes** — wall-clock session time is a reader metric; print **Duration (min)** (one decimal is enough). The harness ledger may store milliseconds — convert at render (`min = ms / 60000`). Do not put ms in the column header or cell.
 - **Cost by link** — one line linking `token-usage.md` when present; that artifact is the sole cost home.
 - **Exception-oriented** — omit empty metric rows; prefer compact tables over narrative.
 - **Skip when empty** — when tokens are absent or empty, write the one-line skip (or omit the artifact); do not fabricate events.

--- a/work-package/resources/session-trace.md
+++ b/work-package/resources/session-trace.md
@@ -38,3 +38,4 @@ Cost: [token-usage.md](NN-token-usage.md) — the run's sole cost home.
 - **Exception-oriented** — omit empty metric rows; prefer compact tables over narrative.
 - **Skip when empty** — when tokens are absent or empty, write the one-line skip (or omit the artifact); do not fabricate events.
 - **Complementary** — mechanical detail lives here; COMPLETE.md retrospective owns signal classes and recommendations.
+- **Revised after client exit** — a mid-`complete` draft cannot include the terminal activity's own dispatch. Meta `end-workflow` rewrites this artifact via [revise-session-metrics](../../meta/techniques/workflow-engine/revise-session-metrics.md) after the client session exits; that rewrite is authoritative.

--- a/work-package/techniques/conduct-retrospective/retrospective.md
+++ b/work-package/techniques/conduct-retrospective/retrospective.md
@@ -53,7 +53,7 @@ Lean mechanical summary of resolved trace events (dispatch counts, tool counts, 
 ### 2. Resolve Session Trace
 
 - Resolve `{trace_tokens}` once at close-out per [resolve-trace-at-close-out](../../../meta/techniques/workflow-engine/dispatch-activity.md#resolve-trace-at-close-out); skip when empty (no fabrication).
-- Write `{session_trace_document}` under `{planning_folder_path}` via find-or-update ([artifact-prefix](../manage-artifacts/TECHNIQUE.md#artifact-prefix)) following [session-trace](session-trace#template) — mechanical execution only, no token or cost figure.
+- Write `{session_trace_document}` under `{planning_folder_path}` via find-or-update ([artifact-prefix](../manage-artifacts/TECHNIQUE.md#artifact-prefix)) following [session-trace](session-trace#template) — mechanical execution only, no token or cost figure. This mid-`complete` write is a **draft**; meta `end-workflow` rewrites it via [revise-session-metrics](../../../meta/techniques/workflow-engine/revise-session-metrics.md) after the client exits so the terminal activity is included.
 
 ### 3. Conduct Retrospective
 

--- a/work-package/techniques/finalize-documentation/render-token-usage.md
+++ b/work-package/techniques/finalize-documentation/render-token-usage.md
@@ -1,11 +1,11 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
 
-Sole cost home for a run — the token-use and cost-estimate artifact, reconciled against the run's actual dispatch count, with a one-line README link.
+Sole cost home for a run — the token-use and cost-estimate artifact, reconciled against the run's actual dispatch count, with a one-line README link. A draft written mid-`complete` is revised after the client exits by [workflow-engine::revise-session-metrics](../../../meta/techniques/workflow-engine/revise-session-metrics.md) so the terminal activity is included.
 
 ## Inputs
 
@@ -47,10 +47,11 @@ Share of the run's dispatches the ledger accounts for: ledger entry count, actua
 
 - Create `{token_usage_document}` at `{planning_folder_path}` per [artifact-prefix](../manage-artifacts/TECHNIQUE.md#artifact-prefix) containing:
   - A title identifying this as a token-use and cost **estimate** for the work package.
-  - A per-activity table: activity id, input/output/total tokens, cache-read and cache-write columns when present, model, `priceTableVersion`, and per-activity cost (or `unknown` when `cost_usd` is null).
-  - A per-workflow totals section with input/output/total tokens and total cost (or `unknown` when unpriced activities contributed).
+  - A per-activity table: activity id, input/output/total tokens, cache-read and cache-write columns when present, **Duration (min)** (convert harness `duration_ms` with `min = ms / 60000`, one decimal), model, `priceTableVersion`, and per-activity cost (or `unknown` when `cost_usd` is null).
+  - A per-workflow totals section with input/output/total tokens, total wall duration in minutes, and total cost (or `unknown` when unpriced activities contributed).
   - The reconciliation from `{token_usage_document.usage_coverage}`: ledger entries, actual dispatches, and the unaccounted count. When the unaccounted count is above zero, state the totals as a floor rather than a total.
   - A caveat that cost is an **estimate** meaningful for API-key per-token billing; on Pro/Max subscriptions the figure is not a bill.
+- A mid-`complete` write is a **draft**: it cannot yet include the terminal activity's own dispatch figure. [workflow-engine::revise-session-metrics](../../../meta/techniques/workflow-engine/revise-session-metrics.md) (meta `end-workflow`) rewrites the same artifact after client exit.
 
 ### 4. Link From the README
 

--- a/work-package/techniques/finalize-documentation/revise-session-metrics.md
+++ b/work-package/techniques/finalize-documentation/revise-session-metrics.md
@@ -1,0 +1,39 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Client-side pointer: the authoritative post-exit rewrite of session-trace and token-usage lives on the meta universal layer as [workflow-engine::revise-session-metrics](../../../meta/techniques/workflow-engine/revise-session-metrics.md). Meta `end-workflow` applies it after the client session completes so the terminal activity is included.
+
+## Inputs
+
+### planning_folder_path
+
+Path to the planning folder holding `token-usage.md` and `session-trace.md`.
+
+### trace_tokens
+
+*(optional)* Opaque trace tokens for the client run.
+
+## Outputs
+
+### token_usage_document
+
+Updated sole cost home (`token-usage.md`).
+
+### session_trace_document
+
+Updated lean mechanical trace (`session-trace.md`).
+
+## Protocol
+
+- Apply [workflow-engine::revise-session-metrics](../../../meta/techniques/workflow-engine/revise-session-metrics.md) with `{planning_folder_path}` and optional `{trace_tokens}`.
+- A mid-`complete` draft from [render-token-usage](./render-token-usage.md) / [retrospective](../conduct-retrospective/retrospective.md) is not final; the meta post-exit apply is authoritative.
+
+## Rules
+
+### after-client-exit
+
+Do not treat an in-`complete` write as the final metrics artifact. The ledger row for `complete` lands only after that activity exits.


### PR DESCRIPTION
## Summary
- Session-trace / token-usage print wall duration as **Duration (min)** (convert harness ms at render).
- Mid-`complete` drafts omit the terminal activity; **meta `end-workflow`** rewrites both artifacts via `workflow-engine::revise-session-metrics` after the client session exits.
- Successful terminal dispatch with no `activity_usage` row is recorded as an unpriced duration note / coverage gap, not invented tokens.

## Test plan
- [ ] `session-trace.md` template header is `Duration (min)`
- [ ] `meta/activities/04-end-workflow.yaml` includes `revise-session-metrics` after `read-session` when `client_workflow_completed`
- [ ] Next work-package close-out: mid-complete draft, then post-exit revise includes `complete` ledger row when `record_usage` fired