### PR TITLE
Contract silence: name the two ways an I/O contract reads as satisfied when it is not

### DIFF
--- a/workflow-design/resources/anti-patterns.md
+++ b/workflow-design/resources/anti-patterns.md
@@ -401,11 +401,11 @@ Definition-prose smells: rationale, sequence narration, avoidance/comparative fr
 
 Description fields carry rationale, process narration, or structural restatement.
 
-**Detect:** `description`, `message`, option/action descriptions, or procedure bullets explain why a construct exists, what consumes it, compare to prior impls, or restate facts already encoded by adjacent structure (`steps[]` order, `when`, effects, transitions, defaults).
+**Detect:** `description`, `message`, option/action descriptions, procedure bullets, or a technique `## Rules` entry / `rules.*` string explain why a construct exists, what consumes it, whose remit it falls under, compare to prior impls, or restate facts already encoded by adjacent structure (`steps[]` order, `when`, effects, transitions, defaults). Test on a rule: delete the clause; if the prohibition or invariant still says what is constrained, the clause was rationale, and attributing the constraint to another actor's remit couples the rule to a contract it does not own.
 
-**Do not flag:** One-line WHAT summaries that state what the construct does; structural fields themselves.
+**Do not flag:** One-line WHAT summaries that state what the construct does; structural fields themselves; a prohibition citing the home that owns the behaviour it forbids bypassing, which is the pointer that makes it checkable (`no-rule-protocol-restatement`); rules whose own subject is the boundary between actors.
 
-**Fix:** Delete rationale/narration/restatement; keep only WHAT that would lose a fact if removed. Put rationale in commits/ADRs/planning docs.
+**Fix:** Delete rationale/narration/restatement; keep only WHAT that would lose a fact if removed. Where a reader genuinely needs another actor's contract, link that contract's home rather than restating whose it is. Put rationale in commits/ADRs/planning docs.
 
 ### AP-27. validate-message-economy
 
