### PR TITLE
fix(audit): whole-file change surface and I/O-contract closure

### DIFF
--- a/examples/cursor-workspace/.claude/skills/workflow-canon/SKILL.md
+++ b/examples/cursor-workspace/.claude/skills/workflow-canon/SKILL.md
@@ -51,13 +51,20 @@ A draft self-check is not an audit and does not produce a findings register. If 
 
 ### 1. Scope the surface
 
-Name, before reading criteria:
+Name, before reading criteria. Build the **change surface** first; the walk is against that set (and the wider target surface for pre-existing attribution), never against a hunk list.
 
-- **Surface files** — every definition file of the target: `workflow.yaml`, `activities/`, `techniques/`, `resources/`, and the READMEs.
-- **Changed files** — the subset differing from the base ref. Without this, nothing can be attributed.
-- **Consumer surface** — the references other workflows hold *into* the target, each resolved to the file it names. A violation reachable only from a consumer is reachable. `grep -rn "<target-id>/" workflows/ --include=*.md --include=*.yaml` finds the cross-workflow refs.
-- **Reference workflows** — the siblings of similar type whose conventions the target is compared against.
 - **Base ref** — the ref the change is measured against.
+- **Surface files** — every definition file of the target: `workflow.yaml`, `activities/`, `techniques/`, `resources/`, and the READMEs.
+- **Touched files** — every path under the target (and any other definition path in the diff) that differs from the base ref. A path is in or out as a **whole file**. Diff hunks only discover membership; they never bound what Detect may inspect inside that file.
+- **I/O-contract closure** — when any touched technique or activity changes its **I/O contract**, every other activity or technique that references that file is also in the change surface, whether or not its bytes differ from the base ref.
+  - **I/O contract** means: technique `## Inputs` / `## Outputs` (including nested component / artifact declarations); activity-declared inputs/outputs and step binds that name technique input or output ids; renames, additions, removals, optionality flips, and type/shape changes of those ids.
+  - **Reference** means any of: activity `techniques[]` or step `technique` / `technique.name` binds; technique Protocol `Apply` / `::` / markdown links to a sibling or cross-workflow op; resource or README cites that resolve to the op file. Resolve each reference to a concrete definition file path.
+  - Sweep the whole workflows tree (same target and other workflows). A referencer outside the original target still joins the change surface.
+- **Change surface** — the union of **touched files** and **I/O-contract closure**, each entry the full file. Report the two subsets separately in the audit header so a reader can see what git touched versus what contract reach pulled in.
+- **Consumer surface** — the references other workflows hold *into* the target, each resolved to the file it names. Always computed; when a resolved target file is on the change surface (touched or pulled in by I/O-contract closure), that consumer file is on the change surface too. `grep -rn "<target-id>/" workflows/ --include=*.md --include=*.yaml` finds the cross-workflow refs; expand with bind and Apply resolution, not path string match alone.
+- **Reference workflows** — the siblings of similar type whose conventions the target is compared against.
+
+**Forbidden scopes.** Do not treat "the lines the diff shows" as the audit surface. Do not mark a unit `walked` on a touched file after reading only the hunk. Do not omit a silent referencer because the bind site was not edited.
 
 ### 2. Run the mechanical guards first
 
@@ -73,15 +80,21 @@ Do not restate, summarise, or renumber the entries a unit contains. Follow each 
 
 ### 4. Walk every unit against the surface
 
-- Apply each entry's **Detect**, honour its **Do not flag** carve-outs, and record its **Fix** verbatim in intent when it fires.
+- Apply each entry's **Detect** to the **entire contents** of every file on the **change surface** (touched ∪ I/O-contract closure ∪ consumers of those files). Honour **Do not flag** carve-outs; record **Fix** verbatim in intent when it fires.
+- Also apply Detect to the rest of **surface files** so pre-existing defects remain attributable; those findings are not excused by sitting outside the hunk list.
 - **Detect comes from the anti-pattern and inventory homes only.** From the principles home take only whether the authored content honours the stance — so one violation is not counted twice under two homes.
-- Extend the same criteria to the consumer surface.
 - Compare against the reference workflows wherever a unit states its criteria relative to sibling convention.
 - Record every unit's disposition into the coverage ledger as you go — `walked`, `not-applicable` with the reason it does not reach this surface, or `blocked` with what prevented the walk. Only `blocked` is missing coverage; `not-applicable` is an evidenced negative.
