### PR TITLE
Plain language: author, rewrite, and audit documents against ISO 24495-1

### DIFF
--- a/plain-language/README.md
+++ b/plain-language/README.md
@@ -1,0 +1,88 @@
+# Plain Language Workflow
+
+> v1.0.0 — Author, rewrite, or audit a document so its readers can find what they need, understand what they find, and use it. Applies the four principles and guidelines of [ISO 24495-1](./resources/plain-language-standard.md), with an optional [ASD-STE100](./resources/asd-ste100.md) controlled-language overlay for technical documentation. `{headless_mode}` defaults to true, and a checkpoint declaring neither a default option nor an auto-advance interval always waits for a person.
+
+---
+
+## Overview
+
+Activity `#` columns match the on-disk `NN-` file prefixes; the prefix is server-computed from the filename and orders both activities and the artifacts they produce, so gaps are intentional and renumbering is not free.
+
+| # | Activity | Mode | Purpose |
+|---|----------|------|---------|
+| 01 | [**Intake and Profile**](./activities/README.md#01-intake-and-profile) | All | Classify author/rewrite/audit, settle the reader profile and content selection, persist the document profile |
+| 02 | [**Source Analysis**](./activities/README.md#02-source-analysis) | Rewrite, Audit | Audit the existing document against the principles; record findings and strengths |
+| 03 | [**Draft**](./activities/README.md#03-draft) | Author, Rewrite | Produce the plain-language document for its readers |
+| 04 | [**Evaluate**](./activities/README.md#04-evaluate) | Author, Rewrite | Evaluate against the four principles, revise while issues remain, complete the ISO checklist |
+| 05 | [**Deliver**](./activities/README.md#05-deliver) | Author, Rewrite | Write the document to its output path with its conformance record |
+
+**Detailed documentation:**
+
+- **Activities:** [activities/README.md](./activities/README.md) — the per-activity orientation map, linking the authoritative YAML.
+- **Techniques:** [techniques/README.md](./techniques/README.md) — the local operation group and the shared operations this workflow binds.
+- **Resources:** [resources/README.md](./resources/README.md) — the criteria home, the controlled-language overlay, and the creation guides.
+
+---
+
+## Modes
+
+| Mode | Activation | Description |
+|------|------------|-------------|
+| **Author** | "write", "draft", "create a document" | Build a new plain-language document from a description of its readers and purpose |
+| **Rewrite** | "rewrite", "make this plain", "simplify" | Rework an existing document, fixing recorded findings and preserving strengths |
+| **Audit** | "review", "audit", "check this document" | Assess an existing document against the principles and report where it fails its readers |
+
+`{operation_type}` is the sole mode state. Source analysis runs only in rewrite and audit modes; drafting, evaluation, and delivery run only in author and rewrite modes; an audit run closes on its source analysis.
+
+`{controlled_language}` is an independent overlay flag, not a mode. When true, the [ASD-STE100](./resources/asd-ste100.md) writing rules and approved-word discipline layer over the ISO base for technical documentation.
+
+---
+
+## Criteria
+
+The governing criteria this workflow applies — the four principles and guidelines of ISO 24495-1 — live in [plain-language-standard](./resources/plain-language-standard.md), cited by section rather than restated. The ASD-STE100 controlled-language overlay lives in [asd-ste100](./resources/asd-ste100.md). See [resources/README.md](./resources/README.md#criteria-homes).
+
+---
+
+## Outputs
+
+The workflow seeds a **planning folder** under `.engineering/artifacts/planning/`: a `README.md` from the universal [planning-readme](../meta/resources/planning-readme.md) Template under this workflow's [readme-seed](./resources/readme-seed.md) profile, plus the working artifacts each activity persists via [`work-package::manage-artifacts::write-artifact`](../work-package/techniques/manage-artifacts/write-artifact.md).
+
+**Author and rewrite modes:** a document profile, the plain-language document (also written to `{output_path}`), an evaluation report, and a completed ISO checklist. A rewrite run adds a source analysis.
+
+**Audit mode:** the source analysis is the run's terminal record. No document is authored, no checklist is completed, and nothing is delivered — the run reports where the existing document fails its readers.
+
+---
+
+## File Structure
+
+```
+workflows/plain-language/
+├── workflow.yaml                           # Workflow definition (variables, rules, inherited techniques)
+├── README.md                               # This file
+├── activities/
+│   ├── README.md                           # Per-activity orientation map
+│   ├── 01-intake-and-profile.yaml          # Classify mode, settle reader profile, persist document profile
+│   ├── 02-source-analysis.yaml             # Audit the existing document, record findings and strengths
+│   ├── 03-draft.yaml                       # Produce the plain-language document
+│   ├── 04-evaluate.yaml                    # Evaluate, revise loop, complete the ISO checklist
+│   └── 05-deliver.yaml                     # Write the document to its output path
+├── techniques/
+│   ├── README.md                           # Technique orientation map
+│   └── plain-language/                     # Local operation group — cross-workflow addressable
+│       ├── TECHNIQUE.md                    # Group contract
+│       ├── intake-and-profile.md
+│       ├── analyze-source.md
+│       ├── draft-document.md
+│       ├── evaluate-document.md
+│       └── complete-checklist.md
+└── resources/
+    ├── README.md                           # Resource index and artifact-to-guide map
+    ├── plain-language-standard.md          # ISO 24495-1 criteria home, section-delivered
+    ├── asd-ste100.md                       # ASD-STE100 controlled-language overlay
+    ├── document-profile.md                 # Creation guide
+    ├── source-analysis.md                  # Creation guide
+    ├── evaluation-report.md                # Creation guide
+    ├── iso-checklist.md                    # Creation guide
+    └── readme-seed.md                      # Progress inventory and mode map for the planning README
+```

--- a/plain-language/activities/01-intake-and-profile.yaml
+++ b/plain-language/activities/01-intake-and-profile.yaml
@@ -1,0 +1,107 @@
+id: intake-and-profile
+version: 1.0.0
+name: Intake and Profile
+description: "Classify the request as author, rewrite or audit, settle the reader profile and content selection, and persist the document profile the rest of the run is built on."
+required: true
+steps:
+  - kind: action
+    id: bind-planning-folder-path
+    actions:
+      - action: set
+        target: planning_folder_path
+        message: Absolute planning folder this session writes its working artifacts into, as reported in the server session summary.
+  - kind: technique
+    id: intake-and-profile
+    technique: plain-language::intake-and-profile
+  - kind: checkpoint
+    id: intent-and-profile-batch
+    condition:
+      type: simple
+      variable: intent_needs_confirmation
+      operator: ==
+      value: true
+    message: "Plain-language intent needs confirmation — classified `{operation_type}` for `{document_title}` (controlled language: {controlled_language})."
+    blocking: true
+    options:
+      - id: confirm
+        label: Confirm intent and profile
+        description: Accept the classified operation and the settled reader profile as stated.
+        effect:
+          setVariable:
+            intent_needs_confirmation: false
+            document_profile_confirmed: true
+      - id: confirm-author
+        label: Author a new document
+        description: Correct the classification to author mode.
+        effect:
+          setVariable:
+            operation_type: author
+            operation_type_ambiguous: false
+            intent_needs_confirmation: false
+            document_profile_confirmed: true
+      - id: confirm-rewrite
+        label: Rewrite an existing document
+        description: Correct the classification to rewrite mode.
+        effect:
+          setVariable:
+            operation_type: rewrite
+            operation_type_ambiguous: false
+            intent_needs_confirmation: false
+            document_profile_confirmed: true
+      - id: confirm-audit
+        label: Audit an existing document
+        description: Correct the classification to audit mode.
+        effect:
+          setVariable:
+            operation_type: audit
+            operation_type_ambiguous: false
+            intent_needs_confirmation: false
+            document_profile_confirmed: true
+  - kind: action
+    id: settle-profile-when-clear
+    condition:
+      type: simple
+      variable: intent_needs_confirmation
+      operator: ==
+      value: false
+    actions:
+      - action: set
+        target: document_profile_confirmed
+        value: true
+  - kind: technique
+    id: persist-document-profile
+    technique:
+      name: work-package::manage-artifacts::write-artifact
+      inputs:
+        bare_filename: document-profile.md
+        artifact_content: document_profile
+        target_dir: planning_folder_path
+      outputs:
+        written_artifact: document_profile_path
+  - kind: technique
+    id: seed-planning-readme
+    technique:
+      name: workflow-engine::create-readme
+      inputs:
+        entity_context: "entity_title={document_title}; entity_type={operation_type}; status=Profiling"
+        seed_profile: plain-language/readme-seed
+        operation_type: operation_type
+transitions:
+  - to: source-analysis
+    condition:
+      type: or
+      conditions:
+        - type: simple
+          variable: operation_type
+          operator: ==
+          value: rewrite
+        - type: simple
+          variable: operation_type
+          operator: ==
+          value: audit
+  - to: draft
+    isDefault: true
+outcome:
+  - The run carries a classified operation type and a confirmed reader profile, so every later drafting and evaluation decision branches on settled state rather than re-reading the request
+  - The document profile is persisted, giving the drafting and evaluation passes a single canonical record of who the document is for and what it must carry
+  - A controlled-language overlay is declared up front, so technical documentation is held to ASD-STE100 from the first draft rather than retrofitted

--- a/plain-language/activities/02-source-analysis.yaml
+++ b/plain-language/activities/02-source-analysis.yaml
@@ -1,0 +1,50 @@
+id: source-analysis
+version: 1.0.0
+name: Source Analysis
+description: "Audit the existing document against the principles and persist the findings and strengths a rewrite works from, or an audit run reports."
+required: false
+steps:
+  - kind: technique
+    id: analyze-source
+    technique: plain-language::analyze-source
+  - kind: technique
+    id: persist-source-analysis
+    technique:
+      name: work-package::manage-artifacts::write-artifact
+      inputs:
+        bare_filename: source-analysis.md
+        artifact_content: source_analysis
+        target_dir: planning_folder_path
+      outputs:
+        written_artifact: source_analysis_path
+  - kind: checkpoint
+    id: analysis-reviewed
+    condition:
+      type: simple
+      variable: operation_type
+      operator: ==
+      value: audit
+    message: "{finding_count} plain-language findings recorded against `{document_title}` ([source analysis]({source_analysis_path}))."
+    blocking: false
+    defaultOption: accepted
+    autoAdvanceMs: 30000
+    options:
+      - id: accepted
+        label: Accepted
+        description: The findings accurately record where the document fails its readers.
+      - id: revise
+        label: Needs revision
+        description: The findings miss failures or misstate the guidelines they cite.
+transitions:
+  - to: __terminal__
+    condition:
+      type: simple
+      variable: operation_type
+      operator: ==
+      value: audit
+  - to: draft
+    isDefault: true
+outcome:
+  - The existing document's failures are recorded against the guidelines they breach, so a rewrite fixes named problems rather than restyling on taste
+  - The document's strengths are inventoried, so a rewrite preserves what already works for its readers
+  - An audit run closes on the analysis as its terminal record, authoring no document

--- a/plain-language/activities/03-draft.yaml
+++ b/plain-language/activities/03-draft.yaml
@@ -1,0 +1,41 @@
+id: draft
+version: 1.0.0
+name: Draft
+description: "Produce the plain-language document — fresh on an author run, reworked from the source analysis on a rewrite run — structured and worded for its readers."
+required: false
+steps:
+  - kind: technique
+    id: draft-document
+    technique: plain-language::draft-document
+  - kind: technique
+    id: persist-plain-document
+    technique:
+      name: work-package::manage-artifacts::write-artifact
+      inputs:
+        bare_filename: plain-document.md
+        artifact_content: document_draft
+        target_dir: planning_folder_path
+      outputs:
+        written_artifact: document_path
+  - kind: checkpoint
+    id: draft-reviewed
+    message: "Draft of `{document_title}` ready for evaluation ([draft]({document_path}))."
+    blocking: false
+    defaultOption: confirmed
+    autoAdvanceMs: 30000
+    options:
+      - id: confirmed
+        label: Ready for evaluation
+        description: The draft is structured and worded for its readers and can be evaluated.
+        effect:
+          setVariable:
+            draft_confirmed: true
+      - id: revise
+        label: Keep drafting
+        description: The draft needs more work before it is evaluated.
+transitions:
+  - to: evaluate
+    isDefault: true
+outcome:
+  - The document is drafted or rewritten for its readers — structured for findability, worded for understandability, and held to ASD-STE100 when the controlled-language overlay is on
+  - A rewrite fixes the recorded findings and preserves the inventoried strengths rather than restyling on taste

--- a/plain-language/activities/04-evaluate.yaml
+++ b/plain-language/activities/04-evaluate.yaml
@@ -1,0 +1,109 @@
+id: evaluate
+version: 1.0.0
+name: Evaluate
+description: "Evaluate the draft against the four principles as its reader would, revise while issues remain, and complete the ISO checklist once every principle is met."
+required: false
+steps:
+  - kind: loop
+    id: evaluate-revise-loop
+    name: Evaluate and Revise Loop
+    loopType: doWhile
+    maxIterations: 5
+    condition:
+      type: simple
+      variable: needs_revision
+      operator: ==
+      value: true
+    steps:
+      - kind: technique
+        id: evaluate-document
+        technique: plain-language::evaluate-document
+      - kind: technique
+        id: persist-evaluation-report
+        technique:
+          name: work-package::manage-artifacts::write-artifact
+          inputs:
+            bare_filename: evaluation-report.md
+            artifact_content: evaluation_report
+            target_dir: planning_folder_path
+          outputs:
+            written_artifact: evaluation_report_path
+      - kind: checkpoint
+        id: evaluation-reviewed
+        message: "Round {revision_round}: {open_issue_count} open issues against `{document_title}` ([evaluation report]({evaluation_report_path}))."
+        blocking: false
+        defaultOption: revise
+        autoAdvanceMs: 30000
+        options:
+          - id: revise
+            label: Revise and re-evaluate
+            description: Apply the open fixes and run another evaluation round.
+            effect:
+              setVariable:
+                needs_revision: true
+          - id: accept
+            label: Accept with open issues
+            description: Close the loop, accepting the remaining open issues as recorded.
+            effect:
+              setVariable:
+                needs_revision: false
+      - kind: technique
+        id: revise-document
+        technique: plain-language::draft-document
+        condition:
+          type: simple
+          variable: needs_revision
+          operator: ==
+          value: true
+      - kind: action
+        id: count-revision-round
+        condition:
+          type: simple
+          variable: needs_revision
+          operator: ==
+          value: true
+        actions:
+          - action: set
+            target: revision_round
+            message: Increment the revision round by one.
+  - kind: technique
+    id: complete-checklist
+    technique: plain-language::complete-checklist
+  - kind: technique
+    id: persist-iso-checklist
+    technique:
+      name: work-package::manage-artifacts::write-artifact
+      inputs:
+        bare_filename: iso-checklist.md
+        artifact_content: iso_checklist
+        target_dir: planning_folder_path
+      outputs:
+        written_artifact: checklist_path
+  - kind: checkpoint
+    id: evaluation-gate
+    condition:
+      type: simple
+      variable: open_issue_count
+      operator: ">"
+      value: 0
+    message: "{open_issue_count} open issues remain after the final evaluation round ([evaluation report]({evaluation_report_path}), [ISO checklist]({checklist_path}))."
+    blocking: true
+    options:
+      - id: deliver-with-issues
+        label: Deliver with recorded issues
+        description: Accept the remaining open issues and proceed to delivery.
+        effect:
+          setVariable:
+            needs_revision: false
+      - id: revise-again
+        label: Return to drafting
+        description: Re-enter drafting to resolve the remaining issues before delivery.
+        effect:
+          transitionTo: draft
+transitions:
+  - to: deliver
+    isDefault: true
+outcome:
+  - The draft is evaluated against all four principles as its reader would experience it, the only way to know it works rather than assume it
+  - Revision repeats while issues remain, so the delivered document meets the principles rather than stopping at the first draft
+  - The completed ISO checklist travels with the document as its conformance record

--- a/plain-language/activities/05-deliver.yaml
+++ b/plain-language/activities/05-deliver.yaml
@@ -1,0 +1,26 @@
+id: deliver
+version: 1.0.0
+name: Deliver
+description: "Write the evaluated plain-language document to its output path with its completed ISO checklist, and close the run."
+required: false
+steps:
+  - kind: technique
+    id: deliver-document
+    technique:
+      name: work-package::manage-artifacts::write-artifact
+      inputs:
+        bare_filename: plain-document.md
+        artifact_content: document_draft
+        target_dir: output_path
+      outputs:
+        written_artifact: document_path
+  - kind: action
+    id: announce-delivery
+    actions:
+      - action: message
+        message: "Delivered `{document_title}` to [{output_path}]({document_path}) — {open_issue_count} open issues recorded ([evaluation report]({evaluation_report_path}), [ISO checklist]({checklist_path}))."
+transitions:
+  - to: __terminal__
+    isDefault: true
+outcome:
+  - The plain-language document is written to its output path, with its evaluation report and completed ISO checklist as the conformance record

--- a/plain-language/activities/README.md
+++ b/plain-language/activities/README.md
@@ -1,0 +1,47 @@
+# Plain Language Activities
+
+> Part of the [Plain Language Workflow](../README.md)
+
+Heading numbers match the on-disk `NN-` file prefixes. Prefixes are sparse by design: they are the server-computed artifact prefix and the activity sort key, so a gap costs nothing and a renumber renames artifacts.
+
+This file is an orientation map. Authoritative definitions live in the per-activity YAML linked from each section below.
+
+---
+
+### 01. Intake and Profile
+
+Classifies the request as author, rewrite or audit, settles the reader profile and content selection the run is built on, and persists the document profile. The intake gate fires only when intent or the profile cannot be settled from the request; a clear request flows straight through. Seeds the planning-folder README.
+
+Definition: [`01-intake-and-profile.yaml`](./01-intake-and-profile.yaml). Leads to [Source Analysis](#02-source-analysis) on a rewrite or audit run, otherwise to [Draft](#03-draft).
+
+---
+
+### 02. Source Analysis
+
+Runs only on a rewrite or audit run. Audits the existing document against the four principles, records each failure against the guideline it breaches, and inventories the strengths a rewrite must preserve. An audit run closes here on the analysis as its terminal record; a rewrite run carries the analysis into drafting.
+
+Definition: [`02-source-analysis.yaml`](./02-source-analysis.yaml). Terminal on an audit run; otherwise leads to [Draft](#03-draft).
+
+---
+
+### 03. Draft
+
+Runs on an author or rewrite run. Produces the plain-language document — fresh from the profile on an author run, reworked from the source analysis on a rewrite run — structured for findability, worded for understandability, and held to ASD-STE100 when the controlled-language overlay is on. A soft gate confirms the draft is ready for evaluation.
+
+Definition: [`03-draft.yaml`](./03-draft.yaml). Leads to [Evaluate](#04-evaluate).
+
+---
+
+### 04. Evaluate
+
+Runs on an author or rewrite run. Evaluates the draft against all four principles as its reader would, revises while open issues remain, and completes the ISO checklist once every principle is met. A blocking gate fires only when issues remain after the final round, so the operator decides whether to deliver with recorded issues or return to drafting.
+
+Definition: [`04-evaluate.yaml`](./04-evaluate.yaml). Leads to [Deliver](#05-deliver).
+
+---
+
+### 05. Deliver
+
+Terminal on an author or rewrite run. Writes the evaluated document to its output path and announces delivery with its evaluation report and completed ISO checklist as the conformance record.
+
+Definition: [`05-deliver.yaml`](./05-deliver.yaml). Terminal.

--- a/plain-language/resources/README.md
+++ b/plain-language/resources/README.md
@@ -1,0 +1,62 @@
+# Plain Language Resources
+
+> Part of the [Plain Language Workflow](../README.md)
+
+The **criteria home** for the plain-language standard, the controlled-language overlay, and **creation guides** — Template plus Rules — for every artifact this workflow persists.
+
+---
+
+## Resource index
+
+| Resource | Purpose |
+|----------|---------|
+| [Plain Language Standard](plain-language-standard.md) | ISO 24495-1 principles and guidelines, section-delivered — the criteria home |
+| [ASD-STE100](asd-ste100.md) | Controlled-language overlay for technical documentation |
+| [Document Profile](document-profile.md) | Creation guide: `document-profile.md` |
+| [Source Analysis](source-analysis.md) | Creation guide: `source-analysis.md` |
+| [Evaluation Report](evaluation-report.md) | Creation guide: `evaluation-report.md` |
+| [ISO Checklist](iso-checklist.md) | Creation guide: `iso-checklist.md` |
+| [README Seed](readme-seed.md) | Progress inventory, classifier and mode-exclusion map for the planning-folder `README.md` |
+
+---
+
+## Planning artifact to guide map
+
+Every bare filename this workflow persists maps to a guide that owns its Template.
+
+| Bare filename | Guide |
+|---------------|-------|
+| `README.md` | [planning-readme](../../meta/resources/planning-readme.md) Template plus [readme-seed](readme-seed.md) |
+| `document-profile.md` | [document-profile](document-profile.md) |
+| `source-analysis.md` | [source-analysis](source-analysis.md) |
+| `evaluation-report.md` | [evaluation-report](evaluation-report.md) |
+| `iso-checklist.md` | [iso-checklist](iso-checklist.md) |
+| `plain-document.md` | The delivered document itself — no creation guide; it is the run's product, not a planning artifact |
+
+Layout authority lives in the guide, not in the protocol of the operation that persists the file.
+
+---
+
+## Criteria homes
+
+The governing criteria live here, cited by section rather than restated:
+
+- [Plain Language Standard](plain-language-standard.md) — the four principles and guidelines of ISO 24495-1, split for section delivery: [Principles](plain-language-standard.md#principles), [Relevance](plain-language-standard.md#relevance), [Findability](plain-language-standard.md#findability), [Understandability](plain-language-standard.md#understandability), [Usability](plain-language-standard.md#usability)
+- [ASD-STE100](asd-ste100.md) — the controlled-language overlay: [When It Applies](asd-ste100.md#when-it-applies), [Writing Rules](asd-ste100.md#writing-rules), [Procedure and Description](asd-ste100.md#procedure-and-description), [Approved Words](asd-ste100.md#approved-words)
+
+Techniques cite the section that governs their work; they do not restate the guidelines.
+
+---
+
+## Cross-workflow access
+
+Other workflows may consult this workflow's resources and bind its operations by id:
+
+- `plain-language/plain-language-standard`
+- `plain-language/asd-ste100`
+- `plain-language/document-profile`
+- `plain-language/source-analysis`
+- `plain-language/evaluation-report`
+- `plain-language/iso-checklist`
+
+Operations bind as `plain-language::<operation>` — for example `plain-language::evaluate-document` to run an evaluation from another workflow.

--- a/plain-language/resources/asd-ste100.md
+++ b/plain-language/resources/asd-ste100.md
@@ -1,0 +1,42 @@
+---
+name: asd-ste100
+description: The ASD-STE100 Simplified Technical English controlled-language overlay — writing rules and approved-word discipline layered over the ISO 24495-1 base for technical documentation.
+metadata:
+  order: 1
+---
+
+# ASD-STE100 Overlay
+
+ASD-STE100 Simplified Technical English (STE) is a controlled natural language and international standard for clear, consistent, and safe technical documentation. It has two parts: a set of writing rules covering grammar, sentence structure, and style, and a controlled dictionary of approved words, each with one meaning and one part of speech.
+
+STE is an **overlay**, not a replacement. It applies only when the document is technical documentation and the `controlled_language` mode is on. The ISO 24495-1 base still governs relevance, findability, and evaluation; STE tightens understandability for readers who may have only a basic command of English. Where STE and the ISO base conflict, STE's stricter rule wins for the sentence and word level, and the ISO base still governs structure, audience fit, and evaluation.
+
+## When It Applies
+
+Apply STE when the document is a procedure or a description in a technical domain — maintenance instructions, operating manuals, safety information, engineering or industrial documentation — and readers include non-native English speakers or readers for whom ambiguity carries a safety or cost consequence. Do not apply it to general-audience prose where its restrictions would read as stilted without adding safety.
+
+## Writing Rules
+
+STE's writing rules (Part 1) tighten the ISO understandability guidelines for technical text:
+
+- **Approved verb forms only.** Make only the infinitive, the imperative, the simple present, the simple past, the simple future, and the past participle used as an adjective. Do not use "-ing" verb forms.
+- **One meaning, one part of speech.** Use each approved word only in its approved meaning and part of speech. Where the dictionary gives no approved meaning, do not use the word in that meaning — use an approved alternative.
+- **Active voice and short sentences.** Keep sentences short and direct. In procedures, one instruction per sentence, in the imperative, in the order the reader performs them.
+- **Approved vocabulary.** Use only approved words from the dictionary for the general vocabulary. Use technical nouns and technical verbs for subject-specific terminology, and use them consistently and correctly.
+- **Choose one synonym.** Where English offers synonyms, STE selects one and excludes the others (for example, "start", not "begin", "commence", "initiate", or "originate").
+- **American English spelling.** Approved spellings follow American English and Merriam-Webster.
+
+## Procedure and Description
+
+STE distinguishes two text types and rules each differently:
+
+- **Procedures** tell the reader how to do a task. Use the imperative, one action per step, warnings and cautions before the step they guard, and the chronological order of the work.
+- **Descriptions** tell the reader what something is or how it works. Use the simple present, the active voice, and short declarative sentences.
+
+Classify the document (or each section of it) as procedure or description before drafting, and apply the matching rules.
+
+## Approved Words
+
+The dictionary (Part 2) holds roughly 900 approved words, each approved with one meaning and one part of speech, and lists roughly 1200 unapproved words with approved alternatives. Approved words are written in uppercase in the dictionary; unapproved words in lowercase with their suggested replacements. Writers extend the general vocabulary with technical nouns and technical verbs specific to their field, used per the rules for those terms.
+
+Because the full dictionary is a licensed, versioned artifact, this overlay records the *discipline* — one approved meaning, one part of speech, an approved alternative for every unapproved word — rather than the word list. A run that needs the authoritative list consults the current ASD-STE100 issue.

--- a/plain-language/resources/document-profile.md
+++ b/plain-language/resources/document-profile.md
@@ -1,0 +1,41 @@
+---
+name: document-profile
+description: Creation guide for the document-profile artifact — the settled reader, purpose, context, document type, and content selection a plain-language run is built on.
+metadata:
+  order: 2
+---
+
+# Document Profile Guide
+
+The pre-writing decision surface for a plain-language run. Answers: who reads this, why, in what context, as what kind of document, and carrying what content? Canonical home for the reader profile and the content selection.
+
+## Template
+
+~~~~markdown
+# Document Profile — {document title}
+
+**Operation:** Author | Rewrite | Audit · **Document type:** {type} · **Controlled language:** on | off
+
+## Readers
+
+[Who reads this document: their language proficiency, subject knowledge, cultural background, accessibility needs, and the languages they understand.]
+
+## Purpose
+
+[Why the readers read this document — what they are trying to do, decide, or understand.]
+
+## Context
+
+[Where they read it, the technology they use, the time they have, their interest and emotional state.]
+
+## Content selection
+
+[The questions readers need answered and the content selected to answer them. Note anything deliberately left out as not needed by readers.]
+~~~~
+
+## Rules
+
+- **The reader comes first.** Every entry is written about the readers and their needs, not the author's goals. Where the two conflict, the primary audience wins.
+- **Settle, don't invent.** A profile gap the request does not settle is an open question for the intake gate, not a plausible default filled in silently.
+- **Content selection is ethical.** Selected content is accurate, not false or misleading, and does not hide what readers need to know.
+- **One profile per document.** A document aimed at several audiences names the primary audience and records how each audience's information is distinguished.

--- a/plain-language/resources/evaluation-report.md
+++ b/plain-language/resources/evaluation-report.md
@@ -1,0 +1,42 @@
+---
+name: evaluation-report
+description: Creation guide for the evaluation-report artifact — the structured result of evaluating a draft against the four principles, with the open issues that drive revision.
+metadata:
+  order: 4
+---
+
+# Evaluation Report Guide
+
+The evaluation decision surface. Answers: does the draft meet the principles, and where does it still fail its readers? Canonical home for the per-principle verdict and the open-issue list that gates delivery.
+
+## Template
+
+~~~~markdown
+# Evaluation Report — {document title}
+
+**Round:** {n} · **Open issues:** {count}
+
+[One line: the overall verdict on this draft.]
+
+## Verdict by principle
+
+|| Principle | Verdict | Basis |
+||-----------|---------|-------|
+|| Relevant | met / open | [why] |
+|| Findable | met / open | [why] |
+|| Understandable | met / open | [why] |
+|| Usable | met / open | [why] |
+
+## Open issues
+
+|| # | Location | Principle | Issue | Fix |
+||---|----------|-----------|-------|-----|
+|| 1 | [where] | [principle] | [what the reader hits] | [the change] |
+~~~~
+
+## Rules
+
+- **Evaluate as the reader.** Reread the draft with the readers' understanding, purpose, and context in mind — the profile governs the verdict, not the writer's sense of the prose.
+- **A verdict names its basis.** Each principle's verdict cites the guidelines that carry it from [plain-language-standard](plain-language-standard.md#principles).
+- **Open issues are actionable.** Each open issue locates the passage and names the fix, so the revision pass has no interpretation to redo.
+- **The count gates delivery.** Delivery is blocked while open issues remain; the report's open-issue count is the gate's input.

--- a/plain-language/resources/iso-checklist.md
+++ b/plain-language/resources/iso-checklist.md
@@ -1,0 +1,56 @@
+---
+name: iso-checklist
+description: Creation guide for the iso-checklist artifact — the completed ISO 24495-1 Annex B checklist walked for the document before delivery.
+metadata:
+  order: 5
+---
+
+# ISO Checklist Guide
+
+The final conformance record. Answers: has every guideline been walked for this document, and what is the disposition of each? Canonical home for the completed checklist.
+
+## Template
+
+~~~~markdown
+# ISO 24495-1 Checklist — {document title}
+
+**Result:** {items met} met · {items open} open
+
+## Relevant — readers get what they need
+
+- [ ] Readers and their characteristics identified
+- [ ] Readers' purpose identified
+- [ ] Reading context identified
+- [ ] Document type(s) chosen to match
+- [ ] Content readers need selected
+
+## Findable — readers can easily find what they need
+
+- [ ] Document structured for readers
+- [ ] Visual organization helps readers find information
+- [ ] Headings anticipate what comes next
+- [ ] Additional information isolated
+
+## Understandable — readers can easily understand what they find
+
+- [ ] Familiar words chosen
+- [ ] Sentences clear
+- [ ] Sentences concise
+- [ ] Paragraphs clear and concise
+- [ ] Images and multimedia appropriate
+- [ ] Tone respectful
+- [ ] Document coherent
+
+## Usable — readers can easily use the information
+
+- [ ] Evaluated continuously as developed
+- [ ] Evaluated further with readers (or disposition recorded)
+- [ ] Plan to continue evaluating in use
+~~~~
+
+## Rules
+
+- **Every item has a disposition.** An item is checked (met), or left open with a one-line reason; none is skipped without a note.
+- **Walk it against the document.** The checklist is read against the delivered draft, not recalled from memory of the guidelines.
+- **Open items match the evaluation report.** An open checklist item corresponds to an open issue in the [evaluation report](evaluation-report.md); the two records agree.
+- **It is the last record before delivery.** The checklist is completed after the final evaluation round and travels with the delivered document.

--- a/plain-language/resources/plain-language-standard.md
+++ b/plain-language/resources/plain-language-standard.md
@@ -1,0 +1,62 @@
+---
+name: plain-language-standard
+description: The governing principles and guidelines of ISO 24495-1, distilled as the criteria every plain-language decision cites. Section-delivered per principle.
+metadata:
+  order: 0
+---
+
+# Plain Language Standard
+
+Plain language is communication written, structured, and presented so that readers can find what they are looking for, understand what they find, and use that information well. It focuses on the reader's ability to use the document, not on mechanical measures such as readability formulas, and it is not the same as simplified language — plain language serves a general audience at its own level of expertise, where simplified language serves readers who have difficulty understanding what they read.
+
+This resource is the criteria home. Techniques cite the section that governs their work; they do not restate the guidelines. The four principles are interdependent and iterative, not a linear sequence — the first three make a document likely to work, and only evaluation under the fourth confirms it.
+
+## Principles
+
+| # | Principle | Reader outcome | Guidelines live in |
+|---|-----------|----------------|--------------------|
+| 1 | Readers get what they need | Relevant | [Relevance](#relevance) |
+| 2 | Readers can easily find what they need | Findable | [Findability](#findability) |
+| 3 | Readers can easily understand what they find | Understandable | [Understandability](#understandability) |
+| 4 | Readers can easily use the information | Usable | [Usability](#usability) |
+
+A document is usable when the information it carries is relevant, findable, and understandable. The four principles interact; applying them together is essential.
+
+## Relevance
+
+What the author settles before writing. Understanding the readers and their needs is essential; the document type and content match the readers' needs, purpose, and context.
+
+- **Identify the readers.** Determine who they are and account for language proficiency, cultural background, subject knowledge, accessibility needs, and the languages they understand. Provide the document in a language they know. Draw on prior communications, interviews, surveys, and research.
+- **Identify the readers' purpose.** Determine why they read — following instructions, deciding whether to act, understanding a subject, learning what the author wants, or acquiring knowledge for a specific goal.
+- **Identify the reading context.** Where they read, the technology they use, the time they have, how long they stay focused, their interest, and their emotional state.
+- **Choose the document type.** Match type to reader characteristics, purpose, and context. When it serves the purpose better, choose an alternative to a text document.
+- **Select the content readers need.** Prioritize readers' needs; answer the questions they need answered; leave out what they do not need; and select content ethically — accurate, not false or misleading, and not hiding what readers need to know.
+
+## Findability
+
+Structure and visual organization that let readers determine quickly what the document is about and whether it serves their purpose.
+
+- **Structure for readers.** Group related information and order it logically. Place the most important message where it is found easily, usually first. Build new information on what readers already know. Present instructions chronologically. Put what most readers need before what only some need. Place warnings before the instructions they guard.
+- **Use visual organization.** Signal prominence, proximity, similarity, and sequence. Use headings and a consistent hierarchy, bulleted and numbered lists, readable typography, and — when they help — a table of contents or index. Where audiences differ, identify each one's information.
+- **Use headings.** One heading per new topic; each heading accurately describes what follows, is consistent, short enough to scan, and present in enough number to help without clutter.
+- **Isolate additional information.** Required material most readers do not need (legal basis, sources, detailed explanation) goes in annexes, bibliographies, or an equivalent presentational solution.
+
+## Understandability
+
+Words, sentences, and structure that are easy to understand and that fit together as a coherent whole.
+
+- **Choose familiar words.** Precise, unambiguous words that help readers form a mental image. Use specialized terms only when readers know them or must learn them — and explain them at first appearance. Use abbreviations only when readers know the short form or the full form is excessively long, and spell them out at first appearance unless universally understood. Use the same word for the same meaning and different words for different meanings. Use culturally relevant language.
+- **Write clear sentences.** Prefer a simple, familiar structure readers can interpret only one way. Do not interrupt the main idea. Begin with familiar information, then introduce the new. Address readers directly ("you"). Use the active voice unless there is a specific reason for the passive. Use grammar, spelling, and punctuation suited to the readers.
+- **Write concise sentences.** One idea per sentence. Cut redundant or vague words, clichés, and filler. Prefer short sentences and vary length for rhythm.
+- **Write clear, concise paragraphs.** One topic per paragraph, stated at the start, with clear links within and between paragraphs.
+- **Consider images and multimedia.** Use them to support the text, never as decoration. Choose the simplest form, place them near the related text, label them, and give them white space.
+- **Adopt a respectful tone.** Use non-discriminatory language. Tone is also set by structure, visual organization, images, pronouns, and sentence structures.
+- **Ensure coherence.** Make the relationships among words, sentences, paragraphs, sections, and images clear. Keep visual organization and tone consistent.
+
+## Usability
+
+Evaluation — the only way to know readers can use the document. Evaluate every document throughout its life cycle, with methods suited to each stage.
+
+- **Evaluate continuously as developed.** Reread with the readers' understanding, purpose, and context in mind; determine whether the document meets the principles and guidelines; and revise on the results.
+- **Evaluate further with readers.** The only way to know how readers respond is to involve them, even on a small scale. Weigh time, resources, complexity, audience size, and the severity of consequences if readers cannot use the document.
+- **Continue evaluating in use.** Re-evaluate a document used repeatedly or continuously. Revise it while it stays relevant; withdraw it when it is not. Measure outcomes where possible.

--- a/plain-language/resources/readme-seed.md
+++ b/plain-language/resources/readme-seed.md
@@ -1,0 +1,65 @@
+---
+name: readme-seed
+description: Plain-language planning-folder README seed profile — Progress inventory, classifier vocabulary, and mode-exclusion map for create-readme.
+metadata:
+  order: 6
+---
+
+# Plain Language README Seed
+
+Fill data for [create-readme](../../meta/techniques/workflow-engine/create-readme.md). Layout and policy live in [Planning Folder README Guide](../../meta/resources/planning-readme.md) ([Template](../../meta/resources/planning-readme.md#template)).
+
+## Classifier
+
+Header-line kind labels: `Author`, `Rewrite`, `Audit`.
+
+Lifecycle **Status** values: `Profiling`, `Drafting`, `Evaluating`, `Complete`.
+
+## Links defaults
+
+| Resource | Link shape |
+|----------|------------|
+| Source document | `{source_document_path}` |
+| Delivered document | `{output_path}` |
+
+## Progress inventory
+
+| # | Item | Description | Estimate | Status |
+|---|------|-------------|----------|--------|
+| 1 | Intake and profile | Operation, reader profile, content selection | 10-20m | ⬚ |
+| 2 | [Document profile](document-profile.md) | Readers, purpose, context, content | 10-20m | ⬚ |
+| 3 | Source analysis | Findings against the existing document | 15-30m | ⊘ |
+| 4 | Draft | The plain-language document | 20-60m | ⬚ |
+| 5 | [Evaluation report](evaluation-report.md) | Verdict by principle, open issues | 15-30m | ⬚ |
+| 6 | [ISO checklist](iso-checklist.md) | Completed Annex B checklist | 10-15m | ⬚ |
+| 7 | Delivery | The document written to its output path | 5-10m | ⬚ |
+
+Initial Status icons are from [Status vocabulary](../../meta/resources/planning-readme.md#status-vocabulary). The source-analysis row starts cancelled/N/A because only rewrite and audit runs produce it.
+
+## Row ownership
+
+Which activity owns which rows, per [row-ownership map](../../meta/resources/planning-readme.md#row-ownership-map). Values are Item labels.
+
+| @ | Rows |
+|---|------|
+| 01 | Intake and profile · Document profile |
+| 02 | Source analysis |
+| 03 | Draft |
+| 04 | Evaluation report · ISO checklist |
+| 05 | Delivery |
+
+## Mode exclusion map
+
+Mode key: `{operation_type}` (`author` | `rewrite` | `audit`).
+
+### Author
+
+Leave Progress Status as authored; the source-analysis row stays cancelled/N/A.
+
+### Rewrite
+
+Flip the source-analysis row from cancelled/N/A to pending. Leave the other rows as authored.
+
+### Audit
+
+Flip the source-analysis row from cancelled/N/A to pending. The audit run produces the source analysis as its terminal record; set cancelled/N/A on the draft, ISO checklist, and delivery rows — an audit authors no document and delivers nothing but the analysis.

--- a/plain-language/resources/source-analysis.md
+++ b/plain-language/resources/source-analysis.md
@@ -1,0 +1,37 @@
+---
+name: source-analysis
+description: Creation guide for the source-analysis artifact — the audit of an existing document against the plain-language principles, produced on rewrite and audit runs.
+metadata:
+  order: 3
+---
+
+# Source Analysis Guide
+
+The findings surface for a document that already exists. Answers: where does this document fail its readers, and by which guideline? Canonical home for the per-finding record a rewrite or audit run works from.
+
+## Template
+
+~~~~markdown
+# Source Analysis — {document title}
+
+**Document:** `{source path}` · **Findings:** {count}
+
+[One line: the overall plain-language state of the document.]
+
+## Findings
+
+|| # | Passage | Principle | Guideline | Issue | Recommendation |
+||---|---------|-----------|-----------|-------|----------------|
+|| 1 | [quote or locate] | Relevant / Findable / Understandable / Usable | [the guideline breached] | [what the reader hits] | [the change that fixes it] |
+
+## Strengths
+
+[What the document already does well — preserve this in a rewrite.]
+~~~~
+
+## Rules
+
+- **Cite the guideline.** Every finding names the principle and the guideline it breaches from [plain-language-standard](plain-language-standard.md); an unanchored complaint is not a finding.
+- **Locate the passage.** Each finding quotes or locates the passage so a reader can confirm it without re-reading the whole document.
+- **Recommend, don't rewrite.** The recommendation names the change; the rewrite itself happens in the drafting pass.
+- **Record strengths too.** A rewrite preserves what already works; the strengths list is its don't-break inventory.

--- a/plain-language/techniques/README.md
+++ b/plain-language/techniques/README.md
@@ -1,0 +1,29 @@
+# Plain Language Techniques
+
+> Part of the [Plain Language Workflow](../README.md)
+
+The technique library for this workflow. Each technique is one capability an activity step binds via `step.technique`; the authoritative capability, inputs, outputs, protocol and rules live in the per-technique `.md` file. This file orients — it does not restate protocols.
+
+Operations live in the [`plain-language`](./plain-language/TECHNIQUE.md) group, so each has a `group::operation` address that another workflow can bind without copying the file — the embedded-check use.
+
+---
+
+## Local operations
+
+| Operation | Capability |
+|-----------|------------|
+| [`intake-and-profile`](./plain-language/intake-and-profile.md) | Classify the operation and settle the reader profile and content selection |
+| [`analyze-source`](./plain-language/analyze-source.md) | Audit an existing document against the principles; record findings and strengths |
+| [`draft-document`](./plain-language/draft-document.md) | Produce the plain-language document for its readers |
+| [`evaluate-document`](./plain-language/evaluate-document.md) | Evaluate a draft against the four principles; record verdicts and open issues |
+| [`complete-checklist`](./plain-language/complete-checklist.md) | Walk the ISO 24495-1 checklist against the final draft |
+
+## Shared operations bound by this workflow
+
+Resolved directly from the named workflow — no copy is held here.
+
+| Reference | Used for |
+|-----------|----------|
+| [`variable-binding`](../../meta/techniques/variable-binding.md) | Declared at `workflow.techniques.activity`; inherited by every activity rather than bound per step |
+| [`workflow-engine::create-readme`](../../meta/techniques/workflow-engine/create-readme.md) | Seed the planning-folder `README.md` from the universal Template under this workflow's seed profile |
+| [`work-package::manage-artifacts`](../../work-package/techniques/manage-artifacts/TECHNIQUE.md) | `write-artifact` — the numbered planning-folder artifact write |

--- a/plain-language/techniques/plain-language/TECHNIQUE.md
+++ b/plain-language/techniques/plain-language/TECHNIQUE.md
@@ -1,0 +1,32 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Shared inputs and domain invariants for every plain-language operation in this group.
+
+## Inputs
+
+### document_profile
+
+*(optional)* The settled reader, purpose, context, and content selection the operation works to (ISO 24495-1 5.1). Author and rewrite operations require it; intake produces it.
+
+### controlled_language
+
+*(optional)* Default `false`. When `true`, the operation applies the [ASD-STE100 overlay](../../resources/asd-ste100.md) over the ISO 24495-1 base for technical documentation.
+
+## Rules
+
+### reader-governs
+
+Every drafting and evaluation decision cites the reader profile and the governing guideline from [plain-language-standard](../../resources/plain-language-standard.md), not the writer's preference. A choice that cannot name its reader and guideline is not settled.
+
+### cite-dont-restate
+
+Operations cite the relevant section of [plain-language-standard](../../resources/plain-language-standard.md) or [asd-ste100](../../resources/asd-ste100.md); they do not restate the guidelines in protocol prose.
+
+### overlay-not-replacement
+
+The ASD-STE100 overlay tightens understandability for technical documentation; it never replaces the ISO base's relevance, findability, and evaluation guidelines. Where the two conflict, the stricter STE rule wins at the word and sentence level and the ISO base still governs structure, audience fit, and evaluation.

--- a/plain-language/techniques/plain-language/analyze-source.md
+++ b/plain-language/techniques/plain-language/analyze-source.md
@@ -1,0 +1,51 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Audit an existing document against the plain-language principles and record where it fails its readers, with the strengths a rewrite must preserve.
+
+## Inputs
+
+### source_document_path
+
+Path to the existing document to analyze.
+
+### document_profile
+
+The settled reader, purpose, and context the document is analyzed against.
+
+## Outputs
+
+### source_analysis
+
+The per-finding record and the strengths inventory, shaped by [Template](../../resources/source-analysis.md#template).
+
+#### artifact
+
+`source-analysis.md`
+
+### finding_count
+
+Number of plain-language findings recorded against the document.
+
+## Protocol
+
+### 1. Read the Document as Its Reader
+
+- Read `{source_document_path}` with the readers' understanding, purpose, and context from `{document_profile}` in mind — the profile governs the analysis, not the writer's sense of the prose
+
+### 2. Record Findings Against the Guidelines
+
+- Walk the document against the four principles in [Principles](../../resources/plain-language-standard.md#principles), recording each failure with its passage, its principle, the guideline it breaches, and the change that fixes it — per [Findings](../../resources/source-analysis.md#template)
+- Cite the guideline every finding breaches; an unanchored complaint is not a finding
+
+### 3. Record the Strengths
+
+- Inventory what the document already does well — the don't-break list a rewrite preserves — per [Strengths](../../resources/source-analysis.md#template)
+
+### 4. Count the Findings
+
+- Set `{finding_count}` to the number of rows in the findings table; zero when the document already meets the principles

--- a/plain-language/techniques/plain-language/complete-checklist.md
+++ b/plain-language/techniques/plain-language/complete-checklist.md
@@ -1,0 +1,50 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Walk the ISO 24495-1 Annex B checklist against the final draft and record the disposition of every item, the last record before delivery.
+
+## Inputs
+
+### document_draft
+
+The final draft the checklist is walked against.
+
+### evaluation_report
+
+The latest evaluation — its open issues must agree with the checklist's open items.
+
+## Outputs
+
+### iso_checklist
+
+The completed checklist with every item's disposition, shaped by [Template](../../resources/iso-checklist.md#template).
+
+#### artifact
+
+`iso-checklist.md`
+
+### checklist_complete
+
+True when every checklist item carries a disposition.
+
+## Protocol
+
+### 1. Walk Every Item
+
+- Walk each item of the [ISO 24495-1 checklist](../../resources/iso-checklist.md#template) against `{document_draft}` — against the document itself, not from memory of the guidelines
+
+### 2. Dispose Each Item
+
+- Mark each item met, or leave it open with a one-line reason — no item is skipped without a note, per [Rules](../../resources/iso-checklist.md#rules)
+
+### 3. Reconcile with the Evaluation
+
+- Confirm every open checklist item corresponds to an open issue in `{evaluation_report}` — the two records agree before the run closes
+
+### 4. Record Completion
+
+- Set `{checklist_complete}` true when every item carries a disposition and return the completed checklist as `{iso_checklist}`

--- a/plain-language/techniques/plain-language/draft-document.md
+++ b/plain-language/techniques/plain-language/draft-document.md
@@ -1,0 +1,58 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Produce the plain-language document — drafted fresh on an author run, or rewritten from the source analysis on a rewrite run — structured and worded for its readers.
+
+## Inputs
+
+### document_profile
+
+The settled reader, purpose, context, document type, and content selection the draft is built on.
+
+### source_analysis
+
+*(optional)* The findings and strengths of the existing document — bound on a rewrite run, where the draft fixes the findings and preserves the strengths.
+
+### current_draft
+
+*(optional)* The draft of the prior round — bound on a revision pass, where only the open evaluation issues are addressed.
+
+### open_issues
+
+*(optional)* The actionable issues from the latest evaluation — bound on a revision pass to focus the rework.
+
+## Outputs
+
+### document_draft
+
+The current draft of the plain-language document.
+
+#### artifact
+
+`plain-document.md`
+
+## Protocol
+
+### 1. Select the Mode
+
+- On an author run, draft fresh from `{document_profile}`; on a rewrite run, rework the source by fixing each finding in `{source_analysis}` and preserving its strengths; on a revision pass, address only the `{open_issues}` against `{current_draft}`
+
+### 2. Structure for the Reader
+
+- Order and group the content per [Findability](../../resources/plain-language-standard.md#findability) — the most important message first, logical grouping, headings that anticipate, lists and visual organization that help readers find what they need
+
+### 3. Word and Build the Prose
+
+- Write the words, sentences, and paragraphs per [Understandability](../../resources/plain-language-standard.md#understandability) — familiar precise words, clear concise sentences, one-topic paragraphs, a respectful tone, a coherent whole
+
+### 4. Apply the Overlay
+
+- When `{controlled_language}` is true, apply the [ASD-STE100 writing rules](../../resources/asd-ste100.md#writing-rules) at the word and sentence level, matching the [procedure or description](../../resources/asd-ste100.md#procedure-and-description) text type — the ISO base still governs structure and audience fit
+
+### 5. Return the Draft
+
+- Return the drafted document as `{document_draft}`; the calling activity persists it via `manage-artifacts::write-artifact`

--- a/plain-language/techniques/plain-language/evaluate-document.md
+++ b/plain-language/techniques/plain-language/evaluate-document.md
@@ -1,0 +1,58 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Evaluate a draft against the four principles as its reader would, recording the per-principle verdict and the open issues that gate delivery.
+
+## Inputs
+
+### document_draft
+
+The draft to evaluate.
+
+### document_profile
+
+The settled reader, purpose, and context the draft is evaluated against.
+
+### revision_round
+
+*(optional)* The evaluation round this is — the first pass is round 0.
+
+## Outputs
+
+### evaluation_report
+
+The per-principle verdict and the open-issue list, shaped by [Template](../../resources/evaluation-report.md#template).
+
+#### artifact
+
+`evaluation-report.md`
+
+### open_issue_count
+
+Number of evaluation issues still open against this draft.
+
+### needs_revision
+
+True when any open issue sends the draft back for another pass; false when every principle is met.
+
+## Protocol
+
+### 1. Reread as the Reader
+
+- Reread `{document_draft}` with the readers' understanding, purpose, and context from `{document_profile}` in mind — the profile governs the verdict, not the writer's sense of the prose
+
+### 2. Verdict Each Principle
+
+- Assign each of the four principles a verdict per [Usability](../../resources/plain-language-standard.md#usability) and the guidelines it cites — relevant, findable, understandable, usable — naming the guidelines that carry each verdict per [Verdict by principle](../../resources/evaluation-report.md#template)
+
+### 3. Record the Open Issues
+
+- Record each failure as an open issue with its location, principle, the problem the reader hits, and the fix — per [Open issues](../../resources/evaluation-report.md#template) — so the revision pass has no interpretation to redo
+
+### 4. Set the Revision Signal
+
+- Set `{open_issue_count}` to the number of open issues and `{needs_revision}` true when any remain, false when every principle is met

--- a/plain-language/techniques/plain-language/intake-and-profile.md
+++ b/plain-language/techniques/plain-language/intake-and-profile.md
@@ -1,0 +1,78 @@
+---
+metadata:
+  version: 1.0.0
+---
+
+## Capability
+
+Classify the request as author, rewrite, or audit, and settle the reader, purpose, context, document type, and content selection the run is built on.
+
+## Inputs
+
+### user_request
+
+Free-form statement of the document the user wants authored, rewritten, or audited.
+
+### source_document_path
+
+*(optional)* Path to the existing document a rewrite or audit run reads. Its presence signals a non-author operation.
+
+## Outputs
+
+### operation_type
+
+The classified operation — `author`, `rewrite`, or `audit`.
+
+### operation_type_ambiguous
+
+True when the request admits more than one plausible operation and the choice is not settled.
+
+### controlled_language
+
+True when the document is technical documentation the user wants held to the ASD-STE100 controlled language.
+
+### document_title
+
+Short title of the document this run produces or reads.
+
+### document_type
+
+The class of document (email, web page, instruction, report, form, and so on) chosen to match the reader profile.
+
+### document_profile
+
+The settled reader, purpose, context, and content selection, shaped by [Template](../../resources/document-profile.md#template).
+
+#### artifact
+
+`document-profile.md`
+
+### intent_needs_confirmation
+
+True when the operation type is ambiguous or the reader profile cannot be settled from the request — drives the intake gate.
+
+## Protocol
+
+### 1. Classify the Operation
+
+- Classify `{user_request}` as `author` (a new document), `rewrite` (an existing document made plain), or `audit` (an existing document assessed against the principles) — a named `{source_document_path}` signals `rewrite` or `audit`; the user's goal selects between them
+- Set `{operation_type_ambiguous}` true when the request admits more than one plausible reading, false when it is clear
+
+### 2. Detect the Controlled-Language Mode
+
+- Determine whether the document is technical documentation to be held to [ASD-STE100](../../resources/asd-ste100.md) — procedures and descriptions in a technical domain, or an explicit user request — and set `{controlled_language}`
+
+### 3. Settle the Reader Profile
+
+- Capture the readers, their purpose, the reading context, the document type, and the content selection per [Relevance](../../resources/plain-language-standard.md#relevance), at the depth [Template](../../resources/document-profile.md#template) declares
+- Omit a question already answered by the request; where an answer the user did not give would have to be invented, leave the gap rather than choosing for them
+
+### 4. Flag Unsettled Intent
+
+- Set `{intent_needs_confirmation}` true when `{operation_type_ambiguous}` is true or the profile still carries an unsettled gap; false when operation and profile are both settled
+
+## Rules
+
+### gap-not-invention
+
+An unsettled profile question is surfaced through `{intent_needs_confirmation}`, never resolved by picking a plausible default. A profile that reads complete because its gaps were silently filled is worse than one that names them.

--- a/plain-language/workflow.yaml
+++ b/plain-language/workflow.yaml
@@ -1,0 +1,133 @@
+$schema: ../../schemas/workflow.schema.json
+id: plain-language
+version: 1.0.0
+title: Plain Language Workflow
+description: >-
+  Author, rewrite, or audit a document so its readers can find what they need, understand
+  what they find, and use it. Applies the four principles and guidelines of ISO 24495-1, with
+  an optional ASD-STE100 controlled-language overlay for technical documentation.
+author: m2ux
+tags:
+  - plain-language
+  - iso-24495-1
+  - asd-ste100
+  - technical-writing
+  - document-authoring
+  - document-audit
+rules:
+  activity:
+    - >-
+      gate-correction-sticks — once the user corrects a value at a gate, every later gate is
+      answered from the corrected value, not the one it replaced.
+    - >-
+      explicit-checkpoint-waits — a checkpoint declaring neither `defaultOption` nor
+      `autoAdvanceMs` always waits for a person; under `{headless_mode}`, one declaring both
+      resolves to its `defaultOption` without presentation.
+    - >-
+      reader-governs — the document is written for its readers, not its author: every drafting
+      and evaluation decision cites the reader profile and the governing guideline rather than
+      the writer's preference.
+techniques:
+  activity:
+    - variable-binding
+variables:
+  - name: planning_folder_path
+    type: string
+    description: Absolute path to this run's planning folder — the write location for every working artifact.
+  - name: operation_type
+    type: string
+    description: The classified operation for the request — author, rewrite, or audit.
+  - name: operation_type_ambiguous
+    type: boolean
+    description: True when intake cannot confidently classify author vs rewrite vs audit from the request alone.
+    defaultValue: false
+  - name: intent_needs_confirmation
+    type: boolean
+    description: Composite gap flag for the intake gate — true when the operation type is ambiguous or the reader profile cannot be settled from the request.
+    defaultValue: false
+  - name: headless_mode
+    type: boolean
+    description: When true, soft mid-flow gates auto-resolve without presentation.
+    defaultValue: true
+  - name: controlled_language
+    type: boolean
+    description: When true, layer the ASD-STE100 writing rules and approved-word discipline over the ISO 24495-1 base for technical documentation.
+    defaultValue: false
+  - name: source_document_path
+    type: string
+    description: Path to the existing document a rewrite or audit run reads. Empty on an author run.
+    defaultValue: ""
+  - name: document_title
+    type: string
+    description: Short title of the document this run authors, rewrites, or audits.
+    defaultValue: ""
+  - name: document_type
+    type: string
+    description: The class of document (email, web page, instruction, report, form, and so on) chosen to match the reader profile.
+    defaultValue: ""
+  - name: output_path
+    type: string
+    description: Absolute path the delivered plain-language document is written to.
+    defaultValue: ""
+  - name: document_profile
+    type: object
+    description: The settled reader, purpose, context, and content selection for the document (ISO 24495-1 5.1).
+  - name: document_profile_confirmed
+    type: boolean
+    description: Whether the reader profile and content selection are confirmed.
+    defaultValue: false
+  - name: document_profile_path
+    type: string
+    description: Absolute path to the persisted document-profile artifact.
+    defaultValue: ""
+  - name: source_analysis
+    type: object
+    description: The audit of the existing document against the principles, produced on rewrite and audit runs.
+  - name: source_analysis_path
+    type: string
+    description: Absolute path to the persisted source-analysis artifact.
+    defaultValue: ""
+  - name: finding_count
+    type: number
+    description: Count of plain-language findings recorded against the existing document.
+    defaultValue: 0
+  - name: document_draft
+    type: string
+    description: The current draft of the plain-language document.
+    defaultValue: ""
+  - name: document_path
+    type: string
+    description: Absolute path to the persisted plain-language document.
+    defaultValue: ""
+  - name: draft_confirmed
+    type: boolean
+    description: Whether the current draft is confirmed as ready for evaluation.
+    defaultValue: false
+  - name: evaluation_report
+    type: object
+    description: The structured result of evaluating the draft against the four principles (ISO 24495-1 5.4).
+  - name: evaluation_report_path
+    type: string
+    description: Absolute path to the persisted evaluation-report artifact.
+    defaultValue: ""
+  - name: open_issue_count
+    type: number
+    description: Count of evaluation issues still open against the current draft.
+    defaultValue: 0
+  - name: needs_revision
+    type: boolean
+    description: True when the evaluation surfaces issues that send the draft back for another pass.
+    defaultValue: false
+  - name: revision_round
+    type: number
+    description: Count of evaluate-revise rounds completed on the current document.
+    defaultValue: 0
+  - name: checklist_complete
+    type: boolean
+    description: Whether the ISO 24495-1 Annex B checklist has been walked and recorded for the document.
+    defaultValue: false
+  - name: checklist_path
+    type: string
+    description: Absolute path to the persisted iso-checklist artifact.
+    defaultValue: ""
+initialActivity: intake-and-profile


### PR DESCRIPTION
## Summary

A step that says "write it plainly" leaves the agent to guess what plain means. This change adds a `plain-language` workflow that gives that instruction a concrete home: it authors a new document, rewrites an existing one, or audits one, and in each case measures the result against the four principles of ISO 24495-1 — readers get what they need, can find it, can understand it, and can use it.

The standard's principles and guidelines live in one shared resource that every technique cites rather than restates, so the rules have a single home. An optional ASD-STE100 controlled-language overlay tightens word- and sentence-level writing for technical documentation when the run calls for it.

## How it works

The workflow runs in one of three modes, set once at intake and read off a single `operation_type` variable:

- **Author** — settle who the readers are, why they read, and what the document must carry (the reader profile), then draft for those readers, evaluate, and deliver.
- **Rewrite** — first audit the existing document against the principles and record where it fails its readers (and what it already does well), then rework the draft from those findings.
- **Audit** — stop at the audit; the source analysis is the deliverable, and no document is written.

Drafting and evaluation cite the reader profile and the governing guideline, not the writer's taste. Evaluation follows the standard's fourth principle as an evaluate–revise loop that repeats while issues remain, and the run closes by walking the ISO 24495-1 Annex B checklist as the document's conformance record. When `{controlled_language}` is on, the ASD-STE100 writing rules apply at the word and sentence level while the ISO base still governs structure and audience fit.

## Why now is cheap

The capability is a self-contained family under `workflows/plain-language/` — a `workflow.yaml`, five activities, five atomic techniques, and the resources they cite. Nothing existing is edited: it adds 23 files and touches no other workflow. The atomic techniques are cross-workflow addressable as `plain-language::<op>` (for example `plain-language::evaluate-document`), so other workflows can invoke a single capability without copying it. The ISO criteria are distilled once into a section-delivered resource, so a technique fetches only the section that governs its work.

## Scope of change

- **New workflow** `plain-language/` — definition, activities, techniques, resources, and READMEs.
- **No server, schema, or other-workflow changes.** The main-repo submodule pointer is intentionally not bumped in this PR.

## Acceptance criteria

- [x] The workflow authors, rewrites, and audits against the four ISO 24495-1 principles, branched on a single `operation_type`.
- [x] The ISO principles and guidelines live in one shared resource, cited by section; techniques do not restate them.
- [x] The ASD-STE100 overlay is opt-in via `{controlled_language}` and layered over the ISO base.
- [x] Evaluation is an evaluate–revise loop with a human gate; the Annex B checklist is completed before delivery.
- [x] All definition guards that touch the new files pass (`check:all` clean for this family; typecheck clean).

## Non-goals

- Bumping the main-repo `workflows` submodule pointer — left out of this PR by request.
- Encoding the full licensed ASD-STE100 dictionary; the overlay records the discipline, not the word list.

## Two register items from a run that applied the standard by hand

**Link text is a named reference** — the symbol, construct, file, finding or thread the link points
at, reading naturally in the sentence that holds it, with the URL as the inline target and plain text
inside the brackets. Three forms breach §5.3.3 item 1.3, which tells authors not to interrupt a
sentence's main idea with additional information:

- link text that is only a location, `[:1358]` or `[fetcher.rs:204]`, where a name belongs;
- a citation appended as a trailing parenthetical, which is that interruption;
- a code span inside the link text, which falls back to literal source in some viewers and, with two
  spans, collapses to plain text carrying no link at all — a rendering fault rather than a style
  choice, in a document the reader navigates by its links.

Reference-style links were tried on the source run and reverted: an unresolved label renders as
literal bracket text with no link, and definition blocks do not travel when a report is posted in
parts. The inline form is not later improved into reference style.

**Derivation vocabulary stays in the working artifacts.** Terms the analysis needed — the names of
its lenses, its epistemic framing — leak into the finished document, where the plain term is what the
reader wants. This is the same register question as the rest of the standard, applied to the words a
method leaves behind.

Source: items 2 and 6 of the [July–August retrospective review](https://github.com/shieldedtech/midnight-agent-eng/blob/mike/.engineering/artifacts/planning/2026-08-06-workflow-retrospective-review/03-item-tracker.md).
