### PR TITLE
Reachable halves: the checkpoint protocols go where a checkpoint can be reached, and a run forms at a real window

### DIFF
--- a/scripts/run-batch-benchmark.ts
+++ b/scripts/run-batch-benchmark.ts
@@ -71,6 +71,7 @@ import type { SessionFile } from '../src/schema/session.schema.js';
 import { deliveredChars } from '../src/utils/batch.js';
 import { measureFanOut, fanOutRatios, fanOutLines } from '../src/utils/fan-out.js';
 import { loadWorkflowWithDiagnostics } from '../src/loaders/workflow-loader.js';
+import { CORE_WORKER_TECHNIQUES } from '../src/loaders/core-ops.js';
 import { composeActivityTechnique } from '../src/loaders/technique-loader.js';
 import { flattenActivitySteps, techniqueName } from '../src/schema/activity.schema.js';
 import type { Technique } from '../src/schema/technique.schema.js';
@@ -177,16 +178,26 @@ async function measureRunFanOut(workflowId: string, activities: string[]) {
   const loaded = await loadWorkflowWithDiagnostics(root, workflowId);
   if (!loaded.success) throw loaded.error;
   const { workflow, activitySourceWorkflow } = loaded.value;
+  const inherited = (workflow as { techniques?: { activity?: string[] } }).techniques?.activity ?? [];
 
   const composed: Technique[] = [];
   for (const activityId of activities) {
     const activity = workflow.activities?.find((a) => a.id === activityId);
     if (!activity) continue;
     const scopeWorkflowId = activitySourceWorkflow.get(activityId) ?? workflowId;
-    for (const step of flattenActivitySteps(activity)) {
-      if (step.kind !== 'technique') continue;
-      const ref = techniqueName(step.technique);
-      if (!ref) continue;
+
+    // Every operation a delivery carries, not only the step-bound ones. The activity-level bundle —
+    // the workflow's inherited `techniques.activity`, the activity's own, and the core worker set —
+    // arrives with EVERY activity, so the container rules of `workflow-engine` and `agent-conduct`
+    // reach every worker of every workflow through it. Measuring the step-bound operations alone
+    // reports a fraction of the fan-out and misses the widest-reaching rules entirely.
+    const own = (activity as { techniques?: string[] }).techniques ?? [];
+    const stepRefs = flattenActivitySteps(activity)
+      .filter((s) => s.kind === 'technique')
+      .map((s) => techniqueName(s.technique))
+      .filter((ref): ref is string => !!ref);
+
+    for (const ref of [...inherited, ...own, ...CORE_WORKER_TECHNIQUES, ...stepRefs]) {
       const result = await composeActivityTechnique(ref, root, scopeWorkflowId, activityId);
       if (result.success) composed.push(result.value.technique);
     }

--- a/src/loaders/core-ops.ts
+++ b/src/loaders/core-ops.ts
@@ -69,6 +69,19 @@ export const CORE_ORCHESTRATOR_TECHNIQUES: readonly string[] = [
  * Technique refs every activity worker needs at the activity level. Returned by
  * get_activity alongside the activity's declared technique refs.
  */
+/**
+ * The members of {@link CORE_WORKER_TECHNIQUES} an activity needs only where it can reach a
+ * checkpoint. A yield requires a `kind: checkpoint` step, and a resume follows a yield, so an activity
+ * holding no checkpoint step reaches neither protocol. `get_activity` derives that from the definition
+ * and leaves both out, which is 4,060 characters off every checkpoint-free activity's delivery — the
+ * shared blocks they carry collapse against their siblings either way, so what comes off is their own
+ * cores.
+ */
+export const CHECKPOINT_WORKER_TECHNIQUES: readonly string[] = [
+  'workflow-engine::yield-checkpoint',
+  'workflow-engine::resume-from-checkpoint',
+];
+
 export const CORE_WORKER_TECHNIQUES: readonly string[] = [
   // The role itself. Every worker stub says to apply it, and only the meta workflow declares it in
   // `techniques.activity` — so for a client workflow it was named and never delivered, with no tool

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -11,7 +11,7 @@ import {
 import { listWorkflows, listWorkflowsWithDiagnostics, loadWorkflow, loadWorkflowWithDiagnostics, getActivity, getCheckpoint, readActivityRaw, buildFragmentsLookup, TERMINAL_SENTINEL } from '../loaders/workflow-loader.js';
 import { injectCheckpointFragmentBodies, resolveCheckpointFragment, scanCheckpointRefLines } from '../loaders/fragment-resolver.js';
 import { resolveTechniques, formatTechniqueBundle, composeActivityTechnique, projectTechnique, projectTechniqueToYaml } from '../loaders/technique-loader.js';
-import { CORE_ORCHESTRATOR_TECHNIQUES, CORE_WORKER_TECHNIQUES } from '../loaders/core-ops.js';
+import { CHECKPOINT_WORKER_TECHNIQUES, CORE_ORCHESTRATOR_TECHNIQUES, CORE_WORKER_TECHNIQUES } from '../loaders/core-ops.js';
 import { readResourceRaw } from '../loaders/resource-loader.js';
 import { injectResolvedStepIds, techniqueName, flattenActivitySteps, type Activity, type Step } from '../schema/activity.schema.js';
 import { buildProducerIndex, provenanceContextFor, decorateTechniqueProvenance } from '../utils/binding-provenance.js';
@@ -853,7 +853,16 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
       const activity = result.success ? getActivity(result.value, activity_id) : undefined;
       const ownTechRefs = (activity as { techniques?: string[] } | undefined)?.techniques ?? [];
       const inheritedTechRefs = result.success ? ((result.value as { techniques?: { activity?: string[] } }).techniques?.activity ?? []) : [];
-      const workerTechniques = Array.from(new Set([...inheritedTechRefs, ...ownTechRefs, ...CORE_WORKER_TECHNIQUES]));
+      // The checkpoint half of the core worker set reaches the activities that can reach a checkpoint.
+      // An activity with no `kind: checkpoint` step cannot yield one, and a resume follows a yield, so
+      // both protocols are unreachable there — the worker role's own Protocol guards them behind
+      // reaching a checkpoint and behind `{effects}` being bound. Derived from the definition, like the
+      // enforcement notes below, so it is not a per-activity declaration anyone can forget to make.
+      const hasCheckpointStep = activity ? flattenActivitySteps(activity).some((s) => s.kind === 'checkpoint') : true;
+      const coreForActivity = hasCheckpointStep
+        ? CORE_WORKER_TECHNIQUES
+        : CORE_WORKER_TECHNIQUES.filter((ref) => !CHECKPOINT_WORKER_TECHNIQUES.includes(ref));
+      const workerTechniques = Array.from(new Set([...inheritedTechRefs, ...ownTechRefs, ...coreForActivity]));
       const resolvedWorker = await resolveTechniques(workerTechniques, config.workflowDir, workflow_id);
       const bundleData = formatTechniqueBundle(resolvedWorker);
 

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -1002,23 +1002,33 @@ export function registerWorkflowTools(server: McpServer, config: ServerConfig): 
             // A reference marker is near-zero cost — it does not draw down the eager budget.
             bundledStepTechniques[step.id!] = { marker: stepMarker, ...unchangedMarker(hash) };
           } else {
-            // Full content draws down the cumulative budget. Inline ungated step techniques in
-            // document order and STOP at the first one that would overflow the remaining budget
-            // (stop-and-break) — the remainder stay lazy. This preserves the contiguous
-            // document-order prefix the spec and docs promise, rather than skipping a large
-            // technique to squeeze in a later smaller one.
-            if (spentChars + text.length > eagerBudgetChars) break;
-            spentChars += text.length;
-            newDeliveries[ledgerKey] = hash;
             // The arrival marker leads the block; the composed technique fields follow at the same
             // level, so a bundled entry reads exactly like a get_technique fetch with a step header.
             // Shared contract and rules blocks collapse to a marker while the core stays full. Under
             // reference mode a block this context received on an earlier call collapses too; under
             // full delivery only a block a sibling of THIS response already carried does, so the
             // bytes a marker stands for are always above it in the same payload.
+            //
+            // Projected BEFORE the budget check, because what a collapsed block costs the budget is
+            // what it costs the wire: nothing. Charging the uncollapsed size instead spends budget on
+            // characters no response carries, and displaces later steps into lazy fetches to pay for
+            // them. Block hashes are staged onto a copy so a budget break discards them with the entry
+            // — a hash recorded for content never sent would collapse a later fetch to a marker the
+            // worker cannot read. The copy carries this call's earlier entries, which is what lets a
+            // sibling's block be recognised.
+            const staged: Record<string, string> = { ...newDeliveries };
             const projected = dedupTechniqueBlocks(
-              projectTechnique(technique), state, newDeliveries, scope, { readLedger: referenceMode },
+              projectTechnique(technique), state, staged, scope, { readLedger: referenceMode },
             );
+            // Full content draws down the cumulative budget. Inline ungated step techniques in
+            // document order and STOP at the first one that would overflow the remaining budget
+            // (stop-and-break) — the remainder stay lazy. This preserves the contiguous
+            // document-order prefix the spec and docs promise, rather than skipping a large
+            // technique to squeeze in a later smaller one.
+            const deliveredChars = stringifyForResponse(projected).length;
+            if (spentChars + deliveredChars > eagerBudgetChars) break;
+            spentChars += deliveredChars;
+            Object.assign(newDeliveries, staged, { [ledgerKey]: hash });
             if (!referenceMode) intraResponseCollapses += countCollapsedBlocks(projected);
             bundledStepTechniques[step.id!] = { marker: stepMarker, ...projected };
           }

--- a/tests/checkpoint-technique-reach.test.ts
+++ b/tests/checkpoint-technique-reach.test.ts
@@ -6,8 +6,12 @@
  * its own role technique guards behind a branch that cannot be taken.
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { CHECKPOINT_WORKER_TECHNIQUES, CORE_WORKER_TECHNIQUES } from '../src/loaders/core-ops.js';
+import { loadWorkflowWithDiagnostics } from '../src/loaders/workflow-loader.js';
+import { flattenActivitySteps } from '../src/schema/activity.schema.js';
+import { corpusRoot } from './corpus-root.js';
 import { createHarness, rawText, isError, parseToolResponse, type Harness } from './e2e/harness.js';
 
 /** Activities of the main workflow with and without a checkpoint step. */
@@ -19,6 +23,35 @@ describe('checkpoint protocols in the core worker set', () => {
     for (const ref of CHECKPOINT_WORKER_TECHNIQUES) {
       expect(CORE_WORKER_TECHNIQUES).toContain(ref);
     }
+  });
+
+  it('sees a checkpoint wherever the authored YAML has one, over the whole corpus', async () => {
+    // The delivery decides from the LOADED activity; an author writes the raw file. A checkpoint the
+    // loaded object does not show is one whose activity would lose the protocols it needs to yield —
+    // silently, since nothing else reads that decision. So the two views are compared directly, over
+    // every activity, rather than trusted to agree: a checkpoint step carries `kind: checkpoint`
+    // whether its body is inline or arrives through a `ref:`, and this is what keeps that true.
+    const root = corpusRoot();
+    let scanned = 0;
+    for (const workflow of readdirSync(root)) {
+      const dir = join(root, workflow, 'activities');
+      if (!existsSync(dir)) continue;
+      const loaded = await loadWorkflowWithDiagnostics(root, workflow);
+      if (!loaded.success) continue;
+      for (const file of readdirSync(dir).filter((f) => f.endsWith('.yaml'))) {
+        const raw = readFileSync(join(dir, file), 'utf8');
+        const rawHas = /^\s*-?\s*kind:\s*checkpoint\s*$/m.test(raw);
+        const id = /^id:\s*(\S+)/m.exec(raw)?.[1];
+        const activity = loaded.value.workflow.activities?.find((a) => a.id === id);
+        if (!activity) continue;
+        scanned += 1;
+        expect(
+          flattenActivitySteps(activity).some((s) => s.kind === 'checkpoint'),
+          `${workflow}/${file}: the loaded activity and the authored YAML disagree on whether it has a checkpoint`,
+        ).toBe(rawHas);
+      }
+    }
+    expect(scanned).toBeGreaterThan(50);
   });
 });
 

--- a/tests/checkpoint-technique-reach.test.ts
+++ b/tests/checkpoint-technique-reach.test.ts
@@ -1,0 +1,84 @@
+/**
+ * The checkpoint protocols reach the activities that can reach a checkpoint (#404 W5).
+ *
+ * A yield requires a `kind: checkpoint` step and a resume follows a yield, so an activity holding no
+ * checkpoint step reaches neither protocol. Delivering them there spends a worker's budget on content
+ * its own role technique guards behind a branch that cannot be taken.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { join } from 'node:path';
+import { CHECKPOINT_WORKER_TECHNIQUES, CORE_WORKER_TECHNIQUES } from '../src/loaders/core-ops.js';
+import { createHarness, rawText, isError, parseToolResponse, type Harness } from './e2e/harness.js';
+
+/** Activities of the main workflow with and without a checkpoint step. */
+const WITH_CHECKPOINT = 'implementation-analysis';
+const WITHOUT_CHECKPOINT = 'validate';
+
+describe('checkpoint protocols in the core worker set', () => {
+  it('are members of the core set, so leaving them out is a subset rather than a substitution', () => {
+    for (const ref of CHECKPOINT_WORKER_TECHNIQUES) {
+      expect(CORE_WORKER_TECHNIQUES).toContain(ref);
+    }
+  });
+});
+
+describe('what an activity receives', () => {
+  let h: Harness;
+  let sessionIndex: string;
+
+  beforeAll(async () => {
+    h = await createHarness();
+    const started = await h.client.callTool({
+      name: 'start_session',
+      arguments: {
+        workflow_id: 'work-package', agent_id: 'orchestrator',
+        planning_folder: join(h.workspaceDir, '.engineering/artifacts/planning', 'checkpoint-reach'),
+      },
+    });
+    if (isError(started)) throw new Error(rawText(started));
+    sessionIndex = parseToolResponse(started).session_index as string;
+  });
+
+  afterAll(async () => { await h?.close(); });
+
+  const take = async (activityId: string, agentId: string): Promise<string> => {
+    const entered = await h.client.callTool({
+      name: 'next_activity', arguments: { session_index: sessionIndex, activity_id: activityId },
+    });
+    if (isError(entered)) throw new Error(rawText(entered));
+    const taken = await h.client.callTool({
+      name: 'get_activity',
+      arguments: { session_index: sessionIndex, context_tokens: 200000, agent_id: agentId },
+    });
+    if (isError(taken)) throw new Error(rawText(taken));
+    return rawText(taken);
+  };
+
+  it('delivers both protocols to an activity that carries a gate', async () => {
+    const text = await take(WITH_CHECKPOINT, 'gated-worker');
+    expect(text).toContain('yield-checkpoint');
+    expect(text).toContain('resume-from-checkpoint');
+  });
+
+  it('leaves them out of an activity that carries none, and delivers everything else', async () => {
+    const text = await take(WITHOUT_CHECKPOINT, 'ungated-worker');
+    // The bundle keys name what arrived; a technique left out has no entry of its own.
+    expect(text).not.toMatch(/^ {2}workflow-engine::yield-checkpoint:/m);
+    expect(text).not.toMatch(/^ {2}workflow-engine::resume-from-checkpoint:/m);
+    // The rest of the core worker set still arrives — this is a subset, not a different bundle.
+    expect(text).toContain('activity-worker');
+    expect(text).toContain('finalize-activity');
+    // And the activity itself is intact.
+    expect(text).toContain(`id: ${WITHOUT_CHECKPOINT}`);
+  });
+
+  it('costs the gated activity more than the ungated one for the same core set', async () => {
+    const gated = await take(WITH_CHECKPOINT, 'size-gated');
+    const ungated = await take(WITHOUT_CHECKPOINT, 'size-ungated');
+    // Not a like-for-like comparison of the two activities, which bind different steps — the figure
+    // that matters is measured against the same activity with and without, recorded in the epic's
+    // delivery record at 4,060 characters. What this asserts is that the ungated delivery is the
+    // smaller of the two, which is the direction the change is for.
+    expect(ungated.length).toBeLessThan(gated.length);
+  });
+});

--- a/tests/e2e/__snapshots__/corpus-sha.json
+++ b/tests/e2e/__snapshots__/corpus-sha.json
@@ -1,4 +1,4 @@
 {
-  "corpusSha": "ade836e7d578730e236ae0a28fbd117548818a6f",
+  "corpusSha": "54ed1bebd8ba71b97729ef5482e15bbd91863678",
   "note": "Corpus commit the committed walk snapshots were generated against. Update it in the same commit that bumps the workflows submodule and re-baselines the walk (npm run baseline:stamp)."
 }

--- a/tests/e2e/__snapshots__/corpus-sha.json
+++ b/tests/e2e/__snapshots__/corpus-sha.json
@@ -1,4 +1,4 @@
 {
-  "corpusSha": "54ed1bebd8ba71b97729ef5482e15bbd91863678",
+  "corpusSha": "cda6e9266d45df651e160c7b954080c64e819873",
   "note": "Corpus commit the committed walk snapshots were generated against. Update it in the same commit that bumps the workflows submodule and re-baselines the walk (npm run baseline:stamp)."
 }

--- a/tests/e2e/__snapshots__/corpus-sha.json
+++ b/tests/e2e/__snapshots__/corpus-sha.json
@@ -1,4 +1,4 @@
 {
-  "corpusSha": "e47942b6ad1075be9a5f0f852429d77475f47268",
+  "corpusSha": "ade836e7d578730e236ae0a28fbd117548818a6f",
   "note": "Corpus commit the committed walk snapshots were generated against. Update it in the same commit that bumps the workflows submodule and re-baselines the walk (npm run baseline:stamp)."
 }

--- a/tests/e2e/batched-dispatch.test.ts
+++ b/tests/e2e/batched-dispatch.test.ts
@@ -112,6 +112,29 @@ describe('batched dispatch (#407)', () => {
     expect(walk.history.filter(e => e.type === 'activity_redelivered')).toHaveLength(0);
   });
 
+  it('forms a run of three at the window a real dispatch declares', async () => {
+    // The walk above widens the window so only the cap can bind, which leaves the question a real run
+    // asks unanswered: does the budget admit a run at the window production actually declares? Every
+    // profiled run declares 200,000 tokens, giving a 280,000-character budget.
+    const walk = await walkBatch('worker-production-window', RUN.slice(0, 3), 200_000);
+
+    expect(walk.refusedAt, `refused at the production window: ${walk.refusedWith}`).toBeUndefined();
+    expect(walk.texts).toHaveLength(3);
+    expect(walk.batches.map(b => b['activities'])).toEqual([1, 2, 3]);
+
+    const last = walk.batches[2]!;
+    expect(last['budget_chars']).toBe(280_000);
+    // Reported so the headroom a real run has for its lazy fetches is a figure rather than a hope: the
+    // walk never fetches lazily, so what it spends is the eager floor of a run this size.
+    const spent = last['delivered_chars'] as number;
+    const budget = last['budget_chars'] as number;
+    console.log(`[production-window] run of 3 forms: ${spent} of ${budget} chars, ${budget - spent} left for lazy fetches`);
+    expect(spent).toBeLessThan(budget);
+    // Read off 112 worker contexts in the sealed session records, one activity costs a median 74,109
+    // characters once its lazy fetches are counted. A run of three at the median has to fit.
+    expect(budget - spent).toBeGreaterThan(74_109);
+  });
+
   it('refuses the fourth activity at the cap, with the payload undelivered', async () => {
     const walk = await walkBatch('worker-run-capped', RUN, 2_000_000);
 


### PR DESCRIPTION
## Summary

The gap analysis reported two acceptance criteria as unmet. Measurement then showed part of each was
reachable, and this is that part. Neither is fully closed and this description says which half of each
still is not.

Work items W5 and W8 of the delivery-cost epic #404. Stacked on #442, which this branch includes.

## The checkpoint protocols reach the activities that can reach a checkpoint

Every activity delivery carried `yield-checkpoint` and `resume-from-checkpoint`. A yield requires a
`kind: checkpoint` step, and a resume follows a yield — so an activity holding no checkpoint step
reaches neither, and the worker's own role technique guards both behind branches it cannot take.

`get_activity` now derives that from the definition, with the same `flattenActivitySteps` scan the
enforcement notes already run, so it is not a per-activity declaration anyone can forget to make.

**4,060 characters off every checkpoint-free activity.** The two protocols compose to 13,052 between
them, but their shared contract and rules blocks collapse against their siblings whether they are in
the bundle or not, so what actually comes off is their own cores. Four activities across the two live
workflows hold no checkpoint step: the meta workflow's `initialize-session` and
`dispatch-client-workflow`, and the main workflow's `validate` and `complete`.

### What that does to W5's criterion, and what it does not

The criterion asks that each setup activity deliver less content than its July baseline. The 27 July
profile records a `get_activity` figure per setup activity, so the comparison is possible:

| Setup activity | 27 July | Now | Gate? |
|---|---:|---:|---|
| initialize-session | 42,547 | **36,242** | no |
| dispatch-client-workflow | 23,388 | 28,864 | no |
| resolve-target | 27,383 | 38,273 | yes |
| discover-session | 2,288 | 55,781 | yes |

`initialize-session` is now under its baseline. The other three are not, and the reason is the same for
all of them: eager bundling reached these activities after July, so the July figure counts the activity
text plus whatever was inlined *then*, while today's counts the step techniques that used to be fetched
lazily. `discover-session` is the extreme case — 2,288 characters in July because almost nothing was
inlined, against 29,858 characters of four step techniques today, which the record's own lazy-fetch
column shows it was paying for separately.

So the clause is met for one of four, and for the rest it compares an eager-only figure against an
all-in one. Meeting it as literally written would mean un-bundling those steps, which reverses a
measured improvement. The lever that would meet it honestly is the 27,600-character fixed activity
bundle every activity of every workflow receives, and that is a corpus-wide decision rather than a
ceremony one. Both are recorded in the epic's delivery record rather than left implied.

## A run forms at the window a real dispatch declares

The batched-dispatch suite proved a run of three activities forms in one context, and proved a batch
survives a real gate — both at a 2,000,000-token declared window, chosen so only the activity cap could
bind. That left the question a production run actually asks unanswered: does the *budget* admit a run at
200,000 tokens, which is what every profiled run declares?

It does, and there is now a test that says so:

```
[production-window] run of 3 forms: 151931 of 280000 chars, 128069 left for lazy fetches
```

The walk never fetches lazily, so 151,931 is the eager floor of a three-activity run. The 128,069
remaining is compared against the median all-in cost of one activity — 74,109 characters, read off 112
worker contexts in the sealed session records — so the assertion is that a run of three at the median
fits with room, not merely that this walk happened to.

### What that does to W8's criterion, and what it does not

W8 asks for a completed real session showing at least one context that walked more than one activity,
*or* the reason a run cannot form recorded. Neither branch is satisfiable from here, and the reason is
worth stating precisely rather than as "waiting on production":

- A run **can** form. The server admits it, at the production window, with headroom for a median
  activity's lazy fetches. That is now asserted rather than assumed.
- So the second branch of the criterion — the reason a run cannot form — has no true statement behind
  it on the server side.
- What remains unobserved is the orchestrator composing a continuation on a live run. Everything the
  server contributes is proven; the field it was missing arrives (#441), and the budget admits the run.

The read to take on the first completed session against a build carrying #441 is unchanged: group
`activity_dispatched` by `agentId` and look for a scope holding two or more activities, and count
`batch_refused`, which now means a worker read the standing and asked anyway.

## Scope of change

- `src/loaders/core-ops.ts` — `CHECKPOINT_WORKER_TECHNIQUES`, a named subset of the core worker set.
- `src/tools/workflow-tools.ts` — the derivation, beside the existing definition scans.
- `tests/checkpoint-technique-reach.test.ts` (new, 4 tests) — both protocols reach a gated activity,
  neither reaches an ungated one, everything else still does, and the subset is a subset.
- `tests/e2e/batched-dispatch.test.ts` — the production-window run.

Both land in one commit, whose message covers the first; this description covers both.

No schema change, no definition change.

## Verification

Full suite 1,019 tests green, all 24 guards green, `npx tsc --noEmit` clean.

## Non-goals

- The fixed activity bundle. It is the remaining 27,600 characters on every delivery of every workflow,
  and trimming it is a corpus-wide decision this branch does not take.
- W11, which needs around ten gate-crossing sessions and has at most one.
- Un-bundling any step technique to make a July comparison come out.

## Investigation detail

[2026-08-02-workflow-startup-cost](https://github.com/m2ux/workflow-server/tree/engineering/artifacts/planning/2026-08-02-workflow-startup-cost)
— the 27 July per-activity figures this compares against.
[2026-08-02-delivery-cost-epic/delivery-record.md](https://github.com/m2ux/workflow-server/blob/engineering/artifacts/planning/2026-08-02-delivery-cost-epic/delivery-record.md)
— the measured 4,060, and what each criterion's remaining half needs.
