### PR TITLE
fix(workflows): pin session-blind host-repo technique prose

### DIFF
--- a/tests/e2e/__snapshots__/corpus-sha.json
+++ b/tests/e2e/__snapshots__/corpus-sha.json
@@ -1,4 +1,4 @@
 {
-  "corpusSha": "752c67febbed95d4a23e529a96e696bbbb9018d8",
+  "corpusSha": "e6e0b34dd54d55538965c45da58222c8a7249142",
   "note": "Corpus commit the committed walk snapshots were generated against. Update it in the same commit that bumps the workflows submodule and re-baselines the walk (npm run baseline:stamp)."
 }


### PR DESCRIPTION
## Summary

- Pins `workflows` to include [PR #392](https://github.com/m2ux/workflow-server/pull/392) (session-blind host-repo technique prose).
- Techniques no longer describe products as "the host repository a session belongs to"; session binding remains activity/variable scope.

## Test plan

- [ ] CI green
- [ ] Pin SHA matches `workflow/session-blind-host-repo-prose` tip after merge