### PR TITLE
fix(workflow-authoring): whole-file change surface for canon audit

### DIFF
--- a/workflow-authoring/activities/08-quality-review.yaml
+++ b/workflow-authoring/activities/08-quality-review.yaml
@@ -59,7 +59,8 @@ transitions:
     isDefault: true
 outcome:
   - Every criteria home is walked once per target against the working tree, so a finding is attributed to this change rather than to the catalogue it came from
+  - The change surface is whole touched files closed under I/O-contract referencers, so Detect is never limited to diff hunks and silent bind sites still join the walk
   - A violation reachable only through another workflow's reference into the target is reachable, because the consumer surface is part of what the walk covers
   - Every enumeration unit the walk could not apply is recorded with the reason, so absent coverage is visible rather than indistinguishable from a clean result
-  - Walked units that reach the change surface carry field-level evidence, so a narrative "walked" claim without Detect is a coverage gap
+  - Walked units that reach the change surface carry field-level evidence on each whole file, so a narrative "walked" claim without Detect is a coverage gap
   - The definition guards run against the tree this run edits as a mechanical net separate from canon coverage

--- a/workflow-authoring/resources/findings-register.md
+++ b/workflow-authoring/resources/findings-register.md
@@ -2,13 +2,13 @@
 name: findings-register
 description: Creation guide for the findings-register planning artifact — findings rows, coverage divergences, known exclusions, sources.
 metadata:
-  version: 1.1.0
+  version: 1.2.0
   order: 13
 ---
 
 # Findings Register Guide
 
