### PR TITLE
Undeclared thresholds: name a branch the agent has no value to evaluate

### DIFF
--- a/workflow-design/resources/anti-patterns.md
+++ b/workflow-design/resources/anti-patterns.md
@@ -1852,3 +1852,15 @@ A Protocol Apply passes some of the applied operation's declared inputs and omit
 **Do not flag:** Inputs the target marks optional or backs with a `#### default`. Inputs the applying technique declares under the same id, which bind by name. Container-merged inputs the whole group shares. Activity `steps[]` binds, whose argument conformance is a bind-site concern.
 
 **Fix:** Name the omitted input at the Apply site. Where the value has no home on the applying technique, declare it there first, then pass it. The mirror defect — a slot declared and never passed on — is `declared-input-never-read`.
+
+### AP-142. branch-on-undeclared-threshold
+
+"When the worker does not return within the expected time"
+
+A Protocol branch conditions on a magnitude nothing declares, so the agent cannot evaluate it and either supplies its own limit or never takes the branch.
+
+**Detect:** A Protocol branch, `>` note, gate, or rule conditions on a duration, size, count, or limit — "within the expected time", "if it takes too long", "when the payload is large", "after enough retries" — that no declared input, `#### default`, workflow variable, policy resource row, or tool-surface field supplies. Test: name the value the agent compares against. If nothing in the contract or the harness surface holds it, the branch is not a path, and whatever behaviour hangs off it is unspecified.
+
+**Do not flag:** Thresholds the harness or server owns and reports (`autoAdvanceMs`, a budget returned on a response). A branch on a declared input's value. Qualitative branches carrying no magnitude — "fewer steps than the activity defines" is countable from the definition the agent already holds.
+
+**Fix:** Declare the threshold and compare it by designator — a technique input with a `#### default`, a workflow variable, or a row in the owning policy resource. Where no owner can supply it, delete the branch and rebuild any behaviour it guarded on a condition the agent can observe. See [Encode Constraints as Structure](./design-principles.md#9-encode-constraints-as-structure).


### PR DESCRIPTION
## Summary

A Protocol branch can condition on a duration, size, count, or limit that nothing declares. The agent reading it has no value to compare against, so it either invents a limit or never takes the branch — and whichever it does, the behaviour hanging off that branch is unspecified. This adds one entry naming that shape.

It continues [#413](https://github.com/m2ux/workflow-server/pull/413), which merged while this third entry was still in review. The branch is unchanged apart from the new entry.

## What prompted it

The meta engine's dispatch operation carried this branch:

> When the worker does not return within the expected time and is still running, apply continue-agent…

Nothing in the corpus defines "the expected time". No technique input, no `#### default`, no workflow variable, no policy resource row, no field on any tool response. The only timeout-shaped value anywhere in meta is a checkpoint's auto-advance timer, which measures how long to wait for a *person*, not for a worker.

Worse, the branch could not fire even in principle. The harness contract that governs every dispatch requires a blocking-equivalent wait — the orchestrator observes a yield or a completion before continuing, and fire-and-forget dispatch is forbidden. Under that contract there is no "did not return in time" state to observe, so the branch was unreachable, and acting on it would have meant abandoning the wait the rule requires.

The phantom had also spread. Two further sites — the accounting phase and the accounting rule — had come to describe "each fresh worker dispatched after a timeout", so a threshold that never existed was load-bearing in the cost contract.

## Why no existing entry reaches it

`anchored-protocol-references` covers a dangling reference to a declared input, rule, operation, or resource — not to a bare quantity that was never a declaration in the first place. `structure-backed-constraints` is about rules lacking structural enforcement, and this is a Protocol branch. `no-contradictory-rules` is scoped to entries within one technique or bucket, so it does not see a branch contradicting another group's rule.

## The entry

`branch-on-undeclared-threshold`. Detect names the shape — a branch, note, gate, or rule conditioning on a magnitude no declaration, policy row, or tool field supplies — and gives the test: name the value the agent compares against, and if nothing holds it, the branch is not a path.

Carve-outs keep it off the legitimate cases: thresholds the harness or server owns and reports; a branch on a declared input's value; and qualitative branches carrying no magnitude, such as "fewer steps than the activity defines", which is countable from the definition the agent already holds.

The Fix carries both remedies, because either can be the right one. Declare the threshold and compare it by designator. Or, where no owner can supply it, delete the branch and rebuild whatever it guarded on a condition the agent can observe.

## Scope of change

One file, one appended entry: `workflow-design/resources/anti-patterns.md`.

## Acceptance criteria

- [x] Follows the catalogue's Creation Rules: two-line intro, Detect / Do not flag / Fix on their own blocks, a structural test that transfers to a workflow that never saw the originating defect.
- [x] Cross-references cite siblings by name, and the entry re-teaches no sibling's Detect body.
- [x] The designator follows the last entry in file order.
- [x] All 21 repository guards pass.

## Non-goals

- The mechanical net. Whether a magnitude has a declared owner is decidable from the definitions, so this is a guard candidate, but run corpus-wide it wants per-finding triage rather than a zero gate.
- Sweeping the corpus for other instances. This adds the criterion; the sweep is its own work.

## Investigation detail

The first remediation lands alongside the entry, in the engine change that surfaced it: [#410](https://github.com/m2ux/workflow-server/pull/410) rebuilds the branch on the harness reporting the worker ended without an envelope, and removes the phantom threshold from both accounting sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
