### PR TITLE
feat(workflow-authoring): coverage evidence + prose inventory for quality-review

### DIFF
--- a/workflow-authoring/activities/08-quality-review.yaml
+++ b/workflow-authoring/activities/08-quality-review.yaml
@@ -1,7 +1,7 @@
 id: quality-review
-version: 1.0.0
+version: 1.1.0
 name: Quality Review
-description: "Walk every criteria home against each target's definition surface in one pass, extend that walk to the references other workflows hold into the target, and run the repository's definition guards against the tree the run edits."
+description: "Criteria walk with field-level coverage evidence per target, consumer-surface reach, and definition guards as a separate mechanical net."
 required: true
 steps:
   - kind: technique
@@ -42,6 +42,9 @@ steps:
         id: resolve-consumer-surface
         technique: workflow-definition::resolve-consumer-surface
       - kind: technique
+        id: inventory-prose-fields
+        technique: workflow-definition::inventory-prose-fields
+      - kind: technique
         id: sweep-canon
         technique: workflow-definition::audit-canon
       - kind: technique
@@ -50,7 +53,7 @@ steps:
         actions:
           - action: set
             target: register_sections
-            message: "This target's register section appended to the sections already gathered: `{target_workflow_id}` with `{audit_findings}`, the divergences in `{coverage_ledger}`, and `{fail_count}`. Appends; never replaces a prior target's section."
+            message: "This target's register section appended to the sections already gathered: `{target_workflow_id}` with `{audit_findings}`, `{coverage_ledger}` (divergences and evidence), and `{fail_count}`. Appends; never replaces a prior target's section."
 transitions:
   - to: validate-and-commit
     isDefault: true
@@ -58,4 +61,5 @@ outcome:
   - Every criteria home is walked once per target against the working tree, so a finding is attributed to this change rather than to the catalogue it came from
   - A violation reachable only through another workflow's reference into the target is reachable, because the consumer surface is part of what the walk covers
   - Every enumeration unit the walk could not apply is recorded with the reason, so absent coverage is visible rather than indistinguishable from a clean result
-  - The definition guards run against the tree this run edits, not against a checkout it never touched
+  - Walked units that reach the change surface carry field-level evidence, so a narrative "walked" claim without Detect is a coverage gap
+  - The definition guards run against the tree this run edits as a mechanical net separate from canon coverage

--- a/workflow-authoring/resources/findings-register.md
+++ b/workflow-authoring/resources/findings-register.md
@@ -2,13 +2,13 @@
 name: findings-register
 description: Creation guide for the findings-register planning artifact — findings rows, coverage divergences, known exclusions, sources.
 metadata:
-  version: 1.0.0
+  version: 1.1.0
   order: 13
 ---
 
 # Findings Register Guide
 
