### PR TITLE
Creation guides: the artifacts that had no prescribed shape get a template, rules and a budget

### DIFF
--- a/cicd-pipeline-security-audit/resources/README.md
+++ b/cicd-pipeline-security-audit/resources/README.md
@@ -1,0 +1,40 @@
+# CI/CD Pipeline Security Audit Resources
+
+> Part of the [CI/CD Pipeline Security Audit Workflow](../README.md)
+
+Reference content loaded on demand by the workflow's techniques. The authoritative content lives in each `.md` file and is served by `get_resource` addressed by bare slug (e.g. `resource_id: injection-pattern-catalog`). This file is the catalog — what each resource owns.
+
+---
+
+## Resource Catalog
+
+| Resource | Owns |
+|----------|------|
+| [`start-here.md`](start-here.md) | Quick-start orientation and the entry procedure, and the shape of the run's `START-HERE.md` |
+| [`injection-pattern-catalog.md`](injection-pattern-catalog.md) | The injection patterns and mechanical checks each scanner applies |
+| [`cicd-severity-rubric.md`](cicd-severity-rubric.md) | The impact and feasibility scales, the severity mapping, and the crosscheck |
+| [`sub-agent-output-schema.md`](sub-agent-output-schema.md) | The structured output schema every dispatched scanner conforms to |
+| [`intermediate-artifact-schemas.md`](intermediate-artifact-schemas.md) | The JSON shapes of the artifacts that flow between reconnaissance, dispatch, verification, and merge |
+| [`cicd-audit-report-template.md`](cicd-audit-report-template.md) | The document skeleton for the audit report |
+| [`remediation-playbook.md`](remediation-playbook.md) | The remediation each finding class attaches |
+
+---
+
+## Planning artifact to guide map
+
+| Bare filename | Guide |
+|---------------|-------|
+| `START-HERE.md` | [start-here](start-here.md) |
+| `01-cicd-audit-report.md` | [cicd-audit-report-template](cicd-audit-report-template.md) |
+| `reconnaissance-summary.json` | [intermediate-artifact-schemas](intermediate-artifact-schemas.md#workflow-inventory) |
+| `scanner-assignments.json` | [intermediate-artifact-schemas](intermediate-artifact-schemas.md) |
+| `verification-report.json` | [intermediate-artifact-schemas](intermediate-artifact-schemas.md) |
+| `merged-findings.json` | [intermediate-artifact-schemas](intermediate-artifact-schemas.md) |
+| `reconciliation-table.json` | [intermediate-artifact-schemas](intermediate-artifact-schemas.md) |
+| `{scanner_id}.json`, `s{scanner_number}-{submodule_path}.json` | [sub-agent-output-schema](sub-agent-output-schema.md) |
+
+---
+
+## Addressing
+
+Resources are addressed by bare slug via `get_resource`; a `#section` suffix narrows the load to one anchor.

--- a/codebase-wiki/resources/README.md
+++ b/codebase-wiki/resources/README.md
@@ -2,7 +2,7 @@
 
 > Part of the [Codebase Wiki Workflow](../README.md)
 
-Four Markdown resources that concretize the wiki standard the techniques work to: the Karpathy-adapted page format, the per-type page templates, the lint checklist, and the citation conventions. Each is loaded via `get_resource` by the technique that references it — this file orients, it does not restate the resource content.
+Five Markdown resources that concretize the wiki standard the techniques work to: the Karpathy-adapted page format, the per-type page templates, the lint checklist, the citation conventions, and the creation guide for the catalog and ledger every mutation touches. Each is loaded via `get_resource` by the technique that references it — this file orients, it does not restate the resource content.
 
 ---
 
@@ -14,6 +14,17 @@ Four Markdown resources that concretize the wiki standard the techniques work to
 | `01` | [Page Templates](./page-templates.md) | One body skeleton per page type (concept, entity, source-summary, comparison) — the frontmatter block and the cited-claim, confidence-scored layout each page follows. |
 | `02` | [Lint Checklist](./lint-checklist.md) | The integrity checks the wiki is verified against, each with its pass/fail criterion. |
 | `03` | [Citation Conventions](./citation-conventions.md) | The raw-baseline citation form, the confidence vocabulary, and the `[[wikilink]]` cross-reference convention. |
+| `04` | [Index and Log](./index-and-log.md) | Creation guide: `index.md` and `log.md` — the navigation catalog and the append-only mutation ledger. |
+
+---
+
+## Planning artifact to guide map
+
+| Bare filename | Guide |
+|---------------|-------|
+| `{$page_slug}.md` | [page-templates](./page-templates.md) |
+| `index.md` | [index-and-log](./index-and-log.md) |
+| `log.md` | [index-and-log](./index-and-log.md) |
 
 ---
 

--- a/codebase-wiki/resources/index-and-log.md
+++ b/codebase-wiki/resources/index-and-log.md
@@ -54,4 +54,4 @@ Creation guide for the two files every wiki mutation touches. `index.md` is how 
 - **Wikilinks, not paths.** Both files address pages by `[[slug]]`, so a page move does not break the catalog.
 - **The log is append-only.** A new entry is added per operation, in operation order. A prior entry is never edited, so the ledger stays a faithful history.
 - **Every log entry names its baseline commit.** That commit is what the entry's claims were read against, and it is what makes a stale claim detectable later.
-- **Line budget:** the index grows with the wiki and carries no budget; a log entry is one row.
+- **Line budget:** one line per page in the index and one row per operation in the log. Both grow with the wiki, so the budget is per entry rather than per file: an index entry over one line, or a log entry over one row, is over budget.

--- a/codebase-wiki/resources/index-and-log.md
+++ b/codebase-wiki/resources/index-and-log.md
@@ -1,0 +1,57 @@
+---
+name: index-and-log
+description: Creation guide for bare filenames `index.md` and `log.md` — the wiki's navigation catalog and its append-only mutation ledger. One guide, two templates, because the pair is written by the same mutation.
+---
+
+# Index and Log Guide
+
+Creation guide for the two files every wiki mutation touches. `index.md` is how a reader finds a page; `log.md` is how anyone establishes when a claim was written and against which commit. They share a guide because they are written together and neither is meaningful without the other.
+
+## Index Template
+
+```markdown
+# Wiki Index
+
+## Concepts
+
+| Page | Summary |
+|------|---------|
+| [[page-slug]] | one line |
+
+## Entities
+
+| Page | Summary |
+|------|---------|
+| [[page-slug]] | one line |
+
+## Sources
+
+| Page | Summary |
+|------|---------|
+| [[page-slug]] | one line |
+
+## Comparisons
+
+| Page | Summary |
+|------|---------|
+| [[page-slug]] | one line |
+```
+
+## Log Template
+
+```markdown
+# Mutation Log
+
+| When | Operation | Pages | Baseline | Trigger |
+|------|-----------|-------|----------|---------|
+| {timestamp} | one line on what was ingested | [[slug]], [[slug]] | `{commit}` | code-driven \| task-driven |
+```
+
+## Rules
+
+- **One index entry per page, grouped by page type.** The type sections are the navigation, so a page appears under exactly one of them. An empty type section is omitted until it has a page.
+- **The index summary is one line.** It exists to let a reader choose between pages; the page itself holds the content.
+- **Wikilinks, not paths.** Both files address pages by `[[slug]]`, so a page move does not break the catalog.
+- **The log is append-only.** A new entry is added per operation, in operation order. A prior entry is never edited, so the ledger stays a faithful history.
+- **Every log entry names its baseline commit.** That commit is what the entry's claims were read against, and it is what makes a stale claim detectable later.
+- **Line budget:** the index grows with the wiki and carries no budget; a log entry is one row.

--- a/codebase-wiki/techniques/maintain-index-log.md
+++ b/codebase-wiki/techniques/maintain-index-log.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -47,12 +47,11 @@ The appended ledger: one entry per create/update operation, in operation order.
 
 ### 1. Update The Index
 
-- For each page in `{mutated_pages}`, ensure `{wiki_index}` has an entry under its type section linking to the page by `[[wikilink]]`, with its title and one-line summary; add a new entry for a new page, refresh the summary for an updated one.
-- Keep the index organized by page type (`concepts`, `entities`, `sources`, `comparisons`) so it stays navigable as it grows.
+- For each page in `{mutated_pages}`, ensure `{wiki_index}` has an entry under its type section per [Index Template](../resources/index-and-log.md#index-template); add a new entry for a new page, refresh the summary for an updated one.
 
 ### 2. Append The Log
 
-- Append one entry to `{mutation_log}` recording the operation: a timestamp, the `{operation_summary}`, the pages touched, the `{raw_baseline_commit}` the claims cite, and whether the mutation was code-driven or task-driven. The log is append-only — never rewrite prior entries.
+- Append one entry to `{mutation_log}` per [Log Template](../resources/index-and-log.md#log-template), recording the `{operation_summary}` and the `{raw_baseline_commit}` the claims cite.
 
 ### 3. Write Both Files
 

--- a/midnight-system-review/resources/README.md
+++ b/midnight-system-review/resources/README.md
@@ -15,3 +15,15 @@ Reference content loaded on demand by the workflow's techniques. The authoritati
 | [`grading-rubric.md`](grading-rubric.md) | The six-dimension grade tuple applied by [`grade-findings`](../techniques/finding-adjudication/grade-findings.md), the accepted-issue threshold applied by [`register-findings`](../techniques/finding-adjudication/register-findings.md), and calibration anchors from representative findings |
 | [`verdict-rubric.md`](verdict-rubric.md) | The 1-5 merge-readiness scale computed by [`compute-verdict`](../techniques/verdict-and-report/compute-verdict.md), its calibration anchors, the run status vocabulary, and the verdict-to-`review_type` mapping |
 | [`review-format.md`](review-format.md) | The canonical review structure rendered by [`render-review`](../techniques/verdict-and-report/render-review.md) and the Review Details accounting rules the reconciliation gate checks |
+| [`findings-register.md`](findings-register.md) | Creation guide: `findings-register.md` — the disposition table, the per-finding detail sections, and the completeness bar on the grade tuple |
+| [`publication-record.md`](publication-record.md) | Creation guide: `publication-record.md` — the post outcome, the verdict it carried, and the artifacts it traces back to |
+
+---
+
+## Planning artifact to guide map
+
+| Bare filename | Guide |
+|---------------|-------|
+| `findings-register.md` | [findings-register](findings-register.md) |
+| `publication-record.md` | [publication-record](publication-record.md) |
+| `review-report.md` | [review-format](review-format.md) |

--- a/midnight-system-review/resources/findings-register.md
+++ b/midnight-system-review/resources/findings-register.md
@@ -33,4 +33,4 @@ Creation guide for bare filename `findings-register.md`. The register holds the 
 - **Every row has a detail section.** The row is the index; the section carries the full tuple, the anchor, and the rationale. A dismissed candidate records the contradicting anchor there.
 - **The tuple is complete before the register is finished.** An incomplete tuple is what the grade-tuple completeness gate looks for, so a row with a partial tuple is unfinished work rather than a finding.
 - **Disposition comes from the threshold.** Accepted, observation, and dismissed are assigned per the [accepted-issue threshold](./grading-rubric.md#accepted-issue-threshold); this template records the assignment and its rationale.
-- **Line budget:** ~15 lines per finding section, and the summary line replaces any count table.
+- **Line budget:** ~15 lines per finding section and ~200 lines for the register, and the summary line replaces any count table. A register at the ceiling with candidates left to record means the sections are carrying evidence the probe artifacts own.

--- a/midnight-system-review/resources/findings-register.md
+++ b/midnight-system-review/resources/findings-register.md
@@ -1,0 +1,36 @@
+---
+name: findings-register
+description: Creation guide for bare filename `findings-register.md` — the adjudicated record of every graded candidate, its disposition against the accepted-issue threshold, and the grade tuple behind it.
+metadata:
+  order: 6
+---
+
+# Findings Register Guide
+
+Creation guide for bare filename `findings-register.md`. The register holds the whole adjudication trail: what was accepted, what stands as an observation, what the evidence contradicted, and the grade tuple behind each call. The verdict computation reads the accepted subset; a reader auditing the review reads the rest.
+
+## Template
+
+```markdown
+# Findings Register
+
+**Candidates:** {n} · **Accepted:** {n} · **Observations:** {n} · **Dismissed:** {n}
+
+| ID | Area | Tuple | Disposition |
+|----|------|-------|-------------|
+| F1 | area name | severity/confidence/anchor summary | accepted \| observation \| dismissed |
+
+## F1 — {one-line title}
+
+**Tuple:** {full grade tuple}
+**Anchor:** {locus link}
+**Rationale:** {why the tuple grades this way, and why the disposition follows}
+```
+
+## Rules
+
+- **Every candidate is a row.** A candidate absent from the disposition table is a candidate nobody adjudicated.
+- **Every row has a detail section.** The row is the index; the section carries the full tuple, the anchor, and the rationale. A dismissed candidate records the contradicting anchor there.
+- **The tuple is complete before the register is finished.** An incomplete tuple is what the grade-tuple completeness gate looks for, so a row with a partial tuple is unfinished work rather than a finding.
+- **Disposition comes from the threshold.** Accepted, observation, and dismissed are assigned per the [accepted-issue threshold](./grading-rubric.md#accepted-issue-threshold); this template records the assignment and its rationale.
+- **Line budget:** ~15 lines per finding section, and the summary line replaces any count table.

--- a/midnight-system-review/resources/findings-register.md
+++ b/midnight-system-review/resources/findings-register.md
@@ -7,7 +7,7 @@ metadata:
 
 # Findings Register Guide
 
-Creation guide for bare filename `findings-register.md`. The register holds the whole adjudication trail: what was accepted, what stands as an observation, what the evidence contradicted, and the grade tuple behind each call. The verdict computation reads the accepted subset; a reader auditing the review reads the rest.
+Creation guide for bare filename `findings-register.md`. The register holds the whole adjudication trail: what was accepted, what stands as an observation, what the evidence contradicted, and the grade tuple behind each call. The accepted subset is what the verdict rests on; the rest is the trail behind it.
 
 ## Template
 

--- a/midnight-system-review/resources/publication-record.md
+++ b/midnight-system-review/resources/publication-record.md
@@ -1,0 +1,35 @@
+---
+name: publication-record
+description: Creation guide for bare filename `publication-record.md` — the close-out record of what was posted, where, as which review type, under which verdict, with links back to the artifacts that produced it.
+metadata:
+  order: 7
+---
+
+# Publication Record Guide
+
+Creation guide for bare filename `publication-record.md`. The record answers one question later: what did this review actually publish, and what can it be traced back to. It reflects what happened, including a post that failed.
+
+## Template
+
+```markdown
+# Publication Record
+
+| Field | Value |
+|-------|-------|
+| Posted | yes \| no |
+| PR | #{n} |
+| Review type | approve \| request-changes \| comment |
+| Verdict | {merge-readiness verdict} |
+| Posted at | {timestamp} |
+
+**Traces to:** [review report](review-report.md) · [findings register](findings-register.md) · [evidence log](evidence-log.md)
+
+{When the post failed: one line on the reason.}
+```
+
+## Rules
+
+- **The record states the outcome, not the intent.** A failed post is recorded as a failed post with its reason. Whether to retry is decided elsewhere.
+- **Three links, always.** The report, the register, and the evidence log are what the posted review rests on, so the record links all three.
+- **No verdict rationale.** The verdict's reasoning lives in the review report; the record carries the value.
+- **Line budget:** ~20 lines.

--- a/midnight-system-review/techniques/finding-adjudication/register-findings.md
+++ b/midnight-system-review/techniques/finding-adjudication/register-findings.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -40,5 +40,5 @@ The accepted subset in area order — the only findings the verdict computation 
 
 ### 2. Write Register
 
-- Write `{findings_register}` to the planning folder and emit `{accepted_findings}`.
+- Write `{findings_register}` to the planning folder per [findings-register](../../resources/findings-register.md#template) and its [Rules](../../resources/findings-register.md#rules), and emit `{accepted_findings}`.
 - Confirm every register entry carries its complete grade tuple before finishing — this is what the grade-tuple completeness gate checks.

--- a/midnight-system-review/techniques/publish-review/record-publication.md
+++ b/midnight-system-review/techniques/publish-review/record-publication.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -43,5 +43,5 @@ The publication close-out: post status, PR, review type, verdict, and links back
 
 ### 1. Record Publication
 
-- Write `{publication_record}` to the planning folder: `{review_posted}` status, PR `{pr_number}`, `{review_type}`, `{merge_readiness_verdict}`, the posting timestamp, and links to `review-report.md`, `findings-register.md`, and `evidence-log.md`.
+- Write `{publication_record}` to the planning folder per [publication-record](../../resources/publication-record.md#template) and its [Rules](../../resources/publication-record.md#rules): `{review_posted}` status, PR `{pr_number}`, `{review_type}`, `{merge_readiness_verdict}`, and the posting timestamp.
   > If `{review_posted}` is false, record the failed post with its reason — the record reflects what actually happened, and the orchestrator decides whether to retry.

--- a/prism-evaluate/resources/README.md
+++ b/prism-evaluate/resources/README.md
@@ -12,6 +12,14 @@
 | [Evaluation Report Template](evaluation-report-template.md) | Structure for the EVALUATION-REPORT.md artifact (executive summary, core finding, per-dimension findings, recommendations) |
 | [Mitigation Plan Template](mitigation-plan-template.md) | Structure for the MITIGATION-PLAN.md artifact (summary table, detailed mitigations, implementation priority) |
 
+## Planning artifact to guide map
+
+| Bare filename | Guide |
+|---------------|-------|
+| `evaluation-plan.md` | [evaluation-plan-template](evaluation-plan-template.md) |
+| `EVALUATION-REPORT.md` | [evaluation-report-template](evaluation-report-template.md) |
+| `MITIGATION-PLAN.md` | [mitigation-plan-template](mitigation-plan-template.md) |
+
 ---
 
 ### Default Dimensions

--- a/prism/resources/README.md
+++ b/prism/resources/README.md
@@ -278,6 +278,21 @@ Lenses for pre-analysis preparation and post-analysis claim verification.
 
 ---
 
+## Planning artifact to guide map
+
+Document skeletons, as distinct from the lens prompts above. A per-lens analysis artifact takes its shape from the lens the unit runs, so its guide is that lens resource.
+
+| Bare filename | Guide |
+|---------------|-------|
+| `analysis-plan.md` | [analysis-plan](analysis-plan.md) |
+| `REPORT.md` | [final-output-template](final-output-template.md) |
+| `DEFINITIVE-FINDINGS.md` | [definitive-findings-template](definitive-findings-template.md) |
+| `behavioral-synthesis.md` | [behavioral-synthesis](behavioral-synthesis.md) |
+| `dispute-synthesis.md` | [dispute-synthesis](dispute-synthesis.md) |
+| A per-lens analysis artifact (`{lens_name}-analysis.md`, `portfolio-{lens_name}.md`, `reflect-*.md`, `verified-*.md`, `adaptive-stage*.md`, `behavioral-*.md`, `subsystem-*.md`, `smart-prereq.md`, `structural-analysis.md`, `adversarial-analysis.md`, `synthesis.md`, `dispute-lens-*.md`) | The lens resource the unit's lens slug names |
+
+---
+
 ## Cross-Workflow Access
 
 Any workflow can load prism resources without depending on the prism workflow's activities or orchestration:

--- a/prism/resources/README.md
+++ b/prism/resources/README.md
@@ -289,7 +289,26 @@ Document skeletons, as distinct from the lens prompts above. A per-lens analysis
 | `DEFINITIVE-FINDINGS.md` | [definitive-findings-template](definitive-findings-template.md) |
 | `behavioral-synthesis.md` | [behavioral-synthesis](behavioral-synthesis.md) |
 | `dispute-synthesis.md` | [dispute-synthesis](dispute-synthesis.md) |
-| A per-lens analysis artifact (`{lens_name}-analysis.md`, `portfolio-{lens_name}.md`, `reflect-*.md`, `verified-*.md`, `adaptive-stage*.md`, `behavioral-*.md`, `subsystem-*.md`, `smart-prereq.md`, `structural-analysis.md`, `adversarial-analysis.md`, `synthesis.md`, `dispute-lens-*.md`) | The lens resource the unit's lens slug names |
+| `{lens_name}-analysis.md`, `portfolio-{lens_name}.md`, `dispute-lens-a.md`, `dispute-lens-b.md` | The lens resource the unit's lens slug names |
+| `subsystem-{code_subsystem.subsystem_name}.md` | The prism resource the subsystem assignment names for that region |
+| `structural-analysis.md` | [l12](l12.md) |
+| `adversarial-analysis.md` | [l12-complement-adversarial](l12-complement-adversarial.md) |
+| `synthesis.md` | [l12-synthesis](l12-synthesis.md) |
+| `reflect-l12.md` | [l12](l12.md) |
+| `reflect-meta.md` | [claim](claim.md) |
+| `verified-initial.md` | [l12](l12.md) |
+| `verified-gaps.md` | [knowledge-boundary](knowledge-boundary.md) with [knowledge-audit](knowledge-audit.md) |
+| `verified-corrected.md` | [l12](l12.md) |
+| `adaptive-stage1.md` | [deep-scan](deep-scan.md) |
+| `adaptive-stage2.md` | [l12](l12.md) |
+| `behavioral-errors.md` | [error-resilience](error-resilience.md) |
+| `behavioral-costs.md` | [optimize](optimize.md) |
+| `behavioral-changes.md` | [evolution](evolution.md) |
+| `behavioral-promises.md` | [api-surface](api-surface.md) |
+| `subsystem-synthesis.md` | [subsystem-synthesis](subsystem-synthesis.md) |
+| `smart-prereq.md` | [prereq](prereq.md) |
+
+`reflect-synthesis.md` and `portfolio-synthesis.md` are absent from this map on purpose: their producing steps prescribe the sections inline and dispatch no lens, so no resource owns their shape yet. Both are triaged as owing a guide rather than mapped to a lens that does not shape them.
 
 ---
 

--- a/prism/resources/analysis-plan.md
+++ b/prism/resources/analysis-plan.md
@@ -1,0 +1,46 @@
+---
+name: analysis-plan
+description: Creation guide for bare filename `analysis-plan.md` — the human-readable plan a run writes before any analysis pass executes. Template plus fill rules; the machine-readable unit array is a separate output and is not laid out here.
+metadata:
+  order: 66
+  type: template
+---
+
+# Analysis Plan Guide
+
+Creation guide for bare filename `analysis-plan.md`. The reader is deciding whether to spend the run: what will be analysed, how deep each unit goes, what it costs, and what is being skipped. One plan per run, written before the first pass.
+
+## Template
+
+```markdown
+# Analysis Plan — {target}
+
+**Scope:** query | file | module | codebase | document-set · **Budget:** quick | standard | thorough · **Units:** {n} · **Dispatches:** {n}
+
+{One or two sentences: the strategy and why this depth suits the goal.}
+
+## Units
+
+| # | Target | Role | Risk | Mode | Lenses | Why |
+|---|--------|------|------|------|--------|-----|
+| 1 | `path or query` | api-surface | high | full-prism | l12 | one line |
+
+## Execution
+
+**Order:** {risk tier order, and the dependency reason where one applies}
+**Concurrent:** {which units may run at the same time}
+
+## Skipped
+
+| Target | Why |
+|--------|-----|
+| `path` | below the budget threshold |
+```
+
+## Rules
+
+- **Every unit is a row.** One row per unit in execution order, with the mode and lens the row will actually run. A unit missing from the table is a unit nobody agreed to pay for.
+- **Why is one line.** The rationale cell says what made this risk and this mode the right call — not what the lens does.
+- **Single-unit scopes drop the multi-unit sections.** A query or single-file plan carries the header, the strategy sentence, and one Units row; Execution and Skipped are omitted.
+- **Skipped is explicit or absent.** List every unit the budget excluded with its reason, or omit the section when nothing was skipped.
+- **Line budget:** ~50 lines.

--- a/prism/resources/definitive-findings-template.md
+++ b/prism/resources/definitive-findings-template.md
@@ -7,7 +7,6 @@ metadata:
   quality_baseline: null
   optimal_model: sonnet
   type: template
-  type: template
 ---
 
 # Definitive Findings Template

--- a/prism/resources/definitive-findings-template.md
+++ b/prism/resources/definitive-findings-template.md
@@ -7,6 +7,7 @@ metadata:
   quality_baseline: null
   optimal_model: sonnet
   type: template
+  type: template
 ---
 
 # Definitive Findings Template

--- a/prism/techniques/plan-analysis.md
+++ b/prism/techniques/plan-analysis.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.2.0
+  version: 1.3.0
 ---
 
 ## Capability
@@ -153,7 +153,7 @@ Array of `{ target, target_type, pipeline_mode, lens_name, lenses, role, risk, r
 ### 10. Format Plan
 
 - Produce `{analysis_plan}` as structured output and expose `{analysis_units}` as the ordered execution collection
-- If `{output_path}` is provided, write the human-readable plan as `{analysis_plan}` into `{output_path}`
+- If `{output_path}` is provided, write `{analysis_plan}` into `{output_path}` per [analysis-plan](../resources/analysis-plan.md#template) and its [Rules](../resources/analysis-plan.md#rules)
 - A single-unit `{analysis_units}` array runs one analysis pass; a multi-unit array runs one pass per unit in order
 
 ## Rules

--- a/remediate-vuln/techniques/security-setup/initialize-planning-folder.md
+++ b/remediate-vuln/techniques/security-setup/initialize-planning-folder.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -26,4 +26,4 @@ Planning-folder README seeded from the standard template with the Links table om
 ### 1. Initialize Planning Folder
 
 - Create `{planning_folder_path}` if it does not exist.
-- Write `{planning_readme}` into `{planning_folder_path}` from the standard planning README template, omitting the Links table so no public PR or Issue link appears.
+- Write `{planning_readme}` into `{planning_folder_path}` per [planning-readme](../../../meta/resources/planning-readme.md#template), omitting the Links table so no public PR or Issue link appears.

--- a/requirements-refinement/resources/README.md
+++ b/requirements-refinement/resources/README.md
@@ -2,8 +2,8 @@
 
 > Part of the [Requirements Refinement Workflow](../README.md)
 
-Reference material the techniques draw on: the canonical specification protocol and the templates for
-the analysis report, validation, and change summary.
+Reference material the techniques draw on: the canonical specification protocol, the validation rubric,
+and a creation guide for each artifact a run persists.
 
 | Resource | Contents |
 |----------|----------|
@@ -11,3 +11,18 @@ the analysis report, validation, and change summary.
 | [requirements-analysis-report](requirements-analysis-report.md) | Structure for the analysis of requirement changes derived from a source document |
 | [validation-rubric](validation-rubric.md) | Validation checks and the severity/type categorization that drives routing |
 | [change-summary](change-summary.md) | Structure for the change summary that accompanies a finalized specification |
+| [intake-record](intake-record.md) | Creation guide: `intake.md` |
+| [validation-report](validation-report.md) | Creation guide: `validation-report-{correction_iteration}.md` |
+| [failure-report](failure-report.md) | Creation guide: `failure-report.md` |
+
+## Planning artifact to guide map
+
+| Bare filename | Guide |
+|---------------|-------|
+| `intake.md` | [intake-record](intake-record.md) |
+| `requirements-analysis.md` | [requirements-analysis-report](requirements-analysis-report.md) |
+| `working-spec-{correction_iteration}.md` | [specification-protocol](specification-protocol.md) |
+| `validation-report-{correction_iteration}.md` | [validation-report](validation-report.md) |
+| `final-spec.md` | [specification-protocol](specification-protocol.md) |
+| `change-summary.md` | [change-summary](change-summary.md) |
+| `failure-report.md` | [failure-report](failure-report.md) |

--- a/requirements-refinement/resources/failure-report.md
+++ b/requirements-refinement/resources/failure-report.md
@@ -1,0 +1,26 @@
+# Failure Report
+
+Creation guide for bare filename `failure-report.md`. Written when refinement cannot complete on its own. Answers: what remains unresolved after the correction passes, and what a requirements engineer has to do by hand. This is the run's terminal artifact when it fails, so it stands alone for a reader who never saw the validation reports.
+
+## Template
+
+```markdown
+# Failure Report — {spec basename}
+
+**Verdict:** critical · **Correction passes attempted:** {n}
+
+## Unresolved issues
+
+| ID | Check | Detail | Manual resolution |
+|----|-------|--------|-------------------|
+| V3 | source coverage | one line naming the section and the defect | one line naming what to do |
+
+{One line stating that no specification was promoted.}
+```
+
+## Rules
+
+- **Every unresolved issue carries a resolution.** An issue listed without the manual step it needs leaves the reader where the run stopped.
+- **Issue IDs carry over.** The IDs are the ones the validation reports assigned, so a reader can trace an issue back through the passes; the report links the final validation report rather than restating its findings.
+- **No correction narrative.** Which pass tried what belongs to the validation reports. This report states what is still broken.
+- **Line budget:** ~30 lines.

--- a/requirements-refinement/resources/intake-record.md
+++ b/requirements-refinement/resources/intake-record.md
@@ -1,0 +1,25 @@
+# Intake Record
+
+Creation guide for bare filename `intake.md`. The record of what a refinement run was given: which source, which target specification, how the source was classified, and whether the run augments an existing specification or creates one. Written before any analysis, so a later reader can tell what the run was working from.
+
+## Template
+
+```markdown
+# Intake — {spec basename}
+
+| Field | Value |
+|-------|-------|
+| Source | `{source path}` |
+| Source type | meeting \| document |
+| Target specification | `{target path}` |
+| Mode | augment \| create |
+
+{One line on how the source type was inferred, when the document's form is not obvious.}
+```
+
+## Rules
+
+- **Captured values only.** The record holds what intake captured and classified. Analysis findings, requirement identifiers, and coverage belong to the analysis artifact.
+- **Source type carries its reference form.** A meeting source is referenced downstream as `SRC-MTG###`, a document source as `SRC-DOC###` — see [Source Reference Format](./specification-protocol.md#source-reference-format). State the type; the format stays there.
+- **Mode is the target's existence.** Augment when the target file exists, create when it does not. No narration of what either mode will do next.
+- **Line budget:** ~20 lines.

--- a/requirements-refinement/resources/validation-report.md
+++ b/requirements-refinement/resources/validation-report.md
@@ -1,6 +1,6 @@
 # Validation Report
 
-Creation guide for bare filename `validation-report-{correction_iteration}.md`. One report per correction pass. Answers: did the specification pass, does it cover the source in full, and which issues are blocking versus correctable. The report is what routes the run — to finalize, to another correction pass, or to a failure report.
+Creation guide for bare filename `validation-report-{correction_iteration}.md`. One report per correction pass. Answers: did the specification pass, does it cover the source in full, and which issues are blocking versus correctable.
 
 ## Template
 

--- a/requirements-refinement/resources/validation-report.md
+++ b/requirements-refinement/resources/validation-report.md
@@ -1,0 +1,31 @@
+# Validation Report
+
+Creation guide for bare filename `validation-report-{correction_iteration}.md`. One report per correction pass. Answers: did the specification pass, does it cover the source in full, and which issues are blocking versus correctable. The report is what routes the run — to finalize, to another correction pass, or to a failure report.
+
+## Template
+
+```markdown
+# Validation Report — pass {n}
+
+**Verdict:** passed | correctable | critical · **Source coverage:** complete | incomplete
+
+## Issues
+
+| ID | Check | Category | Detail |
+|----|-------|----------|--------|
+| V1 | identifier uniqueness | critical \| correctable | one line naming the section and the defect |
+
+## Coverage gaps
+
+| Source statement | Why unmapped |
+|------------------|--------------|
+| `SRC-DOC012` | one line |
+```
+
+## Rules
+
+- **Exceptions only.** A pass with no issues carries the verdict line and one line saying every check passed — not a table of passing checks.
+- **Categories come from the rubric.** Each issue's check and its critical-or-correctable category are assigned per [Issue Categorization](./validation-rubric.md#issue-categorization); this template records the assignment.
+- **Every issue carries an ID.** A later correction pass reports against these IDs, so they are stable within the run.
+- **Coverage gaps are omitted when coverage is complete.**
+- **Line budget:** ~40 lines.

--- a/requirements-refinement/techniques/intake-sources.md
+++ b/requirements-refinement/techniques/intake-sources.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.2.0
+  version: 1.3.0
 ---
 
 ## Capability
@@ -63,7 +63,7 @@ Absolute path to the written intake record.
 
 ### 6. Record Intake
 
-- Write `{intake_record}` to `{planning_folder_path}`, capturing `{source_path}`, `{target_doc_path}`, `{source_type}`, `{target_doc_exists}`, and `{spec_basename}`; capture its written location as `{intake_record_path}`.
+- Write `{intake_record}` to `{planning_folder_path}` per [intake-record](../resources/intake-record.md#template), capturing `{source_path}`, `{target_doc_path}`, `{source_type}`, `{target_doc_exists}`, and `{spec_basename}`; capture its written location as `{intake_record_path}`.
 
 ## Rules
 

--- a/requirements-refinement/techniques/report-failure.md
+++ b/requirements-refinement/techniques/report-failure.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.2.0
+  version: 1.3.0
 ---
 
 ## Capability
@@ -43,7 +43,7 @@ Absolute path to the written failure report.
 
 ### 3. Write Failure Report
 
-- Write `{failure_report}` to `{planning_folder_path}`; capture its written location as `{failure_report_path}`.
+- Write `{failure_report}` to `{planning_folder_path}` per [failure-report](../resources/failure-report.md#template) and its [Rules](../resources/failure-report.md#rules); capture its written location as `{failure_report_path}`.
 
 ## Rules
 

--- a/requirements-refinement/techniques/validate-specification.md
+++ b/requirements-refinement/techniques/validate-specification.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.4.0
+  version: 1.5.0
 ---
 
 ## Capability
@@ -67,7 +67,7 @@ Overall verdict — `true` when the specification is conformant and covers the s
 
 ### 4. Compile Verdict
 
-- Write `{validation_report}` to `{planning_folder_path}`, recording the overall verdict (passed, correctable, or critical), the categorized issues, the source-coverage result, and the correction-pass number; capture its written location as `{validation_report_path}`.
+- Write `{validation_report}` to `{planning_folder_path}` per [validation-report](../resources/validation-report.md#template) and its [Rules](../resources/validation-report.md#rules); capture its written location as `{validation_report_path}`.
 
 ### 5. Derive Routing Verdict
 

--- a/substrate-node-security-audit/resources/README.md
+++ b/substrate-node-security-audit/resources/README.md
@@ -20,6 +20,19 @@ Reference content loaded on demand by the workflow's techniques. The authoritati
 | [`target-profile.md`](target-profile.md) | Target-specific crate assignments, file paths, node agent scope split, verification-agent spec, calibration benchmarks, and ensemble blind-spot items |
 | [`vulnerability-pattern-vocabulary.md`](vulnerability-pattern-vocabulary.md) | Known cross-project vulnerability patterns used as a recognition aid during architectural analysis |
 | [`gap-analysis-template.md`](gap-analysis-template.md) | The document skeleton for the gap-analysis report |
+| [`second-pass-findings.md`](second-pass-findings.md) | Creation guide: `second-pass-findings.md` — the blind-spot verdicts, the second-pass findings, and the sub-agent results that attest the pass ran |
+
+---
+
+## Planning artifact to guide map
+
+| Bare filename | Guide |
+|---------------|-------|
+| `START-HERE.md` | [start-here](start-here.md) |
+| `01-audit-report.md` | [audit-prompt-template](audit-prompt-template.md) (§4 Reporting Format) |
+| `02-gap-analysis.md` | [gap-analysis-template](gap-analysis-template.md) |
+| `second-pass-findings.md` | [second-pass-findings](second-pass-findings.md) |
+| `{agent_id}.json`, `s-architectural-analysis.json`, `r-function-registry.json`, `r-crate-map.json`, `r-reconnaissance-data.json`, `m-merge.json`, `dependency-scan.json` | [sub-agent-output-schema](sub-agent-output-schema.md) |
 
 ---
 

--- a/substrate-node-security-audit/resources/second-pass-findings.md
+++ b/substrate-node-security-audit/resources/second-pass-findings.md
@@ -1,0 +1,44 @@
+---
+name: second-pass-findings
+description: Creation guide for bare filename `second-pass-findings.md` — the second independent audit pass over the priority-1/2 components, carrying the blind-spot verdicts and at least one sub-agent result.
+---
+
+# Second Pass Findings Guide
+
+Creation guide for bare filename `second-pass-findings.md`. The artifact is the execution attestation for the second pass: its existence, and the sub-agent result inside it, are what show the pass actually ran. A reader checks two things — was every blind-spot item verified, and did an independent agent apply the checklist.
+
+## Template
+
+```markdown
+# Second Pass Findings
+
+**Scope:** {crates covered} · **Variation:** {different model, temperature, or system prompt} · **Sub-agents:** {n}
+
+## Blind spot verdicts
+
+| Item | Check | Verdict |
+|------|-------|---------|
+| §3.1 | weight accounting | CONFIRMED \| REFUTED \| INSUFFICIENT |
+
+## Findings
+
+| ID | Crate | Severity | Finding | Location |
+|----|-------|----------|---------|----------|
+| SP1 | crate name | High | one line | `path:line` |
+
+## Sub-agent results
+
+| Agent | Scope | Findings |
+|-------|-------|----------|
+| `{agent_id}` | crates covered | {n} |
+
+{When scope was reduced under context pressure: one line naming what was covered and what was not.}
+```
+
+## Rules
+
+- **Every blind-spot item gets a verdict.** The four universal items and every target-specific item carry CONFIRMED, REFUTED, or INSUFFICIENT. An item with no verdict is an unverified item, not a passing one.
+- **At least one sub-agent row.** The pass is not complete without an independent sub-agent result, and the row is where a reader sees it.
+- **Reduced scope is stated, never silent.** A pass scoped to the top files under context pressure records what it covered; a silent reduction reads as full coverage.
+- **Finding IDs are distinct from the first pass.** The `SP` prefix keeps second-pass findings traceable when the two passes are merged.
+- **Line budget:** ~60 lines.

--- a/substrate-node-security-audit/techniques/execute-ensemble-pass.md
+++ b/substrate-node-security-audit/techniques/execute-ensemble-pass.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 > The `§X.Y` identifiers used throughout this technique refer to the audit checklist taxonomy in [§2 Static Analysis Phase](../resources/audit-template-reference.md#2-static-analysis-phase), [§3 Systematic Manual Review Strategies](../resources/audit-template-reference.md#3-systematic-manual-review-strategies) and [§5 Execution Strategy](../resources/audit-template-reference.md#5-execution-strategy).
@@ -38,7 +38,7 @@ Findings from the second independent pass, including at least one sub-agent resu
 
 - Dispatch at least one sub-agent that independently applies the §3 checklist to the priority-1/2 crates, following the same §3 checklist and §5 execution requirements.
   > Under context-window pressure, scope to the top 3-5 files by priority rather than skipping — a reduced-scope pass is always preferable to a skipped one.
-- Record the results into `{second_pass_findings}` and persist it to its declared artifact file.
+- Record the results into `{second_pass_findings}` per [second-pass-findings](../resources/second-pass-findings.md#template) and its [Rules](../resources/second-pass-findings.md#rules), and persist it to its declared artifact file.
 
 ## Rules
 

--- a/work-package/resources/README.md
+++ b/work-package/resources/README.md
@@ -38,3 +38,4 @@ Markdown resources for planning-folder templates, elicitation and review guidanc
 | `assumption-reconciliation` | Assumption Reconciliation | Assumptions-log integration and scorecard formats |
 | `research-reconciliation` | Research Reconciliation | Research-candidate inventory shape, reconcilability statuses, and scorecard format |
 | `pr-review-response` | PR Review Response | Response-format and review-document templates |
+| `prior-feedback-triage` | Prior Feedback Triage | Creation guide: `prior-feedback-triage.md` — the disposition register the rating cap is computed from |

--- a/work-package/resources/README.md
+++ b/work-package/resources/README.md
@@ -39,3 +39,19 @@ Markdown resources for planning-folder templates, elicitation and review guidanc
 | `research-reconciliation` | Research Reconciliation | Research-candidate inventory shape, reconcilability statuses, and scorecard format |
 | `pr-review-response` | PR Review Response | Response-format and review-document templates |
 | `prior-feedback-triage` | Prior Feedback Triage | Creation guide: `prior-feedback-triage.md` — the disposition register the rating cap is computed from |
+
+## Planning artifact to guide map
+
+Where a filename's shape is not stated by a guide that names it. Every other artifact resolves through the guide carrying its name.
+
+| Bare filename | Guide |
+|---------------|-------|
+| `README.md` | [readme](readme.md) pointer to the meta [planning-readme](../../meta/resources/planning-readme.md) Template plus [readme-seed](readme-seed.md) |
+| `architecture-summary.md` | [architecture-summary](architecture-summary.md) |
+| `strategic-review-{n}.md` | [strategic-review](strategic-review.md) |
+| `{codebase_area}.md` | [codebase-comprehension](codebase-comprehension.md) |
+| `{YYYY-MM-DD}-pr{pr_number}-review-analysis.md` | [pr-review-response](pr-review-response.md) |
+| `kb-research.md` | [knowledge-base-research](knowledge-base-research.md) |
+| `design-philosophy.md` | [design-framework](design-framework.md) |
+| `COMPLETE.md` | [complete-wp-guide](complete-wp-guide.md) |
+| `work-package-plan.md` | [wp-plan](wp-plan.md) |

--- a/work-package/resources/prior-feedback-triage.md
+++ b/work-package/resources/prior-feedback-triage.md
@@ -1,0 +1,31 @@
+---
+name: prior-feedback-triage
+description: Creation guide for bare filename `prior-feedback-triage.md` — the register of every prior comment and review on the PR under review, each with its disposition, author class, and blocker class.
+metadata:
+  order: 29
+---
+
+# Prior Feedback Triage Guide
+
+Creation guide for bare filename `prior-feedback-triage.md`. Answers: what did earlier readers already say, which of it still stands, and does any of it cap the verdict. The register carries two columns the posted summary section drops — author class and blocker class — because the rating cap is derived from them.
+
+## Template
+
+```markdown
+# Prior Feedback Triage — PR #{n}
+
+**Threads:** {n} · **Confirmed:** {n} · **Blocker-class confirmed:** {n} · **Rating cap:** request-changes | unset
+
+| # | Finding | Author | Class | Blocker | Reasoning | Disposition |
+|---|---------|--------|-------|---------|-----------|-------------|
+| [1](pr-comment-url) | Storage record never cleared on close | reviewer | human | yes | Clear missing on the governance-close path | Confirmed |
+| [2](pr-comment-url) | Naming nit on handler | bot | bot | no | Name follows the crate convention | Refuted |
+```
+
+## Rules
+
+- **Row shape follows the posted section.** Finding, Author, Reasoning and Disposition carry the same content as [Prior Feedback Triage](./review-mode.md#prior-feedback-triage) in the review comment; this register adds the Class and Blocker columns the cap is computed from.
+- **Every thread is a row.** Confirmed, Refuted, or Superseded, one per prior comment or review thread, human and bot alike. A thread with no row is a thread nobody dispositioned.
+- **The header states the cap.** The cap is a fact of this register, so it is stated once here and read by the summary rather than recomputed.
+- **A reported runtime error is tagged once.** The row carrying it is the single ingest point; later reported-failure triage reads the tag.
+- **Line budget:** ~40 lines. A thread whose reasoning needs a paragraph gets a link to the report section that holds it.

--- a/work-package/techniques/review-existing-feedback.md
+++ b/work-package/techniques/review-existing-feedback.md
@@ -56,7 +56,7 @@ The ceiling the Overall Rating may not exceed, derived from the triage. When any
 
 ### 4. Create the Triage
 
-- Create the `{prior_feedback_triage}` artifact in `{planning_folder_path}` so the consolidated summary renders the triage section and applies the cap.
+- Create the `{prior_feedback_triage}` artifact in `{planning_folder_path}` per [prior-feedback-triage](../resources/prior-feedback-triage.md#template) and its [Rules](../resources/prior-feedback-triage.md#rules).
 
 ## Rules
 

--- a/work-packages/resources/README.md
+++ b/work-packages/resources/README.md
@@ -13,3 +13,15 @@ Markdown resources for initiative planning, package plans, prioritization, and r
 | 04 | `prioritization-framework` | Prioritization Framework | Framework for evaluating and ordering packages |
 | 05 | `roadmap-template` | Roadmap Template | Templates for finalized roadmap documentation |
 | 06 | `workflow-triggering-protocol` | Workflow Triggering Protocol | How to trigger and manage work-package workflow instances |
+| 07 | `priority-ranking` | Priority Ranking | Creation guide: `priority-ranking.md` |
+
+## Planning artifact to guide map
+
+| Bare filename | Guide |
+|---------------|-------|
+| `START-HERE.md` | [planning-folder-template](planning-folder-template.md) + [roadmap-template](roadmap-template.md) |
+| `README.md` | [planning-folder-template](planning-folder-template.md) |
+| `{package_name}-plan.md` | [package-plan-template](package-plan-template.md) |
+| `priority-ranking.md` | [priority-ranking](priority-ranking.md) |
+| `01-COMPLETION-ANALYSIS.md` | [completion-analysis-guide](completion-analysis-guide.md) |
+| `02-CONTEXT-ANALYSIS.md` | [context-analysis-guide](context-analysis-guide.md) |

--- a/work-packages/resources/priority-ranking.md
+++ b/work-packages/resources/priority-ranking.md
@@ -1,0 +1,48 @@
+---
+name: priority-ranking
+description: Creation guide for bare filename `priority-ranking.md` — the execution order of the roadmap's work packages, with the value, risk and effort assessment behind each position.
+metadata:
+  order: 7
+---
+
+# Priority Ranking Guide
+
+Creation guide for bare filename `priority-ranking.md`. The reader is choosing what to start. The document answers: in what order, why that order, what can run in parallel, and what else would have been valid.
+
+## Template
+
+````markdown
+# Priority Ranking
+
+**Packages:** {n} · **Layers:** {n} · **Parallel groups:** {n}
+
+| # | Package | Value | Risk | Effort | Rationale |
+|---|---------|-------|------|--------|-----------|
+| 1 | [package name](package-plan.md) | High | Low | Medium | one line |
+
+## Dependencies
+
+```mermaid
+graph LR
+  A[package] --> B[package]
+```
+
+## Parallel
+
+| Group | Packages |
+|-------|----------|
+| 1 | package, package |
+
+## Alternatives
+
+{One line per other valid sequence and what would make it the better choice. Omit when the dependency graph admits one order.}
+````
+
+## Rules
+
+- **Every package is a row, in execution order.** The row index is the position; a package with no row has no agreed place in the sequence.
+- **Rationale is one line.** It says what put the package at this position — the dependency, the value-to-effort ratio, or the risk that argues for going early.
+- **Assessments come from the framework.** High, Medium and Low on value, risk and effort are assigned per the [evaluation criteria](./prioritization-framework.md#step-2-evaluation-criteria); this template records the assignment.
+- **A dependency cycle is recorded, not ordered around.** Name the cycle and its packages, and state the extraction or removal that breaks it.
+- **The order is a recommendation.** The user decides the final order; the document does not assert one was chosen.
+- **Line budget:** ~50 lines.

--- a/work-packages/techniques/prioritize-packages.md
+++ b/work-packages/techniques/prioritize-packages.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 ## Capability
@@ -58,7 +58,7 @@ Per-package rationale for the ordering, with the value, risk, and effort assessm
 
 - Apply priority ordering rules: dependency-first, then high-value/low-effort, then high-risk-early
 - Identify packages that could be parallelized (independent, no shared resources)
-- Write `{priority_order}` as the ranking document: the priority table with package, value, risk, effort, and rationale, the dependency graph as text or a mermaid diagram, and any alternative valid sequences
+- Write `{priority_order}` as the ranking document per [priority-ranking](../resources/priority-ranking.md#template) and its [Rules](../resources/priority-ranking.md#rules)
 - If all packages evaluate identically on every criterion, ask the user which dimension matters most for their context to break the tie
 
 ## Rules

--- a/workflow-design/techniques/context-loading.md
+++ b/workflow-design/techniques/context-loading.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.4.0
+  version: 1.5.0
 ---
 
 ## Capability
@@ -59,10 +59,10 @@ Absolute path to the written applicable-constructs artifact (create mode only).
 
 ### 6. Persist Format Conventions
 
-- When `{operation_type}` is `create` and `{planning_folder_path}` is bound: persist a concise format-conventions summary (YAML syntax rules and observed project conventions — naming, folder structure, field ordering, versions, transition and checkpoint shapes) via the calling activity's bound `manage-artifacts::write-artifact` step with *target_dir* `{planning_folder_path}` and bare filename `format-conventions.md`; capture `{format_conventions_path}`
+- When `{operation_type}` is `create` and `{planning_folder_path}` is bound: persist the format-conventions summary per [format-conventions](../resources/format-conventions.md#template) and its [Rules](../resources/format-conventions.md#rules), via the calling activity's bound `manage-artifacts::write-artifact` step with *target_dir* `{planning_folder_path}` and bare filename `format-conventions.md`; capture `{format_conventions_path}`
 - Skip when `{operation_type}` is `update` or `review`
 
 ### 7. Persist Applicable Constructs
 
-- When `{operation_type}` is `create` and `{planning_folder_path}` is bound: persist the applicable-constructs list (construct name, why it applies, reference example) via the calling activity's bound `manage-artifacts::write-artifact` step with *target_dir* `{planning_folder_path}` and bare filename `applicable-constructs.md`; capture `{applicable_constructs_path}`
+- When `{operation_type}` is `create` and `{planning_folder_path}` is bound: persist the applicable-constructs list per [applicable-constructs](../resources/applicable-constructs.md#template) and its [Rules](../resources/applicable-constructs.md#rules), via the calling activity's bound `manage-artifacts::write-artifact` step with *target_dir* `{planning_folder_path}` and bare filename `applicable-constructs.md`; capture `{applicable_constructs_path}`
 - Skip when `{operation_type}` is `update` or `review`


### PR DESCRIPTION
## Summary

Ten artifacts were persisted with their layout invented in the producing technique's protocol prose, and one — the prism analysis plan — with no layout stated anywhere at all ("write the human-readable plan", and nothing more). The design canon already requires the opposite: every artifact a workflow persists has a creation-guide resource with a template and the rules that populate it, and the persist technique cites that template rather than inventing sections. This work writes those guides, closes two sites where the guide already existed and the technique simply failed to link it, and adds the filename-to-guide map each affected workflow was missing.

## The guides

Each carries a `## Template`, `## Rules`, and a line budget, following the shape the existing workflow-design guides established.

| Artifact | New guide |
|---|---|
| `analysis-plan.md` | `prism/resources/analysis-plan.md` |
| `prior-feedback-triage.md` | `work-package/resources/prior-feedback-triage.md` |
| `intake.md` | `requirements-refinement/resources/intake-record.md` |
| `validation-report-{correction_iteration}.md` | `requirements-refinement/resources/validation-report.md` |
| `failure-report.md` | `requirements-refinement/resources/failure-report.md` |
| `index.md`, `log.md` | `codebase-wiki/resources/index-and-log.md` |
| `findings-register.md` | `midnight-system-review/resources/findings-register.md` |
| `publication-record.md` | `midnight-system-review/resources/publication-record.md` |
| `priority-ranking.md` | `work-packages/resources/priority-ranking.md` |
| `second-pass-findings.md` | `substrate-node-security-audit/resources/second-pass-findings.md` |

The wiki index and log share one guide with two templates, because the pair is written by the same mutation and neither is meaningful without the other. The prior-feedback triage guide adds only what the register needs beyond the review comment's own table shape — the author-class and blocker-class columns the rating cap is computed from — and cites the shared shape for the rest.

## The wiring gaps

The workflow-design format-conventions and applicable-constructs guides already existed with templates and budgets, and the persist steps described the content in prose instead of citing them. Remediate-vuln named "the standard planning README template" with no link. Three cites.

## The filename-to-guide map

Two workflows carried an authored map from a filename to its guide; the rest left the resolution to a search. Every workflow touched here now carries a `## Planning artifact to guide map` section, and cicd-pipeline-security-audit gains the resources README it lacked entirely. In prism the map states the rule rather than inventing guides: a per-lens analysis artifact takes its shape from the lens the unit runs, and the map names each filename against the lens resource that shapes it.

The workflow-design heading now reads "to" rather than an arrow, so every workflow's map answers to the same anchor.

## Scope of change

Ten new guide resources, one new resources README, seven resource-index and map edits, twelve technique cites.

## Acceptance

- [x] Every artifact whose shape was prescribed nowhere now has a guide with a template, rules, and a budget.
- [x] Every persist step cites its guide instead of laying out sections in protocol prose.
- [x] Both wiring gaps resolve to the guide that already existed.
- [x] All 22 guards pass, including anchor and reference resolution.

## Non-goals

- Artifacts whose shape is prescribed inline in protocol prose rather than nowhere. That is a different and larger class; the enforcement work item counts it and triages it rather than leaving it invisible.
- Lens prompts. A prism analysis artifact's shape belongs to its lens, and inventing a guide per lens would duplicate it.

Part of #403 (W4). Stacked on #422.
