### PR TITLE
Policy boundary: a rule that binds beyond the operation it sits on gets a test

### DIFF
--- a/workflow-design/resources/anti-patterns.md
+++ b/workflow-design/resources/anti-patterns.md
@@ -1912,3 +1912,15 @@ A rule, Protocol step, or I/O description describes an actor instead of instruct
 **Do not flag:** A duty stated as outside the reader's, with no account of who holds it. A value the reader takes from its own tool responses. A precondition the reader can check. The contract the reader itself applies, on the surface that owns it. An actor role carried as data a stub or manifest binds. Prose restating a contract owned elsewhere, which is `prompt-restates-owned-mechanics`. A rule whose only defect is its bucket, which is `rule-audience-bucket` — one that is mis-filed AND narrating is both, and the two fixes differ.
 
 **Fix:** Address the reader. Where the clause carried a duty of the reader's, restate it as the imperative it always was. Where it described another actor, restate the reason from the reader's own position or delete it — an instruction whose reason cannot be put that way had no reason the reader could use. See [One Authoritative Home](./design-principles.md#6-one-authoritative-home).
+
+### AP-147. rule-binds-beyond-its-operation
+
+"`sync-progress-status` is the only writer of Progress status — not a per-activity YAML step, not a client-workflow activity rule, not a worker duty" on a persistence operation's `## Rules`
+
+An operation's rule states policy over a subject the operation does not own, so it binds readers who never apply it.
+
+**Detect:** For each `## Rules` entry, name the subject it constrains and ask whether the operation performs or produces that subject. Flag an entry whose subject outlives it — a sole writer, owner or home named for something the operation only contributes to, or a duty assigned to an actor the entry is not delivered to. Test: strike the operation from the sentence; where the claim still binds somebody, it is policy, and its home is the surface that owns the subject rather than the Rules of one caller. Filing it there also narrows its reach, since an operation's rules travel only with that operation.
+
+**Do not flag:** A prohibition or conformance statement addressed to the reader — a worker rule barring a worker's own call, an adapter rule naming the only conforming form of its own dispatch. An invariant on the operation's own cadence, outputs, or the composition of what it writes. A one-line pointer to the surface that does own the policy. The same claim already held in both places, which is `no-technique-resource-dual-home`, and the mirror defect of operational cadence filed in a resource, which is `resource-fills-not-does`.
+
+**Fix:** Move the claim to the surface that owns the subject, widening that surface's own statement to cover whatever the rule uniquely carried, and delete the rule where nothing operation-specific remains. Cite the owning surface from the phase that needs it. Where no surface owns the subject yet, `operative-criteria-need-a-home` names the migration. See [One Authoritative Home](./design-principles.md#6-one-authoritative-home).


### PR DESCRIPTION
## Summary

The canon already draws the line between policy and operational behaviour, and already detects two ways
of crossing it. It does not detect the third, which is the hardest of the three to see — because nothing
looks duplicated.

This adds one catalog entry for that case. No principle changes: the stance was already there.

## What was already covered

**One Authoritative Home** states the boundary: resources hold templates, vocabularies, criteria and
policy tables, while operational cadence and HOW live outside them — and "normative criteria /
vocabulary / policy matrices … remain resource consult **even when a technique Applies them**."

Two entries detect a crossing:

- `resource-fills-not-does` — operational cadence or gate routing filed in a **resource**. Its
  discriminator is the clearest statement of the boundary anywhere in the catalog: vocabulary and labels
  a template consumes stay; behavioural cadence that operations apply moves to the technique.
- `no-technique-resource-dual-home` — the same operative criteria held in **both** places.

## What was not

Policy filed in an operation's `## Rules` where **no resource holds it yet**.

- `resource-fills-not-does` fires only on resources.
- `no-technique-resource-dual-home` needs the duplicate to already exist.
- `operative-criteria-need-a-home` targets reusable criteria and multi-item checklists in a technique
  **Protocol** — not a single policy claim in Rules.

So the case falls between all three, and it is the one that hides best: a rule stating who may write
some shared surface reads as an ordinary invariant until you ask whether the operation owns that
surface.

## The entry

`rule-binds-beyond-its-operation`, appended as AP-147 at the tail where recent entries live.

The test it supplies is the one the stance implies, and it is structural rather than a phrase list: name
the subject a rule constrains, ask whether the operation performs or produces it, then **strike the
operation from the sentence and see whether the claim still binds somebody**. If it does, the claim is
policy and its home is the surface that owns the subject.

The load-bearing carve-out is the common legitimate case: a rule that prohibits **its own reader** is an
invariant, not policy. Without it the entry would fire on a worker-conduct rule barring a worker's own
tool call, and on an adapter rule naming the only conforming form of its own dispatch — both correct as
written. I checked those two specifically against the draft.

It cites its two siblings by name rather than re-teaching either, and cites One Authoritative Home for
the positive form, so Detect is not the sole home of the stance.

## How it was found

By asking where a persistence operation's four rules belonged. Three were cadence and commit-composition
invariants — the operation's own. The fourth stated that one technique is the only writer of a planning
README's Progress status, and that neither an activity YAML step nor a worker may write it: policy over a
surface the operation only contributes to, which the planning README guide already owned. That rule is
now gone and the guide carries the exclusions
([m2ux/workflow-server#439](https://github.com/m2ux/workflow-server/pull/439) — corpus branch
`workflow/delivery-cost-startup-ceremony`).

That fix keyed on `no-technique-resource-dual-home`, because the resource happened to hold the claim
already. Had it not, nothing would have flagged it — which is the gap this entry closes.

## Verification

All 24 guards pass against this corpus. The entry follows the Creation Rules: two-line intro with the
exemplar quoted and one framing sentence, Detect / Do not flag / Fix each on its own block, a structural
test rather than an incident freeze, no restatement of a sibling's Detect, and cross-references by
kebab-case name in backticks. The unit inventory in the workflow-canon skill is unaffected — recent
`AP-` entries live in the tail unit it already describes, so the unit count does not move.

## Non-goals

- A new design principle. One Authoritative Home carries the stance, and a second statement of it would
  be `canon-layer-cites-not-restates`.
- A guard. The mechanically checkable half is the dual-home case a linked resource makes visible; the
  general test needs a reader. Worth considering separately.
- Sweeping the corpus for existing instances. A phrasing screen over all 535 technique rules returned 16
  candidates, and the two strongest both turned out legitimate under the carve-out — so the screen is a
  starting filter, not a findings list, and a sweep is its own piece of work.
