### PR TITLE
fix(meta,work-package): host-shell invariants on remote technique groups

### DIFF
--- a/meta/techniques/github-cli-protocol/TECHNIQUE.md
+++ b/meta/techniques/github-cli-protocol/TECHNIQUE.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 3.4.1
+  version: 3.4.2
 ---
 
 ## Capability
@@ -30,3 +30,7 @@ Outside this technique group, GitHub access is an Apply of a leaf op. Domain tec
 ### ask-before-replying
 
 Ask the user before replying to PR comments or review feedback.
+
+### host-shell-for-gh
+
+Every `gh` invocation runs with full host permissions (Cursor Shell `required_permissions: ["all"]`, or the harness equivalent outside the agent sandbox). `GH_TOKEN` and `GITHUB_TOKEN` stay unset unless a known-good PAT is intentionally supplied. A sandbox denial is not a credential failure.

--- a/meta/techniques/github-cli-protocol/TECHNIQUE.md
+++ b/meta/techniques/github-cli-protocol/TECHNIQUE.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 3.4.2
+  version: 3.4.3
 ---
 
 ## Capability
@@ -33,4 +33,4 @@ Ask the user before replying to PR comments or review feedback.
 
 ### host-shell-for-gh
 
-Every `gh` invocation runs with full host permissions (Cursor Shell `required_permissions: ["all"]`, or the harness equivalent outside the agent sandbox). `GH_TOKEN` and `GITHUB_TOKEN` stay unset unless a known-good PAT is intentionally supplied. A sandbox denial is not a credential failure.
+Every `gh` invocation runs on the host shell — host credentials, host network, and host SSH agent. Isolated execution environments that block those are outside this technique. `GH_TOKEN` and `GITHUB_TOKEN` stay unset unless a known-good PAT is intentionally supplied. An isolation denial is not a credential failure.

--- a/meta/techniques/version-control/TECHNIQUE.md
+++ b/meta/techniques/version-control/TECHNIQUE.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 5.3.1
+  version: 5.3.2
 ---
 
 ## Capability
@@ -8,6 +8,10 @@ metadata:
 Version-control operations for planning folders and artifacts — parent repos, submodules, and branch push. Owns the host-versus-component distinction: host path and `owner/repo` come from git; a repository name in request prose identifies a component only.
 
 ## Rules
+
+### host-shell-for-remote-git
+
+Every git invocation that contacts a remote (`fetch`, `pull`, `push`, `ls-remote`, network `clone`, and `ssh` to the git host) runs with full host permissions (Cursor Shell `required_permissions: ["all"]`, or the harness equivalent outside the agent sandbox). Local-only git may use the default shell. A sandbox denial is not a credential or key failure.
 
 ### no-destructive-ops
 

--- a/meta/techniques/version-control/TECHNIQUE.md
+++ b/meta/techniques/version-control/TECHNIQUE.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 5.3.2
+  version: 5.3.3
 ---
 
 ## Capability
@@ -11,7 +11,7 @@ Version-control operations for planning folders and artifacts — parent repos, 
 
 ### host-shell-for-remote-git
 
-Every git invocation that contacts a remote (`fetch`, `pull`, `push`, `ls-remote`, network `clone`, and `ssh` to the git host) runs with full host permissions (Cursor Shell `required_permissions: ["all"]`, or the harness equivalent outside the agent sandbox). Local-only git may use the default shell. A sandbox denial is not a credential or key failure.
+Every git invocation that contacts a remote (`fetch`, `pull`, `push`, `ls-remote`, network `clone`, and `ssh` to the git host) runs on the host shell — host credentials, host network, and host SSH agent. Isolated execution environments that block those are outside this technique. Local-only git may use the default shell. An isolation denial is not a credential or key failure.
 
 ### no-destructive-ops
 

--- a/work-package/techniques/manage-git/TECHNIQUE.md
+++ b/work-package/techniques/manage-git/TECHNIQUE.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 2.1.0
+  version: 2.1.1
 ---
 
 ## Capability
