### PR TITLE
Technique design: a canon path for deciding what a technique should be

### DIFF
--- a/examples/cursor-workspace/.claude/skills/workflow-canon/SKILL.md
+++ b/examples/cursor-workspace/.claude/skills/workflow-canon/SKILL.md
@@ -31,14 +31,24 @@ Read [references/canon-map.md](references/canon-map.md) before the first fetch: 
 
 | Situation | Path |
 |-----------|------|
+| Deciding what a technique or operation group should *be* — its members, granularity, and where each piece lives | **Design** below |
 | About to write or edit a definition file | **Draft** below |
 | Reviewing or auditing existing definitions | **Audit** below |
 | One narrow question ("is X an anti-pattern?", "which construct for Y?") | Fetch that single entry or inventory row, answer, stop. No walk, no report. |
+
+## Design
+
+Applied before there is a file to check — when the question is which operations should exist, how big each one is, and which construct owns each piece of what you are about to write.
+
+Read [references/technique-design.md](references/technique-design.md). It carries the correspondence between the technique metamodel and an object system, SOLID mapped onto that correspondence, the placement table that routes a sentence to its construct and its smallest covering scope, the granularity tests for operation boundaries, and the design lenses — ontological soundness, stylistic elegance, efficiency — for reviewing a technique past compliance.
+
+It holds no criteria of its own either: every judgement it raises resolves to an entry, a principle title, or an inventory row. Design settles shape; **Draft** then writes the file and **Audit** walks it.
 
 ## Draft
 
 Applied *before* content exists, so the stance does the work and the Detect pass finds nothing.
 
