### PR TITLE
workflow(corpus): migrate legacy structured step conditions to when (#338 W7)

### DIFF
--- a/meta/activities/04-end-workflow.yaml
+++ b/meta/activities/04-end-workflow.yaml
@@ -10,17 +10,7 @@ steps:
   - kind: technique
     id: revise-session-metrics
     technique: workflow-engine::revise-session-metrics
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: client_workflow_completed
-          operator: ==
-          value: true
-        - type: simple
-          variable: planning_folder_path
-          operator: "!="
-          value: ""
+    when: client_workflow_completed == true && planning_folder_path != ''
   - kind: technique
     id: verify-outcomes
     technique:

--- a/meta/activities/patterns/02-supervisor.yaml
+++ b/meta/activities/patterns/02-supervisor.yaml
@@ -26,11 +26,7 @@ steps:
         expected_ids: worker_briefs
   - kind: action
     id: announce-escalation
-    condition:
-      type: simple
-      variable: lane_id
-      operator: ==
-      value: escalate
+    when: lane_id == 'escalate'
     actions:
       - action: message
         message: "Supervisor escalation — no lane matched. Rationale: {classification_rationale}"

--- a/meta/activities/patterns/03-plan-and-execute.yaml
+++ b/meta/activities/patterns/03-plan-and-execute.yaml
@@ -27,11 +27,7 @@ steps:
     variable: current_step
     over: execution_plan.steps
     maxIterations: 50
-    condition:
-      type: simple
-      variable: plan_needs_replan
-      operator: "!="
-      value: true
+    when: plan_needs_replan != true
     steps:
       - kind: technique
         id: execute-step

--- a/meta/techniques/workflow-engine/activity-worker.md
+++ b/meta/techniques/workflow-engine/activity-worker.md
@@ -43,7 +43,7 @@ Worker agent identity for this dispatch.
 - Execute each activity step in document order
 - For `kind: technique` steps, load the bound operation on reach per [progressive-step-technique-load](./TECHNIQUE.md#progressive-step-technique-load)
 - Apply each bound operation via [variable-binding](../variable-binding.md)
-- Honor `when:` gates against the variable bag
+- Honor `when:` gates against the variable bag — operators `==`/`!=`/`>`/`<`/`>=`/`<=`, bare truthiness, unary `!`, `&&`, `||`, parentheses; C-style precedence (`()` > `!` > comparisons > `&&` > `||`); mixed `&&`/`||` at one depth requires parentheses; match the reference evaluator in `src/schema/when-expression.ts` (invalid expressions do not run the step)
 - When a step reaches a checkpoint, apply [yield-checkpoint](./yield-checkpoint.md)
 
 ## Rules

--- a/meta/workflow.yaml
+++ b/meta/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: meta
-version: 5.14.0
+version: 5.15.0
 title: Meta Workflow
 description: Top-level lifecycle workflow that orchestrates client workflow sessions. Excluded from list_workflows — bootstrap navigates here directly.
 author: m2ux

--- a/prism-audit/activities/01-prompt-generation.yaml
+++ b/prism-audit/activities/01-prompt-generation.yaml
@@ -30,11 +30,7 @@ steps:
   - kind: technique
     id: map-trust-boundaries
     technique: compose-audit-prompt::map-trust-boundaries
-    condition:
-      type: simple
-      variable: gitnexus_available
-      operator: ==
-      value: true
+    when: gitnexus_available == true
   - kind: technique
     id: map-audit-domains
     technique: compose-audit-prompt::map-audit-domains

--- a/prism-audit/workflow.yaml
+++ b/prism-audit/workflow.yaml
@@ -1,5 +1,5 @@
 id: prism-audit
-version: 1.2.0
+version: 1.3.0
 title: Security Audit Workflow
 description: Orchestrate security audits by generating tailored audit prompts from user descriptions and triggering prism workflow(s) for analysis. Audit-specific customisation is isolated here, keeping the prism workflow generic.
 author: m2ux

--- a/prism/activities/01-structural-pass.yaml
+++ b/prism/activities/01-structural-pass.yaml
@@ -32,23 +32,7 @@ steps:
           name: structural-analysis
           inputs:
             target_content: "{current_unit.target}"
-        condition:
-          type: or
-          conditions:
-            - type: and
-              conditions:
-                - type: simple
-                  variable: current_unit.pipeline_mode
-                  operator: ==
-                  value: single
-                - type: simple
-                  variable: current_unit.lens_name
-                  operator: ==
-                  value: l12
-            - type: simple
-              variable: current_unit.pipeline_mode
-              operator: ==
-              value: full-prism
+        when: (current_unit.pipeline_mode == "single" && current_unit.lens_name == "l12") || current_unit.pipeline_mode == "full-prism"
       - kind: technique
         id: run-single-lens
         technique:

--- a/prism/activities/01-structural-pass.yaml
+++ b/prism/activities/01-structural-pass.yaml
@@ -56,17 +56,7 @@ steps:
           inputs:
             lens_name: "{current_unit.lens_name}"
             target_content: "{current_unit.target}"
-        condition:
-          type: and
-          conditions:
-            - type: simple
-              variable: current_unit.pipeline_mode
-              operator: ==
-              value: single
-            - type: simple
-              variable: current_unit.lens_name
-              operator: "!="
-              value: l12
+        when: current_unit.pipeline_mode == 'single' && current_unit.lens_name != 'l12'
       - kind: technique
         id: run-portfolio
         technique:
@@ -74,22 +64,14 @@ steps:
           inputs:
             target_content: "{current_unit.target}"
             selected_lenses: current_unit.lenses
-        condition:
-          type: simple
-          variable: current_unit.pipeline_mode
-          operator: ==
-          value: portfolio
+        when: current_unit.pipeline_mode == 'portfolio'
       - kind: technique
         id: dispatch-behavioral-lenses
         technique:
           name: behavioral-pipeline::independent-lenses
           inputs:
             target_content: "{current_unit.target}"
-        condition:
-          type: simple
-          variable: current_unit.pipeline_mode
-          operator: ==
-          value: behavioral
+        when: current_unit.pipeline_mode == 'behavioral'
       - kind: action
         id: collect-behavioral-paths
         actions:

--- a/prism/activities/02-adversarial-pass.yaml
+++ b/prism/activities/02-adversarial-pass.yaml
@@ -24,11 +24,7 @@ steps:
           - action: set
             target: all_artifact_paths
             description: Accumulated artifact paths across units.
-        condition:
-          type: simple
-          variable: current_unit.pipeline_mode
-          operator: ==
-          value: full-prism
+        when: current_unit.pipeline_mode == 'full-prism'
 transitions:
   - to: synthesis-pass
     isDefault: true

--- a/prism/activities/03-synthesis-pass.yaml
+++ b/prism/activities/03-synthesis-pass.yaml
@@ -24,11 +24,7 @@ steps:
           - action: set
             target: all_artifact_paths
             description: Accumulated artifact paths across units.
-        condition:
-          type: simple
-          variable: current_unit.pipeline_mode
-          operator: ==
-          value: full-prism
+        when: current_unit.pipeline_mode == 'full-prism'
 transitions:
   - to: generate-report
     isDefault: true

--- a/prism/activities/05-behavioral-synthesis-pass.yaml
+++ b/prism/activities/05-behavioral-synthesis-pass.yaml
@@ -24,11 +24,7 @@ steps:
           - action: set
             target: all_artifact_paths
             description: Accumulated artifact paths across units.
-        condition:
-          type: simple
-          variable: current_unit.pipeline_mode
-          operator: ==
-          value: behavioral
+        when: current_unit.pipeline_mode == 'behavioral'
 transitions:
   - to: generate-report
     isDefault: true

--- a/prism/activities/12-adaptive-pass.yaml
+++ b/prism/activities/12-adaptive-pass.yaml
@@ -15,22 +15,14 @@ steps:
       name: adaptive-analysis::stage-2-l12
       inputs:
         target_content: "{target}"
-    condition:
-      type: simple
-      variable: adaptive_signal_quality
-      operator: ==
-      value: insufficient
+    when: adaptive_signal_quality == 'insufficient'
   - kind: technique
     id: run-stage-3
     technique:
       name: adaptive-analysis::stage-3-full
       inputs:
         target_content: "{target}"
-    condition:
-      type: simple
-      variable: adaptive_signal_quality
-      operator: ==
-      value: insufficient
+    when: adaptive_signal_quality == 'insufficient'
   - kind: action
     id: collect-paths
     actions:

--- a/prism/workflow.yaml
+++ b/prism/workflow.yaml
@@ -1,5 +1,5 @@
 id: prism
-version: 2.3.0
+version: 2.4.0
 title: Structural Analysis Prism Workflow
 description: Apply cognitive lenses to code or text through isolated sub-agent passes. Each pass runs in a fresh context window to guarantee analytical independence. For security audit use cases, use the prism-audit workflow which triggers prism and adds audit-specific post-processing.
 author: m2ux

--- a/substrate-node-security-audit/activities/05-report-generation.yaml
+++ b/substrate-node-security-audit/activities/05-report-generation.yaml
@@ -62,21 +62,7 @@ steps:
         expected_outputs: domain_map
   - kind: technique
     id: write-report
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: dispatch_complete
-          operator: ==
-          value: true
-        - type: simple
-          variable: verification_complete
-          operator: ==
-          value: true
-        - type: simple
-          variable: merge_complete
-          operator: ==
-          value: true
+    when: dispatch_complete == true && verification_complete == true && merge_complete == true
     technique:
       name: write-report
       inputs:

--- a/substrate-node-security-audit/workflow.yaml
+++ b/substrate-node-security-audit/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: substrate-node-security-audit
-version: 4.19.0
+version: 4.20.0
 title: Security Audit Workflow
 description: Fully automated multi-phase AI security audit for Substrate-based blockchain node codebases.
 author: m2ux

--- a/work-package/activities/01-start-work-package.yaml
+++ b/work-package/activities/01-start-work-package.yaml
@@ -14,17 +14,7 @@ steps:
     technique: review-mode-detection
   - kind: action
     id: announce-derived-review-mode
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: is_review_mode
-          operator: ==
-          value: true
-        - type: simple
-          variable: review_mode_ambiguous
-          operator: "!="
-          value: true
+    when: is_review_mode == true && review_mode_ambiguous != true
     actions:
       - action: message
         message: "Review mode derived from the request."
@@ -139,18 +129,10 @@ steps:
   - kind: technique
     id: ingest-prior-feedback
     technique: review-existing-feedback
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
+    when: is_review_mode == true
   - kind: action
     id: seed-review-mode-outcomes
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
+    when: is_review_mode == true
     actions:
       - action: set
         target: target_workflow_outcomes
@@ -237,11 +219,7 @@ steps:
       name: atlassian-operations::get-jira-issue
       inputs:
         issueIdOrKey: "{issue_number}"
-    condition:
-      type: simple
-      variable: issue_platform
-      operator: ==
-      value: jira
+    when: issue_platform == 'jira'
     actions:
       - action: validate
         target: cloudId != null
@@ -252,22 +230,14 @@ steps:
       name: github-cli-protocol::view-issue
       inputs:
         issue_identifier: "{issue_number}"
-    condition:
-      type: simple
-      variable: issue_platform
-      operator: ==
-      value: github
+    when: issue_platform == 'github'
   - kind: technique
     id: search-github-issue
     technique:
       name: github-cli-protocol::list-issues
       inputs:
         filters: --search '{jira_issue_key}' --json number,title,url --limit 5
-    condition:
-      type: simple
-      variable: issue_platform
-      operator: ==
-      value: jira
+    when: issue_platform == 'jira'
     actions:
       - action: set
         target: github_issue_found
@@ -319,11 +289,7 @@ steps:
       name: create-issue
       inputs:
         issue_platform: github
-    condition:
-      type: simple
-      variable: needs_github_issue_creation
-      operator: ==
-      value: true
+    when: needs_github_issue_creation == true
   - kind: checkpoint
     id: jira-project-selection
     condition:
@@ -348,21 +314,7 @@ steps:
   - kind: technique
     id: derive-issue-type
     technique: issue-type-detection
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: is_review_mode
-          operator: "!="
-          value: true
-        - type: simple
-          variable: needs_issue_creation
-          operator: "!="
-          value: true
-        - type: simple
-          variable: issue_skipped
-          operator: "!="
-          value: true
+    when: is_review_mode != true && needs_issue_creation != true && issue_skipped != true
   - kind: checkpoint
     id: issue-type-selection
     condition:
@@ -452,11 +404,7 @@ steps:
   - kind: technique
     id: create-issue
     technique: create-issue
-    condition:
-      type: simple
-      variable: needs_issue_creation
-      operator: ==
-      value: true
+    when: needs_issue_creation == true
   - kind: checkpoint
     id: platform-selection
     condition:
@@ -489,34 +437,14 @@ steps:
       inputs:
         issueIdOrKey: "{issue_number}"
         fields: "{ assignee: { accountId: {accountId} } }"
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: issue_skipped
-          operator: "!="
-          value: true
-        - type: simple
-          variable: issue_platform
-          operator: ==
-          value: jira
+    when: issue_skipped != true && issue_platform == 'jira'
   - kind: technique
     id: transition-issue-jira
     technique:
       name: atlassian-operations::transition-jira-issue
       inputs:
         issueIdOrKey: "{issue_number}"
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: issue_skipped
-          operator: "!="
-          value: true
-        - type: simple
-          variable: issue_platform
-          operator: ==
-          value: jira
+    when: issue_skipped != true && issue_platform == 'jira'
   - kind: technique
     id: assign-issue-github
     technique:
@@ -524,17 +452,7 @@ steps:
       inputs:
         number: "{issue_number}"
         assignee: "@me"
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: issue_skipped
-          operator: "!="
-          value: true
-        - type: simple
-          variable: issue_platform
-          operator: ==
-          value: github
+    when: issue_skipped != true && issue_platform == 'github'
   - kind: action
     id: bind-planning-folder-path
     actions:
@@ -567,33 +485,21 @@ steps:
       name: naming-conventions
       inputs:
         issue_title: "{issue_title}"
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: "!="
-      value: true
+    when: is_review_mode != true
   - kind: technique
     id: compute-canonical-target-path
     technique: naming-conventions
   - kind: technique
     id: create-component-worktree
     technique: manage-git::create-worktree
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: "!="
-      value: true
+    when: is_review_mode != true
   - kind: technique
     id: create-review-worktree
     technique:
       name: manage-git::create-worktree
       inputs:
         create_branch: false
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
+    when: is_review_mode == true
   - kind: technique
     id: check-branch
     technique: manage-git::verify-feature-branch
@@ -607,11 +513,7 @@ steps:
       name: github-cli-protocol::list-prs
       inputs:
         filters: --head {branch_name} --json number,url --limit 1
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: "!="
-      value: true
+    when: is_review_mode != true
     actions:
       - action: set
         target: pr_exists
@@ -627,17 +529,7 @@ steps:
         description: When use_existing_pr was set true by a pr_number/existing_pr_number match, bind pr_number from existing_pr_number; otherwise leave unchanged
   - kind: action
     id: announce-auto-use-existing-pr
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: pr_exists
-          operator: ==
-          value: true
-        - type: simple
-          variable: use_existing_pr
-          operator: ==
-          value: true
+    when: pr_exists == true && use_existing_pr == true
     actions:
       - action: message
         message: "Continuing with existing PR #{existing_pr_number} (already bound for this branch)."
@@ -710,21 +602,7 @@ steps:
       inputs:
         issue_number: "{issue_number}"
         issue_platform: "{issue_platform}"
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: is_review_mode
-          operator: "!="
-          value: true
-        - type: simple
-          variable: use_existing_pr
-          operator: ==
-          value: false
-        - type: simple
-          variable: pr_skipped
-          operator: "!="
-          value: true
+    when: is_review_mode != true && use_existing_pr == false && pr_skipped != true
     actions:
       - action: set
         target: pr_exists

--- a/work-package/activities/02-design-philosophy.yaml
+++ b/work-package/activities/02-design-philosophy.yaml
@@ -100,11 +100,7 @@ steps:
   - kind: technique
     id: assess-ticket-completeness
     technique: assess-ticket-completeness
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
+    when: is_review_mode == true
   - kind: checkpoint
     id: ticket-completeness
     condition:
@@ -143,11 +139,7 @@ steps:
             ticket_refactor_needed: false
   - kind: action
     id: set-review-mode-path
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
+    when: is_review_mode == true
     actions:
       - action: set
         target: needs_elicitation

--- a/work-package/activities/04-research.yaml
+++ b/work-package/activities/04-research.yaml
@@ -94,11 +94,7 @@ steps:
         description: true only when run evidence cannot decide among repo-only / web-retrieval / mixed; false when context_scope was derived confidently
   - kind: action
     id: announce-derived-context-scope
-    condition:
-      type: simple
-      variable: context_scope_uncertain
-      operator: "!="
-      value: true
+    when: context_scope_uncertain != true
     actions:
       - action: message
         message: "Research context scope derived as `{context_scope}`."
@@ -141,17 +137,7 @@ steps:
   - kind: technique
     id: record-batch-response
     technique: review-assumptions::record
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: has_open_assumptions
-          operator: ==
-          value: true
-        - type: simple
-          variable: needs_individual_interview
-          operator: "!="
-          value: true
+    when: has_open_assumptions == true && needs_individual_interview != true
   - kind: loop
     id: assumption-interview
     name: Individual Assumption Interview Loop
@@ -159,17 +145,7 @@ steps:
     variable: current_assumption
     over: open_assumptions
     maxIterations: 20
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: needs_individual_interview
-          operator: ==
-          value: true
-        - type: simple
-          variable: has_open_assumptions
-          operator: ==
-          value: true
+    when: needs_individual_interview == true && has_open_assumptions == true
     steps:
       - kind: technique
         id: present-assumption

--- a/work-package/activities/05-implementation-analysis.yaml
+++ b/work-package/activities/05-implementation-analysis.yaml
@@ -9,11 +9,7 @@ steps:
   - kind: technique
     id: review-baseline-state
     technique: review-baseline-state
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
+    when: is_review_mode == true
   - kind: technique
     id: analyze-implementation
     technique: analyze
@@ -55,21 +51,7 @@ steps:
   - kind: technique
     id: record-batch-response
     technique: review-assumptions::record
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: is_review_mode
-          operator: "!="
-          value: true
-        - type: simple
-          variable: has_open_assumptions
-          operator: ==
-          value: true
-        - type: simple
-          variable: needs_individual_interview
-          operator: "!="
-          value: true
+    when: is_review_mode != true && has_open_assumptions == true && needs_individual_interview != true
   - kind: loop
     id: assumption-interview
     name: Individual Assumption Interview Loop
@@ -77,21 +59,7 @@ steps:
     variable: current_assumption
     over: open_assumptions
     maxIterations: 20
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: is_review_mode
-          operator: "!="
-          value: true
-        - type: simple
-          variable: needs_individual_interview
-          operator: ==
-          value: true
-        - type: simple
-          variable: has_open_assumptions
-          operator: ==
-          value: true
+    when: is_review_mode != true && needs_individual_interview == true && has_open_assumptions == true
     steps:
       - kind: technique
         id: present-assumption

--- a/work-package/activities/06-plan-prepare.yaml
+++ b/work-package/activities/06-plan-prepare.yaml
@@ -82,17 +82,7 @@ steps:
       name: update-pr::render
       inputs:
         pr_template_variant: initial
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: is_review_mode
-          operator: "!="
-          value: true
-        - type: simple
-          variable: stealth_mode
-          operator: "!="
-          value: true
+    when: is_review_mode != true && stealth_mode != true
   - kind: checkpoint
     id: approach-confirmed
     condition:

--- a/work-package/activities/07-assumptions-review.yaml
+++ b/work-package/activities/07-assumptions-review.yaml
@@ -26,59 +26,21 @@ steps:
       name: review-assumptions::interview
       inputs:
         assembly_mode: batch
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: is_review_mode
-          operator: "!="
-          value: true
-        - type: simple
-          variable: has_open_assumptions
-          operator: ==
-          value: true
+    when: is_review_mode != true && has_open_assumptions == true
   - kind: checkpoint
     id: residual-assumption-batch
     ref: assumption-interview
   - kind: technique
     id: record-batch-decision
     technique: review-assumptions::record
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: is_review_mode
-          operator: "!="
-          value: true
-        - type: simple
-          variable: has_open_assumptions
-          operator: ==
-          value: true
-        - type: simple
-          variable: needs_individual_interview
-          operator: "!="
-          value: true
+    when: is_review_mode != true && has_open_assumptions == true && needs_individual_interview != true
   - kind: loop
     id: assumption-interview-loop
     name: Individual Assumption Interview Loop
     loopType: forEach
     variable: current_assumption
     over: open_assumptions
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: is_review_mode
-          operator: "!="
-          value: true
-        - type: simple
-          variable: needs_individual_interview
-          operator: ==
-          value: true
-        - type: simple
-          variable: has_open_assumptions
-          operator: ==
-          value: true
+    when: is_review_mode != true && needs_individual_interview == true && has_open_assumptions == true
     steps:
       - kind: technique
         id: present-assumption
@@ -124,29 +86,7 @@ steps:
   - kind: technique
     id: post-summary-jira
     technique: atlassian-operations::comment-jira-issue
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: stealth_mode
-          operator: "!="
-          value: true
-        - type: simple
-          variable: is_review_mode
-          operator: "!="
-          value: true
-        - type: simple
-          variable: issue_platform
-          operator: ==
-          value: jira
-        - type: simple
-          variable: has_deferred_assumptions
-          operator: ==
-          value: true
-        - type: simple
-          variable: post_jira_comment
-          operator: "!="
-          value: false
+    when: stealth_mode != true && is_review_mode != true && issue_platform == 'jira' && has_deferred_assumptions == true && post_jira_comment != false
   - kind: checkpoint
     id: post-summary-review
     condition:
@@ -184,25 +124,7 @@ steps:
   - kind: technique
     id: post-summary-github
     technique: github-cli-protocol::comment-issue
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: stealth_mode
-          operator: "!="
-          value: true
-        - type: simple
-          variable: is_review_mode
-          operator: "!="
-          value: true
-        - type: simple
-          variable: issue_platform
-          operator: ==
-          value: github
-        - type: simple
-          variable: has_deferred_assumptions
-          operator: ==
-          value: true
+    when: stealth_mode != true && is_review_mode != true && issue_platform == 'github' && has_deferred_assumptions == true
 transitions:
   - to: codebase-comprehension
     condition:

--- a/work-package/activities/08-implement.yaml
+++ b/work-package/activities/08-implement.yaml
@@ -91,17 +91,7 @@ steps:
   - kind: technique
     id: record-batch-response
     technique: review-assumptions::record
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: has_open_assumptions
-          operator: ==
-          value: true
-        - type: simple
-          variable: needs_individual_interview
-          operator: "!="
-          value: true
+    when: has_open_assumptions == true && needs_individual_interview != true
   - kind: loop
     id: assumption-interview
     name: Individual Assumption Interview Loop
@@ -109,17 +99,7 @@ steps:
     variable: current_assumption
     over: open_assumptions
     maxIterations: 20
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: needs_individual_interview
-          operator: ==
-          value: true
-        - type: simple
-          variable: has_open_assumptions
-          operator: ==
-          value: true
+    when: needs_individual_interview == true && has_open_assumptions == true
     steps:
       - kind: technique
         id: present-assumption

--- a/work-package/activities/10-post-impl-review.yaml
+++ b/work-package/activities/10-post-impl-review.yaml
@@ -45,11 +45,7 @@ steps:
     variable: current_block_index
     over: flagged_block_indices
     maxIterations: 50
-    condition:
-      type: simple
-      variable: has_flagged_blocks
-      operator: ==
-      value: true
+    when: has_flagged_blocks == true
     steps:
       - kind: checkpoint
         id: block-interview#{current_block_index}
@@ -88,11 +84,7 @@ steps:
         value: complex
   - kind: action
     id: dispatch-prism
-    condition:
-      type: simple
-      variable: problem_complexity
-      operator: ==
-      value: complex
+    when: problem_complexity == 'complex'
     actions: []
   - kind: technique
     id: test-suite-review
@@ -139,11 +131,7 @@ steps:
     id: architecture-summary
     technique: summarize-architecture
     required: false
-    condition:
-      type: simple
-      variable: skip_architecture_summary
-      operator: "!="
-      value: true
+    when: skip_architecture_summary != true
   - kind: technique
     id: classify-and-route-findings
     technique:

--- a/work-package/activities/10-post-impl-review.yaml
+++ b/work-package/activities/10-post-impl-review.yaml
@@ -1,5 +1,5 @@
 id: post-impl-review
-version: 1.18.0
+version: 1.19.0
 name: Post-Implementation Review
 description: Review implementation quality before validation.
 required: true
@@ -75,13 +75,7 @@ steps:
       name: prism/structural-analysis
       inputs:
         findings_destination: code-review.md
-    condition:
-      type: not
-      condition:
-        type: simple
-        variable: problem_complexity
-        operator: ==
-        value: complex
+    when: problem_complexity != 'complex'
   - kind: action
     id: dispatch-prism
     when: problem_complexity == 'complex'

--- a/work-package/activities/11-validate.yaml
+++ b/work-package/activities/11-validate.yaml
@@ -32,44 +32,18 @@ steps:
       name: findings-classification
       inputs:
         findings_to_classify: "{validation_results.failed_checks}"
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
+    when: is_review_mode == true
   - kind: technique
     id: assess-test-coverage
     technique: review-test-suite
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
+    when: is_review_mode == true
   - kind: technique
     id: triage-reported-failures
     technique: review-test-suite
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
+    when: is_review_mode == true
   - kind: action
     id: fix-failures
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: is_review_mode
-          operator: "!="
-          value: true
-        - type: simple
-          variable: run_local_validation
-          operator: ==
-          value: true
-        - type: simple
-          variable: validation_results.validation_passed
-          operator: ==
-          value: false
+    when: is_review_mode != true && run_local_validation == true && validation_results.validation_passed == false
     actions: []
   - kind: loop
     id: fix-revalidate-cycle

--- a/work-package/activities/12-strategic-review.yaml
+++ b/work-package/activities/12-strategic-review.yaml
@@ -13,17 +13,7 @@ steps:
       name: update-pr::render
       inputs:
         pr_template_variant: final
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: is_review_mode
-          operator: "!="
-          value: true
-        - type: simple
-          variable: stealth_mode
-          operator: "!="
-          value: true
+    when: is_review_mode != true && stealth_mode != true
   - kind: checkpoint
     id: unsigned-commits-prompt
     condition:
@@ -55,17 +45,7 @@ steps:
   - kind: technique
     id: resign-unsigned-commits
     technique: resign-commits
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: is_review_mode
-          operator: "!="
-          value: true
-        - type: simple
-          variable: resign_unsigned_commits_requested
-          operator: ==
-          value: true
+    when: is_review_mode != true && resign_unsigned_commits_requested == true
   - kind: technique
     id: verify-readme
     technique:
@@ -96,19 +76,11 @@ steps:
   - kind: technique
     id: document-cleanup-recommendations
     technique: recommend-cleanup
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
+    when: is_review_mode == true
   - kind: technique
     id: apply-cleanup
     technique: apply-cleanup
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: "!="
-      value: true
+    when: is_review_mode != true
   - kind: technique
     id: create-architecture-summary
     technique: summarize-architecture

--- a/work-package/activities/13-submit-for-review.yaml
+++ b/work-package/activities/13-submit-for-review.yaml
@@ -12,19 +12,11 @@ steps:
   - kind: technique
     id: consolidate-review-findings
     technique: findings-classification
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
+    when: is_review_mode == true
   - kind: technique
     id: resolve-artifact-publish
     technique: resolve-artifact-publish
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
+    when: is_review_mode == true
   - kind: technique
     id: commit-review-artifacts
     technique:
@@ -34,30 +26,18 @@ steps:
         issue_key: issue_number
         files: publishable_files
         branch: artifact_publish_ref
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
+    when: is_review_mode == true
   - kind: technique
     id: generate-review-summary
     technique: review-summary
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
+    when: is_review_mode == true
     actions:
       - action: validate
         target: summary_budget_overruns == []
         message: "Consolidated review summary exceeds the review-mode format budget: {summary_budget_overruns}. Move the over-budget content into the report section that owns it, leave the link, and re-run."
   - kind: action
     id: present-summary-to-user
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
+    when: is_review_mode == true
     actions: []
   - kind: checkpoint
     id: review-summary-approval
@@ -105,31 +85,11 @@ steps:
       inputs:
         bare_filename: review-summary.md
         artifact_content: review_summary
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: is_review_mode
-          operator: ==
-          value: true
-        - type: simple
-          variable: review_posted
-          operator: ==
-          value: true
+    when: is_review_mode == true && review_posted == true
   - kind: technique
     id: post-pr-review
     technique: update-pr::post-review-comment
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: is_review_mode
-          operator: ==
-          value: true
-        - type: simple
-          variable: review_posted
-          operator: ==
-          value: true
+    when: is_review_mode == true && review_posted == true
   - kind: checkpoint
     id: dco-sign-off-confirmation
     condition:
@@ -161,19 +121,11 @@ steps:
   - kind: technique
     id: dco-sign-off
     technique: dco-provenance::record-attestation
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: "!="
-      value: true
+    when: is_review_mode != true
   - kind: technique
     id: verify-push-remote
     technique: manage-git::verify-remote-private
-    condition:
-      type: simple
-      variable: stealth_mode
-      operator: ==
-      value: true
+    when: stealth_mode == true
     actions:
       - action: validate
         target: push_remote_verified != false
@@ -197,11 +149,7 @@ steps:
   - kind: technique
     id: verify-push-signatures
     technique: manage-git::verify-commit-signatures
-    condition:
-      type: simple
-      variable: stealth_mode
-      operator: ==
-      value: true
+    when: stealth_mode == true
     actions:
       - action: validate
         target: commits_signed != false
@@ -225,25 +173,11 @@ steps:
   - kind: technique
     id: push-commits
     technique: manage-git::push-commits
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: "!="
-      value: true
+    when: is_review_mode != true
   - kind: technique
     id: update-description
     technique: update-pr::render
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: is_review_mode
-          operator: "!="
-          value: true
-        - type: simple
-          variable: stealth_mode
-          operator: "!="
-          value: true
+    when: is_review_mode != true && stealth_mode != true
   - kind: loop
     id: verify-pr-body-rerender
     name: PR Body Verification Re-render Loop
@@ -315,30 +249,10 @@ steps:
   - kind: technique
     id: instruct-merge-strategy
     technique: manage-git::instruct-merge-strategy
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: is_review_mode
-          operator: "!="
-          value: true
-        - type: simple
-          variable: stealth_mode
-          operator: "!="
-          value: true
+    when: is_review_mode != true && stealth_mode != true
   - kind: action
     id: merge-strategy-guidance
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: is_review_mode
-          operator: "!="
-          value: true
-        - type: simple
-          variable: stealth_mode
-          operator: "!="
-          value: true
+    when: is_review_mode != true && stealth_mode != true
     actions:
       - action: message
         message: |-
@@ -418,17 +332,7 @@ steps:
     actions:
       - action: message
         message: "Pull request marked ready for review — {updated_pr.pr_status}: {updated_pr.pr_url}"
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: is_review_mode
-          operator: "!="
-          value: true
-        - type: simple
-          variable: stealth_mode
-          operator: "!="
-          value: true
+    when: is_review_mode != true && stealth_mode != true
   - kind: loop
     id: await-review-loop
     name: Await Review Loop
@@ -473,31 +377,11 @@ steps:
   - kind: technique
     id: process-review-comments
     technique: respond-to-pr-review
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: is_review_mode
-          operator: "!="
-          value: true
-        - type: simple
-          variable: stealth_mode
-          operator: "!="
-          value: true
+    when: is_review_mode != true && stealth_mode != true
   - kind: technique
     id: analyze-review-outcome
     technique: review-outcome-analysis
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: is_review_mode
-          operator: "!="
-          value: true
-        - type: simple
-          variable: stealth_mode
-          operator: "!="
-          value: true
+    when: is_review_mode != true && stealth_mode != true
   - kind: checkpoint
     id: review-outcome
     condition:

--- a/work-package/activities/14-complete.yaml
+++ b/work-package/activities/14-complete.yaml
@@ -47,11 +47,7 @@ steps:
   - kind: technique
     id: finalize-test-plan
     technique: finalize-documentation::finalize-test-plan
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: "!="
-      value: true
+    when: is_review_mode != true
   - kind: technique
     id: create-complete-doc
     technique: finalize-documentation::create-complete-doc
@@ -61,11 +57,7 @@ steps:
   - kind: technique
     id: ensure-docs
     technique: finalize-documentation::ensure-docs
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: "!="
-      value: true
+    when: is_review_mode != true
   - kind: technique
     id: read-session
     technique: workflow-engine::read-session
@@ -87,11 +79,7 @@ steps:
   - kind: technique
     id: resolve-close-out-publish
     technique: resolve-artifact-publish
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
+    when: is_review_mode == true
   - kind: technique
     id: publish-close-out-artifacts
     technique:
@@ -101,19 +89,11 @@ steps:
         issue_key: issue_number
         files: publishable_files
         branch: artifact_publish_ref
-    condition:
-      type: simple
-      variable: is_review_mode
-      operator: ==
-      value: true
+    when: is_review_mode == true
   - kind: technique
     id: remove-worktree
     technique: manage-git::remove-worktree
-    condition:
-      type: simple
-      variable: worktree_created
-      operator: ==
-      value: true
+    when: worktree_created == true
   - kind: technique
     id: select-next
     technique: conduct-retrospective::select-next

--- a/work-package/activities/14-complete.yaml
+++ b/work-package/activities/14-complete.yaml
@@ -7,43 +7,11 @@ steps:
   - kind: technique
     id: create-adr
     technique: create-adr
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: is_review_mode
-          operator: "!="
-          value: true
-        - type: or
-          conditions:
-            - type: simple
-              variable: problem_complexity
-              operator: ==
-              value: moderate
-            - type: simple
-              variable: problem_complexity
-              operator: ==
-              value: complex
+    when: is_review_mode != true && (problem_complexity == "moderate" || problem_complexity == "complex")
   - kind: technique
     id: update-adr-status
     technique: finalize-documentation::update-adr
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: is_review_mode
-          operator: "!="
-          value: true
-        - type: or
-          conditions:
-            - type: simple
-              variable: problem_complexity
-              operator: ==
-              value: moderate
-            - type: simple
-              variable: problem_complexity
-              operator: ==
-              value: complex
+    when: is_review_mode != true && (problem_complexity == "moderate" || problem_complexity == "complex")
   - kind: technique
     id: finalize-test-plan
     technique: finalize-documentation::finalize-test-plan

--- a/work-package/workflow.yaml
+++ b/work-package/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: work-package
-version: 3.41.0
+version: 3.42.0
 title: Work Package Implementation Workflow
 description: Defines how to plan and implement ONE work package from inception to merged PR. A work package is a discrete unit of work such as a feature, bug-fix, enhancement, refactoring, or any other deliverable change. For multiple related work packages, use the work-packages workflow to create a roadmap first. Also supports review mode for auditing an existing PR or implementation end-to-end.
 author: m2ux

--- a/work-package/workflow.yaml
+++ b/work-package/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: work-package
-version: 3.40.0
+version: 3.41.0
 title: Work Package Implementation Workflow
 description: Defines how to plan and implement ONE work package from inception to merged PR. A work package is a discrete unit of work such as a feature, bug-fix, enhancement, refactoring, or any other deliverable change. For multiple related work packages, use the work-packages workflow to create a roadmap first. Also supports review mode for auditing an existing PR or implementation end-to-end.
 author: m2ux

--- a/workflow-design/activities/01-intake-and-context.yaml
+++ b/workflow-design/activities/01-intake-and-context.yaml
@@ -21,17 +21,7 @@ steps:
         bare_filename: structural-inventory.md
         artifact_content: structural_inventory
         target_dir: planning_folder_path
-    condition:
-      type: or
-      conditions:
-        - type: simple
-          variable: operation_type
-          operator: ==
-          value: update
-        - type: simple
-          variable: operation_type
-          operator: ==
-          value: review
+    when: operation_type == "update" || operation_type == "review"
   - kind: checkpoint
     id: design-intent-batch
     condition:

--- a/workflow-design/activities/01-intake-and-context.yaml
+++ b/workflow-design/activities/01-intake-and-context.yaml
@@ -88,37 +88,13 @@ steps:
             intent_needs_confirmation: false
   - kind: action
     id: announce-certain-intent
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: intent_needs_confirmation
-          operator: ==
-          value: false
-        - type: simple
-          variable: update_seeded_from_review
-          operator: "!="
-          value: true
-        - type: simple
-          variable: operation_type
-          operator: "!="
-          value: review
+    when: intent_needs_confirmation == false && update_seeded_from_review != true && operation_type != 'review'
     actions:
       - action: message
         message: "Classified as a {operation_type} operation for workflow `{workflow_id}` — proceeding without Gate 1."
   - kind: action
     id: announce-certain-review-scope
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: operation_type
-          operator: ==
-          value: review
-        - type: simple
-          variable: intent_needs_confirmation
-          operator: ==
-          value: false
+    when: operation_type == 'review' && intent_needs_confirmation == false
     actions:
       - action: set
         target: review_scope_confirmed
@@ -127,31 +103,19 @@ steps:
         message: "Compliance review target set: {target_workflow_ids} ([structural inventory]({structural_inventory_path}))."
   - kind: action
     id: announce-review-seeded-update
-    condition:
-      type: simple
-      variable: update_seeded_from_review
-      operator: ==
-      value: true
+    when: update_seeded_from_review == true
     actions:
       - action: message
         message: "Update seeded from compliance review — mode is update; findings in the [compliance report]({report_path}) are the change specification."
   - kind: action
     id: announce-headless
-    condition:
-      type: simple
-      variable: headless_mode
-      operator: ==
-      value: true
+    when: headless_mode == true
     actions:
       - action: message
         message: "Headless by default — soft mid-flow gates auto-resolve. Gate 2 (`approve-to-commit`) and safety gaps stay interactive. Say \"interactive\", \"not headless\", or \"with checkpoints\" to opt out."
   - kind: action
     id: announce-interactive
-    condition:
-      type: simple
-      variable: headless_mode
-      operator: ==
-      value: false
+    when: headless_mode == false
     actions:
       - action: message
         message: "Interactive mode — soft mid-flow gates may present AskQuestion. Gate 2 (`approve-to-commit`) and safety gaps stay interactive."
@@ -163,11 +127,7 @@ steps:
         entity_context: "entity_title={workflow_id}; entity_type={operation_type}; status=Planning"
         seed_profile: workflow-design/readme-seed
         operation_type: "{operation_type}"
-    condition:
-      type: simple
-      variable: operation_type
-      operator: "!="
-      value: review
+    when: operation_type != 'review'
   - kind: technique
     id: context-loading
     technique: context-loading
@@ -187,11 +147,7 @@ steps:
         bare_filename: applicable-constructs.md
         artifact_content: applicable_constructs
         target_dir: planning_folder_path
-    condition:
-      type: simple
-      variable: operation_type
-      operator: ==
-      value: create
+    when: operation_type == 'create'
   - kind: technique
     id: present-problem-overview
     technique:
@@ -202,18 +158,10 @@ steps:
     actions:
       - action: message
         message: "Problem Overview for `{workflow_id}` — plain-language summary ([planning README]({planning_folder_path}/README.md#problem-overview))"
-    condition:
-      type: simple
-      variable: operation_type
-      operator: "!="
-      value: review
+    when: operation_type != 'review'
   - kind: action
     id: auto-confirm-literacy
-    condition:
-      type: simple
-      variable: operation_type
-      operator: "!="
-      value: review
+    when: operation_type != 'review'
     actions:
       - action: set
         target: format_literacy_confirmed
@@ -223,11 +171,7 @@ steps:
         value: true
   - kind: action
     id: clear-review-seed-flag
-    condition:
-      type: simple
-      variable: update_seeded_from_review
-      operator: ==
-      value: true
+    when: update_seeded_from_review == true
     actions:
       - action: set
         target: update_seeded_from_review

--- a/workflow-design/activities/03-requirements-refinement.yaml
+++ b/workflow-design/activities/03-requirements-refinement.yaml
@@ -30,11 +30,7 @@ steps:
   - kind: technique
     id: synthesize-update-specification
     technique: synthesize-update-specification
-    condition:
-      type: simple
-      variable: operation_type
-      operator: ==
-      value: update
+    when: operation_type == 'update'
   - kind: loop
     id: dimension-elicitation-loop
     name: Dimension Elicitation Loop
@@ -42,11 +38,7 @@ steps:
     variable: current_dimension
     over: design_dimensions
     maxIterations: 12
-    condition:
-      type: simple
-      variable: operation_type
-      operator: "!="
-      value: update
+    when: operation_type != 'update'
     steps:
       - kind: technique
         id: prepare-dimension
@@ -113,11 +105,7 @@ steps:
         technique: reconcile-design-assumptions
   - kind: action
     id: announce-open-judgements
-    condition:
-      type: simple
-      variable: has_open_assumptions
-      operator: ==
-      value: true
+    when: has_open_assumptions == true
     actions:
       - action: message
         message: "Open design judgements remain after reconcile — batched into Gate 2 (`approve-to-commit`), not interviewed mid-flow."

--- a/workflow-design/activities/05-impact-analysis.yaml
+++ b/workflow-design/activities/05-impact-analysis.yaml
@@ -7,11 +7,7 @@ steps:
   - kind: technique
     id: impact-analysis
     technique: impact-analysis
-    condition:
-      type: simple
-      variable: operation_type
-      operator: ==
-      value: update
+    when: operation_type == 'update'
   - kind: technique
     id: persist-impact-analysis
     technique:
@@ -20,18 +16,10 @@ steps:
         bare_filename: impact-analysis.md
         artifact_content: impact_analysis
         target_dir: planning_folder_path
-    condition:
-      type: simple
-      variable: operation_type
-      operator: ==
-      value: update
+    when: operation_type == 'update'
   - kind: action
     id: impact-no-removals
-    condition:
-      type: simple
-      variable: removal_count
-      operator: ==
-      value: 0
+    when: removal_count == 0
     actions:
       - action: message
         message: "Impact analysis complete — no content removals flagged ([impact analysis]({impact_analysis_path}))."

--- a/workflow-design/activities/06-scope-and-draft.yaml
+++ b/workflow-design/activities/06-scope-and-draft.yaml
@@ -9,19 +9,11 @@ steps:
   - kind: technique
     id: derive-workflows-target-path
     technique: derive-workflows-target-path
-    condition:
-      type: simple
-      variable: operation_type
-      operator: "!="
-      value: review
+    when: operation_type != 'review'
   - kind: technique
     id: ensure-workflow-worktree
     technique: prepare-workflow-branch
-    condition:
-      type: simple
-      variable: operation_type
-      operator: "!="
-      value: review
+    when: operation_type != 'review'
   - kind: technique
     id: scope-definition
     technique: scope-definition
@@ -66,11 +58,7 @@ steps:
     variable: current_file
     over: scope_manifest
     maxIterations: 50
-    condition:
-      type: simple
-      variable: scope_manifest_confirmed
-      operator: ==
-      value: true
+    when: scope_manifest_confirmed == true
     steps:
       - kind: technique
         id: assemble-file-approach
@@ -180,26 +168,14 @@ steps:
   - kind: technique
     id: pre-attestation-audit-principles
     technique: audit-principles
-    condition:
-      type: simple
-      variable: operation_type
-      operator: "=="
-      value: update
+    when: operation_type == 'update'
   - kind: technique
     id: pre-attestation-audit-anti-patterns
     technique: audit-anti-patterns
-    condition:
-      type: simple
-      variable: operation_type
-      operator: "=="
-      value: update
+    when: operation_type == 'update'
   - kind: action
     id: classify-pre-attestation-findings
-    condition:
-      type: simple
-      variable: operation_type
-      operator: "=="
-      value: update
+    when: operation_type == 'update'
     actions:
       - action: set
         target: principle_finding_count
@@ -250,17 +226,7 @@ steps:
             message: After re-running the pre-attestation audits, set true iff any remaining finding is Critical severity.
   - kind: action
     id: pre-attestation-findings-remain
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: operation_type
-          operator: "=="
-          value: update
-        - type: simple
-          variable: needs_audit_fixes
-          operator: "=="
-          value: true
+    when: operation_type == 'update' && needs_audit_fixes == true
     actions:
       - action: message
         message: "Pre-attestation audit: {principle_finding_count} principle + {anti_pattern_finding_count} anti-pattern findings remain after the fix cycle — [principle findings]({principle_findings_path}), [anti-pattern findings]({anti_pattern_findings_path})."

--- a/workflow-design/activities/08-quality-review.yaml
+++ b/workflow-design/activities/08-quality-review.yaml
@@ -11,11 +11,7 @@ steps:
     variable: target_workflow_id
     over: target_workflow_ids
     maxIterations: 20
-    condition:
-      type: simple
-      variable: operation_type
-      operator: ==
-      value: review
+    when: operation_type == 'review'
     steps:
       - kind: technique
         id: load-all-workflow-files
@@ -69,11 +65,7 @@ steps:
         target_dir: planning_folder_path
       outputs:
         written_artifact: report_path
-    condition:
-      type: simple
-      variable: operation_type
-      operator: ==
-      value: review
+    when: operation_type == 'review'
   - kind: checkpoint
     id: review-disposition
     condition:
@@ -106,17 +98,7 @@ steps:
   - kind: technique
     id: audit-expressiveness
     technique: audit-expressiveness
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: operation_type
-          operator: "!="
-          value: review
-        - type: simple
-          variable: scope_manifest_confirmed
-          operator: ==
-          value: true
+    when: operation_type != 'review' && scope_manifest_confirmed == true
   - kind: technique
     id: persist-expressiveness-findings
     technique:
@@ -125,75 +107,23 @@ steps:
         bare_filename: expressiveness-findings.md
         artifact_content: expressiveness_findings
         target_dir: planning_folder_path
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: operation_type
-          operator: "!="
-          value: review
-        - type: simple
-          variable: scope_manifest_confirmed
-          operator: ==
-          value: true
-        - type: simple
-          variable: expressiveness_finding_count
-          operator: ">"
-          value: 0
+    when: operation_type != 'review' && scope_manifest_confirmed == true && expressiveness_finding_count > 0
   - kind: action
     id: expressiveness-clean
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: operation_type
-          operator: "!="
-          value: review
-        - type: simple
-          variable: scope_manifest_confirmed
-          operator: ==
-          value: true
-        - type: simple
-          variable: expressiveness_finding_count
-          operator: ==
-          value: 0
+    when: operation_type != 'review' && scope_manifest_confirmed == true && expressiveness_finding_count == 0
     actions:
       - action: message
         message: Schema expressiveness review complete — 0 findings.
   - kind: action
     id: expressiveness-findings-flagged
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: operation_type
-          operator: "!="
-          value: review
-        - type: simple
-          variable: scope_manifest_confirmed
-          operator: ==
-          value: true
-        - type: simple
-          variable: expressiveness_finding_count
-          operator: ">"
-          value: 0
+    when: operation_type != 'review' && scope_manifest_confirmed == true && expressiveness_finding_count > 0
     actions:
       - action: message
         message: "Schema expressiveness review complete. {expressiveness_finding_count} findings ([expressiveness findings]({expressiveness_findings_path}))."
   - kind: technique
     id: audit-conformance
     technique: audit-conformance
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: operation_type
-          operator: "!="
-          value: review
-        - type: simple
-          variable: scope_manifest_confirmed
-          operator: ==
-          value: true
+    when: operation_type != 'review' && scope_manifest_confirmed == true
   - kind: technique
     id: persist-conformance-findings
     technique:
@@ -202,75 +132,23 @@ steps:
         bare_filename: conformance-findings.md
         artifact_content: conformance_findings
         target_dir: planning_folder_path
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: operation_type
-          operator: "!="
-          value: review
-        - type: simple
-          variable: scope_manifest_confirmed
-          operator: ==
-          value: true
-        - type: simple
-          variable: conformance_finding_count
-          operator: ">"
-          value: 0
+    when: operation_type != 'review' && scope_manifest_confirmed == true && conformance_finding_count > 0
   - kind: action
     id: conformance-clean
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: operation_type
-          operator: "!="
-          value: review
-        - type: simple
-          variable: scope_manifest_confirmed
-          operator: ==
-          value: true
-        - type: simple
-          variable: conformance_finding_count
-          operator: ==
-          value: 0
+    when: operation_type != 'review' && scope_manifest_confirmed == true && conformance_finding_count == 0
     actions:
       - action: message
         message: Convention conformance review complete — 0 divergences.
   - kind: action
     id: conformance-findings-flagged
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: operation_type
-          operator: "!="
-          value: review
-        - type: simple
-          variable: scope_manifest_confirmed
-          operator: ==
-          value: true
-        - type: simple
-          variable: conformance_finding_count
-          operator: ">"
-          value: 0
+    when: operation_type != 'review' && scope_manifest_confirmed == true && conformance_finding_count > 0
     actions:
       - action: message
         message: "Convention conformance review complete. {conformance_finding_count} divergences ([conformance findings]({conformance_findings_path}))."
   - kind: technique
     id: audit-rule-hygiene
     technique: audit-rule-hygiene
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: operation_type
-          operator: "!="
-          value: review
-        - type: simple
-          variable: scope_manifest_confirmed
-          operator: ==
-          value: true
+    when: operation_type != 'review' && scope_manifest_confirmed == true
   - kind: technique
     id: persist-rule-hygiene-findings
     technique:
@@ -279,75 +157,23 @@ steps:
         bare_filename: rule-hygiene-findings.md
         artifact_content: rule_hygiene_findings
         target_dir: planning_folder_path
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: operation_type
-          operator: "!="
-          value: review
-        - type: simple
-          variable: scope_manifest_confirmed
-          operator: ==
-          value: true
-        - type: simple
-          variable: rule_hygiene_finding_count
-          operator: ">"
-          value: 0
+    when: operation_type != 'review' && scope_manifest_confirmed == true && rule_hygiene_finding_count > 0
   - kind: action
     id: rule-hygiene-clean
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: operation_type
-          operator: "!="
-          value: review
-        - type: simple
-          variable: scope_manifest_confirmed
-          operator: ==
-          value: true
-        - type: simple
-          variable: rule_hygiene_finding_count
-          operator: ==
-          value: 0
+    when: operation_type != 'review' && scope_manifest_confirmed == true && rule_hygiene_finding_count == 0
     actions:
       - action: message
         message: Rule hygiene audit complete — 0 findings.
   - kind: action
     id: rule-hygiene-findings-flagged
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: operation_type
-          operator: "!="
-          value: review
-        - type: simple
-          variable: scope_manifest_confirmed
-          operator: ==
-          value: true
-        - type: simple
-          variable: rule_hygiene_finding_count
-          operator: ">"
-          value: 0
+    when: operation_type != 'review' && scope_manifest_confirmed == true && rule_hygiene_finding_count > 0
     actions:
       - action: message
         message: "Rule hygiene audit complete. {rule_hygiene_finding_count} findings ([rule hygiene findings]({rule_hygiene_findings_path}))."
   - kind: technique
     id: audit-rule-enforcement
     technique: audit-rule-enforcement
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: operation_type
-          operator: "!="
-          value: review
-        - type: simple
-          variable: scope_manifest_confirmed
-          operator: ==
-          value: true
+    when: operation_type != 'review' && scope_manifest_confirmed == true
   - kind: technique
     id: persist-enforcement-findings
     technique:
@@ -356,75 +182,23 @@ steps:
         bare_filename: enforcement-findings.md
         artifact_content: enforcement_findings
         target_dir: planning_folder_path
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: operation_type
-          operator: "!="
-          value: review
-        - type: simple
-          variable: scope_manifest_confirmed
-          operator: ==
-          value: true
-        - type: simple
-          variable: enforcement_finding_count
-          operator: ">"
-          value: 0
+    when: operation_type != 'review' && scope_manifest_confirmed == true && enforcement_finding_count > 0
   - kind: action
     id: enforcement-clean
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: operation_type
-          operator: "!="
-          value: review
-        - type: simple
-          variable: scope_manifest_confirmed
-          operator: ==
-          value: true
-        - type: simple
-          variable: enforcement_finding_count
-          operator: ==
-          value: 0
+    when: operation_type != 'review' && scope_manifest_confirmed == true && enforcement_finding_count == 0
     actions:
       - action: message
         message: Rule-to-structure audit complete — 0 text-only rules.
   - kind: action
     id: enforcement-findings-flagged
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: operation_type
-          operator: "!="
-          value: review
-        - type: simple
-          variable: scope_manifest_confirmed
-          operator: ==
-          value: true
-        - type: simple
-          variable: enforcement_finding_count
-          operator: ">"
-          value: 0
+    when: operation_type != 'review' && scope_manifest_confirmed == true && enforcement_finding_count > 0
     actions:
       - action: message
         message: "Rule-to-structure audit complete. {enforcement_finding_count} text-only rules ([enforcement findings]({enforcement_findings_path}))."
   - kind: technique
     id: verify-high-findings
     technique: verify-high-findings
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: operation_type
-          operator: "!="
-          value: review
-        - type: simple
-          variable: scope_manifest_confirmed
-          operator: ==
-          value: true
+    when: operation_type != 'review' && scope_manifest_confirmed == true
   - kind: technique
     id: persist-verified-findings
     technique:
@@ -433,30 +207,10 @@ steps:
         bare_filename: verified-findings.md
         artifact_content: verified_findings
         target_dir: planning_folder_path
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: operation_type
-          operator: "!="
-          value: review
-        - type: simple
-          variable: scope_manifest_confirmed
-          operator: ==
-          value: true
+    when: operation_type != 'review' && scope_manifest_confirmed == true
   - kind: action
     id: classify-audit-findings
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: operation_type
-          operator: "!="
-          value: review
-        - type: simple
-          variable: scope_manifest_confirmed
-          operator: ==
-          value: true
+    when: operation_type != 'review' && scope_manifest_confirmed == true
     actions:
       - action: set
         target: needs_audit_fixes

--- a/workflow-design/activities/09-validate-and-commit.yaml
+++ b/workflow-design/activities/09-validate-and-commit.yaml
@@ -14,40 +14,18 @@ steps:
         target_dir: planning_folder_path
       outputs:
         written_artifact: report_path
-    condition:
-      type: simple
-      variable: operation_type
-      operator: ==
-      value: review
+    when: operation_type == 'review'
   - kind: technique
     id: commit-report
     technique: version-control::commit-regular-files
-    condition:
-      type: simple
-      variable: operation_type
-      operator: ==
-      value: review
+    when: operation_type == 'review'
   - kind: technique
     id: run-schema-validation
     technique: audit-schema-validation
-    condition:
-      type: simple
-      variable: operation_type
-      operator: "!="
-      value: review
+    when: operation_type != 'review'
   - kind: action
     id: validation-clean
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: operation_type
-          operator: "!="
-          value: review
-        - type: simple
-          variable: fail_count
-          operator: ==
-          value: 0
+    when: operation_type != 'review' && fail_count == 0
     actions:
       - action: message
         message: "Schema validation passed — {pass_count} file(s), 0 failed."
@@ -78,24 +56,10 @@ steps:
   - kind: technique
     id: verify-scope-manifest
     technique: scope-verification
-    condition:
-      type: simple
-      variable: operation_type
-      operator: "!="
-      value: review
+    when: operation_type != 'review'
   - kind: action
     id: scope-complete
-    condition:
-      type: and
-      conditions:
-        - type: simple
-          variable: operation_type
-          operator: "!="
-          value: review
-        - type: simple
-          variable: unaddressed_count
-          operator: ==
-          value: 0
+    when: operation_type != 'review' && unaddressed_count == 0
     actions:
       - action: message
         message: "Scope manifest verification complete — {addressed_count}/{total_count} items addressed ([scope manifest]({scope_manifest_path}))."
@@ -129,19 +93,11 @@ steps:
       name: workflow-engine::verify-readme-conforms
       inputs:
         seed_profile: workflow-design/readme-seed
-    condition:
-      type: simple
-      variable: operation_type
-      operator: "!="
-      value: review
+    when: operation_type != 'review'
   - kind: technique
     id: readme-authoring
     technique: readme-authoring
-    condition:
-      type: simple
-      variable: operation_type
-      operator: "!="
-      value: review
+    when: operation_type != 'review'
   - kind: checkpoint
     id: approve-to-commit
     condition:
@@ -168,11 +124,7 @@ steps:
   - kind: technique
     id: stage-and-commit
     technique: version-control::commit-regular-files
-    condition:
-      type: simple
-      variable: operation_type
-      operator: "!="
-      value: review
+    when: operation_type != 'review'
   - kind: technique
     id: verify-commit
     technique: commit-verification
@@ -184,19 +136,11 @@ steps:
         repo_path: target_path
         branch: workflow_branch
         remote_name: origin
-    condition:
-      type: simple
-      variable: operation_type
-      operator: "!="
-      value: review
+    when: operation_type != 'review'
   - kind: technique
     id: compose-workflow-pr-description
     technique: publish-workflow-pr
-    condition:
-      type: simple
-      variable: operation_type
-      operator: "!="
-      value: review
+    when: operation_type != 'review'
   - kind: technique
     id: create-pr
     technique:
@@ -208,22 +152,14 @@ steps:
         title: title
         body: body
         as_draft: true
-    condition:
-      type: simple
-      variable: operation_type
-      operator: "!="
-      value: review
+    when: operation_type != 'review'
   - kind: technique
     id: mark-ready
     technique:
       name: github-cli-protocol::mark-ready
       inputs:
         repo_path: target_path
-    condition:
-      type: simple
-      variable: operation_type
-      operator: "!="
-      value: review
+    when: operation_type != 'review'
   - kind: action
     id: announce-completion
     actions:

--- a/workflow-design/activities/10-post-update-review.yaml
+++ b/workflow-design/activities/10-post-update-review.yaml
@@ -18,11 +18,7 @@ steps:
         bare_filename: expressiveness-findings.md
         artifact_content: expressiveness_findings
         target_dir: planning_folder_path
-    condition:
-      type: simple
-      variable: expressiveness_finding_count
-      operator: ">"
-      value: 0
+    when: expressiveness_finding_count > 0
   - kind: technique
     id: audit-conformance
     technique: audit-conformance
@@ -34,11 +30,7 @@ steps:
         bare_filename: conformance-findings.md
         artifact_content: conformance_findings
         target_dir: planning_folder_path
-    condition:
-      type: simple
-      variable: conformance_finding_count
-      operator: ">"
-      value: 0
+    when: conformance_finding_count > 0
   - kind: technique
     id: audit-principles
     technique: audit-principles
@@ -82,11 +74,7 @@ steps:
         written_artifact: report_path
   - kind: action
     id: post-update-clean
-    condition:
-      type: simple
-      variable: review_findings_count
-      operator: ==
-      value: 0
+    when: review_findings_count == 0
     actions:
       - action: set
         target: needs_audit_fixes
@@ -98,11 +86,7 @@ steps:
         message: "Post-update review complete — 0 findings ([post-update review]({report_path}))."
   - kind: action
     id: classify-post-update-fixes
-    condition:
-      type: simple
-      variable: review_findings_count
-      operator: ">"
-      value: 0
+    when: review_findings_count > 0
     actions:
       - action: set
         target: needs_audit_fixes
@@ -158,11 +142,7 @@ steps:
             message: After re-running the audits and summarize-findings, set true iff review_findings_count is still greater than 0; false when every pass comes back at 0 findings.
   - kind: action
     id: remedia-still-dirty
-    condition:
-      type: simple
-      variable: needs_audit_fixes
-      operator: ==
-      value: true
+    when: needs_audit_fixes == true
     actions:
       - action: message
         message: "Post-update remedia exhausted with findings remaining ([post-update review]({report_path}))."

--- a/workflow-design/activities/11-retrospective.yaml
+++ b/workflow-design/activities/11-retrospective.yaml
@@ -7,11 +7,7 @@ steps:
   - kind: technique
     id: create-completion-doc
     technique: create-completion-doc
-    condition:
-      type: simple
-      variable: operation_type
-      operator: "!="
-      value: review
+    when: operation_type != 'review'
   - kind: technique
     id: persist-completion-doc
     technique:
@@ -20,11 +16,7 @@ steps:
         bare_filename: completion.md
         artifact_content: completion_document
         target_dir: planning_folder_path
-    condition:
-      type: simple
-      variable: operation_type
-      operator: "!="
-      value: review
+    when: operation_type != 'review'
   - kind: technique
     id: conduct-retrospective
     technique: conduct-retrospective
@@ -42,11 +34,7 @@ steps:
       name: work-package::manage-git::remove-worktree
       inputs:
         component_name: workflows
-    condition:
-      type: simple
-      variable: worktree_created
-      operator: ==
-      value: true
+    when: worktree_created == true
 outcome:
   - A completion summary records what the session delivered, the key design decisions and alternatives rejected, and known limitations
   - A session retrospective captures friction points and prioritized workflow improvements before the work ends

--- a/workflow-design/workflow.yaml
+++ b/workflow-design/workflow.yaml
@@ -1,6 +1,6 @@
 $schema: ../../schemas/workflow.schema.json
 id: workflow-design
-version: 1.31.0
+version: 1.32.0
 title: DEPRECATED — use workflow-authoring — Workflow Design Workflow
 description: >-
   DEPRECATED — start `workflow-authoring` instead. This workflow remains only so sessions already


### PR DESCRIPTION
## Summary

Migrate the legacy structured step conditions to `when` inline expressions across the corpus (#338 W7 / #189 C8), keeping checkpoint steps and exists-shaped predicates structured, with every site's disposition recorded in a migration register.

**Accounts for [PR #383](https://github.com/m2ux/workflow-server/pull/383):** the four OR keep-sites (`create-adr`, `update-adr-status`, `persist-structural-inventory`, `run-structural`) use parenthesized `when:`; the NOT keep-site `structural-analysis-inline` is `when: problem_complexity != 'complex'`. Host evaluator + `check:when` are the authority for mixed `&&`/`||` and `!=`. Register totals: **150 migrated**, 0 OR-kept, 0 NOT-kept.

🐛 [Issue #338](https://github.com/m2ux/workflow-server/issues/338) · 📐 [Planning](https://github.com/m2ux/workflow-server/blob/engineering/artifacts/planning/2026-08-01-migrate-legacy-structured-step-conditions-to-when/README.md)

---

## Motivation

The schema documents structured `condition` as legacy with `when` as the preferred step gate, but the corpus still carries both dialects — the last surviving duplicate-declaration duality from #189 F7. This PR makes the corpus match the schema's stated direction. Gated on the server PR that extends checkpoint dismissal to `when`-gated checkpoints; checkpoint steps keep structured conditions until it merges. OR-shaped gates migrate only after #383 lands the parentheses/precedence dialect.

---

## Changes

* **Migration** — every non-checkpoint structured step condition with a plain comparison becomes the equivalent `when` expression, semantics preserved exactly; compound forms migrate under live dialect precedent (`&&`, parenthesized `||`, and `!=` after #383).
* **OR keep-sites (#383)** — four sites migrated to parenthesized `when:`:
  * `work-package/14-complete` `create-adr` / `update-adr-status`
  * `workflow-design/01-intake-and-context` `persist-structural-inventory`
  * `prism/01-structural-pass` `run-structural`
* **NOT keep-site** — `work-package/10-post-impl-review` `structural-analysis-inline` → `when: problem_complexity != 'complex'`
* **Kept sites** — checkpoint steps, exists-shaped predicates, and loop continuations stay structured, each recorded in the migration register.
* **Verification** — `check:when` OK on the branch tip.

---

## Dependencies

* **[PR #383](https://github.com/m2ux/workflow-server/pull/383)** (host + corpus OR dialect) — required for the four parenthesized OR `when:` gates, NOT/`!=` forms, and `check:when`.
* Server PR for checkpoint `when` dismissal remains a separate gate for the remaining checkpoint keeps (out of scope here).

---

## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: [corpus definitions only]
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [x] Update documentation (if relevant)
- [x] No new todos introduced

---

## 🗹 TODO before merging

- [x] [PR #383](https://github.com/m2ux/workflow-server/pull/383) merged (or its workflows pin is on `workflows`) so OR/`!=` `when:` gates evaluate with the shared module
- [ ] Server PR (feat/when-merge-rule-fragments-ap134-guard) merged first for checkpoint dismissal path (checkpoint keeps remain until then)
- [x] Migration register accounts for #383 OR + NOT keep-site migration
- [ ] Ready for review