+- Status `walked` on a unit that intersects the change surface requires field-level evidence on **each whole file** in that intersection the unit can reach — not on the diff hunks alone. A narrative "walked the change" without whole-file evidence is `blocked`.
 
 ### 5. Attribute and exclude
 
-Attribute each finding against the base ref: a violation in a changed file arrived with this change; one anywhere else pre-existed it. Mark findings whose key a prior pass already accepted as **known** and keep them out of the decision surface — recorded, not deleted, so a later pass can ask whether the acceptance still holds.
+Attribute each finding against the base ref:
+
+- **Origin `diff`** — the violation is in a **touched** file (path bytes differ from base), **or** it is a break that only exists because an I/O contract on the change surface changed (including a stale bind or Apply in an untouched referencer or consumer). Contract-closure membership alone is enough for `diff` when the defect is contract-drift at the reference site.
+- **Origin `pre-existing`** — the same construct and evidence were already present at the base ref on that path, and the finding does not depend on an I/O contract change in this change surface.
+
+Mark findings whose key a prior pass already accepted as **known** and keep them out of the decision surface — recorded, not deleted, so a later pass can ask whether the acceptance still holds.
 
 ### 6. Verify High findings adversarially
 
@@ -91,10 +104,12 @@ Only confirmed findings are eligible to drive fixes.
 
 ### 7. Report
 
-Per [references/reporting.md](references/reporting.md): the finding row shape, the coverage ledger, the severity scale, and which report shape applies. Inside a workflow-authoring or workflow-design run, that run's creation guides own the layout and this skill defers to them.
+Per [references/reporting.md](references/reporting.md): the finding row shape, the coverage ledger, the severity scale, and which report shape applies. The standalone header **must** state change-surface counts: touched (whole files), I/O-contract closure, and consumers pulled in — never "N hunks" or "diff lines only". Inside a workflow-authoring or workflow-design run, that run's creation guides own the layout and this skill defers to them.
 
 ## Non-negotiables
 
+- **Whole file on the change surface.** Every touched path is audited as a complete definition file. Diff hunks discover which paths joined the surface; they do not limit Detect.
+- **I/O contract pulls referencers.** A modified Inputs/Outputs (or activity bind contract) expands the change surface to every activity and technique that references that file, in-tree and cross-workflow.
 - **Structural evidence or it is not a finding.** A finding names the field, shape, or phrase its entry's Detect keys on. Inferred intent is never that evidence. Where an entry keys on the harness tool surface or an authoritative bootstrap resource, the evidence is that surface read directly — not the authored claim about it.
 - **Cite by name.** Kebab-case entry name and principle title. No bare `AP-XX`, no entry counts — both drift.
 - **One violation, one home.** Do not report the same bad sentence under a principle and its covering anti-pattern.

--- a/examples/cursor-workspace/.claude/skills/workflow-canon/references/canon-map.md
+++ b/examples/cursor-workspace/.claude/skills/workflow-canon/references/canon-map.md
@@ -46,6 +46,16 @@ One unit: Reference Conventions. It is explicitly *not* a substitute for reading
 
 The registry is the enumeration; each entry carries a one-line `proves`. Read it rather than assuming a roster. `npm run check:all` runs every entry; `npx tsx scripts/check-delta.ts --base <ref>` reports only what the change added.
 
+## Change-surface scope (audit)
+
+When the path is **Audit** (SKILL.md), the walk's **change surface** is not the diff hunk list:
+
+1. **Whole touched files** — every definition path that differs from the base ref, inspected in full.
+2. **I/O-contract closure** — every activity or technique that references a file whose Inputs/Outputs (or activity I/O / bind contract) changed, whether or not that referencer's bytes changed.
+3. **Consumers** — cross-workflow references that resolve to a file already on the change surface.
+
+File-kind routing still chooses which units can fire; it does not shrink a touched file to its hunks or drop contract referencers. Details and forbidden scopes live in SKILL.md § Audit → Scope the surface.
+
 ## Fetching
 
 `anti-patterns.md` exceeds the per-resource eager-delivery cap, so it is never bundled whole. Fetch by section in every mode:

--- a/examples/cursor-workspace/.claude/skills/workflow-canon/references/reporting.md
+++ b/examples/cursor-workspace/.claude/skills/workflow-canon/references/reporting.md
@@ -22,11 +22,13 @@ A guard that exits 2 has not measured. That is `blocked` coverage, not a pass, a
 | Entry | The criteria entry by its kebab-case **name** — never a bare `AP-XX`, never a count of the catalog |
 | Location | File and field, at the depth the evidence sits |
 | Evidence | The construct the entry's Detect keys on, quoted or named |