-The audit record for a run: what the criteria walk found, which enumeration units it could not walk, field-level coverage evidence for units that reached the change surface, and which findings a prior pass already accepted. Read by later steps of the same run as much as by a person, so its sections are one row per item rather than prose. Canonical home for audit findings ([canonical-home map](../techniques/TECHNIQUE.md#canonical-home-map)).
+The audit record for a run: what the criteria walk found, which enumeration units it could not walk, field-level coverage evidence for units that reached the change surface (whole touched files closed under I/O-contract referencers and their consumers), and which findings a prior pass already accepted. Read by later steps of the same run as much as by a person, so its sections are one row per item rather than prose. Canonical home for audit findings ([canonical-home map](../techniques/TECHNIQUE.md#canonical-home-map)).
 
 Each section below is fetched on its own. A consumer that needs the row shape does not load the skeleton, and a consumer that needs the skeleton does not load the exclusion rules.
 
@@ -19,6 +19,7 @@ Each section below is fetched on its own. A consumer that needs the row shape do
 
 **Date:** YYYY-MM-DD · **Mode:** Create | Update | Review
 **Base ref:** `{ref}` · **Targets:** one row per target below
+**Change surface:** N files (touched: N whole files · I/O-contract closure: N · consumers: N)
 
 ## Summary
 
@@ -31,13 +32,23 @@ Each section below is fetched on its own. A consumer that needs the row shape do
 
 **Coverage:** walked W · not-applicable N · blocked B · evidence rows E
 
+## Change surface
+
+| Path | How it joined |
+|------|----------------|
+| `{path}` | touched (whole file) |
+| `{path}` | I/O-contract closure — references `{contract-path}` |
+| `{path}` | consumer of change-surface target |
+
+[One table per target, or one combined table with a Target column. Omit only when the change surface is empty. Never a hunk list.]
+
 ## Findings
 
 [One section per target swept, each holding that target's findings table.]
 
 ## Coverage
 
-[Divergences (`blocked` / `not-applicable`) and, when any walked unit reached changed files, the Coverage evidence table.]
+[Divergences (`blocked` / `not-applicable`) and, when any walked unit reached the change surface, the Coverage evidence table.]
 
 ## Known
 
@@ -48,6 +59,16 @@ Each section below is fetched on its own. A consumer that needs the row shape do
 [One row per input artifact consulted, label and path. Omit when none.]
 ~~~~
 
+## Change surface
+
+The walk's change surface is path-level, never hunk-level:
+
+1. **Touched** — every definition path whose bytes differ from the base ref (whole file).
+2. **I/O-contract closure** — every activity or technique that references a file whose Inputs/Outputs (or activity bind contract) changed, whether or not the referencer's bytes changed.
+3. **Consumers** — cross-workflow references that resolve to a file already on that set; the referencing file joins as a whole file.
+
+Header counts and this table must match that union. A register that only lists diff hunks or omits silent referencers is incomplete coverage.
+
 ## Findings
 
 One row per finding, in severity order — Critical, then High, Medium, Low.
@@ -57,9 +78,9 @@ One row per finding, in severity order — Critical, then High, Medium, Low.
 | ID | Stable within the register, so a disposition can name a row |
 | Severity | `Critical` for a schema-invalid or structurally broken construct that must not be committed, then `High`, `Medium`, `Low` |
 | Entry | The criteria entry by its kebab-case name — never a bare historic number, and never the catalogue's entry count |
-| Location | File and field, at the depth the entry's evidence sits |
-| Evidence | The construct the entry's Detect keys on, quoted or named |
-| Origin | `diff` when the violation arrived with this change, `pre-existing` when it was already there at the base ref |
+| Location | File and field, at the depth the entry's evidence sits — anywhere in a change-surface file, not only hunk lines |
+| Evidence | The construct the entry's Detect keys on, quoted or named; when the file joined only via I/O-contract closure, name the contract path it references |
+| Origin | `diff` when the path was touched **or** the defect is contract-drift at a referencer/consumer on the change surface; `pre-existing` when the same construct was already at the base ref and does not depend on an I/O contract change in this surface |
 | Known | Set when a prior pass accepted this finding's key |
 | Fix | The action the entry prescribes, in one line |
 
@@ -81,19 +102,19 @@ Only `blocked` represents missing coverage. `not-applicable` is an evidenced neg
 
 ### Coverage evidence
 
-Required whenever a unit is `walked` and reaches any file in the change set. One row per inspected field or locus on those files.
+Required whenever a unit is `walked` and reaches any file on the change surface. One row per inspected field or locus on those **whole** files — not limited to diff hunks.
 
 | Column | Carries |
 |--------|---------|
 | Unit | Enumeration unit anchor (e.g. `description-hygiene-anti-patterns`) |
-| File | Path under the edit surface |
+| File | Path on the change surface |
 | Field | Field path (`activity.description`, `steps[id].set[target].description`, …) |
 | Disposition | Criteria entry kebab-case on a hit, or `clean` |
 | Quote | Short quote or path:line of the construct inspected |
 
-A unit that reaches changed files with **no** evidence rows is incomplete coverage — record it as `blocked` (missing evidence), not as a silent walk. Description Hygiene without a prose-field inventory and evidence table is the canonical form of that defect.
+A unit that reaches the change surface with **no** evidence rows is incomplete coverage — record it as `blocked` (missing evidence), not as a silent walk. Evidence limited to hunk lines while the unit claims the whole file is the same defect. Description Hygiene without a prose-field inventory and evidence table is the canonical form of that defect.
 
-The obligation is one divergence row per unwalked enumeration unit of each named home, plus evidence rows for every walked unit that touches the change. The inventory of units is not restated here — it lives in the walking operation's own first phase, which is its single home.
+The obligation is one divergence row per unwalked enumeration unit of each named home, plus evidence rows for every walked unit that reaches the change surface. The inventory of units is not restated here — it lives in the walking operation's own first phase, which is its single home.
 
 ## Known
 

--- a/workflow-authoring/techniques/workflow-definition/audit-canon.md
+++ b/workflow-authoring/techniques/workflow-definition/audit-canon.md
@@ -1,11 +1,11 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
 
-One walk of every criteria home against a target's definition surface, with each finding attributed against the change and each enumeration unit's coverage recorded.
+One walk of every criteria home against a target's definition surface and its change surface (whole touched files closed under I/O-contract referencers and their consumers), with each finding attributed against the change and each enumeration unit's coverage recorded.
 
 ## Inputs
 
@@ -15,7 +15,11 @@ Every definition file of the target in scope for this walk.
 
 ### changed_files
 
-The subset of `{surface_files}` that differs from the run's base ref.
+The change surface: whole files that differ from the base ref, plus every activity or technique pulled in because it references a file whose I/O contract changed. Not a hunk list.
+
+### touched_files
+
+*(optional)* The subset of the change surface whose path bytes differ from `{base_ref}`. When present, distinguishes git-touched paths from I/O-contract closure for attribution. When absent, treat every path in `{changed_files}` as touched for origin purposes only when the path's bytes differ from `{base_ref}`.
 
 ### base_ref
 
@@ -27,7 +31,7 @@ Keys of findings already accepted or baselined, each pairing a criteria entry wi
 
 ### consumer_surface
 
-The references other workflows hold into the target, each resolved to the file it names and marked for whether this run changed it.
+The references other workflows hold into the target, each resolved to the file it names and marked for whether that file is on `{changed_files}`. Referencing files whose target is on the change surface are walked as whole files.
 
 ### reference_workflows
 
@@ -45,11 +49,11 @@ The sibling workflows whose established conventions the target is compared again
 
 ### audit_findings
 
-One entry per violation: the criteria entry by its kebab-case name, the file and field it was found in, the structural evidence satisfying that entry's Detect, the fix that entry prescribes, a severity, whether the violation arrived with `{changed_files}` or pre-existed at `{base_ref}`, and whether its key was already known. Severity is `Critical` for a schema-invalid or structurally broken construct, then `High`, `Medium`, `Low`.
+One entry per violation: the criteria entry by its kebab-case name, the file and field it was found in, the structural evidence satisfying that entry's Detect, the fix that entry prescribes, a severity, whether the violation arrived with this change (`diff`) or pre-existed at `{base_ref}`, and whether its key was already known. Severity is `Critical` for a schema-invalid or structurally broken construct, then `High`, `Medium`, `Low`. Origin `diff` covers path-byte touches and contract-drift defects at referencers or consumers on the change surface; origin `pre-existing` is only the same construct already at `{base_ref}` with no dependence on an I/O contract change in this surface.
 
 ### coverage_ledger
 
-One row per enumeration unit walked, each carrying the unit's home, the unit's anchor, one of three statuses, and — when status is `walked` and the unit reaches any file in `{changed_files}` — a non-empty `evidence` list. `walked` means the unit's criteria were applied to every file in scope **and** each changed file the unit reaches has at least one evidence row naming the field (or construct locus) inspected and a short quote or path:line. `not-applicable` carries the reason the unit does not reach this surface and is an evidenced negative, not a skip. `blocked` carries what prevented the walk and is the only status representing missing coverage. A unit may not be recorded as `walked` with an empty `evidence` list when it intersects `{changed_files}`.
+One row per enumeration unit walked, each carrying the unit's home, the unit's anchor, one of three statuses, and — when status is `walked` and the unit reaches any file in `{changed_files}` — a non-empty `evidence` list. `walked` means the unit's criteria were applied to every file in scope **and** each change-surface file the unit reaches has at least one evidence row naming the field (or construct locus) inspected and a short quote or path:line — evidence spans the **whole file**, not the diff hunk. `not-applicable` carries the reason the unit does not reach this surface and is an evidenced negative, not a skip. `blocked` carries what prevented the walk and is the only status representing missing coverage. A unit may not be recorded as `walked` with an empty `evidence` list when it intersects `{changed_files}`.
 
 ## Protocol
 
@@ -74,18 +78,20 @@ One row per enumeration unit walked, each carrying the unit's home, the unit's a
 
 ### 2. Walk Every Unit Against the Surface
 
-- For each unit, apply its criteria to `{surface_files}`: honour each entry's Detect, its exclusions and its Fix exactly as that entry states them
+- For each unit, apply its criteria to the **entire contents** of every file in `{changed_files}` and of every referencing file on `{consumer_surface}` whose resolved target is on `{changed_files}`: honour each entry's Detect, its exclusions and its Fix exactly as that entry states them. Diff hunks do not bound inspection inside those files
+- Also apply the same criteria to the rest of `{surface_files}` so pre-existing defects remain attributable
 - Take Detect from the anti-pattern and construct-inventory homes; take from the principles home only whether the authored content honours a stance, so one violation is not counted twice under two homes
-- Extend the same criteria to `{consumer_surface}` — a reference another workflow holds is part of the surface this change can break, and a violation reachable only from there is reachable
 - Compare against `{reference_workflows}` wherever a unit states its criteria relative to established sibling convention
 - When `{change_constraints}` is present, check each authored identifier against its collision set and each file against its co-change set
 - When walking [Description Hygiene Anti-Patterns](../../../workflow-design/resources/anti-patterns.md#description-hygiene-anti-patterns) or bound-step description criteria, apply Detect to every row of `{prose_field_inventory}` and to the same field classes on the rest of `{surface_files}`. When `{prose_field_inventory}` is required and absent or incomplete for `{changed_files}`, record the unit as `blocked` with that gap — never as `walked`
-- For every unit marked `walked` that reaches `{changed_files}`, attach `evidence` rows: each row is `(file, field-or-locus, entry-or-clean, quote-or-path)`. A clean field still gets a row with disposition `clean`
+- For every unit marked `walked` that reaches `{changed_files}`, attach `evidence` rows: each row is `(file, field-or-locus, entry-or-clean, quote-or-path)`. A clean field still gets a row with disposition `clean`. Evidence covers the whole file the unit reaches on the change surface
 - Record every violation into `{audit_findings}` and every unit's disposition into `{coverage_ledger}`, at the shapes their Output declarations state
 
 ### 3. Attribute and Exclude
 
-- Attribute each finding against `{base_ref}`: a violation in a file listed in `{changed_files}` arrived with this change; one anywhere else pre-existed it
+- Attribute each finding against `{base_ref}`:
+  - Origin `diff` when the path is in `{touched_files}` (or its bytes differ from `{base_ref}`), **or** when the defect is contract-drift at a referencer or consumer that joined `{changed_files}` / `{consumer_surface}` because an I/O contract on the change surface changed
+  - Origin `pre-existing` when the same construct and evidence were already present at `{base_ref}` on that path and the finding does not depend on an I/O contract change in this change surface
 - Mark a finding whose key appears in `{known_finding_keys}` as known and leave it out of the decision surface — recorded, not deleted, so a later pass can ask whether the acceptance still holds
 
 ## Rules
@@ -96,7 +102,11 @@ A finding names the structural evidence its entry's Detect keys on — the field
 
 ### walked-requires-evidence
 
-Status `walked` on a unit that intersects `{changed_files}` requires a non-empty `evidence` list covering each changed file the unit reaches. A narrative claim that the unit was considered, without field-level evidence, is recorded as `blocked` (missing evidence), not `walked`.
+Status `walked` on a unit that intersects `{changed_files}` requires a non-empty `evidence` list covering each **whole** change-surface file the unit reaches. A narrative claim that the unit was considered, or evidence limited to diff hunk lines, is recorded as `blocked` (missing evidence), not `walked`.
+
+### whole-file-and-contract-closure
+
+The change surface is never "the lines the diff shows". Every touched path is a full file; every I/O-contract referencer and every consumer of a change-surface target file is a full file on the walk.
 
 ### guards-are-not-canon-coverage
 

--- a/workflow-authoring/techniques/workflow-definition/compile-report.md
+++ b/workflow-authoring/techniques/workflow-definition/compile-report.md
@@ -37,7 +37,7 @@ Keys of findings already accepted or baselined, each pairing a criteria entry wi
 
 ### findings_register
 
-The register body: the severity summary, one findings section per target, the coverage divergences, the accepted exclusions and the sources consulted. Shaped by [Template](../../resources/findings-register.md#template). Read by later steps of the same run as much as by a person, so every section is one row per item rather than prose.
+The register body: the severity summary, the change-surface membership table (touched whole files, I/O-contract closure, consumers), one findings section per target, the coverage divergences, the accepted exclusions and the sources consulted. Shaped by [Template](../../resources/findings-register.md#template). Read by later steps of the same run as much as by a person, so every section is one row per item rather than prose.
 
 #### artifact
 
@@ -49,11 +49,12 @@ The register body: the severity summary, one findings section per target, the co
 
 - Fold `{register_sections}` into one findings section per target, taking each row's severity, entry, location, evidence, origin and known marking from `{verified_findings}` where an entry was re-derived
 - Count the severity summary from the surviving entries, with entries keyed in `{known_finding_keys}` counted under Known rather than Open
+- Emit the header change-surface counts and the **Change surface** table (path × how it joined: touched whole file, I/O-contract closure, or consumer) from each target's `{changed_files}` / `{touched_files}` / `{consumer_surface}` — never a hunk list
 
 ### 2. Record the Divergences and the Exclusions
 
 - Take the rows of `{coverage_ledger}` that carry `blocked` or `not-applicable` into the coverage section
-- When any `walked` unit that intersects the change surface carries `evidence`, include a **Coverage evidence** subsection with those rows (file, field, entry-or-clean, quote) — required for Description Hygiene and every other unit that reached changed files; omit the subsection only when no unit required evidence
+- When any `walked` unit that intersects the change surface carries `evidence`, include a **Coverage evidence** subsection with those rows (file, field, entry-or-clean, quote) — required for Description Hygiene and every other unit that reached whole change-surface files; omit the subsection only when no unit required evidence
 - Omit the coverage section entirely only when every unit was walked with no divergences and no evidence obligation
 - Take the entries excluded by `{known_finding_keys}` into the known section, and omit it when nothing is excluded
 - When `{fixes_applied}` is present, record what the remediation round changed against the findings it resolved

--- a/workflow-authoring/techniques/workflow-definition/inventory-prose-fields.md
+++ b/workflow-authoring/techniques/workflow-definition/inventory-prose-fields.md
@@ -1,11 +1,11 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
 
-The inventory of every definition-prose field on the target's changed definition surface that Description Hygiene and bound-step criteria reach.
+The inventory of every definition-prose field on the change surface (whole touched files and I/O-contract closure) that Description Hygiene and bound-step criteria reach.
 
 ## Inputs
 
@@ -15,19 +15,19 @@ Every definition file of the target in scope for this walk.
 
 ### changed_files
 
-The subset of `{surface_files}` that differs from the run's base ref.
+The change surface: whole files that differ from the base ref plus I/O-contract referencers. Inventory covers each file in full, not the diff hunks.
 
 ## Outputs
 
 ### prose_field_inventory
 
-One row per prose field on `{changed_files}` that Description Hygiene or bound-step criteria can key on: file path, field path (`activity.description`, `steps[<id>].description`, `steps[<id>].set[<target>].description`, `steps[<id>].name`, checkpoint `message` / option `description`, technique `## Capability` when the file is a technique), and a short quote of the field's text. Empty when `{changed_files}` holds no such field.
+One row per prose field on `{changed_files}` that Description Hygiene or bound-step criteria can key on: file path, field path (`activity.description`, `steps[<id>].description`, `steps[<id>].set[<target>].description`, `steps[<id>].name`, checkpoint `message` / option `description`, technique `## Capability` when the file is a technique), and a short quote of the field's text. Empty when `{changed_files}` holds no such field. Every qualifying field on each change-surface file is listed, including fields outside the git hunks.
 
 ## Protocol
 
 ### 1. Restrict to the Change Surface
 
-- Take `{changed_files}` as the inventory scope. Files only in `{surface_files}` stay out of this inventory; the full-surface walk still covers them under other units.
+- Take `{changed_files}` as the inventory scope — whole files. Files only in `{surface_files}` stay out of this inventory; the full-surface walk still covers them under other units. Do not restrict rows to lines present in the diff.
 
 ### 2. Enumerate Prose Fields
 
@@ -38,10 +38,10 @@ One row per prose field on `{changed_files}` that Description Hygiene or bound-s
 ### 3. Emit the Inventory
 
 - Emit `{prose_field_inventory}` as one row per field at the shape its Output declaration states
-- When no field qualifies, emit an empty inventory — emptiness is evidence that Description Hygiene has no changed prose to walk, not a skip
+- When no field qualifies, emit an empty inventory — emptiness is evidence that Description Hygiene has no change-surface prose to walk, not a skip
 
 ## Rules
 
 ### inventory-before-hygiene-walk
 
-Description Hygiene Detect runs against this inventory (and the full surface for pre-existing fields). A walk that marks Description Hygiene `walked` without an inventory that covers every changed prose field is incomplete — the unit is `blocked` for missing inventory, not `walked`.
+Description Hygiene Detect runs against this inventory (and the full surface for pre-existing fields). A walk that marks Description Hygiene `walked` without an inventory that covers every prose field on every change-surface file is incomplete — the unit is `blocked` for missing inventory, not `walked`.

--- a/workflow-authoring/techniques/workflow-definition/reload-workflow.md
+++ b/workflow-authoring/techniques/workflow-definition/reload-workflow.md
@@ -1,11 +1,11 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
 
-Current definition surface of one target and the base ref its change is measured against.
+Current definition surface of one target, the base ref its change is measured against, and the change surface as whole touched files closed under I/O-contract referencers.
 
 ## Outputs
 
@@ -17,9 +17,13 @@ The git ref this run's change is measured against — the merge base between the
 
 Every definition file of the target as it stands on the branch under change: the root definition, the activity files, the technique files at every level, the resource files and the README.
 
+### touched_files
+
+Every path under the target that differs from `{base_ref}`, each entry a **whole file**. Diff hunks only discover membership. Empty when the branch has not yet touched this target.
+
 ### changed_files
 
-The subset of `{surface_files}` that differs from `{base_ref}`. Empty when the branch has not yet touched this target, which is the ordinary case for a target under audit rather than under change.
+The **change surface**: the union of `{touched_files}` and every activity or technique (in this target or another workflow under `{target_path}`) that references a touched file whose **I/O contract** changed. Each entry is a whole file. I/O contract means technique `## Inputs` / `## Outputs` (including nested component and artifact declarations), and activity-declared inputs/outputs plus step binds that name technique input or output ids — including renames, additions, removals, and optionality flips. Empty when nothing was touched and nothing was pulled in by contract closure.
 
 ## Protocol
 
@@ -31,12 +35,23 @@ The subset of `{surface_files}` that differs from `{base_ref}`. Empty when the b
 
 - Enumerate the target's files under `{target_path}/{target_workflow_id}` as `{surface_files}`, at every technique level — standalone, group index and nested
 
-### 3. Diff the Surface Against the Base Ref
+### 3. Diff Touched Paths Against the Base Ref
 
-- Set `{changed_files}` to the entries of `{surface_files}` that differ from their state at `{base_ref}`
+- Set `{touched_files}` to the entries of `{surface_files}` whose bytes differ from their state at `{base_ref}` — whole paths only, never hunk ranges
+
+### 4. Close Under I/O-Contract Referencers
+
+- For each path in `{touched_files}`, compare its I/O contract at `{base_ref}` to the working tree. When Inputs, Outputs, or activity bind-facing ids differ, record that path as a **contract-changed** file
+- Sweep every workflow directory under `{target_path}` for references that resolve to a contract-changed file: activity `techniques[]` and step `technique` / `technique.name` binds, technique Protocol Apply / `::` / markdown links to the op, and resource or README cites that resolve to the op file
+- Set `{changed_files}` to the union of `{touched_files}` and every resolved referencer file (whole file), including referencers outside `{target_workflow_id}`
+- A path that joins only via contract closure is still a full member of `{changed_files}`; Detect later walks the entire file
 
 ## Rules
 
 ### one-target-per-binding
 
-This operation resolves exactly the target `{target_workflow_id}` names. When that id is rebound across a set of targets, each binding produces the surface of its own target and nothing else — a surface carrying two targets' files cannot be attributed against a single base ref.
+This operation resolves exactly the target `{target_workflow_id}` names for `{surface_files}` and `{touched_files}`. Contract-closure may add referencers from other workflow ids under `{target_path}` into `{changed_files}`; those paths stay attributed against the same `{base_ref}`.
+
+### whole-file-change-surface
+
+`{changed_files}` never carries hunk ranges or "lines modified" scopes. Membership is path-level; audit walks the full file contents of every member.

--- a/workflow-authoring/techniques/workflow-definition/resolve-consumer-surface.md
+++ b/workflow-authoring/techniques/workflow-definition/resolve-consumer-surface.md
@@ -1,34 +1,34 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
 
-The references other workflows hold into one target, resolved against the files this run changed.
+The references other workflows hold into one target, resolved against the change surface (whole touched files closed under I/O-contract referencers).
 
 ## Inputs
 
 ### changed_files
 
-The definition files of the target that differ from the run's base ref.
+The change surface for this target: whole touched files plus I/O-contract closure. Consumers that resolve into this set join the walk.
 
 ## Outputs
 
 ### consumer_surface
 
-One entry per reference another workflow holds into the target: the referencing file, the reference form it uses, the target file it resolves to, and whether that file is one this run changed. Empty when nothing outside the target references it.
+One entry per reference another workflow holds into the target: the referencing file, the reference form it uses, the target file it resolves to, and whether that target file is on `{changed_files}`. Empty when nothing outside the target references it. Every referencing file whose resolved target is on `{changed_files}` is itself part of the change surface the criteria walk covers (whole file).
 
 ## Protocol
 
 ### 1. Find the References Into the Target
 
-- Sweep every workflow directory other than `{target_workflow_id}` for references that resolve into it: step and activity technique binds carrying it as their leading segment, resource references qualified with it, and activity file references borrowed from it
+- Sweep every workflow directory other than `{target_workflow_id}` for references that resolve into it: step and activity technique binds carrying it as their leading segment, technique Protocol Apply / `::` / markdown links, resource references qualified with it, and activity file references borrowed from it
 
-### 2. Resolve Each Reference Against the Change
+### 2. Resolve Each Reference Against the Change Surface
 
-- For each reference, resolve the file it names inside the target and record whether that file appears in `{changed_files}`
-- A reference resolving to a changed file is a consumer this change can break, and belongs in the surface a criteria walk covers
+- For each reference, resolve the file it names inside the target and record whether that file appears in `{changed_files}` (touched or I/O-contract closure)
+- A reference resolving to a change-surface file is a consumer this change can break; the **referencing file** joins the change surface as a whole file and belongs in the surface a criteria walk covers
 
 ## Rules
 


### PR DESCRIPTION
## Summary

- Canon audit **change surface** is path-level: every **touched** definition file is walked in full (diff hunks only discover membership).
- When a technique/activity **I/O contract** changes, every activity/technique that **references** that file joins the change surface (in-tree and cross-workflow), even if its bytes did not change.
- Consumers of change-surface target files join as whole files.
- `reload-workflow`, `resolve-consumer-surface`, `audit-canon`, `inventory-prose-fields`, `compile-report`, `findings-register`, and quality-review outcomes encode the same rules for in-workflow audits.

## Test plan

- [ ] Read `reload-workflow` / `audit-canon` protocol: no hunk-scoped walk language remains
- [ ] Spot-check findings-register template has Change surface table + origin rules
- [ ] Companion main PR pins this commit and ships `workflow-canon` skill updates