@@ -1828,3 +1828,27 @@ A resource carries operative prose in a span no `##` anchor reaches, while techn
 **Do not flag:** Orientation-only framing a section consumer does not need (record the verdict). Single-section resources with no anchored citers. Framing already under a named `##` that citers can request. Whole-resource citations where the consumer loads the full file (`whole-resource-for-one-section` Do-not-flag carve-outs).
 
 **Fix:** Classify the framing — delete when it duplicates the citing technique; mint a `##` section (or move the obligation into the technique) when it is operative and unique; leave when it is orientation only. Cross-section deixis becomes an anchored link. See [Resources at the Abstract Level; Split for Section Delivery](./design-principles.md#30-resources-at-the-abstract-level-split-for-section-delivery) (content a section-scoped reader depends on lives in a section) and [Cite Resources at Section Grain](./design-principles.md#32-cite-resources-at-section-grain). Related: `whole-resource-for-one-section`.
+
+### AP-140. declared-input-never-read
+
+"`### activity_id` and `### session_index` declared, with no phase naming either"
+
+A technique declares an input its own Protocol and Rules never reach, so the bind contract promises a value the operation cannot spend.
+
+**Detect:** For each `### <id>` under a technique's `## Inputs`, search that technique's `## Protocol` and `## Rules` for the id — braced as `{id}`, as `{id}.field`, or named bare inside a tool-call signature a phase passes (`next_activity { session_index, … }`). Flag an entry with no occurrence. Test: name the phase that spends the value; if the only answer is the declaration itself, a caller reading the contract wires a value nothing consumes.
+
+**Do not flag:** Inputs on a container `TECHNIQUE.md`, which descendants reference after the merge. An input whose whole value is handed to an applied op as a substitution map or pass-through argument, where a phase references the map rather than each member. Outputs no consumer reads, which are `output-without-destination`.
+
+**Fix:** Reference `{id}` from the phase that spends it, or delete the declaration. Where the value belongs to an op this technique applies, pass it at the Apply site rather than redeclaring it here (`apply-omits-declared-input`).
+
+### AP-141. apply-omits-declared-input
+
+"Apply [continue-agent] with the composed prompt"
+
+A Protocol Apply passes some of the applied operation's declared inputs and omits others, so the applied op runs on whatever the bag happens to hold.
+
+**Detect:** For each Protocol `Apply` / `::` invocation, resolve the target's `## Inputs`, including any merged from its container. Flag a required input the Apply site neither passes nor covers by a declared `default`, and that no same-name slot on the applying technique makes ambient. Test: read the Apply line alone and list what the target receives; if a required slot of the target is absent from both that list and the applying technique's own contract, the call is contract-silent.
+
+**Do not flag:** Inputs the target marks optional or backs with a `#### default`. Inputs the applying technique declares under the same id, which bind by name. Container-merged inputs the whole group shares. Activity `steps[]` binds, whose argument conformance is a bind-site concern.
+
+**Fix:** Name the omitted input at the Apply site. Where the value has no home on the applying technique, declare it there first, then pass it. The mirror defect — a slot declared and never passed on — is `declared-input-never-read`.


### PR DESCRIPTION
## Summary

A technique can declare an input and never spend it. A Protocol step can apply another operation and pass only some of what that operation declares. In both cases the contract reads as satisfied — every slot is declared, every call is made — and a reader has no way to tell that a value is going nowhere or arriving from nowhere. Neither shape had a Detect anywhere in the canon. This adds one entry for each, and extends an existing entry so that rationale sitting inside a rule has a home.

## How the gap was found

A small change to the meta engine — five files, one new operation — was audited three times against the canon. The first pass found ten defects, the second five, the third three. The third pass's three had all been present since the first commit, and the first pass had walked those files whole and missed them.

The reason was not reading depth. Two of the three were the same shape: a new operation declared `session_index` and `activity_id` and referenced neither, and the operation it applied declared `session_index` as an input the Apply site never passed — so the resumed worker's prompt would have carried no session index to authenticate with. Nothing could have caught either. The walk follows the catalogue entry by entry, and the catalogue has no entry for it.

## What already exists, and what it does not reach

`output-without-destination` covers the output side of exactly this concern: a declared output with no reader. There is no input twin. `bind-protocol-locals` covers a dead `{$local}`, not a dead declared input. And the mechanical net stops short too — `binding-fidelity` proves that step bindings resolve and their arguments conform, but its subject is activity `steps[]` binds; a Protocol `Apply` is not a bind site, so every such call is unchecked.

Separately, `no-rationale-in-description` lists the surfaces its Detect reaches — `description`, `message`, option and action descriptions, procedure bullets — and technique `## Rules` is not among them. So a rule that justifies its own prohibition has no home either, which is how a rule reading "orchestrators never call this tool; the definition is the worker's domain" survives an audit: the second clause is rationale, and it couples the rule to a contract it does not own.

## The additions

**`declared-input-never-read`** — an input declared on a technique that its own Protocol and Rules never reference. Detect searches for the braced designator, the dotted field form, and the bare name inside a tool-call signature a phase passes, because that last form is how several engine operations legitimately reference an argument. Carve-outs keep it off container inputs the descendants reference after the merge, and off an input handed wholesale to an applied operation as a substitution map.

**`apply-omits-declared-input`** — a Protocol Apply that omits a required input of the operation it applies. Detect resolves the target's Inputs through the loader, including container merges, and flags a required slot the Apply site neither passes nor covers by a declared default, and that no same-name slot on the applying technique makes ambient. Carve-outs keep it off optional inputs, defaulted inputs, same-name ambient binds, and activity step binds, whose conformance is a bind-site concern.

**`no-rationale-in-description` gains two surfaces** — technique `## Rules` and `rules.*` strings, with a test for the rule case: delete the clause, and if the constraint still says what is constrained, the clause was rationale. The Do-not-flag preserves what `no-rule-protocol-restatement` already protects, so a prohibition that cites the home it forbids bypassing keeps its pointer.

## Scope of change

One file: `workflow-design/resources/anti-patterns.md`. Two appended entries and one amended Detect triad. No other workflow, technique, or activity is touched.

## Acceptance criteria

- [x] Each new entry follows the catalogue's Creation Rules: two-line intro, Detect / Do not flag / Fix on their own blocks, a structural test that transfers to a workflow that never saw the originating defect.
- [x] Neither entry re-teaches a sibling's Detect body; both cross-reference by name.
- [x] The amendment extends an existing Detect surface rather than minting a near-duplicate entry.
- [x] All 21 repository guards pass, including `resource-anchors` and `source-encoding`.

## Non-goals

- The mechanical net. Both new entries are decidable from technique markdown alone and belong in the guard suite beside `binding-fidelity`, but run corpus-wide they will report well beyond any one change, so they want per-finding triage rather than a zero gate from day one. That is a separate change against the server.
- Fixing what the entries find. This adds the criteria; the corpus sweep is its own work.

## Investigation detail

The audit that surfaced the gap, and the change it was auditing: [#410](https://github.com/m2ux/workflow-server/pull/410) and [#411](https://github.com/m2ux/workflow-server/pull/411).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