-| Origin | `diff` when the violation arrived with this change, `pre-existing` when it was already there at the base ref |
+| Origin | `diff` when the violation arrived with this change (path touched, **or** contract-drift at a referencer/consumer pulled in by I/O-contract closure), `pre-existing` when the same construct was already at the base ref and does not depend on an I/O contract change in this surface |
 | Known | Set when a prior pass accepted this key |
 | Fix | The action the entry prescribes, in one line |
 
 **A row whose Evidence cannot name a construct is not a finding** and does not belong in the table. Inferred intent is not evidence. Where the entry keys on the harness tool surface or an authoritative bootstrap resource, the evidence is that surface read directly.
+
+**Change surface is whole files.** Evidence and Location cite constructs anywhere in a change-surface file. A finding is not limited to diff hunk lines. When the file joined via I/O-contract closure only, say so in Evidence (referencer of `{path}` whose Inputs/Outputs changed).
 
 ## Coverage ledger
 
@@ -59,7 +61,7 @@ Fetch the guide's `## Template` section and fill it; persist through the activit
 ~~~markdown
 # Canon Audit — `{target}`
 
-**Base ref:** `{ref}` · **Surface:** N files · **Guards:** clean | N findings | N unmeasured
+**Base ref:** `{ref}` · **Target surface:** N files · **Change surface:** N files (touched: N whole files · I/O-contract closure: N · consumers: N) · **Guards:** clean | N findings | N unmeasured
 
 | Severity | Open | Known |
 |----------|-----:|------:|
@@ -67,6 +69,16 @@ Fetch the guide's `## Template` section and fill it; persist through the activit
 | High     | N | N |
 | Medium   | N | N |
 | Low      | N | N |
+
+## Change surface
+
+| Path | How it joined |
+|------|----------------|
+| `{path}` | touched (whole file) |
+| `{path}` | I/O-contract closure — references `{contract-path}` |
+| `{path}` | consumer of change-surface target |
+
+[Omit the table only when the change surface is empty. Never replace it with a hunk list.]
 
 ## Findings
 
@@ -90,3 +102,4 @@ Fetch the guide's `## Template` section and fill it; persist through the activit
 - **No criteria prose in the report.** Link the entry; the catalog is its home.
 - **Cite entries by name.** Never a bare designator, never any count of the catalog's entries.
 - **Report the verify pass honestly.** Say which Highs were withdrawn or downgraded on re-derivation; a register that silently drops them reads as a walk that never found them.
+- **Report the change surface honestly.** Header counts and the Change surface table must match the skill's union (whole touched files ∪ I/O-contract closure ∪ consumers). A report that only lists diff hunks or omits silent referencers is incomplete coverage, not a clean sweep.

--- a/tests/e2e/__snapshots__/corpus-sha.json
+++ b/tests/e2e/__snapshots__/corpus-sha.json
@@ -1,4 +1,4 @@
 {
-  "corpusSha": "d891ed7376c1bd80596df4861491905a4483015b",
+  "corpusSha": "752c67febbed95d4a23e529a96e696bbbb9018d8",
   "note": "Corpus commit the committed walk snapshots were generated against. Update it in the same commit that bumps the workflows submodule and re-baselines the walk (npm run baseline:stamp)."
 }

--- a/tests/workflow-authoring-delivery.test.ts
+++ b/tests/workflow-authoring-delivery.test.ts
@@ -54,6 +54,7 @@ const EAGER_STEP_IDS = [
   'survey-reference-workflows',
   'rebind-target-baseline',
   'resolve-consumer-surface',
+  'inventory-prose-fields',
   'sweep-canon',
   'validate-schema',
 ];


### PR DESCRIPTION
## Summary

- **`workflow-canon` skill:** change surface = whole touched files ∪ I/O-contract referencers ∪ consumers; Detect spans entire files; forbidden hunk-only audits; report header + Change surface table required.
- **Reporting / canon-map:** origin and coverage rules match; standalone report template includes change-surface membership.
- **`workflows` pin:** companion corpus branch `workflow/audit-whole-file-change-surface` (workflow-authoring audit techniques + findings-register).

## Test plan

- [ ] Skill Audit §1 lists whole-file + I/O-contract closure + forbidden scopes
- [ ] `references/reporting.md` standalone template has Change surface section
- [ ] Submodule pin matches the workflows PR tip
- [ ] Merge workflows PR first (or with), then this pin