### PR TITLE
fix(meta): keep host-repo technique prose session-blind

### DIFF
--- a/meta/techniques/TECHNIQUE.md
+++ b/meta/techniques/TECHNIQUE.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.1.1
 ---
 
 ## Capability
@@ -11,7 +11,7 @@ Shared Inputs, Outputs, Rules, and Errors for every technique in this set.
 
 ### host_repo_path
 
-Absolute path to the host repository the session belongs to — the outermost superproject when the component is a submodule, the checkout itself otherwise.
+Absolute path of the outermost git host for the workspace checkout — the outermost superproject when the component is a submodule, the checkout itself otherwise.
 
 ### component_path
 

--- a/meta/techniques/version-control/TECHNIQUE.md
+++ b/meta/techniques/version-control/TECHNIQUE.md
@@ -1,11 +1,11 @@
 ---
 metadata:
-  version: 5.4.0
+  version: 5.4.1
 ---
 
 ## Capability
 
-Version-control operations for planning folders and artifacts — parent repos, submodules, and branch push. Owns the host-versus-component distinction that keeps a session bound to the repository git resolves rather than one prose names.
+Version-control operations for planning folders and artifacts — parent repos, submodules, and branch push. Owns the host-versus-component distinction: host path and `owner/repo` come from git; a repository name in request prose identifies a component only.
 
 ## Rules
 
@@ -39,7 +39,7 @@ A submodule is infrastructure when its `path` equals `workflows`, equals `.engin
 
 ### host-is-derived-component-is-named
 
-The host repository a session belongs to and the component being worked on are two facts, never one variable. The host is DERIVED from git by [resolve-host-repo](./resolve-host-repo.md) — the outermost superproject that claims the workspace checkout — and lands as `{host_repo_path}` and `{target_repo}`. A repository named in the user's request, such as the `owner/repo` in a PR or issue URL, identifies the COMPONENT and lands as `{mentioned_repo}`; it is component context for [select-target-component](./select-target-component.md) alone and never binds the session. Binding a session to a repository merely because the request mentioned it is what produces a checkout that does not exist.
+Host repository and component under work are two facts, never one variable. The host is DERIVED from git by [resolve-host-repo](./resolve-host-repo.md) — the outermost superproject that claims the workspace checkout — and lands as `{host_repo_path}` and `{target_repo}`. A repository named in the user's request, such as the `owner/repo` in a PR or issue URL, identifies the COMPONENT and lands as `{mentioned_repo}`; it is component context for [select-target-component](./select-target-component.md) alone and never substitutes for the derived host. Treating a prose-named repository as the host is what produces a checkout that does not exist.
 
 ### host-shell-for-remote-git
 

--- a/meta/techniques/version-control/resolve-host-repo.md
+++ b/meta/techniques/version-control/resolve-host-repo.md
@@ -1,17 +1,17 @@
 ---
 metadata:
-  version: 2.0.1
+  version: 2.0.2
 ---
 
 ## Capability
 
-The host repository a session belongs to, derived from git rather than from prose. Answers *which repository the session belongs to*, never *which component is being worked on* — version-control.host-is-derived-component-is-named.
+Outermost git host repository for a workspace path, derived from git rather than from prose. Answers *which repository owns this checkout*, never *which component is being worked on* — version-control.host-is-derived-component-is-named.
 
 ## Inputs
 
 ### workspace_path
 
-*(optional)* Directory the session was opened in — the starting point for the ascent.
+*(optional)* Directory that is the starting point for the ascent.
 
 #### default
 
@@ -29,7 +29,7 @@ Absolute path of the outermost repository that claims the workspace checkout —
 
 ### component_hint
 
-Basename of the innermost toplevel when the ascent crossed a non-infrastructure submodule boundary — the component the session is already inside. Unset when the ascent crossed nothing, or crossed only infrastructure submodules.
+Basename of the innermost toplevel when the ascent crossed a non-infrastructure submodule boundary — the component the workspace path already sits inside. Unset when the ascent crossed nothing, or crossed only infrastructure submodules.
 
 ### host_binding_mismatch
 

--- a/meta/techniques/version-control/select-target-component.md
+++ b/meta/techniques/version-control/select-target-component.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.2.0
+  version: 1.2.1
 ---
 
 ## Capability
@@ -19,7 +19,7 @@ The enumerated target-component submodules (infrastructure submodules already ex
 
 ### component_hint
 
-*(optional)* Basename of the component the session was opened inside, as derived from git.
+*(optional)* Basename of the component the workspace path already sits inside, as derived from git.
 
 ### mentioned_repo
 

--- a/work-package/techniques/repo-root-resolution.md
+++ b/work-package/techniques/repo-root-resolution.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 2.0.0
+  version: 2.0.1
 ---
 
 ## Capability
@@ -15,19 +15,19 @@ Absolute path of the host repository, as produced by [resolve-host-repo](../../m
 
 ### component_hint
 
-*(optional)* Basename of the component the session was opened inside. Unset when the session sits at the host root.
+*(optional)* Basename of the component the workspace path already sits inside. Unset when the path is at the host root.
 
 ## Outputs
 
 ### component_name
 
-Basename of the component being worked on — the basename of `{host_repo_path}` when the session sits at the host root.
+Basename of the component being worked on — the basename of `{host_repo_path}` when the path is at the host root.
 
 ### component_path
 
-Path of the component being worked on, relative to `{host_repo_path}` — `.` when the session sits at the host root.
+Path of the component being worked on, relative to `{host_repo_path}` — `.` when the path is at the host root.
 
 ## Protocol
 
-1. When `{component_hint}` is unset, set `{component_path}` to `.` and `{component_name}` to the basename of `{host_repo_path}` — the session sits at the host root. Done.
+1. When `{component_hint}` is unset, set `{component_path}` to `.` and `{component_name}` to the basename of `{host_repo_path}` — the path is at the host root. Done.
 2. Read `{host_repo_path}/.gitmodules` and take the submodule `path` whose basename equals `{component_hint}`. Set `{component_path}` to that path and `{component_name}` to `{component_hint}`.


### PR DESCRIPTION
## Summary

- Techniques are **session-blind** ([Keep Session Interaction in Activities](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/design-principles.md#24-keep-session-interaction-in-activities) / `session-interaction-in-technique`).
- Strip "session belongs to" / "session was opened" framing from host-repo and component techniques.
- State products as git-derived host path, `owner/repo`, and component facts. Session binding stays on activities / workflow variables.

### Files

- `meta/techniques/version-control/resolve-host-repo.md`
- `meta/techniques/version-control/TECHNIQUE.md` (`host-is-derived-component-is-named`)
- `meta/techniques/version-control/select-target-component.md`
- `meta/techniques/TECHNIQUE.md` (`host_repo_path`)
- `work-package/techniques/repo-root-resolution.md`

Activity/workflow variable descriptions that correctly own session binding are unchanged.

## Test plan

- [ ] No technique under the change set says a technique owns session membership
- [ ] Capability/I/O still distinguish host (git-derived) vs component (named)
- [ ] `check:all` on a pin that includes this tip