### PR TITLE
fix: REST-only GitHub technique commands; drop host-shell essays

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,45 +50,7 @@ This repo is an **MCP server** for AI agent workflow orchestration (TypeScript, 
 - **Commit incrementally. Do not amend or squash to tidy up.** Each change lands as its own commit with its own message, so the branch carries a readable record of how it was built. Push with plain `git push`; when a push will not fast-forward, stop and ask rather than rewriting.
   - **`--force`/`--force-with-lease` has exactly one use:** correcting a genuine error in an earlier commit, on a branch with **no other contributors**. Not for squashing, not for rewording, not for folding a follow-up into the commit it fixes, and never on a shared branch.
   - Repeated amending is the failure mode to avoid: it silently collapses distinct pieces of work into one commit, and the intermediate states survive only in a local reflog. Once collapsed, the history cannot be recovered — only reconstructed by hand, which is a rewrite of its own.
-- **GitHub CLI — REST only (no GraphQL).** `gh pr create`, `gh pr view`, `gh pr list`, and any call that hits `api.github.com/graphql` are **forbidden** here (GraphQL is deprecated/unreliable and fails). Create and manage PRs with REST only, e.g.:
-
-  ```bash
-  git push -u origin HEAD
-  gh api --method POST repos/{owner}/{repo}/pulls \
-    -f title='...' -f head='branch' -f base='main' -f body='...'
-  ```
-
-  Other ops: `gh api repos/...`, `gh api --method PATCH|POST|GET ...`. Never use `gh pr *`.
-
-### GitHub auth and agent shell (required)
-
-Host auth is **keyring + SSH** (`gh` as the active user; `origin` is `git@github.com:...`). Most agent GitHub failures are a **sandboxed shell**, not a broken login. Workflow ops under `github-cli-protocol` and remote `version-control` carry the same invariant (`host-shell-for-gh`, `host-shell-for-remote-git`).
-
-1. **First attempt, every time — full host permissions.**  
-   For every `gh` call (including `gh api`) and every remote git/SSH call (`fetch` / `pull` / `push` / `ls-remote` / network `clone` / `ssh` to the git host), run the Shell with `required_permissions: ["all"]` (or the harness equivalent outside the agent sandbox). Local-only git (`status`, `add`, `commit`, `rev-parse`) may use the default shell. Do not start these remote calls sandboxed and “escalate after failure.”
-
-2. **Leave token env unset unless a known-good PAT is intentional.**  
-   Unset `GH_TOKEN` and `GITHUB_TOKEN` for keyring auth. `gh` prefers those env vars over the keyring; a wrong or garbage value yields `Bad credentials` / HTTP 401 even when keyring login is fine. Never scrape `~/.config/gh/hosts.yml` into them (tokens live in the keyring, not that file).
-
-3. **Sandbox denial is not auth failure.**  
-   These signatures mean the shell is still sandboxed — re-run the **same** command once under full host permissions. Do not conclude credentials or SSH keys are invalid; do not thrash sandboxed retries; if the harness refuses full host permissions, stop and surface that blockage:
-
-   ```text
-   Bad owner or permissions on /etc/ssh/ssh_config.d/20-systemd-ssh-proxy.conf
-   read tcp 127.0.0.1:…->127.0.0.1:… connection reset by peer
-   Get "https://api.github.com/...": unexpected EOF
-   fatal: Could not read from remote repository.
-   ```
-
-4. **Health check** (unsandboxed only — same permissions as step 1):
-
-   ```bash
-   unset GH_TOKEN GITHUB_TOKEN
-   gh auth status
-   gh api user --jq .login
-   ssh -T git@github.com
-   git ls-remote origin HEAD
-   ```
+- **GitHub CLI: do not use GraphQL.** Prefer REST only (`gh api repos/...`, `gh api --method PATCH|POST|GET ...`). Avoid `gh pr view/create/list` and any path that hits `api.github.com/graphql` — GraphQL is deprecated/unreliable here.
 
 ## Where to look
 

--- a/examples/cursor-workspace/AGENTS.md
+++ b/examples/cursor-workspace/AGENTS.md
@@ -28,11 +28,3 @@ owner/repo
 ```
 
 Replace with your project (for example `m2ux/workflow-server`).
-
-## GitHub auth and agent shell (required)
-
-Host auth is **keyring + SSH**. Most agent GitHub failures are a **sandboxed shell**, not a broken login. When the project checkout carries `github-cli-protocol` / remote `version-control` ops, those techniques state the same invariant (`host-shell-for-gh`, `host-shell-for-remote-git`).
-
-1. **First attempt, every time — full host permissions.** For every `gh` call (including `gh api`) and every remote git/SSH call (`fetch` / `pull` / `push` / `ls-remote` / network `clone` / `ssh` to the git host), run the Shell with `required_permissions: ["all"]` (or the harness equivalent outside the agent sandbox). Local-only git may use the default shell. Do not start these remote calls sandboxed and escalate after failure.
-2. **Leave token env unset unless a known-good PAT is intentional.** Unset `GH_TOKEN` and `GITHUB_TOKEN` for keyring auth. Never scrape `~/.config/gh/hosts.yml` into them.
-3. **Sandbox denial is not auth failure.** Signatures such as `Bad owner or permissions on …/ssh_config.d/…`, TCP via `127.0.0.1`, or `unexpected EOF` on `api.github.com` mean re-run the same command once under full host permissions — not that credentials failed. If the harness refuses full host permissions, stop and surface that blockage.

--- a/scripts/binding-fidelity-triage.json
+++ b/scripts/binding-fidelity-triage.json
@@ -529,13 +529,6 @@
     },
     {
       "check": "read-resolution",
-      "site": "work-package/techniques/manage-git/detect-merge-strategy.md:26",
-      "detail": "{allow_squash_merge} has no producer (declared id / $-local / workflow var / set-target)",
-      "verdict": "harmless",
-      "rationale": "external-tool-syntax"
-    },
-    {
-      "check": "read-resolution",
       "site": "work-package/techniques/review-summary.md:81",
       "detail": "{sha} has no producer (declared id / $-local / workflow var / set-target)",
       "verdict": "harmless",

--- a/scripts/binding-fidelity-triage.json
+++ b/scripts/binding-fidelity-triage.json
@@ -459,13 +459,6 @@
     },
     {
       "check": "orphan-input",
-      "site": "work-package :: meta::github-cli-protocol::comment-issue",
-      "detail": "own input 'number' has no producer in workflow 'work-package' (no step-binding entry, workflow variable, step output, or default)",
-      "verdict": "harmless",
-      "rationale": "shared-op-caller-argument"
-    },
-    {
-      "check": "orphan-input",
       "site": "work-package :: meta::gitnexus-operations::analyze",
       "detail": "own input 'force_rebuild' has no producer in workflow 'work-package' (no step-binding entry, workflow variable, step output, or default)",
       "verdict": "harmless",

--- a/scripts/deploy-cursor-workspace.sh
+++ b/scripts/deploy-cursor-workspace.sh
@@ -606,14 +606,6 @@ owner/repo
 \`\`\`
 
 Replace with your project (for example \`m2ux/${REPO_BASENAME}\`).
-
-## GitHub auth and agent shell (required)
-
-Host auth is **keyring + SSH**. Most agent GitHub failures are a **sandboxed shell**, not a broken login. When the project checkout carries \`github-cli-protocol\` / remote \`version-control\` ops, those techniques state the same invariant (\`host-shell-for-gh\`, \`host-shell-for-remote-git\`).
-
-1. **First attempt, every time — full host permissions.** For every \`gh\` call (including \`gh api\`) and every remote git/SSH call (\`fetch\` / \`pull\` / \`push\` / \`ls-remote\` / network \`clone\` / \`ssh\` to the git host), run the Shell with \`required_permissions: ["all"]\` (or the harness equivalent outside the agent sandbox). Local-only git may use the default shell. Do not start these remote calls sandboxed and escalate after failure.
-2. **Leave token env unset unless a known-good PAT is intentional.** Unset \`GH_TOKEN\` and \`GITHUB_TOKEN\` for keyring auth. Never scrape \`~/.config/gh/hosts.yml\` into them.
-3. **Sandbox denial is not auth failure.** Signatures such as \`Bad owner or permissions on …/ssh_config.d/…\`, TCP via \`127.0.0.1\`, or \`unexpected EOF\` on \`api.github.com\` mean re-run the same command once under full host permissions — not that credentials failed. If the harness refuses full host permissions, stop and surface that blockage.
 EOF
 )
 

--- a/tests/e2e/__snapshots__/corpus-sha.json
+++ b/tests/e2e/__snapshots__/corpus-sha.json
@@ -1,4 +1,4 @@
 {
-  "corpusSha": "34818b4a80d587fd846707ce76f50a9b89d89485",
+  "corpusSha": "ada56baa7b476159436cb5809424bbfab81e8834",
   "note": "Corpus commit the committed walk snapshots were generated against. Update it in the same commit that bumps the workflows submodule and re-baselines the walk (npm run baseline:stamp)."
 }

--- a/tests/e2e/__snapshots__/corpus-sha.json
+++ b/tests/e2e/__snapshots__/corpus-sha.json
@@ -1,4 +1,4 @@
 {
-  "corpusSha": "f0629df5f1fd66ac7520d036ce31acaa66042c12",
+  "corpusSha": "b3a72c1b8d6dc611d05a85212e4e5edc2db343f0",
   "note": "Corpus commit the committed walk snapshots were generated against. Update it in the same commit that bumps the workflows submodule and re-baselines the walk (npm run baseline:stamp)."
 }

--- a/tests/e2e/__snapshots__/corpus-sha.json
+++ b/tests/e2e/__snapshots__/corpus-sha.json
@@ -1,4 +1,4 @@
 {
-  "corpusSha": "f37f0ee2558586df5ad7292930198b2c6c63f68c",
+  "corpusSha": "f0629df5f1fd66ac7520d036ce31acaa66042c12",
   "note": "Corpus commit the committed walk snapshots were generated against. Update it in the same commit that bumps the workflows submodule and re-baselines the walk (npm run baseline:stamp)."
 }

--- a/tests/e2e/__snapshots__/corpus-sha.json
+++ b/tests/e2e/__snapshots__/corpus-sha.json
@@ -1,4 +1,4 @@
 {
-  "corpusSha": "ada56baa7b476159436cb5809424bbfab81e8834",
+  "corpusSha": "f37f0ee2558586df5ad7292930198b2c6c63f68c",
   "note": "Corpus commit the committed walk snapshots were generated against. Update it in the same commit that bumps the workflows submodule and re-baselines the walk (npm run baseline:stamp)."
 }

--- a/tests/e2e/__snapshots__/corpus-sha.json
+++ b/tests/e2e/__snapshots__/corpus-sha.json
@@ -1,4 +1,4 @@
 {
-  "corpusSha": "d891ed7376c1bd80596df4861491905a4483015b",
+  "corpusSha": "34818b4a80d587fd846707ce76f50a9b89d89485",
   "note": "Corpus commit the committed walk snapshots were generated against. Update it in the same commit that bumps the workflows submodule and re-baselines the walk (npm run baseline:stamp)."
 }

--- a/tests/workflow-authoring-delivery.test.ts
+++ b/tests/workflow-authoring-delivery.test.ts
@@ -50,7 +50,6 @@ const TREE_PRESENT = existsSync(join(WORKFLOWS_ROOT, 'workflow-authoring', 'work
  * into rather than pushed, so neither appears.
  */
 const EAGER_STEP_IDS = [
-  'inventory-prose-fields',
   'load-known-findings',
   'survey-reference-workflows',
   'rebind-target-baseline',

--- a/tests/workflow-authoring-delivery.test.ts
+++ b/tests/workflow-authoring-delivery.test.ts
@@ -50,6 +50,7 @@ const TREE_PRESENT = existsSync(join(WORKFLOWS_ROOT, 'workflow-authoring', 'work
  * into rather than pushed, so neither appears.
  */
 const EAGER_STEP_IDS = [
+  'inventory-prose-fields',
   'load-known-findings',
   'survey-reference-workflows',
   'rebind-target-baseline',


### PR DESCRIPTION
## Summary

Disposable `start-work-package` workers still hit sandbox EOFs and GraphQL because **Protocol lines** prescribed `gh pr view` / `gh pr create` / etc., while the prior “fix” lived in soft AGENTS.md / host-shell group rules workers do not copy.

This PR:

1. **Rewrites technique command templates** to `gh api` REST only (`github-cli-protocol` + work-package / related inline recipes). Workflows commit on branch `workflow/gh-rest-api-protocols` (base `workflows`).
2. **Reverts the failed soft fix surface**: AGENTS.md host-shell essay, cursor-workspace seed, deploy-script seed, and `host-shell-for-gh` / `host-shell-for-remote-git` group rules that did not change the commands workers execute.

## Test plan

- [ ] Worker following `review-existing-feedback` / `view-pr` runs only `gh api repos/...` (no `gh pr *`, no `api.github.com/graphql`)
- [ ] Create-PR path uses `POST repos/{owner}/{repo}/pulls`
- [ ] AGENTS.md no longer contains the long “GitHub auth and agent shell” section
- [ ] Workflows pin points at the REST protocol commit