+0. **Settle the shape first** when the file does not exist yet — which operations, how big, what each construct holds. That is the **Design** path above; it decides what you are about to write before the construct rules decide how.
 1. **Fix the construct before the prose.** Fetch the construct-inventory section for the kind you are authoring (activity / workflow / technique / condition) and pick the most specific formal construct it offers. Prose that an inventory row maps to a construct is a defect the moment it is written, not at audit time.
 2. **Load the stance that binds this file kind.** Use the routing table in [references/canon-map.md](references/canon-map.md#file-kind-routing) — it names the principles and the anti-pattern families a technique, activity, resource, or README can actually violate. Read the stance sections, not a summary of them.
 3. **Read a live sibling.** Convention conformance is defined relative to existing workflows; the reference files are the baseline, and this skill does not substitute for opening them.
@@ -119,4 +129,5 @@ Per [references/reporting.md](references/reporting.md): the finding row shape, t
 ## References
 
 - [references/canon-map.md](references/canon-map.md) — unit inventory, fetch anchors, file-kind routing, per-home boundaries.
+- [references/technique-design.md](references/technique-design.md) — the object-system correspondence, SOLID, functionality placement, granularity tests, design review lenses.
 - [references/reporting.md](references/reporting.md) — severity scale, finding and coverage row shapes, report templates.

--- a/examples/cursor-workspace/.claude/skills/workflow-canon/SKILL.md
+++ b/examples/cursor-workspace/.claude/skills/workflow-canon/SKILL.md
@@ -17,11 +17,11 @@ Confirm the resolved root holds `workflows/workflow-design/resources/` before re
 
 | Home | Path | Owns |
 |------|------|------|
-| Design Principles | `workflows/workflow-design/resources/design-principles.md` | *Prefer / before / only after* stance. One unit per `##` section. |
-| Anti-Patterns | `workflows/workflow-design/resources/anti-patterns.md` | Specific smells as **Detect / Do not flag / Fix**. One unit per `##` family section. ~1700 lines — fetch by anchor. |
-| Schema Construct Inventory | `workflows/workflow-design/resources/schema-construct-inventory.md` | Informal-prose → formal-construct mappings. One unit per `##` section. |
-| Convention Conformance | `workflows/workflow-design/resources/convention-conformance.md` | Comparison against sibling workflows. One unit. |
-| Guard suite | `scripts/guards.ts` (registry) | Mechanical checks. The registry is the enumeration — never maintain a parallel list. |
+| [Design Principles](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/design-principles.md) | `workflows/workflow-design/resources/design-principles.md` | *Prefer / before / only after* stance. One unit per `##` section. |
+| [Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md) | `workflows/workflow-design/resources/anti-patterns.md` | Specific smells as **Detect / Do not flag / Fix**. One unit per `##` family section. Long enough to exceed the delivery cap — fetch by anchor. |
+| [Schema Construct Inventory](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/schema-construct-inventory.md) | `workflows/workflow-design/resources/schema-construct-inventory.md` | Informal-prose → formal-construct mappings. One unit per `##` section. |
+| [Convention Conformance](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/convention-conformance.md) | `workflows/workflow-design/resources/convention-conformance.md` | Comparison against sibling workflows. One unit. |
+| [Guard suite](https://github.com/m2ux/workflow-server/blob/main/scripts/guards.ts) | `scripts/guards.ts` (registry) | Mechanical checks. The registry is the enumeration — never maintain a parallel list. |
 
 Anchors on the principles home embed the ordinal (`#13-separate-contract-from-procedure`). Cite by **title**; if an anchor fails to resolve, the section was renumbered — re-read the heading rather than guessing.
 

--- a/examples/cursor-workspace/.claude/skills/workflow-canon/SKILL.md
+++ b/examples/cursor-workspace/.claude/skills/workflow-canon/SKILL.md
@@ -15,13 +15,13 @@ The canon is four criteria homes plus a guard suite, all on disk in this repo.
 
 Confirm the resolved root holds `workflows/workflow-design/resources/` before reading anything. `workflows/` is a git submodule, so a shallow checkout may not have it; if the canon files are absent, say so rather than auditing from memory.
 
-| Home | Path | Owns |
-|------|------|------|
-| [Design Principles](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/design-principles.md) | `workflows/workflow-design/resources/design-principles.md` | *Prefer / before / only after* stance. One unit per `##` section. |
-| [Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md) | `workflows/workflow-design/resources/anti-patterns.md` | Specific smells as **Detect / Do not flag / Fix**. One unit per `##` family section. Long enough to exceed the delivery cap — fetch by anchor. |
-| [Schema Construct Inventory](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/schema-construct-inventory.md) | `workflows/workflow-design/resources/schema-construct-inventory.md` | Informal-prose → formal-construct mappings. One unit per `##` section. |
-| [Convention Conformance](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/convention-conformance.md) | `workflows/workflow-design/resources/convention-conformance.md` | Comparison against sibling workflows. One unit. |
-| [Guard suite](https://github.com/m2ux/workflow-server/blob/main/scripts/guards.ts) | `scripts/guards.ts` (registry) | Mechanical checks. The registry is the enumeration — never maintain a parallel list. |
+| Home | Path from the repo root | Owns |
+|------|------------------------|------|
+| Design Principles | [workflows/workflow-design/resources/design-principles.md](../../../../../workflows/workflow-design/resources/design-principles.md) | *Prefer / before / only after* stance. One unit per `##` section. |
+| Anti-Patterns | [workflows/workflow-design/resources/anti-patterns.md](../../../../../workflows/workflow-design/resources/anti-patterns.md) | Specific smells as **Detect / Do not flag / Fix**. One unit per `##` family section. Long enough to exceed the delivery cap — fetch by anchor. |
+| Schema Construct Inventory | [workflows/workflow-design/resources/schema-construct-inventory.md](../../../../../workflows/workflow-design/resources/schema-construct-inventory.md) | Informal-prose → formal-construct mappings. One unit per `##` section. |
+| Convention Conformance | [workflows/workflow-design/resources/convention-conformance.md](../../../../../workflows/workflow-design/resources/convention-conformance.md) | Comparison against sibling workflows. One unit. |
+| Guard suite | [scripts/guards.ts](../../../../../scripts/guards.ts) | Mechanical checks. The registry is the enumeration — never maintain a parallel list. |
 
 Anchors on the principles home embed the ordinal (`#13-separate-contract-from-procedure`). Cite by **title**; if an anchor fails to resolve, the section was renumbered — re-read the heading rather than guessing.
 

--- a/examples/cursor-workspace/.claude/skills/workflow-canon/references/canon-map.md
+++ b/examples/cursor-workspace/.claude/skills/workflow-canon/references/canon-map.md
@@ -6,43 +6,43 @@ Where the criteria live, how to fetch them, and which ones bind what. No criteri
 
 The enumeration a walk covers. Take **this list**; do not derive it by pattern-matching section titles at read time.
 
-### [Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md)
+### [Anti-Patterns](../../../../../../workflows/workflow-design/resources/anti-patterns.md)
 
 Entries sit outside the family sections, so a title pattern silently drops them:
 
 | Unit | Anchor |
 |------|--------|
-| [Creation Rules](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#creation-rules) | `#creation-rules` |
-| [Structural Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#structural-anti-patterns) | `#structural-anti-patterns` |
-| [Interaction Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#interaction-anti-patterns) | `#interaction-anti-patterns` |
-| [Schema Expressiveness Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#schema-expressiveness-anti-patterns) | `#schema-expressiveness-anti-patterns` |
-| [Rule Hygiene Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#rule-hygiene-anti-patterns) | `#rule-hygiene-anti-patterns` |
-| [Description Hygiene Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#description-hygiene-anti-patterns) | `#description-hygiene-anti-patterns` |
-| [Coupling Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#coupling-anti-patterns) | `#coupling-anti-patterns` |
-| [Tool-Technique-Doc Consistency Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#tool-technique-doc-consistency-anti-patterns) | `#tool-technique-doc-consistency-anti-patterns` |
-| [Execution Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#execution-anti-patterns) | `#execution-anti-patterns` |
-| [Output Economy Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#output-economy-anti-patterns) | `#output-economy-anti-patterns` |
-| [Canon Hygiene Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#canon-hygiene-anti-patterns) | `#canon-hygiene-anti-patterns` |
-| [Technique Protocol Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#technique-protocol-anti-patterns) | `#technique-protocol-anti-patterns` |
-| [Authoring Guidance (MR)](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#authoring-guidance-mr) | `#authoring-guidance-mr` |
+| [Creation Rules](../../../../../../workflows/workflow-design/resources/anti-patterns.md#creation-rules) | `#creation-rules` |
+| [Structural Anti-Patterns](../../../../../../workflows/workflow-design/resources/anti-patterns.md#structural-anti-patterns) | `#structural-anti-patterns` |
+| [Interaction Anti-Patterns](../../../../../../workflows/workflow-design/resources/anti-patterns.md#interaction-anti-patterns) | `#interaction-anti-patterns` |
+| [Schema Expressiveness Anti-Patterns](../../../../../../workflows/workflow-design/resources/anti-patterns.md#schema-expressiveness-anti-patterns) | `#schema-expressiveness-anti-patterns` |
+| [Rule Hygiene Anti-Patterns](../../../../../../workflows/workflow-design/resources/anti-patterns.md#rule-hygiene-anti-patterns) | `#rule-hygiene-anti-patterns` |
+| [Description Hygiene Anti-Patterns](../../../../../../workflows/workflow-design/resources/anti-patterns.md#description-hygiene-anti-patterns) | `#description-hygiene-anti-patterns` |
+| [Coupling Anti-Patterns](../../../../../../workflows/workflow-design/resources/anti-patterns.md#coupling-anti-patterns) | `#coupling-anti-patterns` |
+| [Tool-Technique-Doc Consistency Anti-Patterns](../../../../../../workflows/workflow-design/resources/anti-patterns.md#tool-technique-doc-consistency-anti-patterns) | `#tool-technique-doc-consistency-anti-patterns` |
+| [Execution Anti-Patterns](../../../../../../workflows/workflow-design/resources/anti-patterns.md#execution-anti-patterns) | `#execution-anti-patterns` |
+| [Output Economy Anti-Patterns](../../../../../../workflows/workflow-design/resources/anti-patterns.md#output-economy-anti-patterns) | `#output-economy-anti-patterns` |
+| [Canon Hygiene Anti-Patterns](../../../../../../workflows/workflow-design/resources/anti-patterns.md#canon-hygiene-anti-patterns) | `#canon-hygiene-anti-patterns` |
+| [Technique Protocol Anti-Patterns](../../../../../../workflows/workflow-design/resources/anti-patterns.md#technique-protocol-anti-patterns) | `#technique-protocol-anti-patterns` |
+| [Authoring Guidance (MR)](../../../../../../workflows/workflow-design/resources/anti-patterns.md#authoring-guidance-mr) | `#authoring-guidance-mr` |
 
 **Authoring Guidance (MR)** is the tail of the file and holds both the `MR-` guidance entries and the catalog's most recently appended `AP-` entries. Read it to its end; the last entry is not signposted by a new `##`.
 
 **Creation Rules** governs authoring the catalog itself. It reaches the surface only when the audited change edits the catalog — otherwise it is `not-applicable`, with that as the recorded reason.
 
-### [Design Principles](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/design-principles.md)
+### [Design Principles](../../../../../../workflows/workflow-design/resources/design-principles.md)
 
 One unit per `##` section, each a numbered principle. Anchors embed the ordinal (`#22-modular-over-inline`); the **title** is the stable citation. If an anchor fails to resolve, the section was renumbered — re-read the headings.
 
-### [Schema Construct Inventory](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/schema-construct-inventory.md)
+### [Schema Construct Inventory](../../../../../../workflows/workflow-design/resources/schema-construct-inventory.md)
 
-One unit per `##` section: Activity-Level Constructs, Workflow-Level Constructs, Technique-Level Constructs, Condition Constructs, Checkpoint Effects, Action Types. The header block names the authoritative schema files under `schemas/`; [schemas/README.md](https://github.com/m2ux/workflow-server/blob/main/schemas/README.md) is the deep home for field tables and examples.
+One unit per `##` section: Activity-Level Constructs, Workflow-Level Constructs, Technique-Level Constructs, Condition Constructs, Checkpoint Effects, Action Types. The header block names the authoritative schema files under `schemas/`; [schemas/README.md](../../../../../../schemas/README.md) is the deep home for field tables and examples.
 
-### [Convention Conformance](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/convention-conformance.md)
+### [Convention Conformance](../../../../../../workflows/workflow-design/resources/convention-conformance.md)
 
 One unit: Reference Conventions. It is explicitly *not* a substitute for reading the live sibling workflows it compares against, and YAML syntax literacy is out of its scope.
 
-### [Guards](https://github.com/m2ux/workflow-server/blob/main/scripts/guards.ts)
+### [Guards](../../../../../../scripts/guards.ts)
 
 The registry is the enumeration; each entry carries a one-line `proves`. Read it rather than assuming a roster. `npm run check:all` runs every entry; `npx tsx scripts/check-delta.ts --base <ref>` reports only what the change added.
 
@@ -58,7 +58,7 @@ File-kind routing still chooses which units can fire; it does not shrink a touch
 
 ## Fetching
 
-The [anti-pattern catalog](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md) exceeds the per-resource eager-delivery cap, so it is never bundled whole. Fetch by section in every mode:
+The [anti-pattern catalog](../../../../../../workflows/workflow-design/resources/anti-patterns.md) exceeds the per-resource eager-delivery cap, so it is never bundled whole. Fetch by section in every mode:
 
 - **On disk** — `grep -n "^## " <file>` to get the section line numbers, then Read the one range you need. For a single entry, `grep -n "^### " ` and read that block.
 - **In an active workflow session** — `get_resource` with a cross-workflow ref and anchor: `workflow-design/anti-patterns#coupling-anti-patterns`, `workflow-design/design-principles`, `workflow-design/schema-construct-inventory`, `workflow-design/convention-conformance`.

--- a/examples/cursor-workspace/.claude/skills/workflow-canon/references/canon-map.md
+++ b/examples/cursor-workspace/.claude/skills/workflow-canon/references/canon-map.md
@@ -67,16 +67,19 @@ Do not summarise a section into working notes and then audit against the notes. 
 
 ## File-kind routing
 
-Which units a given file kind can actually violate. Use it to scope a draft self-check or a narrow review. A full audit walks every unit regardless — this table narrows effort, not coverage, and a unit skipped on its strength is `not-applicable` with this table as the reason.
+Where to start reading for a given file kind. Use it to scope a draft self-check or a narrow review. A full audit walks every unit regardless — this table narrows effort, not coverage.
+
+It routes; it does not decide. Each entry's Detect states the surface it keys on, so that is what a `not-applicable` disposition cites — the entry and why it cannot reach this surface. A row's silence is a starting point, never the evidence.
 
 | Authoring / auditing | Principles (by title) | Anti-pattern units | Inventory units |
 |---|---|---|---|
-| **Technique** `techniques/*.md` | Separate Contract from Procedure · Phase by Sequenced Outcome · Distinguish Designators from Parameters · Keep Orchestration in Structure · Keep Session Interaction in Activities · Bind Sibling Operations as Steps · Atomic Techniques; Compose at Activities · Prefer Shared Capability · Cite Resource Policy; Do Not Restate It · Name Symbols Affirmatively · Match the Harness Surface · Single Source of Truth | Technique Protocol · Coupling · Rule Hygiene · Description Hygiene · Tool-Technique-Doc Consistency | Technique-Level Constructs |
+| **Technique** `techniques/*.md` | Separate Contract from Procedure · Phase by Sequenced Outcome · Distinguish Designators from Parameters · Isolate Conditional Branches as Notes · Cite Resources at Section Grain · Keep Orchestration in Structure · Keep Session Interaction in Activities · Bind Sibling Operations as Steps · Atomic Techniques; Compose at Activities · Prefer Shared Capability · Cite Resource Policy; Do Not Restate It · Name Symbols Affirmatively · Match the Harness Surface · Single Source of Truth | Technique Protocol · Coupling · Rule Hygiene · Description Hygiene · Tool-Technique-Doc Consistency | Technique-Level Constructs |
 | **Container** `TECHNIQUE.md` | the technique row, plus State Contract Contribution | Technique Protocol · Canon Hygiene | Technique-Level Constructs |
 | **Activity** `activities/NN-*.yaml` | Encode Constraints as Structure · Keep Orchestration in Structure · Keep Session Interaction in Activities · Bind Sibling Operations as Steps · Atomic Techniques; Compose at Activities · Maximize Schema Expressiveness · Output Economy · Single Source of Truth · Document in Positive Present | Schema Expressiveness · Interaction · Output Economy · Rule Hygiene · Description Hygiene | Activity-Level Constructs · Condition Constructs · Checkpoint Effects · Action Types |
 | **Workflow** `workflow.yaml` | Single Source of Truth · Maximize Schema Expressiveness · Encode Constraints as Structure · Name Symbols Affirmatively | Rule Hygiene · Description Hygiene · Schema Expressiveness | Workflow-Level Constructs |
 | **Resource** `resources/*.md` | One Authoritative Home · Creation Guide for Generated Documents · Cite Resource Policy; Do Not Restate It · Resources at the Abstract Level; Split for Section Delivery · Output Economy | Output Economy · Canon Hygiene | — |
 | **README** `README.md` | Complete Documentation Structure · Document in Positive Present · Output Economy · Non-Destructive Updates | Description Hygiene · Output Economy · Coupling | — |
+| **Pre-session prose** the `discover` bootstrap procedure | Pre-Session Prose Stands Alone · One Authoritative Home | Authoring Guidance (MR) · Tool-Technique-Doc Consistency | — |
 | **The catalog itself** `anti-patterns.md` | One Authoritative Home | Creation Rules · Canon Hygiene | — |
 | **Every change** | Internalize Before Producing · Define Complete Scope Before Execution · Clarify Before Assuming · Convention Over Invention · Confirm Before Irreversible Changes · Non-Destructive Updates · Modular Over Inline · Close the Loop · Workflows Ossify Patterns | Structural · Execution | — |
 

--- a/examples/cursor-workspace/.claude/skills/workflow-canon/references/canon-map.md
+++ b/examples/cursor-workspace/.claude/skills/workflow-canon/references/canon-map.md
@@ -8,7 +8,7 @@ The enumeration a walk covers. Take **this list**; do not derive it by pattern-m
 
 ### Anti-Patterns — `workflows/workflow-design/resources/anti-patterns.md`
 
-Thirteen units. Entries sit outside the family sections, so a title pattern silently drops them:
+Entries sit outside the family sections, so a title pattern silently drops them:
 
 | # | Unit | Anchor |
 |---|------|--------|
@@ -32,11 +32,11 @@ Unit 1 (**Creation Rules**) governs authoring the catalog itself. It reaches the
 
 ### Design Principles — `workflows/workflow-design/resources/design-principles.md`
 
-One unit per `##` section: thirty numbered principles. Anchors embed the ordinal (`#22-modular-over-inline`); the **title** is the stable citation. If an anchor fails to resolve, the section was renumbered — re-read the headings.
+One unit per `##` section, each a numbered principle. Anchors embed the ordinal (`#22-modular-over-inline`); the **title** is the stable citation. If an anchor fails to resolve, the section was renumbered — re-read the headings.
 
 ### Schema Construct Inventory — `workflows/workflow-design/resources/schema-construct-inventory.md`
 
-Six units, by `##` section: Activity-Level Constructs, Workflow-Level Constructs, Technique-Level Constructs, Condition Constructs, Checkpoint Effects, Action Types. The header block names the authoritative schema files under `schemas/`; `schemas/README.md` is the deep home for field tables and examples.
+One unit per `##` section: Activity-Level Constructs, Workflow-Level Constructs, Technique-Level Constructs, Condition Constructs, Checkpoint Effects, Action Types. The header block names the authoritative schema files under `schemas/`; `schemas/README.md` is the deep home for field tables and examples.
 
 ### Convention Conformance — `workflows/workflow-design/resources/convention-conformance.md`
 

--- a/examples/cursor-workspace/.claude/skills/workflow-canon/references/canon-map.md
+++ b/examples/cursor-workspace/.claude/skills/workflow-canon/references/canon-map.md
@@ -6,43 +6,43 @@ Where the criteria live, how to fetch them, and which ones bind what. No criteri
 
 The enumeration a walk covers. Take **this list**; do not derive it by pattern-matching section titles at read time.
 
-### Anti-Patterns — `workflows/workflow-design/resources/anti-patterns.md`
+### [Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md)
 
 Entries sit outside the family sections, so a title pattern silently drops them:
 
-| # | Unit | Anchor |
-|---|------|--------|
-| 1 | Creation Rules | `#creation-rules` |
-| 2 | Structural Anti-Patterns | `#structural-anti-patterns` |
-| 3 | Interaction Anti-Patterns | `#interaction-anti-patterns` |
-| 4 | Schema Expressiveness Anti-Patterns | `#schema-expressiveness-anti-patterns` |
-| 5 | Rule Hygiene Anti-Patterns | `#rule-hygiene-anti-patterns` |
-| 6 | Description Hygiene Anti-Patterns | `#description-hygiene-anti-patterns` |
-| 7 | Coupling Anti-Patterns | `#coupling-anti-patterns` |
-| 8 | Tool-Technique-Doc Consistency Anti-Patterns | `#tool-technique-doc-consistency-anti-patterns` |
-| 9 | Execution Anti-Patterns | `#execution-anti-patterns` |
-| 10 | Output Economy Anti-Patterns | `#output-economy-anti-patterns` |
-| 11 | Canon Hygiene Anti-Patterns | `#canon-hygiene-anti-patterns` |
-| 12 | Technique Protocol Anti-Patterns | `#technique-protocol-anti-patterns` |
-| 13 | Authoring Guidance (MR) | `#authoring-guidance-mr` |
+| Unit | Anchor |
+|------|--------|
+| [Creation Rules](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#creation-rules) | `#creation-rules` |
+| [Structural Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#structural-anti-patterns) | `#structural-anti-patterns` |
+| [Interaction Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#interaction-anti-patterns) | `#interaction-anti-patterns` |
+| [Schema Expressiveness Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#schema-expressiveness-anti-patterns) | `#schema-expressiveness-anti-patterns` |
+| [Rule Hygiene Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#rule-hygiene-anti-patterns) | `#rule-hygiene-anti-patterns` |
+| [Description Hygiene Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#description-hygiene-anti-patterns) | `#description-hygiene-anti-patterns` |
+| [Coupling Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#coupling-anti-patterns) | `#coupling-anti-patterns` |
+| [Tool-Technique-Doc Consistency Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#tool-technique-doc-consistency-anti-patterns) | `#tool-technique-doc-consistency-anti-patterns` |
+| [Execution Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#execution-anti-patterns) | `#execution-anti-patterns` |
+| [Output Economy Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#output-economy-anti-patterns) | `#output-economy-anti-patterns` |
+| [Canon Hygiene Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#canon-hygiene-anti-patterns) | `#canon-hygiene-anti-patterns` |
+| [Technique Protocol Anti-Patterns](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#technique-protocol-anti-patterns) | `#technique-protocol-anti-patterns` |
+| [Authoring Guidance (MR)](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md#authoring-guidance-mr) | `#authoring-guidance-mr` |
 
-Unit 13 is the tail of the file and holds both the `MR-` guidance entries and the catalog's most recently appended `AP-` entries. Read it to its end; the last entry is not signposted by a new `##`.
+**Authoring Guidance (MR)** is the tail of the file and holds both the `MR-` guidance entries and the catalog's most recently appended `AP-` entries. Read it to its end; the last entry is not signposted by a new `##`.
 
-Unit 1 (**Creation Rules**) governs authoring the catalog itself. It reaches the surface only when the audited change edits `anti-patterns.md` — otherwise it is `not-applicable`, with that as the recorded reason.
+**Creation Rules** governs authoring the catalog itself. It reaches the surface only when the audited change edits the catalog — otherwise it is `not-applicable`, with that as the recorded reason.
 
-### Design Principles — `workflows/workflow-design/resources/design-principles.md`
+### [Design Principles](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/design-principles.md)
 
 One unit per `##` section, each a numbered principle. Anchors embed the ordinal (`#22-modular-over-inline`); the **title** is the stable citation. If an anchor fails to resolve, the section was renumbered — re-read the headings.
 
-### Schema Construct Inventory — `workflows/workflow-design/resources/schema-construct-inventory.md`
+### [Schema Construct Inventory](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/schema-construct-inventory.md)
 
-One unit per `##` section: Activity-Level Constructs, Workflow-Level Constructs, Technique-Level Constructs, Condition Constructs, Checkpoint Effects, Action Types. The header block names the authoritative schema files under `schemas/`; `schemas/README.md` is the deep home for field tables and examples.
+One unit per `##` section: Activity-Level Constructs, Workflow-Level Constructs, Technique-Level Constructs, Condition Constructs, Checkpoint Effects, Action Types. The header block names the authoritative schema files under `schemas/`; [schemas/README.md](https://github.com/m2ux/workflow-server/blob/main/schemas/README.md) is the deep home for field tables and examples.
 
-### Convention Conformance — `workflows/workflow-design/resources/convention-conformance.md`
+### [Convention Conformance](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/convention-conformance.md)
 
 One unit: Reference Conventions. It is explicitly *not* a substitute for reading the live sibling workflows it compares against, and YAML syntax literacy is out of its scope.
 
-### Guards — `scripts/guards.ts`
+### [Guards](https://github.com/m2ux/workflow-server/blob/main/scripts/guards.ts)
 
 The registry is the enumeration; each entry carries a one-line `proves`. Read it rather than assuming a roster. `npm run check:all` runs every entry; `npx tsx scripts/check-delta.ts --base <ref>` reports only what the change added.
 
@@ -58,7 +58,7 @@ File-kind routing still chooses which units can fire; it does not shrink a touch
 
 ## Fetching
 
-`anti-patterns.md` exceeds the per-resource eager-delivery cap, so it is never bundled whole. Fetch by section in every mode:
+The [anti-pattern catalog](https://github.com/m2ux/workflow-server/blob/workflows/workflow-design/resources/anti-patterns.md) exceeds the per-resource eager-delivery cap, so it is never bundled whole. Fetch by section in every mode:
 
 - **On disk** — `grep -n "^## " <file>` to get the section line numbers, then Read the one range you need. For a single entry, `grep -n "^### " ` and read that block.
 - **In an active workflow session** — `get_resource` with a cross-workflow ref and anchor: `workflow-design/anti-patterns#coupling-anti-patterns`, `workflow-design/design-principles`, `workflow-design/schema-construct-inventory`, `workflow-design/convention-conformance`.

--- a/examples/cursor-workspace/.claude/skills/workflow-canon/references/reporting.md
+++ b/examples/cursor-workspace/.claude/skills/workflow-canon/references/reporting.md
@@ -42,7 +42,7 @@ Divergences only. A unit walked cleanly gets no row — the absence of a row is 
 
 Only `blocked` represents missing coverage. `not-applicable` is an evidenced negative and must carry its reason; a bare skip is not one.
 
-The obligation is one row per unwalked unit of every home in the inventory. If the ledger cannot account for all thirteen anti-pattern units, the six inventory units, the thirty principles, and the conformance unit, the walk was partial — say so rather than reporting a clean sweep.
+The obligation is one row per unwalked unit of every home in the inventory. If the ledger cannot account for every anti-pattern unit, every inventory unit, every principle, and the conformance unit — as [canon-map.md](canon-map.md#unit-inventory) enumerates them — the walk was partial, and saying so beats reporting a clean sweep.
 
 ## Which report
 

--- a/examples/cursor-workspace/.claude/skills/workflow-canon/references/technique-design.md
+++ b/examples/cursor-workspace/.claude/skills/workflow-canon/references/technique-design.md
@@ -1,0 +1,200 @@
+# Technique Design
+
+How to decide the **shape** of a technique or an operation group, and how to review one for more than compliance.
+
+**This reference holds no criteria.** Every judgement below resolves to an entry in the anti-pattern catalog, a principle title, or an inventory row — cited by name, never restated. Open the entry before acting on it; the Detect wording carries the carve-outs. A design question that has no entry is called out as such, and the fix for that is a new entry (`operative-criteria-need-a-home`), not a criterion carried here.
+
+Read [canon-map.md](canon-map.md) for where the homes are and how to fetch them. This file answers the questions that come *before* the walk: what should exist, how big should it be, and where does each piece live.
+
+## The correspondence
+
+Techniques are an object system. Reading them as one makes the placement rules fall out instead of having to be memorised.
+
+| Workflow-server | Object system | What carries over |
+|---|---|---|
+| workflow-root `TECHNIQUE.md` | root base class | contract every operation in the workflow inherits |
+| group `TECHNIQUE.md` | abstract base class | shared Inputs / Outputs / Rules; no work of its own |
+| leaf `<op>.md` | concrete method | one capability, one produce path |
+| `## Capability` | the declaration's doc comment | what it contributes — never how |
+| `## Inputs` | parameter list | `#### default` is a default argument; a description opening *optional* is a nullable slot |
+| `## Outputs` | return type | `#### artifact` is the named side effect; `#### audience` is its serialization |
+| `#### <member>` | a field of the returned structure | shape for the reader; the consumer still binds the whole entry by id |
+| `## Protocol` | the method body | ordered outcomes only |
+| `{$name}` / `{name}` | `let name = …` then `name` | one binding, scoped to a single run |
+| `## Rules` | class invariants | inherited by descendants; a local entry overrides by name |
+| container `Initial` / `Final` | template method around-advice | ancestors wrap descendants outermost-first |
+| I/O merge, local wins by id | field and method override | the leaf's entry shadows the ancestor's |
+| `::` | a call | invokes |
+| `.` | member access | names a symbol without invoking it |
+| `(arg: value)` | argument list | parentheses call; braces name |
+| activity `steps[]` | the caller / composition root | the only place operations are sequenced |
+| workflow `variables[]` | module-level state | the bag both sides read by exact name |
+| a group's uniform output shape | an interface its operations implement | what lets one caller fold any of them |
+
+Where the analogy stops — and these are the parts that catch people:
+
+- **Siblings do not call each other.** Composition happens at the activity, not inside a body, so a group is closer to a stateless service module than to a class whose methods collaborate. `pass-orchestration-in-technique`; principles *Bind Sibling Operations as Steps* and *Atomic Techniques; Compose at Activities*.
+- **Binding is by name, not by position.** The engine resolves against a name-keyed bag by exact string match, so a symbol id *is* the wire. Renaming one is renaming a global, not renaming a parameter. `snake-case-symbols`, `io-id-shape`.
+- **Nothing type-checks a `####` member at runtime.** The declaration is the contract and the reader is the compiler. The guard suite is the only static check there is — run it.
+- **Dispatch is authorial.** There is no vtable; a caller selects an operation by binding it. Polymorphism shows up as *substitutability at a bind site*, not as a runtime lookup.
+
+## SOLID, mapped
+
+### Single responsibility
+
+One capability per operation; one reason to change. The test is the bind test: if two callers would want different halves, they are two operations. A `## Capability` that has to enumerate what it does is a Capability with more than one job.
+
+Judged by `no-monolith-masking-steps`, `capability-as-op-inventory`, `numbered-protocol-phases` (where the phase boundary is really an operation boundary), `artifact-name-is-filename` (a filename selected by a mode means one operation per mode).
+
+### Open–closed
+
+A group is extended by adding a file. Folder contents are the membership set, so a new operation joins with no edit to the container and no edit to a sibling — the container is the extension point, and anything hoisted there reaches every future operation as well as every present one.
+
+When a new caller needs a *variant*, add an operation. When it needs the same operation with one more knob, add an optional input with a `#### default` and keep existing callers working. What you do not do is fork a near-miss: an existing shared operation that almost fits still owns the capability.
+
+Judged by `duplicate-shared-capability` (read its near-miss carve-out), `hoist-shared-inputs`, `alternate-ops-as-protocol-sequence` (modes multiplexed inside one Protocol are the closed form; separate operations are the open one); principle *Prefer Shared Capability*.
+
+### Liskov substitution
+
+The operations of a group are substitutable at a bind site when each honours the container's contract. `meta/techniques/cargo-operations/` is the worked case: `check`, `clippy`, `test`, and `fmt-check` each emit `{ check_id, passed, diagnostics }`, so a caller can fold any of them without knowing which ran.
+
+Two ways to break it:
+
+- **Silent narrowing** — an operation inherits an input it cannot spend and ignores it. `fmt-check` shows the honest form instead: it declares that `{features}` does not apply, because formatting does not compile. Declared narrowing is a contract; silent narrowing is a trap.
+- **Shape drift** — two operations emit differently-shaped values under the same id, so a caller that folds one cannot fold the other.
+
+A related note on redeclaration: a leaf may restate a container slot to narrow it, as `fmt-check` does. A leaf whose declaration is byte-identical to the container's is carrying no meaning and is the redundant form `hoist-shared-inputs` names.
+
+Judged by `io-id-shape`, `hoist-shared-inputs`, `declared-input-never-read`, `output-without-destination`.
+
+### Interface segregation
+
+No consumer should be made to receive what it does not read. This bites on two surfaces:
+
+- **The contract.** Declare narrow. A caller binding an operation should not have to supply values it never spends, and facets of one document belong as `####` members of one output rather than as sibling `###` entries. `declared-input-never-read`, `no-opaque-artifact-path-array`, `output-without-destination`.
+- **The delivery.** A citation is a delivery instruction — what it resolves to is what the server loads into the consumer's context. Cite the section, not the file, and split a resource so its sections *are* deliverable. `whole-resource-for-one-section`, `framing-outside-any-section`; principles *Cite Resources at Section Grain* and *Resources at the Abstract Level; Split for Section Delivery*.
+
+### Dependency inversion
+
+An operation depends on its declared contract, never on who calls it. The bag is the injection point: a value arrives because a name matched, not because a named producer ran. Every form of naming the caller is the same defect wearing different clothes:
+
+| The inversion | Entry |
+|---|---|
+| I/O prose naming a producer or consumer | `io-agnostic-contract`, `technique-ref-in-io-contract` |
+| Reaching a raw harness tool a wrapping operation owns | `canonical-technique-reference`, `unowned-harness-capability` |
+| Naming the surrounding activity, stage, or gate | `technique-stage-agnostic`; principle *Keep Orchestration in Structure* |
+| Requiring a human on the other end | `session-interaction-in-technique`; principle *Keep Session Interaction in Activities* |
+
+### The forces underneath
+
+Cohesion and coupling are what the five principles trade against, and the entry that judges the resulting locus is `capability-group-placement` — a reusable primitive trapped in a client workflow, or a cross-consumer capability named for one activity, is a cohesion failure that every other check will pass.
+
+## Distribution of functionality
+
+Two questions place any sentence you are about to write: **what kind of thing is it**, and **what is the smallest scope that covers everything it governs**.
+
+| The thing | Its construct | Smallest scope | Fires when misplaced |
+|---|---|---|---|
+| what a value *is* | Inputs / Outputs entry | the operation that receives or exposes it | `procedure-in-io-contract`, `technique-ref-in-io-contract` |
+| what the operation contributes | `## Capability` | the operation | `procedure-in-capability`, `capability-as-op-inventory`, `deployment-path-in-capability` |
+| an ordered outcome | Protocol phase | the operation | `rule-as-protocol-step`, `numbered-protocol-phases` |
+| a branch on one instruction | `>` note under that bullet | that step | `constraint-as-blockquote`, `local-rule-as-note`; principle *Isolate Conditional Branches as Notes* |
+| an invariant over the whole operation | `## Rules` entry | the operation | `no-one-step-rules`, `rule-binds-beyond-its-operation` |
+| an invariant over sibling operations | container `## Rules` | the group | `single-rule-authority`, `inherited-rules-re-enumerated` |
+| a vocabulary, criteria table, or policy matrix | a resource, cited by section | the workflow | `operative-criteria-need-a-home`, `resource-fills-not-does` |
+| a document's layout | creation-guide `## Template` | the workflow | `no-template-creation-guide` |
+| the order two operations run in | activity `steps[]` | the activity | `pass-orchestration-in-technique`, `bind-site-is-orchestration-truth` |
+| a gate, a question, a loop | activity checkpoint / `when` / loop step | the activity | `checkpoint-not-prose`, `loop-not-prose`, `technique-stage-agnostic` |
+| a fact of session state | one workflow variable | the workflow | `no-derived-state-shadow`; principle *Single Source of Truth* |
+
+### Hoist and sink
+
+Both moves read the same rule in opposite directions, but the *test* differs by kind, and conflating the two is the common mistake:
+
+- **Inputs hoist on concept identity.** One concept carries one id corpus-wide, so a value several operations share belongs on their smallest common container even where a leaf never spends it. `hoist-shared-inputs` — note its carve-out for a slot only two or three operations share, which does not earn a trip to the root.
+- **Rules hoist on governance reach.** A rule lives at the smallest container covering everything it governs, and no higher. A rule on a container reaches every operation in the folder present and future — that reach is its cost as well as its benefit, because an operation that cannot honour it is a substitution break the loader will never catch. `rule-binds-beyond-its-operation`, `single-rule-authority`, `no-one-step-rules`.
+
+When in doubt, sink. Hoisting is the move that binds readers who never asked.
+
+### How big is an operation
+
+| Test | Question | What it settles |
+|---|---|---|
+| Bind | would two callers bind different halves? | split into two operations |
+| Product | does it yield one coherent thing? | several files means several outputs; a name chosen by a mode means one operation per mode (`artifact-name-is-filename`) |
+| Reorder | does the order of these phases matter? | ordered outcomes are phases; alternatives a caller picks one of are operations or rules (`alternate-ops-as-protocol-sequence`; principle *Phase by Sequenced Outcome*) |
+| Substitution | can a caller fold any sibling's answer without knowing which ran? | if not, the group has no interface yet |
+| Floor | is the second member hypothetical? | do not invent a group for it (`capability-group-placement` carve-out) |
+
+### The aggregate member
+
+A group whose operations share an output shape earns one more member: the one that runs the useful combination and folds the results into a single gateable value. `run-suite` is that member for the cargo group — its contribution is not a new capability but an aggregate shape (`failed_checks`, `first_failure`, `validation_passed`) that lets a caller gate on one value and still reach every diagnostic.
+
+The reusable lesson is the fold surface. **How** the combination runs is a separate question, and it is the one `pass-orchestration-in-technique` judges: sequencing siblings inside a Protocol is what that entry forbids, and the composition layer is the activity. Read the entry before writing an aggregate — a fold over statuses the activity already produced is the shape that is never in doubt.
+
+## Designing a group
+
+1. **Enumerate the domain's real surface.** Read the tool, not your memory of it — a CLI's subcommand list and the flags that change its product, an MCP server's tool schemas and resources. Every operation you write is a promise the surface can keep, and this is the step that stops an operation set from being a guess.
+2. **Cut the surface to what a caller would bind.** The surface is not the operation set. Keep what a step would name; drop what no workflow would ask for, and everything that mutates state outside the working tree (`no-user-env-mutation`).
+3. **Find the shared contract.** What every operation needs — the scope, the target, the credentials — becomes container Inputs. What every operation must honour — a budget, a freshness precondition, a channel restriction — becomes container Rules. This is the constructor and the invariant set.
+4. **Fix one output shape.** Decide what a caller gets back and make every operation's answer wear it. This is the group's interface, and it is what makes an aggregate possible later.
+5. **Write the leaves.** One capability each. Phases only for ordered outcomes. A failure is handled in the step that raises it.
+6. **Name everything once.** One concept, one id, corpus-wide, in the shape its kind requires.
+7. **Place the group.** `meta` when it is reusable across workflows; the workflow root when it is intrinsic; an activity-named group only when the set is genuinely an activity seam. `capability-group-placement`.
+8. **Self-check, then guards.** Route through the file-kind row in [canon-map.md](canon-map.md#file-kind-routing), then run the guard registry.
+
+### Worked: the cargo group
+
+The group in `meta/techniques/cargo-operations/` is the reference for every step above.
+
+**Surface, then cut.** `cargo` exposes far more subcommands than a workflow would ever bind. The ones that change a Rust project's *product* are few, and the cut asks what a step actually needs: a validation gate needs a verdict, an inner test loop needs the *cheapest* verdict, a release step needs the artifact. That yields the cheapest verdict (`check`), the lint verdict (`clippy`), the behaviour verdict (`test`), the style verdict and its fixer (`fmt-check`, `fmt-fix`), the two builds that genuinely differ in product (`build-dev`, `build-release`), documentation as a compile check (`doc`), and the environment probe that makes the rest fail fast (`preflight`). `cargo publish`, `cargo install`, and `cargo add` are on the surface and stay off the operation set — they mutate outside the working tree, and availability is not a reason to wrap.
+
+**Why the fixer is its own operation.** `fmt-check` returns a verdict; `fmt-fix` rewrites the tree. One operation with a boolean input would return a different *kind* of thing depending on an argument — the shape that fails the product test, and a substitution break for any caller folding verdicts.
+
+**Why dev and release are two operations, not one with a profile input.** They differ in product — the release build is the only one that emits the runtime wasm artifact — and in budget, since it is the only one that omits the skip flag. The distinction is load-bearing enough to carry its own rule (`keeps-wasm-artifact`), and a rule that governs one arm of an input branch is a rule whose scope has nowhere to sit.
+
+**Shared contract.** `{build_scope}` and `{features}` sit on the container because every compiling operation takes them — constructor parameters, not per-operation ones. The formatting operations narrow by declaration, stating that `{features}` does not apply.
+
+**Shared invariant.** The resource budget is one rule on the container, not a paragraph repeated on each leaf: every invocation carries the env caps and no operation calls bare `cargo`. Nine copies of that paragraph would be nine places to drift.
+
+**The uniform verdict.** `{ check_id, passed, diagnostics }` costs a leaf nothing and buys the aggregate everything.
+
+## Reviewing a technique
+
+Three lenses past compliance. Each names what to observe; the entry named beside it decides.
+
+### Ontological soundness
+
+Does each construct hold the kind of thing that construct is for, and does each name denote what the thing is?
+
+- **Kind fit** — read each section and name the kind of statement in it. A how in Inputs, a what in Protocol, an invariant standing as a step. `procedure-in-io-contract`, `contract-not-procedure`, `procedure-in-capability`, `rule-as-protocol-step`, `no-one-step-rules`.
+- **Denotation** — does the id name the thing, in the shape its kind requires? `boolean-id-shape`, `collection-id-shape`, `io-id-shape`, `rule-slug-shape`, `resource-id-names-its-content`; principle *Name Symbols Affirmatively*.
+- **Ownership** — for every claim, name the surface that owns its subject. `rule-binds-beyond-its-operation`, `cited-home-owns-claim`, `canonical-fact-home`, `operative-criteria-need-a-home`.
+- **Reachability** — every read has a producer and every product has a reader. `bind-protocol-locals`, `declared-input-never-read`, `output-without-destination`, `unproduced-value-read`. The `binding-fidelity` guard settles most of this mechanically; run it before reading for it.
+
+### Stylistic elegance
+
+Elegance here is not decoration. It is the property that a reader can predict the next line.
+
+- **Symmetry** — sibling operations share section order, slot names for the same concept, and output shape. Asymmetry that carries no meaning is noise. The baseline is the sibling file, not this reference; principle *Convention Over Invention*, and the convention-conformance unit.
+- **Economy** — every sentence earns its line. `no-rationale-in-description`, `no-duplicated-guidance`, `omit-null-sections`, `cut-comment-jsdoc-verbosity`.
+- **Voice** — imperative in Protocol, declarative present elsewhere, addressed to the reader. `avoidance-voice-in-definitions`, `instruction-narrates-an-actor`, `no-delivery-mechanism-narration`; principle *Document in Positive Present*.
+- **Form** — the typographic namespaces stay separate: braces name values, parentheses carry arguments, backticks mark code, dots address rules. `backtick-code-tokens`, `brace-declared-ids`, `paren-invocation-args`, `dotted-rule-address`, `anchored-protocol-references`; principle *Distinguish Designators from Parameters*.
+
+### Efficiency
+
+Three costs, and they trade against each other.
+
+- **Authoring cost** — how many places change when one fact changes. One is the target. `canonical-fact-home`, `single-rule-authority`, `stale-restatement-after-change`, `factor-repeated-paths`, `bag-value-as-literal`.
+- **Delivery cost** — how many bytes reach the agent to do one step. An operation's bundle carries its ancestors' merged contract, so everything on a container is paid for by every operation in the folder — which is the counterweight to hoisting, and the reason a citation names a section. `whole-resource-for-one-section`, `framing-outside-any-section`, `hoist-shared-inputs` read in the other direction.
+- **Runtime cost** — whether a caller can pick the cheapest operation that answers the question. Where a group's operations differ materially in cost, the corpus states that in Capability so the choice is visible at the bind site: `check` is described as the cheapest validation pass, and the group's `scope-narrow-then-wide` rule says when to spend more.
+
+### What a review owes
+
+Findings go through the Audit path and the shapes in [reporting.md](reporting.md) — a design lens does not get its own report format. A judgement with no entry behind it is not a finding: say what would have to change and which entry would then fire. Where a real defect genuinely has no home in the catalog, propose the entry — `operative-criteria-need-a-home` is the migration, and carrying the criterion in a review instead is how a second home starts.
+
+## Where this reference stops
+
+- **No Detect bodies.** Every judgement above resolves to a named entry; open it.
+- **Field-level schema truth** is `schemas/`. **Loader composition** — inheritance merge, `Initial` / `Final` wrapping, renumbering — is `docs/technique-protocol-specification.md` and the meta workflow-canonical resource.
+- **Conventions** are the live sibling files. This reference says which questions to ask about them; it is not the baseline.


### PR DESCRIPTION
## Summary

The workflow-canon skill offers an author two ways in. Draft is for when you are about to write a file and want the stance that keeps the Detect pass empty. Audit is for when a file exists and you want to know what is wrong with it. Both of them start after the hard part: they assume you already know which operations should exist, how big each one is, and which section of which file each sentence belongs in.

That earlier question is the one people actually get wrong, and nothing in the skill answered it. This change adds a third path — Design — and a reference behind it that teaches how to decide a technique's shape, and how to review one for more than rule compliance.

## How it works today

A technique is an object system, and it behaves like one whether or not anyone says so. A group's `TECHNIQUE.md` is an abstract base class: it declares the inputs every operation in the folder receives and the invariants every one of them must honour, and the loader merges both into each descendant, with the local entry winning by id. A leaf file is a concrete method — one capability, one produce path, a parameter list, a return type. A container's `Initial` and `Final` protocol blocks wrap every descendant's protocol from the outside in, which is around-advice. Siblings never call each other; the activity is the composition root.

Read that way, most of the placement rules stop needing to be memorised, because they are the rules any object system has. Read any other way, they are a long list of unrelated prohibitions.

Nothing in the corpus wrote the correspondence down, so every author had to rediscover it — or not.

## The change

One new reference, `references/technique-design.md`, and a Design path in `SKILL.md` that routes to it. The reference has four parts.

**The correspondence.** A table mapping each workflow-server construct to its object-system counterpart — container to base class, leaf to method, Inputs to parameter list, Rules to class invariants, `{$name}` to a local binding, `::` to a call, `.` to member access. It also names the four places the analogy stops, which are exactly the places that catch people: siblings do not call each other, binding is by name rather than position, nothing type-checks a declared member at runtime, and dispatch is authorial rather than dynamic.

**SOLID, mapped onto that correspondence.** Each of the five stated in the vocabulary of this system, with the design move it implies and the entries that judge it. Single responsibility becomes the bind test — if two callers would want different halves, they are two operations. Open–closed becomes: a group is extended by adding a file, because folder contents are the membership set. Liskov becomes substitutability at a bind site, which is what a shared output shape buys and what silent narrowing of an inherited input destroys. Interface segregation bites twice, once on the contract and once on the delivery budget, because a citation is a delivery instruction. Dependency inversion collects every form of naming your own caller into one idea.

**Distribution of functionality.** A table that takes any sentence you are about to write, asks what kind of thing it is and what the smallest scope covering it is, and names both the construct that owns it and the entry that fires when it lands somewhere else. Then the two moves — hoist and sink — with the observation that the test differs by kind, which is the part that is easy to conflate: inputs hoist on concept identity, so one concept carries one id across the corpus; rules hoist on governance reach, and a rule on a container binds every future operation in the folder as well as every present one. Then the granularity tests for where one operation ends and the next begins.

**The design lenses.** Ontological soundness asks whether each construct holds the kind of thing that construct is for and whether each name denotes what the thing is. Stylistic elegance treats elegance as the property that a reader can predict the next line — symmetry across siblings, economy, voice, and keeping the typographic namespaces separate. Efficiency separates three costs that trade against each other: how many places change when one fact changes, how many bytes reach the agent to do one step, and whether a caller can pick the cheapest operation that answers the question.

The cargo group is worked through end to end as the example, because it is the corpus's best one. Why the formatter's fixer is a separate operation from its checker: one returns a verdict and one rewrites the tree, so a single operation with a boolean flag would return a different kind of thing depending on an argument. Why the dev and release builds are two operations rather than one with a profile input: they differ in product, since only the release build emits the runtime wasm artifact, and the distinction carries its own rule, which has nowhere to sit on one arm of an input branch. Why the resource budget is one rule on the container rather than a paragraph on each leaf. Why `cargo publish` and `cargo install` are on cargo's surface and stay off the operation set — availability is not a reason to wrap.

## The skill holds no criteria of its own, and this reference does not change that

The skill's whole design is that it locates the criteria homes and walks them, because a second copy of a Detect body drifts from the first. The catalog names that defect itself.

So the new reference cites and never restates. Every judgement it raises resolves to a catalog entry by its kebab-case name, a design principle by title, an inventory row, or a guard. Where a design question genuinely has no home in the catalog, the reference says so and points at the entry that names the migration, rather than quietly carrying the criterion itself.

Each cited name was checked against the live homes before this was pushed: every catalog entry name resolves to a real entry, and every principle title resolves to a real section.

## Linked homes

Each criteria home was named beside the path that holds it, so reaching one meant copying a path out of a table and into a Read call. The path now carries the link, and each unit row in the map links to the section it names.

The skill ships inside the repo it audits, so those links are paths on disk rather than URLs — a reader following one opens the file the walk needs, with no network round trip and nothing to go stale against a rename.

## Stale counts removed

Two layers above the homes stated how many units a home holds. The principles home had grown past the number both of them named, so a walk that trusted either would have reported a clean sweep over an inventory it had not covered — the failure the coverage ledger exists to prevent.

Unit rows are now cited by name rather than by ordinal, and the catalog's line count comes out of the Homes table. Both drift the next time the catalog gains an entry, which is the same failure the counts had. The fix throughout is to state the enumeration without counting it, which is the discipline the skill already applies to catalog entries, and for the same reason.

## Scope of change

Four files, all under the vendored cursor-workspace skill. One new reference; the Design path, a first step in Draft that defers to it, and a References row in `SKILL.md`; the links and the count removals across `SKILL.md`, `canon-map.md`, and `reporting.md`.

No workflow definitions, no server source, no schemas.

## Acceptance criteria

- An author asking "what operations should this group have?" reaches the Design path from the skill's routing table.
- Every catalog entry name and principle title in the new reference resolves against its home.
- Every link in the skill folder resolves to a file in the checkout, anchors included.
- No layer of the skill states a count of another layer's units, or cites one by ordinal.

## Non-goals

- No new criteria. The reference introduces no Detect body and no rule of its own.
- No change to the Audit path's walk, surface rules, or report shapes. A design review reports through the existing shapes.
- No change to the corpus. Observations about existing techniques are used as examples, not filed as findings.

## File-kind routing kept to routing

The routing table closed by letting a row's silence stand as the reason a unit was recorded not-applicable, which made a map into evidence. Detect is where each entry states the surface it keys on, so that is what a disposition cites now; the table says where to start reading.

Checking the rows against the principles home turned up three principles no row named — the two governing conditional branches in Protocol and citation grain, which belong on the technique row, and the one governing pre-session bootstrap prose, whose surface had no row at all. All three are routed now.
