### PR TITLE
Artifact audience: every artifact a technique persists declares who reads it

### DIFF
--- a/cicd-pipeline-security-audit/techniques/execute-sub-agent.md
+++ b/cicd-pipeline-security-audit/techniques/execute-sub-agent.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -22,6 +22,10 @@ Structured JSON conforming to the [sub-agent output schema](../resources/sub-age
 #### artifact
 
 `{scanner_id}.json`
+
+#### audience
+
+`agent`
 
 #### scanner_id
 

--- a/cicd-pipeline-security-audit/techniques/inventory-workflows/TECHNIQUE.md
+++ b/cicd-pipeline-security-audit/techniques/inventory-workflows/TECHNIQUE.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -22,6 +22,10 @@ Complete [inventory of workflow files](../../resources/intermediate-artifact-sch
 #### artifact
 
 `reconnaissance-summary.json`
+
+#### audience
+
+`agent`
 
 #### workflow_files
 
@@ -51,6 +55,10 @@ AI configuration files and CODEOWNERS coverage found per target, for P6 detectio
 
 `scanner-assignments.json`
 
+#### audience
+
+`agent`
+
 ### start_here
 
 Session overview for the audit run.
@@ -58,3 +66,7 @@ Session overview for the audit run.
 #### artifact
 
 `START-HERE.md`
+
+#### audience
+
+`human`

--- a/cicd-pipeline-security-audit/techniques/merge-scan-findings/TECHNIQUE.md
+++ b/cicd-pipeline-security-audit/techniques/merge-scan-findings/TECHNIQUE.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -23,6 +23,10 @@ Unified [finding set](../../resources/intermediate-artifact-schemas.md#merged-fi
 
 `merged-findings.json`
 
+#### audience
+
+`agent`
+
 #### findings
 
 Deduplicated and correlated findings
@@ -42,6 +46,10 @@ Per-scanner finding mapping to merged findings — the [reconciliation table](..
 #### artifact
 
 `reconciliation-table.json`
+
+#### audience
+
+`agent`
 
 ## Rules
 

--- a/cicd-pipeline-security-audit/techniques/scan-injection-patterns/TECHNIQUE.md
+++ b/cicd-pipeline-security-audit/techniques/scan-injection-patterns/TECHNIQUE.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -38,6 +38,10 @@ Structured findings for this submodule, conforming to the [scanner output schema
 #### artifact
 
 `s{scanner_number}-{submodule_path}.json`
+
+#### audience
+
+`agent`
 
 #### findings
 

--- a/cicd-pipeline-security-audit/techniques/verify-scan-output/TECHNIQUE.md
+++ b/cicd-pipeline-security-audit/techniques/verify-scan-output/TECHNIQUE.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -26,6 +26,10 @@ Scan completeness [verification](../../resources/intermediate-artifact-schemas.m
 #### artifact
 
 `verification-report.json`
+
+#### audience
+
+`agent`
 
 #### file_coverage
 

--- a/cicd-pipeline-security-audit/techniques/write-cicd-report/TECHNIQUE.md
+++ b/cicd-pipeline-security-audit/techniques/write-cicd-report/TECHNIQUE.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -26,6 +26,10 @@ Complete CI/CD security [audit report](../../resources/cicd-audit-report-templat
 #### artifact
 
 `01-cicd-audit-report.md`
+
+#### audience
+
+`human`
 
 ## Rules
 

--- a/codebase-wiki/techniques/ingest.md
+++ b/codebase-wiki/techniques/ingest.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -30,6 +30,10 @@ The typed wiki pages created or updated for `{target_area}` — each with cited,
 #### artifact
 
 `{$page_slug}.md`
+
+#### audience
+
+`human`
 
 #### page_slugs
 

--- a/codebase-wiki/techniques/maintain-index-log.md
+++ b/codebase-wiki/techniques/maintain-index-log.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -27,6 +27,10 @@ The refreshed catalog: one entry per page, organized by page type and routing to
 
 `index.md`
 
+#### audience
+
+`human`
+
 ### mutation_log
 
 The appended ledger: one entry per create/update operation, in operation order.
@@ -34,6 +38,10 @@ The appended ledger: one entry per create/update operation, in operation order.
 #### artifact
 
 `log.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/meta/techniques/workflow-engine/create-readme.md
+++ b/meta/techniques/workflow-engine/create-readme.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 3.2.0
+  version: 3.3.0
 ---
 
 ## Capability
@@ -36,6 +36,10 @@ Full path to the created `README.md`
 #### artifact
 
 `README.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/midnight-system-review/techniques/area-derivation/amend-plan.md
+++ b/midnight-system-review/techniques/area-derivation/amend-plan.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -30,6 +30,10 @@ The amended plan document, updated in place.
 #### artifact
 
 `investigation-plan.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/midnight-system-review/techniques/area-derivation/derive-areas.md
+++ b/midnight-system-review/techniques/area-derivation/derive-areas.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.2.0
+  version: 1.3.0
 ---
 
 ## Capability
@@ -58,6 +58,10 @@ The reviewable plan document: per-area rationale, planned probes, and coverage s
 #### artifact
 
 `investigation-plan.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/midnight-system-review/techniques/evidence-probes/consolidate-evidence.md
+++ b/midnight-system-review/techniques/evidence-probes/consolidate-evidence.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -26,6 +26,10 @@ The consolidated evidence base: per-area probe accounting, all evidence items wi
 #### artifact
 
 `evidence-log.md`
+
+#### audience
+
+`human`
 
 ### candidate_findings
 

--- a/midnight-system-review/techniques/finding-adjudication/register-findings.md
+++ b/midnight-system-review/techniques/finding-adjudication/register-findings.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -22,6 +22,10 @@ The adjudicated register: a disposition table (finding, area, tuple summary, dis
 #### artifact
 
 `findings-register.md`
+
+#### audience
+
+`human`
 
 ### accepted_findings
 

--- a/midnight-system-review/techniques/publish-review/record-publication.md
+++ b/midnight-system-review/techniques/publish-review/record-publication.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -34,6 +34,10 @@ The publication close-out: post status, PR, review type, verdict, and links back
 #### artifact
 
 `publication-record.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/midnight-system-review/techniques/scope-intake/resolve-change-surface.md
+++ b/midnight-system-review/techniques/scope-intake/resolve-change-surface.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 2.0.0
+  version: 2.1.0
 ---
 
 ## Capability
@@ -54,6 +54,10 @@ The authoritative changed-file inventory: target identity, base and head refs, e
 #### artifact
 
 `change-surface.md`
+
+#### audience
+
+`human`
 
 ### has_pr_surface
 

--- a/midnight-system-review/techniques/verdict-and-report/render-review.md
+++ b/midnight-system-review/techniques/verdict-and-report/render-review.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -34,6 +34,10 @@ The full review report in the canonical format, persisted for the planning recor
 #### artifact
 
 `review-report.md`
+
+#### audience
+
+`human`
 
 ### review_summary
 

--- a/plain-language/techniques/analyze-source.md
+++ b/plain-language/techniques/analyze-source.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -22,6 +22,10 @@ The per-finding record and the strengths inventory, shaped by [Template](../reso
 #### artifact
 
 `source-analysis.md`
+
+#### audience
+
+`human`
 
 ### finding_count
 

--- a/plain-language/techniques/complete-checklist.md
+++ b/plain-language/techniques/complete-checklist.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -26,6 +26,10 @@ The completed checklist with every item's disposition, shaped by [Template](../r
 #### artifact
 
 `iso-checklist.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/plain-language/techniques/draft-document.md
+++ b/plain-language/techniques/draft-document.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -30,6 +30,10 @@ The current draft of the plain-language document.
 #### artifact
 
 `plain-document.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/plain-language/techniques/evaluate-document.md
+++ b/plain-language/techniques/evaluate-document.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -26,6 +26,10 @@ The per-principle verdict and the open-issue list, shaped by [Template](../resou
 #### artifact
 
 `evaluation-report.md`
+
+#### audience
+
+`human`
 
 ### open_issue_count
 

--- a/plain-language/techniques/intake-and-profile.md
+++ b/plain-language/techniques/intake-and-profile.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -42,6 +42,10 @@ The class of document (email, web page, instruction, report, form, and so on) ch
 #### artifact
 
 `document-profile.md`
+
+#### audience
+
+`human`
 
 ### intent_needs_confirmation
 

--- a/ponytail/techniques/apply-ladder.md
+++ b/ponytail/techniques/apply-ladder.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -22,6 +22,10 @@ The minimal change that solves the problem at the highest reachable [rung](../..
 #### artifact
 
 `lean-change.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/ponytail/techniques/audit-repo.md
+++ b/ponytail/techniques/audit-repo.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ The repo-wide findings ranked biggest-cut-first — each written as `<tag> <what
 #### artifact
 
 `audit-findings.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/ponytail/techniques/harvest-debt.md
+++ b/ponytail/techniques/harvest-debt.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ The debt ledger — one row per [ponytail marker](../../ponytail/resources/ponyt
 #### artifact
 
 `debt-ledger.md`
+
+#### audience
+
+`human`
 
 ### has_debt_markers
 

--- a/ponytail/techniques/scope-intake.md
+++ b/ponytail/techniques/scope-intake.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ A concise brief recording the task, the target, the chosen intensity and scope, 
 #### artifact
 
 `lean-brief.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/prism-audit/techniques/audit-finalize/TECHNIQUE.md
+++ b/prism-audit/techniques/audit-finalize/TECHNIQUE.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -23,6 +23,10 @@ File path to the summary report.
 
 `AUDIT-REPORT.md`
 
+#### audience
+
+`human`
+
 ### detailed_findings_path
 
 File path to the detailed-findings document.
@@ -31,6 +35,10 @@ File path to the detailed-findings document.
 
 `DETAILED-FINDINGS.md`
 
+#### audience
+
+`human`
+
 ### trade_offs_path
 
 File path to the design trade-off analysis.
@@ -38,6 +46,10 @@ File path to the design trade-off analysis.
 #### artifact
 
 `DESIGN-TRADE-OFFS.md`
+
+#### audience
+
+`human`
 
 ## Rules
 

--- a/prism-audit/techniques/audit-finalize/create-detailed-findings.md
+++ b/prism-audit/techniques/audit-finalize/create-detailed-findings.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ Filesystem path to the written DETAILED-FINDINGS.md (the detailed-findings docum
 #### artifact
 
 `DETAILED-FINDINGS.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/prism-audit/techniques/audit-finalize/create-trade-off-analysis.md
+++ b/prism-audit/techniques/audit-finalize/create-trade-off-analysis.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ Filesystem path to the written DESIGN-TRADE-OFFS.md (the design trade-off analys
 #### artifact
 
 `DESIGN-TRADE-OFFS.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/prism-audit/techniques/audit-finalize/split-report.md
+++ b/prism-audit/techniques/audit-finalize/split-report.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ Filesystem path to the written AUDIT-REPORT.md (the summary report).
 #### artifact
 
 `AUDIT-REPORT.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/prism-audit/techniques/compose-audit-prompt/TECHNIQUE.md
+++ b/prism-audit/techniques/compose-audit-prompt/TECHNIQUE.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -42,6 +42,10 @@ The composed [audit prompt document](../../resources/audit-prompt-template.md#au
 #### artifact
 
 `audit-prompt.md`
+
+#### audience
+
+`human`
 
 #### codebase_overview
 

--- a/prism-evaluate/techniques/compose-evaluation-report/TECHNIQUE.md
+++ b/prism-evaluate/techniques/compose-evaluation-report/TECHNIQUE.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.3.0
+  version: 1.4.0
 ---
 
 ## Capability
@@ -34,6 +34,10 @@ The consolidated [evaluation report](../../resources/evaluation-report-template.
 #### artifact
 
 `EVALUATION-REPORT.md`
+
+#### audience
+
+`human`
 
 #### executive_summary
 

--- a/prism-evaluate/techniques/plan-evaluation/write-evaluation-plan.md
+++ b/prism-evaluate/techniques/plan-evaluation/write-evaluation-plan.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -30,6 +30,10 @@ The composed [evaluation plan](../../resources/evaluation-plan-template.md#evalu
 #### artifact
 
 `evaluation-plan.md`
+
+#### audience
+
+`human`
 
 #### target_overview
 

--- a/prism-evaluate/techniques/resolve-findings/TECHNIQUE.md
+++ b/prism-evaluate/techniques/resolve-findings/TECHNIQUE.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.3.0
+  version: 1.4.0
 ---
 
 ## Capability
@@ -34,6 +34,10 @@ Comprehensive [mitigation plan](../../resources/mitigation-plan-template.md#miti
 #### artifact
 
 `MITIGATION-PLAN.md`
+
+#### audience
+
+`human`
 
 #### summary_table
 

--- a/prism/techniques/adaptive-analysis/stage-1-sdl.md
+++ b/prism/techniques/adaptive-analysis/stage-1-sdl.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -20,6 +20,10 @@ Cheapest-stage deep scan of the target.
 #### artifact
 
 `adaptive-stage1.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/prism/techniques/adaptive-analysis/stage-2-l12.md
+++ b/prism/techniques/adaptive-analysis/stage-2-l12.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -20,6 +20,10 @@ Full L12 analysis of the target at the escalated stage.
 #### artifact
 
 `adaptive-stage2.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/prism/techniques/behavioral-pipeline/independent-lenses.md
+++ b/prism/techniques/behavioral-pipeline/independent-lenses.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -17,6 +17,10 @@ How the code behaves when things fail: error paths, propagation, and handling co
 
 `behavioral-errors.md`
 
+#### audience
+
+`human`
+
 ### cost_analysis
 
 Where the code spends: algorithmic complexity and optimization opportunities. Role label COSTS.
@@ -24,6 +28,10 @@ Where the code spends: algorithmic complexity and optimization opportunities. Ro
 #### artifact
 
 `behavioral-costs.md`
+
+#### audience
+
+`human`
 
 ### evolution_analysis
 
@@ -33,6 +41,10 @@ How the code absorbs change: coupling points and their blast radius. Role label 
 
 `behavioral-changes.md`
 
+#### audience
+
+`human`
+
 ### api_surface_analysis
 
 What the code promises outward: the public surface and its callers. Role label PROMISES.
@@ -40,6 +52,10 @@ What the code promises outward: the public surface and its callers. Role label P
 #### artifact
 
 `behavioral-promises.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/prism/techniques/behavioral-pipeline/synthesis.md
+++ b/prism/techniques/behavioral-pipeline/synthesis.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -22,6 +22,10 @@ The reconciled behavioral reading across failure, cost, change, and promise.
 #### artifact
 
 `behavioral-synthesis.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/prism/techniques/dispute-analysis.md
+++ b/prism/techniques/dispute-analysis.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -17,6 +17,10 @@ Analysis from the first lens of the pair, produced without sight of the second.
 
 `dispute-lens-a.md`
 
+#### audience
+
+`human`
+
 ### lens_b_analysis
 
 Analysis from the second lens of the pair, produced without sight of the first.
@@ -25,6 +29,10 @@ Analysis from the second lens of the pair, produced without sight of the first.
 
 `dispute-lens-b.md`
 
+#### audience
+
+`human`
+
 ### disagreement_synthesis
 
 Synthesis of where the two lenses disagree, with convergence noted only to test implicit shared assumptions.
@@ -32,6 +40,10 @@ Synthesis of where the two lenses disagree, with convergence noted only to test 
 #### artifact
 
 `dispute-synthesis.md`
+
+#### audience
+
+`human`
 
 #### prism_pair
 

--- a/prism/techniques/emit-run-manifest.md
+++ b/prism/techniques/emit-run-manifest.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -38,6 +38,10 @@ Machine-readable manifest of the run's artifacts and completion status.
 #### artifact
 
 `RUN-MANIFEST.md`
+
+#### audience
+
+`human`
 
 ### run_manifest_path
 

--- a/prism/techniques/full-prism/adversarial.md
+++ b/prism/techniques/full-prism/adversarial.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ The challenge to the prior analysis: wrong predictions, overclaims, underclaims,
 #### artifact
 
 `adversarial-analysis.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/prism/techniques/full-prism/synthesis.md
+++ b/prism/techniques/full-prism/synthesis.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ The reconciled reading of the two prior analyses: refined conservation law, refi
 #### artifact
 
 `synthesis.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/prism/techniques/generate-report.md
+++ b/prism/techniques/generate-report.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -35,6 +35,10 @@ Clean final [report](../resources/final-output-template.md#reportmd-template) ar
 
 `REPORT.md`
 
+#### audience
+
+`human`
+
 #### finding_count
 
 Total findings by severity
@@ -54,6 +58,10 @@ Detailed [definitive findings](../resources/definitive-findings-template.md#defi
 #### artifact
 
 `DEFINITIVE-FINDINGS.md`
+
+#### audience
+
+`human`
 
 ### definitive_findings_path
 

--- a/prism/techniques/plan-analysis.md
+++ b/prism/techniques/plan-analysis.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -38,6 +38,10 @@ Human-readable analysis plan artifact
 #### artifact
 
 `analysis-plan.md`
+
+#### audience
+
+`human`
 
 #### scope_type
 

--- a/prism/techniques/portfolio-analysis.md
+++ b/prism/techniques/portfolio-analysis.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -27,6 +27,10 @@ Individual analysis artifact per lens
 
 `portfolio-{lens_name}.md`
 
+#### audience
+
+`human`
+
 #### per_lens_findings
 
 Complete findings from each lens, labelled by lens name
@@ -42,6 +46,10 @@ Cross-lens convergence/divergence synthesis
 #### artifact
 
 `portfolio-synthesis.md`
+
+#### audience
+
+`human`
 
 #### convergent_findings
 

--- a/prism/techniques/reflect-analysis.md
+++ b/prism/techniques/reflect-analysis.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -17,6 +17,10 @@ L12 structural analysis of the target.
 
 `reflect-l12.md`
 
+#### audience
+
+`human`
+
 ### meta_analysis
 
 Claim meta-analysis of the structural analysis text: the hidden assumptions it carries.
@@ -25,6 +29,10 @@ Claim meta-analysis of the structural analysis text: the hidden assumptions it c
 
 `reflect-meta.md`
 
+#### audience
+
+`human`
+
 ### constraint_synthesis
 
 Synthesis over the structural and meta analyses against constraint history, in four sections: recurring patterns, unexplored dimensions, known false positives, next best scan.
@@ -32,6 +40,10 @@ Synthesis over the structural and meta analyses against constraint history, in f
 #### artifact
 
 `reflect-synthesis.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/prism/techniques/single-lens-analysis.md
+++ b/prism/techniques/single-lens-analysis.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -26,6 +26,10 @@ The applied lens's complete output following its own operations
 #### artifact
 
 `{lens_name}-analysis.md`
+
+#### audience
+
+`human`
 
 #### findings
 

--- a/prism/techniques/smart-analysis/prereq-scan.md
+++ b/prism/techniques/smart-analysis/prereq-scan.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ Prerequisite scan of the target, with the atomic questions knowledge fill answer
 #### artifact
 
 `smart-prereq.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/prism/techniques/structural-analysis.md
+++ b/prism/techniques/structural-analysis.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.2.0
+  version: 1.3.0
 ---
 
 ## Capability
@@ -30,6 +30,10 @@ L12 structural analysis with conservation law, meta-law, and classified bug tabl
 #### artifact
 
 `structural-analysis.md`
+
+#### audience
+
+`human`
 
 #### conservation_law
 

--- a/prism/techniques/subsystem-analysis/execute.md
+++ b/prism/techniques/subsystem-analysis/execute.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -22,6 +22,10 @@ Per-subsystem analysis outputs — one for each decomposed subsystem, produced b
 #### artifact
 
 `subsystem-{code_subsystem.subsystem_name}.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/prism/techniques/subsystem-analysis/synthesize.md
+++ b/prism/techniques/subsystem-analysis/synthesize.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ Cross-subsystem findings, cross-boundary bugs, and the file-level conservation l
 #### artifact
 
 `subsystem-synthesis.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/prism/techniques/verified-analysis/corrected-analysis.md
+++ b/prism/techniques/verified-analysis/corrected-analysis.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -22,6 +22,10 @@ L12 structural analysis re-run against the target with the gap context injected.
 #### artifact
 
 `verified-corrected.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/prism/techniques/verified-analysis/gap-detection.md
+++ b/prism/techniques/verified-analysis/gap-detection.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ The epistemic weaknesses the boundary and audit prisms find in the analysis text
 #### artifact
 
 `verified-gaps.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/prism/techniques/verified-analysis/initial-analysis.md
+++ b/prism/techniques/verified-analysis/initial-analysis.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ L12 structural analysis of the target, as first run — before any gap correctio
 #### artifact
 
 `verified-initial.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/remediate-vuln/techniques/security-setup/initialize-planning-folder.md
+++ b/remediate-vuln/techniques/security-setup/initialize-planning-folder.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ Planning-folder README seeded from the standard template with the Links table om
 #### artifact
 
 `README.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/requirements-refinement/techniques/analyze-source.md
+++ b/requirements-refinement/techniques/analyze-source.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.2.0
+  version: 1.3.0
 ---
 
 ## Capability
@@ -26,6 +26,10 @@ Structured analysis of the requirement changes derived from the source document,
 #### artifact
 
 `requirements-analysis.md`
+
+#### audience
+
+`human`
 
 #### source_coverage_matrix
 

--- a/requirements-refinement/techniques/finalize-specification.md
+++ b/requirements-refinement/techniques/finalize-specification.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -27,6 +27,10 @@ The finalized specification staged for promotion.
 
 `final-spec.md`
 
+#### audience
+
+`human`
+
 ### final_specification_path
 
 Absolute path to the staged final specification.
@@ -38,6 +42,10 @@ Human-readable summary of all applied changes and the validation status.
 #### artifact
 
 `change-summary.md`
+
+#### audience
+
+`human`
 
 ### change_summary_path
 

--- a/requirements-refinement/techniques/intake-sources.md
+++ b/requirements-refinement/techniques/intake-sources.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -28,6 +28,10 @@ Record of the captured sources, classified source type, detected augment/create 
 #### artifact
 
 `intake.md`
+
+#### audience
+
+`human`
 
 ### intake_record_path
 

--- a/requirements-refinement/techniques/report-failure.md
+++ b/requirements-refinement/techniques/report-failure.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -22,6 +22,10 @@ Failure report carrying the critical issues, correction history, and manual-reso
 #### artifact
 
 `failure-report.md`
+
+#### audience
+
+`human`
 
 ### failure_report_path
 

--- a/requirements-refinement/techniques/update-specification.md
+++ b/requirements-refinement/techniques/update-specification.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.3.0
+  version: 1.4.0
 ---
 
 ## Capability
@@ -30,6 +30,10 @@ The complete updated specification document for this pass.
 #### artifact
 
 `working-spec-{correction_iteration}.md`
+
+#### audience
+
+`human`
 
 ### working_specification_path
 

--- a/requirements-refinement/techniques/validate-specification.md
+++ b/requirements-refinement/techniques/validate-specification.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.3.0
+  version: 1.4.0
 ---
 
 ## Capability
@@ -26,6 +26,10 @@ Categorized validation findings with an overall verdict and the source-coverage 
 #### artifact
 
 `validation-report-{correction_iteration}.md`
+
+#### audience
+
+`human`
 
 ### validation_report_path
 

--- a/substrate-node-security-audit/techniques/analyze-architecture.md
+++ b/substrate-node-security-audit/techniques/analyze-architecture.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 > The `§X.Y` identifiers used throughout this technique refer to the audit checklist taxonomy in [§3 Systematic Manual Review Strategies](../resources/audit-template-reference.md#3-systematic-manual-review-strategies).
@@ -48,6 +48,10 @@ Vulnerability domains derived from the architecture that fall outside any §3 ch
 #### artifact
 
 `s-architectural-analysis.json`
+
+#### audience
+
+`agent`
 
 ## Protocol
 

--- a/substrate-node-security-audit/techniques/build-function-registry.md
+++ b/substrate-node-security-audit/techniques/build-function-registry.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -30,6 +30,10 @@ Structured function registry table.
 #### artifact
 
 `r-function-registry.json`
+
+#### audience
+
+`agent`
 
 #### registry_table
 

--- a/substrate-node-security-audit/techniques/execute-ensemble-pass.md
+++ b/substrate-node-security-audit/techniques/execute-ensemble-pass.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 > The `§X.Y` identifiers used throughout this technique refer to the audit checklist taxonomy in [§2 Static Analysis Phase](../resources/audit-template-reference.md#2-static-analysis-phase), [§3 Systematic Manual Review Strategies](../resources/audit-template-reference.md#3-systematic-manual-review-strategies) and [§5 Execution Strategy](../resources/audit-template-reference.md#5-execution-strategy).
@@ -18,6 +18,10 @@ Findings from the second independent pass, including at least one sub-agent resu
 #### artifact
 
 `second-pass-findings.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/substrate-node-security-audit/techniques/execute-sub-agent.md
+++ b/substrate-node-security-audit/techniques/execute-sub-agent.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -26,6 +26,10 @@ Structured JSON conforming to the [Schema](../resources/sub-agent-output-schema.
 #### artifact
 
 `{agent_id}.json`
+
+#### audience
+
+`agent`
 
 #### agent_id
 

--- a/substrate-node-security-audit/techniques/map-codebase.md
+++ b/substrate-node-security-audit/techniques/map-codebase.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -31,6 +31,10 @@ The in-scope components with their architectural classification and priority.
 
 `r-crate-map.json`
 
+#### audience
+
+`agent`
+
 #### component_inventory
 
 every crate/module with classification and priority
@@ -42,6 +46,10 @@ The security-relevant structure of the classified components: trust boundaries, 
 #### artifact
 
 `r-reconnaissance-data.json`
+
+#### audience
+
+`agent`
 
 #### trust_boundary_map
 

--- a/substrate-node-security-audit/techniques/merge-findings.md
+++ b/substrate-node-security-audit/techniques/merge-findings.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -34,6 +34,10 @@ Canonical finding flat table with elevation mapping and summary.
 #### artifact
 
 `m-merge.json`
+
+#### audience
+
+`agent`
 
 #### flat_table
 

--- a/substrate-node-security-audit/techniques/setup-audit-target.md
+++ b/substrate-node-security-audit/techniques/setup-audit-target.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -47,6 +47,10 @@ Known-vulnerable dependency report, or the extracted dependency manifest when no
 
 `dependency-scan.json`
 
+#### audience
+
+`agent`
+
 ### start_here
 
 Session overview with audit target, commit, methodology, and artifact index.
@@ -54,6 +58,10 @@ Session overview with audit target, commit, methodology, and artifact index.
 #### artifact
 
 `START-HERE.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/substrate-node-security-audit/techniques/write-gap-analysis.md
+++ b/substrate-node-security-audit/techniques/write-gap-analysis.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -22,6 +22,10 @@ Path to the reference report artifact.
 #### artifact
 
 `02-gap-analysis.md`
+
+#### audience
+
+`human`
 
 #### summary_metrics
 

--- a/substrate-node-security-audit/techniques/write-report.md
+++ b/substrate-node-security-audit/techniques/write-report.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 2.0.0
+  version: 2.1.0
 ---
 
 ## Capability
@@ -22,6 +22,10 @@ Final audit report. Every finding takes the shape and fill rules of [Finding Ent
 #### artifact
 
 `01-audit-report.md`
+
+#### audience
+
+`human`
 
 #### header_table
 

--- a/work-package/techniques/codebase-comprehension/deep-dive.md
+++ b/work-package/techniques/codebase-comprehension/deep-dive.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -26,6 +26,10 @@ Updated comprehension artifact — written as `{codebase_area}.md` in `{comprehe
 #### artifact
 
 `{codebase_area}.md`
+
+#### audience
+
+`human`
 
 #### deep_dives
 

--- a/work-package/techniques/conduct-retrospective/TECHNIQUE.md
+++ b/work-package/techniques/conduct-retrospective/TECHNIQUE.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 2.3.0
+  version: 2.4.0
 ---
 
 ## Capability
@@ -38,6 +38,10 @@ Lean mechanical session-trace summary when `{trace_tokens}` resolves to non-empt
 #### artifact
 
 `session-trace.md`
+
+#### audience
+
+`human`
 
 ## Rules
 

--- a/work-package/techniques/conduct-retrospective/retrospective.md
+++ b/work-package/techniques/conduct-retrospective/retrospective.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.5.0
+  version: 1.6.0
 ---
 
 ## Capability
@@ -34,6 +34,10 @@ Lean mechanical summary of resolved trace events (dispatch counts, tool counts, 
 #### artifact
 
 `session-trace.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/work-package/techniques/create-adr.md
+++ b/work-package/techniques/create-adr.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -34,6 +34,10 @@ Directory holding the project's ADR files
 #### artifact
 
 `NNNN-{decision_title}.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/work-package/techniques/create-test-plan.md
+++ b/work-package/techniques/create-test-plan.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -22,6 +22,10 @@ Test [strategy](../resources/test-plan.md#test-plan-structure) and acceptance cr
 #### artifact
 
 `test-plan.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/work-package/techniques/dco-provenance/append-task-row.md
+++ b/work-package/techniques/dco-provenance/append-task-row.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -58,6 +58,10 @@ The updated provenance log, with the appended task row
 #### artifact
 
 `provenance-log.md`
+
+#### audience
+
+`human`
 
 
 ## Protocol

--- a/work-package/techniques/design-philosophy/document.md
+++ b/work-package/techniques/design-philosophy/document.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -30,6 +30,10 @@ The design philosophy [artifact](../../resources/design-framework.md#design-phil
 #### artifact
 
 `design-philosophy.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/work-package/techniques/finalize-documentation/create-complete-doc.md
+++ b/work-package/techniques/finalize-documentation/create-complete-doc.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.2.0
+  version: 1.3.0
 ---
 
 ## Capability
@@ -34,6 +34,10 @@ Work package's single terminal close-out artifact — delivered work, coverage, 
 #### artifact
 
 `COMPLETE.md`
+
+#### audience
+
+`human`
 
 ### completion_document_path
 

--- a/work-package/techniques/finalize-documentation/render-token-usage.md
+++ b/work-package/techniques/finalize-documentation/render-token-usage.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.2.0
+  version: 1.3.0
 ---
 
 ## Capability
@@ -22,6 +22,10 @@ Per-activity token table, per-workflow totals, cost estimate (labelled an estima
 #### artifact
 
 `token-usage.md`
+
+#### audience
+
+`human`
 
 #### usage_coverage
 

--- a/work-package/techniques/implementation-analysis/document.md
+++ b/work-package/techniques/implementation-analysis/document.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -34,6 +34,10 @@ Current implementation analysis artifact with baselines and improvement opportun
 #### artifact
 
 `implementation-analysis.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/work-package/techniques/plan-prepare/plan.md
+++ b/work-package/techniques/plan-prepare/plan.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -26,6 +26,10 @@ Work package plan artifact with task breakdown and dependencies. Written to `{pl
 #### artifact
 
 `work-package-plan.md`
+
+#### audience
+
+`human`
 
 #### tasks
 

--- a/work-package/techniques/requirements-elicitation/create-document.md
+++ b/work-package/techniques/requirements-elicitation/create-document.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -30,6 +30,10 @@ The requirements [artifact](../../resources/requirements-elicitation.md#document
 #### artifact
 
 `requirements-elicitation.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/work-package/techniques/research/document.md
+++ b/work-package/techniques/research/document.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.2.0
+  version: 1.3.0
 ---
 
 ## Capability
@@ -34,6 +34,10 @@ Knowledge base and web research synthesis artifact for the work package. Written
 #### artifact
 
 `kb-research.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/work-package/techniques/respond-to-pr-review.md
+++ b/work-package/techniques/respond-to-pr-review.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 2.3.0
+  version: 2.4.0
 ---
 
 ## Capability
@@ -20,6 +20,10 @@ PR review [analysis](../resources/pr-review-response.md#review-document-template
 #### artifact
 
 `{YYYY-MM-DD}-pr{pr_number}-review-analysis.md`
+
+#### audience
+
+`human`
 
 #### requires_replan
 

--- a/work-package/techniques/review-assumptions/record.md
+++ b/work-package/techniques/review-assumptions/record.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.2.0
+  version: 1.3.0
 ---
 
 ## Capability
@@ -22,6 +22,10 @@ The assumptions [log](../../resources/assumptions-review.md#assumptions-log-temp
 #### artifact
 
 `assumptions-log.md`
+
+#### audience
+
+`human`
 
 ### has_deferred_assumptions
 

--- a/work-package/techniques/review-code.md
+++ b/work-package/techniques/review-code.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 2.3.0
+  version: 2.4.0
 ---
 
 ## Capability
@@ -31,6 +31,10 @@ Code review [report](../resources/rust-substrate-code-review.md#report-template)
 
 `code-review.md`
 
+#### audience
+
+`human`
+
 ### code_review_method
 
 Method [record](../resources/rust-substrate-code-review.md#method-record-template) of how the review was conducted — the surface walked, the sweeps run and what each returned, and the compliance assessment.
@@ -38,6 +42,10 @@ Method [record](../resources/rust-substrate-code-review.md#method-record-templat
 #### artifact
 
 `code-review-method.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/work-package/techniques/review-diff.md
+++ b/work-package/techniques/review-diff.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 2.2.0
+  version: 2.3.0
 ---
 
 ## Capability
@@ -26,6 +26,10 @@ Conduct structured manual diff review using external side-by-side diff tool with
 #### artifact
 
 `change-block-index.md`
+
+#### audience
+
+`human`
 
 #### block_rationale
 

--- a/work-package/techniques/review-existing-feedback.md
+++ b/work-package/techniques/review-existing-feedback.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.3.0
+  version: 1.4.0
 ---
 
 ## Capability
@@ -22,6 +22,10 @@ The triage table: one row per prior comment or review thread, each marked Confir
 #### artifact
 
 `prior-feedback-triage.md`
+
+#### audience
+
+`human`
 
 ### rating_cap
 

--- a/work-package/techniques/review-test-suite.md
+++ b/work-package/techniques/review-test-suite.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 2.2.0
+  version: 2.3.0
 ---
 
 ## Capability
@@ -27,6 +27,10 @@ Test suite review [report](../resources/test-suite-review.md#report-template) st
 
 `test-suite-review.md`
 
+#### audience
+
+`human`
+
 ### test_suite_review_method
 
 Method [record](../resources/test-suite-review.md#method-record-template) of how the review was conducted — the suite baseline, the coverage map, the anti-pattern sweep, the pyramid and redundancy assessments, and the reported-failure triage.
@@ -34,6 +38,10 @@ Method [record](../resources/test-suite-review.md#method-record-template) of how
 #### artifact
 
 `test-suite-review-method.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/work-package/techniques/strategic-review/TECHNIQUE.md
+++ b/work-package/techniques/strategic-review/TECHNIQUE.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 2.1.0
+  version: 2.2.0
 ---
 
 ## Capability
@@ -50,6 +50,10 @@ Architecture [summary](../../resources/architecture-summary.md#architecture-summ
 #### artifact
 
 `architecture-summary.md`
+
+#### audience
+
+`human`
 
 
 ## Rules

--- a/work-package/techniques/strategic-review/document-findings.md
+++ b/work-package/techniques/strategic-review/document-findings.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.3.0
+  version: 1.4.0
 ---
 
 ## Capability
@@ -17,6 +17,10 @@ The strategic review [document](../../resources/strategic-review.md#strategic-re
 
 `strategic-review-{n}.md`
 
+#### audience
+
+`human`
+
 ### strategic_review_method
 
 Method [record](../../resources/strategic-review.md#method-record-template) of how the review was conducted — the scope, conformance and minimality passes, and the delivery class each designator falls in.
@@ -24,6 +28,11 @@ Method [record](../../resources/strategic-review.md#method-record-template) of h
 #### artifact
 
 `strategic-review-{n}-method.md`
+
+#### audience
+
+`human`
+
 
 ## Protocol
 

--- a/work-package/techniques/summarize-architecture.md
+++ b/work-package/techniques/summarize-architecture.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -26,6 +26,10 @@ Stakeholder-facing architecture [summary](../resources/architecture-summary.md#a
 #### artifact
 
 `architecture-summary.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/work-packages/techniques/analyze-initiative-context/analyze-completion.md
+++ b/work-packages/techniques/analyze-initiative-context/analyze-completion.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ Assess how far a multi-package initiative has already got: the completion state 
 #### artifact
 
 `01-COMPLETION-ANALYSIS.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/work-packages/techniques/analyze-initiative-context/analyze-context.md
+++ b/work-packages/techniques/analyze-initiative-context/analyze-context.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ Establish the starting context for a fresh initiative: the domain and stack it l
 #### artifact
 
 `02-CONTEXT-ANALYSIS.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/work-packages/techniques/document-roadmap.md
+++ b/work-packages/techniques/document-roadmap.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -27,6 +27,10 @@ Completed [START-HERE.md](../resources/roadmap-template.md#start-heremd-final-fo
 
 `START-HERE.md`
 
+#### audience
+
+`human`
+
 ### planning_readme
 
 Updated [README.md](../resources/roadmap-template.md#readmemd-final-format) with navigation links
@@ -34,6 +38,10 @@ Updated [README.md](../resources/roadmap-template.md#readmemd-final-format) with
 #### artifact
 
 `README.md`
+
+#### audience
+
+`human`
 
 ### timeline_estimate
 

--- a/work-packages/techniques/orchestrate-package-execution/execute-package.md
+++ b/work-packages/techniques/orchestrate-package-execution/execute-package.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -30,6 +30,10 @@ Progress indicator (e.g., '3/7 complete'), written into the updated START-HERE.m
 #### artifact
 
 `START-HERE.md`
+
+#### audience
+
+`human`
 
 #### package_planning_paths
 

--- a/work-packages/techniques/plan-work-package-scope/plan-package.md
+++ b/work-packages/techniques/plan-work-package-scope/plan-package.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -22,6 +22,10 @@ Work package [plan document](../../resources/package-plan-template.md#template)
 #### artifact
 
 `{package_name}-plan.md`
+
+#### audience
+
+`human`
 
 #### scope_definitions
 

--- a/work-packages/techniques/prioritize-packages.md
+++ b/work-packages/techniques/prioritize-packages.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -26,6 +26,10 @@ Ordered list of work packages by execution priority, with prioritization rationa
 #### artifact
 
 `priority-ranking.md`
+
+#### audience
+
+`human`
 
 #### dependency_graph
 

--- a/work-packages/techniques/setup-planning-folder.md
+++ b/work-packages/techniques/setup-planning-folder.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -27,6 +27,10 @@ Executive-summary and status-tracking skeleton, written to `{planning_folder_pat
 
 `START-HERE.md`
 
+#### audience
+
+`human`
+
 ### readme_skeleton
 
 Navigation and document-index skeleton, written to `{planning_folder_path}` from the [README.md skeleton](../resources/planning-folder-template.md#readmemd-skeleton).
@@ -34,6 +38,10 @@ Navigation and document-index skeleton, written to `{planning_folder_path}` from
 #### artifact
 
 `README.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/workflow-authoring/techniques/workflow-definition/compile-report.md
+++ b/workflow-authoring/techniques/workflow-definition/compile-report.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -42,6 +42,10 @@ The register body: the severity summary, the change-surface membership table (to
 #### artifact
 
 `findings-register.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/workflow-authoring/techniques/workflow-definition/create-completion-doc.md
+++ b/workflow-authoring/techniques/workflow-definition/create-completion-doc.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -38,6 +38,10 @@ The close-out record: what the run delivered, links to where its decisions live,
 #### artifact
 
 `COMPLETE.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/workflow-authoring/techniques/workflow-definition/elicit-change-brief.md
+++ b/workflow-authoring/techniques/workflow-definition/elicit-change-brief.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ The assembled change brief for a new workflow: purpose, the dimension captures t
 #### artifact
 
 `change-brief.md`
+
+#### audience
+
+`human`
 
 ### open_judgements_count
 

--- a/workflow-authoring/techniques/workflow-definition/impact-analysis.md
+++ b/workflow-authoring/techniques/workflow-definition/impact-analysis.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -34,6 +34,10 @@ The assembled impact report: per-file classification, the integrity verdicts, an
 #### artifact
 
 `impact-analysis.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/workflow-authoring/techniques/workflow-definition/readme-authoring.md
+++ b/workflow-authoring/techniques/workflow-definition/readme-authoring.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -26,6 +26,10 @@ The target workflow's root README: generated whole on a create run, revised in p
 #### artifact
 
 `README.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/workflow-authoring/techniques/workflow-definition/scope-definition.md
+++ b/workflow-authoring/techniques/workflow-definition/scope-definition.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -30,6 +30,10 @@ The complete file manifest — one entry per file to create, modify or remove, e
 #### artifact
 
 `scope-manifest.md`
+
+#### audience
+
+`human`
 
 ### file_count
 

--- a/workflow-authoring/techniques/workflow-definition/synthesize-change-brief.md
+++ b/workflow-authoring/techniques/workflow-definition/synthesize-change-brief.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -30,6 +30,10 @@ The assembled change brief for an existing workflow: purpose, the **changed** me
 #### artifact
 
 `change-brief.md`
+
+#### audience
+
+`human`
 
 ### open_judgements_count
 

--- a/workflow-design/techniques/assemble-file-approach.md
+++ b/workflow-design/techniques/assemble-file-approach.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.2.4
+  version: 1.3.0
 ---
 
 ## Capability
@@ -26,6 +26,10 @@ The per-file delta for `{current_file}` following the [Drafting Plan Guide](../r
 #### artifact
 
 `drafting-plan.md`
+
+#### audience
+
+`human`
 
 ### drafting_plan_path
 

--- a/workflow-design/techniques/audit-anti-patterns.md
+++ b/workflow-design/techniques/audit-anti-patterns.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.12.1
+  version: 1.13.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ Findings grouped by catalog entry **name** / **designator**: file path, offendin
 #### artifact
 
 `anti-pattern-findings.md`
+
+#### audience
+
+`human`
 
 ### anti_pattern_findings_path
 

--- a/workflow-design/techniques/audit-conformance.md
+++ b/workflow-design/techniques/audit-conformance.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.4.1
+  version: 1.5.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ Conformance divergences — each a divergence with its file, the diverging const
 #### artifact
 
 `conformance-findings.md`
+
+#### audience
+
+`human`
 
 ### conformance_finding_count
 

--- a/workflow-design/techniques/audit-expressiveness.md
+++ b/workflow-design/techniques/audit-expressiveness.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.3.1
+  version: 1.4.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ Expressiveness findings — each a flagged instance with its file, the prose pas
 #### artifact
 
 `expressiveness-findings.md`
+
+#### audience
+
+`human`
 
 ### expressiveness_finding_count
 

--- a/workflow-design/techniques/audit-principles.md
+++ b/workflow-design/techniques/audit-principles.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.3.1
+  version: 1.4.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ Per-principle Pass / Partial / Violation classifications with file, field, and l
 #### artifact
 
 `principle-findings.md`
+
+#### audience
+
+`human`
 
 ### principle_findings_path
 

--- a/workflow-design/techniques/audit-rule-enforcement.md
+++ b/workflow-design/techniques/audit-rule-enforcement.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.3.1
+  version: 1.4.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ Text-only rules found — each with its file, rule content, whether it is critic
 #### artifact
 
 `enforcement-findings.md`
+
+#### audience
+
+`human`
 
 ### enforcement_finding_count
 

--- a/workflow-design/techniques/audit-rule-hygiene.md
+++ b/workflow-design/techniques/audit-rule-hygiene.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.3.1
+  version: 1.4.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ Rule-hygiene findings — each a flagged rule with its file, rule key, the hygie
 #### artifact
 
 `rule-hygiene-findings.md`
+
+#### audience
+
+`human`
 
 ### rule_hygiene_finding_count
 

--- a/workflow-design/techniques/context-loading.md
+++ b/workflow-design/techniques/context-loading.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.3.0
+  version: 1.4.0
 ---
 
 ## Capability
@@ -17,6 +17,10 @@ Absolute path to the written format-conventions artifact (create mode only).
 
 `format-conventions.md`
 
+#### audience
+
+`human`
+
 ### applicable_constructs_path
 
 Absolute path to the written applicable-constructs artifact (create mode only).
@@ -24,6 +28,10 @@ Absolute path to the written applicable-constructs artifact (create mode only).
 #### artifact
 
 `applicable-constructs.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/workflow-design/techniques/create-completion-doc.md
+++ b/workflow-design/techniques/create-completion-doc.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.1
+  version: 1.1.0
 ---
 
 ## Capability
@@ -22,6 +22,10 @@ The classified operation. When `update`, the summary frames the delivery as chan
 #### artifact
 
 `COMPLETE.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/workflow-design/techniques/impact-analysis.md
+++ b/workflow-design/techniques/impact-analysis.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.2.0
+  version: 1.3.0
 ---
 
 ## Capability
@@ -20,6 +20,10 @@ Absolute path to the written impact-analysis artifact.
 #### artifact
 
 `impact-analysis.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/workflow-design/techniques/intake-classification.md
+++ b/workflow-design/techniques/intake-classification.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 2.7.0
+  version: 2.8.0
 ---
 
 ## Capability
@@ -52,6 +52,10 @@ Per-target structural inventory following the [Structural Inventory Guide](../re
 #### artifact
 
 `structural-inventory.md`
+
+#### audience
+
+`human`
 
 ### structural_inventory_path
 

--- a/workflow-design/techniques/pattern-analysis.md
+++ b/workflow-design/techniques/pattern-analysis.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.2.4
+  version: 1.3.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ Lean alignment / divergence table following the [Pattern Analysis Guide](../reso
 #### artifact
 
 `pattern-analysis.md`
+
+#### audience
+
+`human`
 
 ### pattern_analysis_path
 

--- a/workflow-design/techniques/persist-design-specification.md
+++ b/workflow-design/techniques/persist-design-specification.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.2.0
+  version: 1.3.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ Absolute path to the written design-specification artifact.
 #### artifact
 
 `design-specification.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/workflow-design/techniques/readme-authoring.md
+++ b/workflow-design/techniques/readme-authoring.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -22,6 +22,10 @@ The workflow root README (create: generate; update: revise for structural change
 #### artifact
 
 `README.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 

--- a/workflow-design/techniques/review-draft-yaml.md
+++ b/workflow-design/techniques/review-draft-yaml.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.2.0
+  version: 1.3.0
 ---
 
 ## Capability
@@ -30,6 +30,10 @@ Absolute path to the written draft-attestation artifact (includes the block-inde
 #### artifact
 
 `draft-attestation.md`
+
+#### audience
+
+`human`
 
 #### draft_attestation
 

--- a/workflow-design/techniques/review-drafted-file.md
+++ b/workflow-design/techniques/review-drafted-file.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.3.0
+  version: 1.4.0
 ---
 
 ## Capability
@@ -26,6 +26,10 @@ Per-file delta note for `{current_file}` following the [File Review Note Guide](
 #### artifact
 
 `file-review-note.md`
+
+#### audience
+
+`human`
 
 ### file_review_note_path
 

--- a/workflow-design/techniques/scope-definition.md
+++ b/workflow-design/techniques/scope-definition.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.4.0
+  version: 1.5.0
 ---
 
 ## Capability
@@ -16,6 +16,10 @@ The complete file manifest: one entry per file to create/modify/remove with its 
 #### artifact
 
 `scope-manifest.md`
+
+#### audience
+
+`human`
 
 ### file_count
 

--- a/workflow-design/techniques/verify-high-findings.md
+++ b/workflow-design/techniques/verify-high-findings.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -20,6 +20,10 @@ Absolute path to the persisted verified-findings artifact.
 #### artifact
 
 `verified-findings.md`
+
+#### audience
+
+`human`
 
 ## Protocol
 


### PR DESCRIPTION
## Summary

A technique that persists an artifact names the file but never said who reads it. The technique protocol has supported an audience attribute on every artifact declaration since #227 — schema, loader, activity-contract carry-through, normative spec, and a repo guard, all shipped — and not one of the corpus's 139 declarations used it. The guard therefore passed over nothing. This work states the reader wherever it can be stated honestly, and records a reviewed decision everywhere else.

## What the declarations say now

| Audience | Declarations |
|---|---|
| `agent` | 14 |
| `human` | 117 |
| absent, pending conversion | 8 |

The 14 agent declarations are the scanner, registry, reconnaissance and merge outputs of the two security-audit workflows. They were already JSON on disk against a declared sub-agent schema; the attribute now says so, and the audience guard measures 14 real declarations instead of zero.

## Why eight carry no declaration at all

An agent-audience artifact is JSON on disk — the protocol specification makes that part of what the attribute means, and the guard enforces it. For a register whose only reader is a later step but which is still markdown, that leaves neither value true: `agent` contradicts the format, and `human` contradicts who reads it. Those eight therefore carry **no** declaration. Absent already means `human` by default, so the file reads identically either way; what changes is that no declaration claims a reader the file's form contradicts. Naming the reader and converting the file are one act, and that act is #428.

Each of the thirteen candidates was reviewed individually against its producer and its consumer. Eight were approved for conversion; five were kept as prose and carry a settled `human`:

| Kept as prose | Why |
|---|---|
| `findings-register.md` (workflow-authoring) | Its own guide says it is read by later steps **as much as by a person** |
| `findings-register.md` (midnight-system-review) | The adjudication trail exists so a verdict can be audited; only the accepted subset is machine-read |
| `follow-ups.md`, `deferred-items.md` | Canonical fact homes every other artifact links to rather than restating |
| `assumptions-log.md`, `change-block-index.md` | Held back deliberately; `assumptions-log` is also the widest retarget surface available, at 30 files |

**Artifacts a person and a later step both read** carry an explicit decision too: the planning README, `START-HERE.md`, the work-package plan and test plan, the format-conventions summary, `DEFINITIVE-FINDINGS.md`, and the wiki index and log. In each, a person reads first and is the reader the format has to serve, and the mechanical read is a narrow field lookup a prose layout survives.

## Scope of change

118 technique files, four lines each. No protocol prose changed, no I/O contract renamed, no consumer retargeted.

## Acceptance

- [x] Every declaration that can state a reader honestly does: the loader parses 131 (117 human, 14 agent), and the 8 awaiting conversion carry none by decision.
- [x] The audience guard is no longer vacuous — 14 real agent declarations pass its JSON-format check. It checks the format convention and not presence, since requiring presence would fail on exactly the 8 that are waiting.
- [x] Every candidate is a reviewed decision with a stated reason, conversions and keeps alike.
- [x] All 22 guards pass.

## Non-goals

- Converting any artifact to JSON. That is the deferred item, tracked separately.
- Changing any consuming step. Nothing reads an artifact differently because of this change.

## Investigation detail

**[engineering/artifacts/planning/2026-08-02-artifact-audience-and-plain-language/audience-classification.md](https://github.com/m2ux/workflow-server/blob/engineering/artifacts/planning/2026-08-02-artifact-audience-and-plain-language/audience-classification.md)**

Part of #403 (W2). Stacked on #421.