-The audit record for a run: what the criteria walk found, which enumeration units it could not walk, and which findings a prior pass already accepted. Read by later steps of the same run as much as by a person, so its sections are one row per item rather than prose. Canonical home for audit findings ([canonical-home map](../techniques/TECHNIQUE.md#canonical-home-map)).
+The audit record for a run: what the criteria walk found, which enumeration units it could not walk, field-level coverage evidence for units that reached the change surface, and which findings a prior pass already accepted. Read by later steps of the same run as much as by a person, so its sections are one row per item rather than prose. Canonical home for audit findings ([canonical-home map](../techniques/TECHNIQUE.md#canonical-home-map)).
 
 Each section below is fetched on its own. A consumer that needs the row shape does not load the skeleton, and a consumer that needs the skeleton does not load the exclusion rules.
 
@@ -29,13 +29,15 @@ Each section below is fetched on its own. A consumer that needs the row shape do
 | Medium   | N | N |
 | Low      | N | N |
 
+**Coverage:** walked W · not-applicable N · blocked B · evidence rows E
+
 ## Findings
 
 [One section per target swept, each holding that target's findings table.]
 
 ## Coverage
 
-[Divergences only. Omit the section entirely when every unit was walked.]
+[Divergences (`blocked` / `not-applicable`) and, when any walked unit reached changed files, the Coverage evidence table.]
 
 ## Known
 
@@ -65,7 +67,9 @@ A row whose Evidence column cannot name a construct is not a finding and does no
 
 ## Coverage
 
-Divergences only. A unit walked cleanly gets no row — the absence of a row is the positive result.
+Two kinds of row live here.
+
+### Divergences
 
 | Column | Carries |
 |--------|---------|
@@ -75,7 +79,21 @@ Divergences only. A unit walked cleanly gets no row — the absence of a row is 
 
 Only `blocked` represents missing coverage. `not-applicable` is an evidenced negative and does not.
 
-The obligation is one row per unwalked enumeration unit of each named home. The inventory of units is not restated here — it lives in the walking operation's own first phase, which is its single home.
+### Coverage evidence
+
+Required whenever a unit is `walked` and reaches any file in the change set. One row per inspected field or locus on those files.
+
+| Column | Carries |
+|--------|---------|
+| Unit | Enumeration unit anchor (e.g. `description-hygiene-anti-patterns`) |
+| File | Path under the edit surface |
+| Field | Field path (`activity.description`, `steps[id].set[target].description`, …) |
+| Disposition | Criteria entry kebab-case on a hit, or `clean` |
+| Quote | Short quote or path:line of the construct inspected |
+
+A unit that reaches changed files with **no** evidence rows is incomplete coverage — record it as `blocked` (missing evidence), not as a silent walk. Description Hygiene without a prose-field inventory and evidence table is the canonical form of that defect.
+
+The obligation is one divergence row per unwalked enumeration unit of each named home, plus evidence rows for every walked unit that touches the change. The inventory of units is not restated here — it lives in the walking operation's own first phase, which is its single home.
 
 ## Known
 
@@ -88,8 +106,9 @@ One row per input artifact the register drew on, each a label and a path. A run 
 ## Rules
 
 - **Rows, not prose.** Every section is one row per item; a section that would read as a narrative belongs somewhere else.
-- **No aggregate scorecard is persisted.** The Summary counts severities; the full per-unit coverage scorecard stays in-session and only its divergences land here.
-- **Omit an empty section** rather than emitting it with a "none" row.
+- **Evidence is part of the decision surface.** Summary counts severities **and** coverage (walked / blocked / evidence rows). A green findings table with blocked units or missing evidence is not a clean audit.
+- **Guards are not coverage.** Definition-guard results may appear under Sources or a findings entry for a guard failure; they never substitute for Coverage evidence rows.
+- **Omit an empty section** rather than emitting it with a "none" row — except Coverage evidence, which is omitted only when no walked unit required it.
 - **Cite entries by name.** Never a bare historic designator, and never any count of the catalogue's entries.
 - **Own facts only.** Link the artifacts the register drew on; do not restate their bodies ([canonical-home map](../techniques/TECHNIQUE.md#canonical-home-map)).
-- **Line budget:** the finding rows are the length; everything around them stays inside ~60 lines.
+- **Line budget:** the finding and evidence rows are the length; everything around them stays inside ~80 lines.

--- a/workflow-authoring/techniques/workflow-definition/audit-canon.md
+++ b/workflow-authoring/techniques/workflow-definition/audit-canon.md
@@ -37,6 +37,10 @@ The sibling workflows whose established conventions the target is compared again
 
 *(optional)* The co-change set and the identifier-collision set for this change. Absent on a run with no impact pass behind it.
 
+### prose_field_inventory
+
+*(optional)* The inventory of definition-prose fields on `{changed_files}` that Description Hygiene and bound-step criteria reach. Required before Description Hygiene may be marked `walked` when `{changed_files}` includes activity YAML, technique markdown, or other definition prose. Absent only when no such file is in the change set.
+
 ## Outputs
 
 ### audit_findings
@@ -45,7 +49,7 @@ One entry per violation: the criteria entry by its kebab-case name, the file and
 
 ### coverage_ledger
 
-One row per enumeration unit walked, each carrying the unit's home, the unit's anchor, and one of three statuses. `walked` means the unit's criteria were applied to every file in scope. `not-applicable` carries the reason the unit does not reach this surface and is an evidenced negative, not a skip. `blocked` carries what prevented the walk and is the only status representing missing coverage.
+One row per enumeration unit walked, each carrying the unit's home, the unit's anchor, one of three statuses, and — when status is `walked` and the unit reaches any file in `{changed_files}` — a non-empty `evidence` list. `walked` means the unit's criteria were applied to every file in scope **and** each changed file the unit reaches has at least one evidence row naming the field (or construct locus) inspected and a short quote or path:line. `not-applicable` carries the reason the unit does not reach this surface and is an evidenced negative, not a skip. `blocked` carries what prevented the walk and is the only status representing missing coverage. A unit may not be recorded as `walked` with an empty `evidence` list when it intersects `{changed_files}`.
 
 ## Protocol
 
@@ -75,6 +79,8 @@ One row per enumeration unit walked, each carrying the unit's home, the unit's a
 - Extend the same criteria to `{consumer_surface}` — a reference another workflow holds is part of the surface this change can break, and a violation reachable only from there is reachable
 - Compare against `{reference_workflows}` wherever a unit states its criteria relative to established sibling convention
 - When `{change_constraints}` is present, check each authored identifier against its collision set and each file against its co-change set
+- When walking [Description Hygiene Anti-Patterns](../../../workflow-design/resources/anti-patterns.md#description-hygiene-anti-patterns) or bound-step description criteria, apply Detect to every row of `{prose_field_inventory}` and to the same field classes on the rest of `{surface_files}`. When `{prose_field_inventory}` is required and absent or incomplete for `{changed_files}`, record the unit as `blocked` with that gap — never as `walked`
+- For every unit marked `walked` that reaches `{changed_files}`, attach `evidence` rows: each row is `(file, field-or-locus, entry-or-clean, quote-or-path)`. A clean field still gets a row with disposition `clean`
 - Record every violation into `{audit_findings}` and every unit's disposition into `{coverage_ledger}`, at the shapes their Output declarations state
 
 ### 3. Attribute and Exclude
@@ -87,3 +93,11 @@ One row per enumeration unit walked, each carrying the unit's home, the unit's a
 ### structural-evidence-first
 
 A finding names the structural evidence its entry's Detect keys on — the field, shape or phrase that entry itself names — and inferred intent is never that evidence. Where an entry keys on the harness tool surface or on an authoritative bootstrap resource, the evidence is that surface read directly, not the authored claim about it. A finding that cannot point at the construct is not a finding.
+
+### walked-requires-evidence
+
+Status `walked` on a unit that intersects `{changed_files}` requires a non-empty `evidence` list covering each changed file the unit reaches. A narrative claim that the unit was considered, without field-level evidence, is recorded as `blocked` (missing evidence), not `walked`.
+
+### guards-are-not-canon-coverage
+
+A clean definition-guard suite is not evidence that any canon enumeration unit was walked. Guard results land only under schema-validation; they never set a coverage_ledger row to `walked`.

--- a/workflow-authoring/techniques/workflow-definition/audit-schema-validation.md
+++ b/workflow-authoring/techniques/workflow-definition/audit-schema-validation.md
@@ -30,6 +30,7 @@ Number of definition files a guard rejected, counted after every resolvable fail
   - `check-technique-template.ts` — every technique file follows the normative template
   - `check-activity-technique-overlap.ts` — no activity-level technique reference duplicates a step binding
   - `check-audience.ts` — every output declaring an agent audience carries a machine-readable artifact name
+  - `check-description-hygiene.ts` — mechanical net on activity YAML: procedure essays in `description` / `action: set` description, and `description`/`name` on bound technique steps
   - `check-self-provisioned-input.ts` — no step interpolates its own set target into its own technique inputs
   - `check-identifier-qualification.ts` — no new bare-word data identifier
   - `check-review-mode-gating.ts` — review-reachable gates are resolvable without a person
@@ -45,3 +46,7 @@ Number of definition files a guard rejected, counted after every resolvable fail
 ### guard-green-is-narrow-evidence
 
 A clean guard is evidence only for the form that guard matches. Two known blind spots stand: a resource reference in already-projected form carries no `.md` and is invisible to the anchor guard, and an unresolvable resource is skipped at delivery with no warning at all. Treat an unexplained absence in a delivered payload as a reference defect, not as an empty result.
+
+### guard-green-is-not-canon-green
+
+`{fail_count}` zero never implies the criteria walk is complete or that `{open_finding_count}` may be treated as zero. Canon coverage is decided only by `{coverage_ledger}` under [audit-canon](./audit-canon.md) (including [walked-requires-evidence](./audit-canon.md#walked-requires-evidence)). Description-hygiene and other mechanical nets catch a subset of Detect; they do not replace the Description Hygiene enumeration unit.

--- a/workflow-authoring/techniques/workflow-definition/compile-report.md
+++ b/workflow-authoring/techniques/workflow-definition/compile-report.md
@@ -52,7 +52,9 @@ The register body: the severity summary, one findings section per target, the co
 
 ### 2. Record the Divergences and the Exclusions
 
-- Take the rows of `{coverage_ledger}` that carry `blocked` or `not-applicable` into the coverage section, and omit that section entirely when every unit was walked
+- Take the rows of `{coverage_ledger}` that carry `blocked` or `not-applicable` into the coverage section
+- When any `walked` unit that intersects the change surface carries `evidence`, include a **Coverage evidence** subsection with those rows (file, field, entry-or-clean, quote) — required for Description Hygiene and every other unit that reached changed files; omit the subsection only when no unit required evidence
+- Omit the coverage section entirely only when every unit was walked with no divergences and no evidence obligation
 - Take the entries excluded by `{known_finding_keys}` into the known section, and omit it when nothing is excluded
 - When `{fixes_applied}` is present, record what the remediation round changed against the findings it resolved
 

--- a/workflow-authoring/techniques/workflow-definition/inventory-prose-fields.md
+++ b/workflow-authoring/techniques/workflow-definition/inventory-prose-fields.md
@@ -1,0 +1,47 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+The inventory of every definition-prose field on the target's changed definition surface that Description Hygiene and bound-step criteria reach.
+
+## Inputs
+
+### surface_files
+
+Every definition file of the target in scope for this walk.
+
+### changed_files
+
+The subset of `{surface_files}` that differs from the run's base ref.
+
+## Outputs
+
+### prose_field_inventory
+
+One row per prose field on `{changed_files}` that Description Hygiene or bound-step criteria can key on: file path, field path (`activity.description`, `steps[<id>].description`, `steps[<id>].set[<target>].description`, `steps[<id>].name`, checkpoint `message` / option `description`, technique `## Capability` when the file is a technique), and a short quote of the field's text. Empty when `{changed_files}` holds no such field.
+
+## Protocol
+
+### 1. Restrict to the Change Surface
+
+- Take `{changed_files}` as the inventory scope. Files only in `{surface_files}` stay out of this inventory; the full-surface walk still covers them under other units.
+
+### 2. Enumerate Prose Fields
+
+- For each activity YAML in scope, record `description` on the activity, on unbound steps, on `action: set` entries, on checkpoint `message` and option `description` / `label` prose, and on bound `kind: technique` steps that still carry `description` or `name`
+- For each technique markdown in scope, record the `## Capability` body as one field
+- For each resource or README markdown in scope whose body is definition orientation (not a planning artifact), record top-level purpose paragraphs that function as description
+
+### 3. Emit the Inventory
+
+- Emit `{prose_field_inventory}` as one row per field at the shape its Output declaration states
+- When no field qualifies, emit an empty inventory — emptiness is evidence that Description Hygiene has no changed prose to walk, not a skip
+
+## Rules
+
+### inventory-before-hygiene-walk
+
+Description Hygiene Detect runs against this inventory (and the full surface for pre-existing fields). A walk that marks Description Hygiene `walked` without an inventory that covers every changed prose field is incomplete — the unit is `blocked` for missing inventory, not `walked`.

--- a/workflow-authoring/techniques/workflow-definition/verify-high-findings.md
+++ b/workflow-authoring/techniques/workflow-definition/verify-high-findings.md
@@ -33,7 +33,7 @@ True when any surviving finding is `Critical` severity: a schema-invalid or stru
 
 ### has_coverage_gap
 
-True when any row of `{coverage_ledger}` carries status `blocked`. Rows carrying `not-applicable` are evidenced negatives and do not set it.
+True when any row of `{coverage_ledger}` carries status `blocked`, or when any row carries status `walked` while intersecting the change surface yet omits the required `evidence` list. Rows carrying `not-applicable` are evidenced negatives and do not set it.
 
 ## Protocol
 
@@ -53,6 +53,7 @@ True when any row of `{coverage_ledger}` carries status `blocked`. Rows carrying
 ### 4. Cross-Check the Coverage and Count the Surface
 
 - Check `{coverage_ledger}` against the enumeration inventory the walking operation holds — [Enumerate the Criteria Units](./audit-canon.md#1-enumerate-the-criteria-units) — and declare no inventory here
+- Treat a `walked` row that reaches changed files without `evidence` as a coverage gap (same weight as `blocked`)
 - Emit `{verified_findings}`, `{open_finding_count}`, `{has_critical_finding}` and `{has_coverage_gap}` at the shapes their Output declarations state
 
 ## Rules
@@ -68,3 +69,7 @@ The re-derivation reads the cited construct and nothing else. The originating pa
 ### remediation-needs-a-re-derived-claim
 
 Do not emit a remediation instruction for a row whose claim has not been re-derived. A withdrawn or unexamined finding drives no edit, whatever its original severity said.
+
+### empty-evidence-is-a-gap
+
+A coverage row marked `walked` without the evidence list [walked-requires-evidence](./audit-canon.md#walked-requires-evidence) demands sets `{has_coverage_gap}` true. Narrative completeness is not coverage.


### PR DESCRIPTION
## Summary

- inventory-prose-fields before audit-canon on quality-review
- walked requires field-level evidence on changed files; guards are not canon coverage
- findings-register Coverage evidence table; has_coverage_gap on empty evidence
- audit-schema-validation lists check-description-hygiene

## Pairing

Host: feat/audit-coverage-evidence-description-hygiene → main