@@ -23,3 +23,7 @@ Edit-side git operations (branch, PR, sync, push) run inside `{target_path}`. Su
 ### code-commit-coauthor-trailer
 
 Every code commit (NOT artifact commits) MUST carry a `Co-authored-by: {display_name} <{email}>` trailer so GitHub renders both the human and the assistant in the commit byline. Whether to add it manually depends on the harness: Claude Code adds it automatically — do NOT add it again or it will appear twice. Other assistants that do not auto-inject the trailer must add it explicitly via `git commit -m "subject\n\nCo-authored-by: {display_name} <{email}>"`. Known assistant identity for the Claude Code harness: `Co-authored-by: Claude <noreply@anthropic.com>` (auto-injected). For other assistants, use the identity provided by their harness or documentation.
+
+### host-shell-for-remote-git
+
+Every git invocation that contacts a remote (`fetch`, `pull`, `push`, `ls-remote`, network `clone`, and `ssh` to the git host) runs with full host permissions (Cursor Shell `required_permissions: ["all"]`, or the harness equivalent outside the agent sandbox). Local-only git may use the default shell. A sandbox denial is not a credential or key failure.

--- a/work-package/techniques/manage-git/TECHNIQUE.md
+++ b/work-package/techniques/manage-git/TECHNIQUE.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 2.1.1
+  version: 2.1.2
 ---
 
 ## Capability
@@ -26,4 +26,4 @@ Every code commit (NOT artifact commits) MUST carry a `Co-authored-by: {display_
 
 ### host-shell-for-remote-git
 
-Every git invocation that contacts a remote (`fetch`, `pull`, `push`, `ls-remote`, network `clone`, and `ssh` to the git host) runs with full host permissions (Cursor Shell `required_permissions: ["all"]`, or the harness equivalent outside the agent sandbox). Local-only git may use the default shell. A sandbox denial is not a credential or key failure.
+Every git invocation that contacts a remote (`fetch`, `pull`, `push`, `ls-remote`, network `clone`, and `ssh` to the git host) runs on the host shell — host credentials, host network, and host SSH agent. Isolated execution environments that block those are outside this technique. Local-only git may use the default shell. An isolation denial is not a credential or key failure.


### PR DESCRIPTION
## Summary

- Restore **invariant-only**, **harness-agnostic** host-shell rules on the three technique containers that contact GitHub/git remotes:
  - `meta/techniques/github-cli-protocol` → `host-shell-for-gh`
  - `meta/techniques/version-control` → `host-shell-for-remote-git`
  - `work-package/techniques/manage-git` → `host-shell-for-remote-git` (fetch/push outside `version-control`)
- Loader merge delivers the rule to every leaf in each group; no leaf protocol changes, no numbered recovery procedure, no AGENTS essay restore.
- Contract: host shell (host credentials, network, SSH agent); isolated environments that block those are out of scope; token env unset unless intentional PAT; isolation denial ≠ credential failure.
- No Cursor Shell / `required_permissions` / product sandbox names on these techniques — harness invocation detail stays out of domain ops (`harness-independence`).

## Scope

| In | Out |
|----|-----|
| Three container `TECHNIQUE.md` files + version bumps | Root/workspace `AGENTS.md` / deploy seed essays |
| Invariant rule text only | Error-signature catalogues, health-check blocks, fail-then-retry choreography |
| `manage-git` (remote ops not routed through `version-control`) | `src/`, schemas, leaf op protocols |
| Host-shell contract in harness-neutral language | Cursor/Claude/product shell API names |

## Why

Agents still hit isolation denials on first remote `git` / `gh`. Prior host-shell essays mixed procedure and harness product detail and were dropped with the REST rewrite. This puts a **non-procedural**, **harness-agnostic** constraint on the surfaces workers load via `get_technique`.

## Test plan

- [ ] Diff is only the three `TECHNIQUE.md` files
- [ ] Rules read as invariants (could not stand unaltered as Protocol phases)
- [ ] No Cursor / harness tool API names in the three rules
- [ ] No duplicate long essay in AGENTS or leaf protocols
- [ ] Spot-check: `get_technique` on a leaf under each group surfaces the container rule after merge (when convenient)