### PR TITLE
fix(meta): require host shell for gh and remote git

### DIFF
--- a/meta/techniques/github-cli-protocol/TECHNIQUE.md
+++ b/meta/techniques/github-cli-protocol/TECHNIQUE.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 3.1.0
+  version: 3.2.0
 ---
 
 ## Capability
@@ -24,3 +24,7 @@ Single-item views MUST pass `--json <fields>`. The default (field-less) view of 
 ### ask-before-replying
 
 Ask the user before replying to PR comments or review feedback.
+
+### host-shell-for-gh
+
+Run every `gh` invocation in a shell with full host permissions (Cursor Shell `required_permissions: ["all"]`, or the harness equivalent outside the agent sandbox). Leave `GH_TOKEN` and `GITHUB_TOKEN` unset unless a known-good PAT is intentionally supplied. Sandbox-denial signatures (`Bad owner or permissions on …/ssh_config.d/…`, TCP via `127.0.0.1`, `unexpected EOF` on `api.github.com`) mean re-run once under full host permissions — not that host credentials failed.

--- a/meta/techniques/version-control/TECHNIQUE.md
+++ b/meta/techniques/version-control/TECHNIQUE.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 5.3.0
+  version: 5.4.0
 ---
 
 ## Capability
@@ -40,3 +40,7 @@ A submodule is infrastructure when its `path` equals `workflows`, equals `.engin
 ### host-is-derived-component-is-named
 
 The host repository a session belongs to and the component being worked on are two facts, never one variable. The host is DERIVED from git by [resolve-host-repo](./resolve-host-repo.md) — the outermost superproject that claims the workspace checkout — and lands as `{host_repo_path}` and `{target_repo}`. A repository named in the user's request, such as the `owner/repo` in a PR or issue URL, identifies the COMPONENT and lands as `{mentioned_repo}`; it is component context for [select-target-component](./select-target-component.md) alone and never binds the session. Binding a session to a repository merely because the request mentioned it is what produces a checkout that does not exist.
+
+### host-shell-for-remote-git
+
+Run every git invocation that contacts a remote (`fetch`, `pull`, `push`, `ls-remote`, network `clone`, and `ssh` to the git host) in a shell with full host permissions (Cursor Shell `required_permissions: ["all"]`, or the harness equivalent outside the agent sandbox). Local-only git may use the default shell. Sandbox-denial signatures (`Bad owner or permissions on …/ssh_config.d/…`, TCP via `127.0.0.1`, connection reset / `unexpected EOF` to the git host) mean re-run once under full host permissions — not that credentials or keys failed.


### PR DESCRIPTION
## Summary

- Add `host-shell-for-gh` on `meta/techniques/github-cli-protocol` so every `gh` invocation runs with full host permissions, leaves token env unset unless a known-good PAT is intentional, and treats sandbox-denial signatures as a re-run (not broken keyring auth).
- Add `host-shell-for-remote-git` on `meta/techniques/version-control` for remote `git`/`ssh` the same way; local-only git stays on the default shell.
- Lean container-only change (no new technique, no leaf-op rewrites). Addresses the recurring disposable-worker friction where sandboxed `gh`/SSH failures were filed as host auth outages.

## Test plan

- [x] `WORKFLOWS_DIR=<worktree> npx tsx scripts/check-technique-template.ts`
- [x] `WORKFLOWS_DIR=<worktree> npx tsx scripts/check-source-encoding.ts`
- [ ] Spot-check composed technique delivery for a `github-cli-protocol::*` and `version-control::push-branch` bind includes the new rules
- [ ] Worker path: first `gh api` / `git push` uses Shell with full host permissions