### PR TITLE
Plain language repair: every step resolves, and the controlled-language overlay is verified

### DIFF
--- a/plain-language/activities/01-intake-and-profile.yaml
+++ b/plain-language/activities/01-intake-and-profile.yaml
@@ -12,7 +12,7 @@ steps:
         message: Absolute planning folder this session writes its working artifacts into, as reported in the server session summary.
   - kind: technique
     id: intake-and-profile
-    technique: plain-language::intake-and-profile
+    technique: intake-and-profile
   - kind: checkpoint
     id: intent-and-profile-batch
     condition:
@@ -36,7 +36,6 @@ steps:
         effect:
           setVariable:
             operation_type: author
-            operation_type_ambiguous: false
             intent_needs_confirmation: false
             document_profile_confirmed: true
       - id: confirm-rewrite
@@ -45,7 +44,6 @@ steps:
         effect:
           setVariable:
             operation_type: rewrite
-            operation_type_ambiguous: false
             intent_needs_confirmation: false
             document_profile_confirmed: true
       - id: confirm-audit
@@ -54,7 +52,6 @@ steps:
         effect:
           setVariable:
             operation_type: audit
-            operation_type_ambiguous: false
             intent_needs_confirmation: false
             document_profile_confirmed: true
   - kind: action

--- a/plain-language/activities/02-source-analysis.yaml
+++ b/plain-language/activities/02-source-analysis.yaml
@@ -6,7 +6,7 @@ required: false
 steps:
   - kind: technique
     id: analyze-source
-    technique: plain-language::analyze-source
+    technique: analyze-source
   - kind: technique
     id: persist-source-analysis
     technique:

--- a/plain-language/activities/03-draft.yaml
+++ b/plain-language/activities/03-draft.yaml
@@ -6,7 +6,7 @@ required: false
 steps:
   - kind: technique
     id: draft-document
-    technique: plain-language::draft-document
+    technique: draft-document
   - kind: technique
     id: persist-plain-document
     technique:

--- a/plain-language/activities/04-evaluate.yaml
+++ b/plain-language/activities/04-evaluate.yaml
@@ -17,7 +17,7 @@ steps:
     steps:
       - kind: technique
         id: evaluate-document
-        technique: plain-language::evaluate-document
+        technique: evaluate-document
       - kind: technique
         id: persist-evaluation-report
         technique:
@@ -49,7 +49,7 @@ steps:
                 needs_revision: false
       - kind: technique
         id: revise-document
-        technique: plain-language::draft-document
+        technique: draft-document
         condition:
           type: simple
           variable: needs_revision
@@ -68,7 +68,7 @@ steps:
             message: Increment the revision round by one.
   - kind: technique
     id: complete-checklist
-    technique: plain-language::complete-checklist
+    technique: complete-checklist
   - kind: technique
     id: persist-iso-checklist
     technique:

--- a/plain-language/resources/asd-ste100.md
+++ b/plain-language/resources/asd-ste100.md
@@ -9,9 +9,11 @@ metadata:
 
 ASD-STE100 Simplified Technical English (STE) is a controlled natural language and international standard for clear, consistent, and safe technical documentation. It has two parts: a set of writing rules covering grammar, sentence structure, and style, and a controlled dictionary of approved words, each with one meaning and one part of speech.
 
-STE is an **overlay**, not a replacement. It applies only when the document is technical documentation and the `controlled_language` mode is on. The ISO 24495-1 base still governs relevance, findability, and evaluation; STE tightens understandability for readers who may have only a basic command of English. Where STE and the ISO base conflict, STE's stricter rule wins for the sentence and word level, and the ISO base still governs structure, audience fit, and evaluation.
+STE is an overlay, not a replacement.
 
 ## When It Applies
+
+STE applies only when the document is technical documentation and the `controlled_language` mode is on. The ISO 24495-1 base still governs relevance, findability, and evaluation; STE tightens understandability for readers who may have only a basic command of English. Where STE and the ISO base conflict, STE's stricter rule wins for the sentence and word level, and the ISO base still governs structure, audience fit, and evaluation.
 
 Apply STE when the document is a procedure or a description in a technical domain — maintenance instructions, operating manuals, safety information, engineering or industrial documentation — and readers include non-native English speakers or readers for whom ambiguity carries a safety or cost consequence. Do not apply it to general-audience prose where its restrictions would read as stilted without adding safety.
 

--- a/plain-language/resources/evaluation-report.md
+++ b/plain-language/resources/evaluation-report.md
@@ -27,6 +27,13 @@ The evaluation decision surface. Answers: does the draft meet the principles, an
 || Understandable | met / open | [why] |
 || Usable | met / open | [why] |
 
+## Controlled language
+
+|| Check | Verdict | Basis |
+||-------|---------|-------|
+|| Writing rules | met / open | [the rule, and where it breaks] |
+|| Approved words | met / open | [the word, and where it appears] |
+
 ## Open issues
 
 || # | Location | Principle | Issue | Fix |
@@ -39,4 +46,6 @@ The evaluation decision surface. Answers: does the draft meet the principles, an
 - **Evaluate as the reader.** Reread the draft with the readers' understanding, purpose, and context in mind — the profile governs the verdict, not the writer's sense of the prose.
 - **A verdict names its basis.** Each principle's verdict cites the guidelines that carry it from [plain-language-standard](plain-language-standard.md#principles).
 - **Open issues are actionable.** Each open issue locates the passage and names the fix, so the revision pass has no interpretation to redo.
+- **The overlay is verified where it applied.** A run that drafted under the ASD-STE100 overlay carries a Controlled language verdict against [Writing Rules](asd-ste100.md#writing-rules) and [Approved Words](asd-ste100.md#approved-words). A run that drafted without it omits the section rather than recording it as not applicable.
+- **An overlay breach is an open issue.** It joins the same list and the same count as a principle failure, naming the STE rule in its Principle cell, so delivery is gated on one number.
 - **The count gates delivery.** Delivery is blocked while open issues remain; the report's open-issue count is the gate's input.

--- a/plain-language/resources/plain-language-standard.md
+++ b/plain-language/resources/plain-language-standard.md
@@ -7,9 +7,9 @@ metadata:
 
 # Plain Language Standard
 
-Plain language is communication written, structured, and presented so that readers can find what they are looking for, understand what they find, and use that information well. It focuses on the reader's ability to use the document, not on mechanical measures such as readability formulas, and it is not the same as simplified language — plain language serves a general audience at its own level of expertise, where simplified language serves readers who have difficulty understanding what they read.
+Plain language is communication written, structured, and presented so that readers can find what they are looking for, understand what they find, and use that information well.
 
-This resource is the criteria home. Techniques cite the section that governs their work; they do not restate the guidelines. The four principles are interdependent and iterative, not a linear sequence — the first three make a document likely to work, and only evaluation under the fourth confirms it.
+This resource is the criteria home. Techniques cite the section that governs their work; they do not restate the guidelines.
 
 ## Principles
 
@@ -20,7 +20,9 @@ This resource is the criteria home. Techniques cite the section that governs the
 | 3 | Readers can easily understand what they find | Understandable | [Understandability](#understandability) |
 | 4 | Readers can easily use the information | Usable | [Usability](#usability) |
 
-A document is usable when the information it carries is relevant, findable, and understandable. The four principles interact; applying them together is essential.
+A document is usable when the information it carries is relevant, findable, and understandable. The four principles are interdependent and iterative, not a linear sequence — the first three make a document likely to work, and only evaluation under the fourth confirms it.
+
+Plain language is measured by the reader's ability to use the document, not by mechanical measures such as readability formulas. It is not the same as simplified language: plain language serves a general audience at its own level of expertise, where simplified language serves readers who have difficulty understanding what they read.
 
 ## Relevance
 

--- a/plain-language/resources/source-analysis.md
+++ b/plain-language/resources/source-analysis.md
@@ -31,7 +31,7 @@ The findings surface for a document that already exists. Answers: where does thi
 
 ## Rules
 
-- **Cite the guideline.** Every finding names the principle and the guideline it breaches from [plain-language-standard](plain-language-standard.md); an unanchored complaint is not a finding.
+- **Cite the guideline.** Every finding names the principle and the guideline it breaches from [plain-language-standard](plain-language-standard.md); an unanchored complaint is not a finding. Where the run carries the ASD-STE100 overlay, a word- or sentence-level finding names the STE rule it breaches from [Writing Rules](asd-ste100.md#writing-rules) or [Approved Words](asd-ste100.md#approved-words) instead.
 - **Locate the passage.** Each finding quotes or locates the passage so a reader can confirm it without re-reading the whole document.
 - **Recommend, don't rewrite.** The recommendation names the change; the rewrite itself happens in the drafting pass.
 - **Record strengths too.** A rewrite preserves what already works; the strengths list is its don't-break inventory.

--- a/plain-language/techniques/README.md
+++ b/plain-language/techniques/README.md
@@ -4,7 +4,7 @@
 
 The technique library for this workflow. Each technique is one capability an activity step binds via `step.technique`; the authoritative capability, inputs, outputs, protocol and rules live in the per-technique `.md` file. This file orients — it does not restate protocols.
 
-Operations live in the [`plain-language`](./plain-language/TECHNIQUE.md) group, so each has a `group::operation` address that another workflow can bind without copying the file — the embedded-check use.
+Every operation inherits the shared contract in [`TECHNIQUE.md`](./TECHNIQUE.md), and carries a `plain-language::operation` address another workflow can bind without copying the file — the embedded-check use.
 
 ---
 
@@ -12,11 +12,11 @@ Operations live in the [`plain-language`](./plain-language/TECHNIQUE.md) group, 
 
 | Operation | Capability |
 |-----------|------------|
-| [`intake-and-profile`](./plain-language/intake-and-profile.md) | Classify the operation and settle the reader profile and content selection |
-| [`analyze-source`](./plain-language/analyze-source.md) | Audit an existing document against the principles; record findings and strengths |
-| [`draft-document`](./plain-language/draft-document.md) | Produce the plain-language document for its readers |
-| [`evaluate-document`](./plain-language/evaluate-document.md) | Evaluate a draft against the four principles; record verdicts and open issues |
-| [`complete-checklist`](./plain-language/complete-checklist.md) | Walk the ISO 24495-1 checklist against the final draft |
+| [`intake-and-profile`](./intake-and-profile.md) | Classify the operation and settle the reader profile and content selection |
+| [`analyze-source`](./analyze-source.md) | Audit an existing document against the principles; record findings and strengths |
+| [`draft-document`](./draft-document.md) | Produce the plain-language document for its readers |
+| [`evaluate-document`](./evaluate-document.md) | Evaluate a draft against the four principles; record verdicts and open issues |
+| [`complete-checklist`](./complete-checklist.md) | Walk the ISO 24495-1 checklist against the final draft |
 
 ## Shared operations bound by this workflow
 

--- a/plain-language/techniques/TECHNIQUE.md
+++ b/plain-language/techniques/TECHNIQUE.md
@@ -15,17 +15,17 @@ Shared inputs and domain invariants for every plain-language operation in this g
 
 ### controlled_language
 
-*(optional)* Default `false`. When `true`, the operation applies the [ASD-STE100 overlay](../../resources/asd-ste100.md) over the ISO 24495-1 base for technical documentation.
+*(optional)* Default `false`. When `true`, the operation applies the [ASD-STE100 overlay](../resources/asd-ste100.md) over the ISO 24495-1 base for technical documentation.
 
 ## Rules
 
 ### reader-governs
 
-Every drafting and evaluation decision cites the reader profile and the governing guideline from [plain-language-standard](../../resources/plain-language-standard.md), not the writer's preference. A choice that cannot name its reader and guideline is not settled.
+Every drafting and evaluation decision cites the reader profile and the governing guideline from [plain-language-standard](../resources/plain-language-standard.md), not the writer's preference. A choice that cannot name its reader and guideline is not settled.
 
 ### cite-dont-restate
 
-Operations cite the relevant section of [plain-language-standard](../../resources/plain-language-standard.md) or [asd-ste100](../../resources/asd-ste100.md); they do not restate the guidelines in protocol prose.
+Operations cite the relevant section of [plain-language-standard](../resources/plain-language-standard.md) or [asd-ste100](../resources/asd-ste100.md); they do not restate the guidelines in protocol prose.
 
 ### overlay-not-replacement
 

--- a/plain-language/techniques/analyze-source.md
+++ b/plain-language/techniques/analyze-source.md
@@ -13,15 +13,11 @@ Audit an existing document against the plain-language principles and record wher
 
 Path to the existing document to analyze.
 
-### document_profile
-
-The settled reader, purpose, and context the document is analyzed against.
-
 ## Outputs
 
 ### source_analysis
 
-The per-finding record and the strengths inventory, shaped by [Template](../../resources/source-analysis.md#template).
+The per-finding record and the strengths inventory, shaped by [Template](../resources/source-analysis.md#template).
 
 #### artifact
 
@@ -39,12 +35,12 @@ Number of plain-language findings recorded against the document.
 
 ### 2. Record Findings Against the Guidelines
 
-- Walk the document against the four principles in [Principles](../../resources/plain-language-standard.md#principles), recording each failure with its passage, its principle, the guideline it breaches, and the change that fixes it — per [Findings](../../resources/source-analysis.md#template)
+- Walk the document against the four principles in [Principles](../resources/plain-language-standard.md#principles), recording each failure with its passage, its principle, the guideline it breaches, and the change that fixes it — per [Findings](../resources/source-analysis.md#template)
 - Cite the guideline every finding breaches; an unanchored complaint is not a finding
 
 ### 3. Record the Strengths
 
-- Inventory what the document already does well — the don't-break list a rewrite preserves — per [Strengths](../../resources/source-analysis.md#template)
+- Inventory what the document already does well — the don't-break list a rewrite preserves — per [Strengths](../resources/source-analysis.md#template)
 
 ### 4. Count the Findings
 

--- a/plain-language/techniques/analyze-source.md
+++ b/plain-language/techniques/analyze-source.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -36,6 +36,7 @@ Number of plain-language findings recorded against the document.
 ### 2. Record Findings Against the Guidelines
 
 - Walk the document against the four principles in [Principles](../resources/plain-language-standard.md#principles), recording each failure with its passage, its principle, the guideline it breaches, and the change that fixes it — per [Findings](../resources/source-analysis.md#template)
+- When `{controlled_language}` is true, extend the walk to the [ASD-STE100 writing rules](../resources/asd-ste100.md#writing-rules) and [Approved Words](../resources/asd-ste100.md#approved-words) at the word and sentence level, under the precedence [When It Applies](../resources/asd-ste100.md#when-it-applies) sets
 - Cite the guideline every finding breaches; an unanchored complaint is not a finding
 
 ### 3. Record the Strengths

--- a/plain-language/techniques/complete-checklist.md
+++ b/plain-language/techniques/complete-checklist.md
@@ -21,25 +21,21 @@ The latest evaluation — its open issues must agree with the checklist's open i
 
 ### iso_checklist
 
-The completed checklist with every item's disposition, shaped by [Template](../../resources/iso-checklist.md#template).
+The completed checklist with every item's disposition, shaped by [Template](../resources/iso-checklist.md#template).
 
 #### artifact
 
 `iso-checklist.md`
 
-### checklist_complete
-
-True when every checklist item carries a disposition.
-
 ## Protocol
 
 ### 1. Walk Every Item
 
-- Walk each item of the [ISO 24495-1 checklist](../../resources/iso-checklist.md#template) against `{document_draft}` — against the document itself, not from memory of the guidelines
+- Walk each item of the [ISO 24495-1 checklist](../resources/iso-checklist.md#template) against `{document_draft}` — against the document itself, not from memory of the guidelines
 
 ### 2. Dispose Each Item
 
-- Mark each item met, or leave it open with a one-line reason — no item is skipped without a note, per [Rules](../../resources/iso-checklist.md#rules)
+- Mark each item met, or leave it open with a one-line reason — no item is skipped without a note, per [Rules](../resources/iso-checklist.md#rules)
 
 ### 3. Reconcile with the Evaluation
 
@@ -47,4 +43,4 @@ True when every checklist item carries a disposition.
 
 ### 4. Record Completion
 
-- Set `{checklist_complete}` true when every item carries a disposition and return the completed checklist as `{iso_checklist}`
+- Return the completed checklist as `{iso_checklist}`, every item carrying its disposition

--- a/plain-language/techniques/draft-document.md
+++ b/plain-language/techniques/draft-document.md
@@ -9,10 +9,6 @@ Produce the plain-language document — drafted fresh on an author run, or rewri
 
 ## Inputs
 
-### document_profile
-
-The settled reader, purpose, context, document type, and content selection the draft is built on.
-
 ### source_analysis
 
 *(optional)* The findings and strengths of the existing document — bound on a rewrite run, where the draft fixes the findings and preserves the strengths.
@@ -43,15 +39,15 @@ The current draft of the plain-language document.
 
 ### 2. Structure for the Reader
 
-- Order and group the content per [Findability](../../resources/plain-language-standard.md#findability) — the most important message first, logical grouping, headings that anticipate, lists and visual organization that help readers find what they need
+- Order and group the content per [Findability](../resources/plain-language-standard.md#findability) — the most important message first, logical grouping, headings that anticipate, lists and visual organization that help readers find what they need
 
 ### 3. Word and Build the Prose
 
-- Write the words, sentences, and paragraphs per [Understandability](../../resources/plain-language-standard.md#understandability) — familiar precise words, clear concise sentences, one-topic paragraphs, a respectful tone, a coherent whole
+- Write the words, sentences, and paragraphs per [Understandability](../resources/plain-language-standard.md#understandability) — familiar precise words, clear concise sentences, one-topic paragraphs, a respectful tone, a coherent whole
 
 ### 4. Apply the Overlay
 
-- When `{controlled_language}` is true, apply the [ASD-STE100 writing rules](../../resources/asd-ste100.md#writing-rules) at the word and sentence level, matching the [procedure or description](../../resources/asd-ste100.md#procedure-and-description) text type — the ISO base still governs structure and audience fit
+- When `{controlled_language}` is true, apply the [ASD-STE100 writing rules](../resources/asd-ste100.md#writing-rules) at the word and sentence level, matching the [procedure or description](../resources/asd-ste100.md#procedure-and-description) text type, under the precedence [When It Applies](../resources/asd-ste100.md#when-it-applies) sets
 
 ### 5. Return the Draft
 

--- a/plain-language/techniques/evaluate-document.md
+++ b/plain-language/techniques/evaluate-document.md
@@ -13,10 +13,6 @@ Evaluate a draft against the four principles as its reader would, recording the 
 
 The draft to evaluate.
 
-### document_profile
-
-The settled reader, purpose, and context the draft is evaluated against.
-
 ### revision_round
 
 *(optional)* The evaluation round this is — the first pass is round 0.
@@ -25,7 +21,7 @@ The settled reader, purpose, and context the draft is evaluated against.
 
 ### evaluation_report
 
-The per-principle verdict and the open-issue list, shaped by [Template](../../resources/evaluation-report.md#template).
+The per-principle verdict and the open-issue list, shaped by [Template](../resources/evaluation-report.md#template).
 
 #### artifact
 
@@ -47,11 +43,11 @@ True when any open issue sends the draft back for another pass; false when every
 
 ### 2. Verdict Each Principle
 
-- Assign each of the four principles a verdict per [Usability](../../resources/plain-language-standard.md#usability) and the guidelines it cites — relevant, findable, understandable, usable — naming the guidelines that carry each verdict per [Verdict by principle](../../resources/evaluation-report.md#template)
+- Assign each of the four principles a verdict per [Principles](../resources/plain-language-standard.md#principles) and [Usability](../resources/plain-language-standard.md#usability) and the guidelines it cites — relevant, findable, understandable, usable — naming the guidelines that carry each verdict per [Verdict by principle](../resources/evaluation-report.md#template)
 
 ### 3. Record the Open Issues
 
-- Record each failure as an open issue with its location, principle, the problem the reader hits, and the fix — per [Open issues](../../resources/evaluation-report.md#template) — so the revision pass has no interpretation to redo
+- Record each failure as an open issue with its location, principle, the problem the reader hits, and the fix — per [Open issues](../resources/evaluation-report.md#template) — so the revision pass has no interpretation to redo
 
 ### 4. Set the Revision Signal
 

--- a/plain-language/techniques/evaluate-document.md
+++ b/plain-language/techniques/evaluate-document.md
@@ -1,6 +1,6 @@
 ---
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 ## Capability
@@ -45,10 +45,16 @@ True when any open issue sends the draft back for another pass; false when every
 
 - Assign each of the four principles a verdict per [Principles](../resources/plain-language-standard.md#principles) and [Usability](../resources/plain-language-standard.md#usability) and the guidelines it cites — relevant, findable, understandable, usable — naming the guidelines that carry each verdict per [Verdict by principle](../resources/evaluation-report.md#template)
 
-### 3. Record the Open Issues
+### 3. Verdict the Overlay
+
+- When `{controlled_language}` is true, assign a verdict against the [ASD-STE100 writing rules](../resources/asd-ste100.md#writing-rules) and [Approved Words](../resources/asd-ste100.md#approved-words) at the word and sentence level, under the precedence [When It Applies](../resources/asd-ste100.md#when-it-applies) sets — per [Controlled language](../resources/evaluation-report.md#template)
+  > Skip this phase when `{controlled_language}` is false; the report carries no overlay section for a run that drafted without it.
+
+### 4. Record the Open Issues
 
 - Record each failure as an open issue with its location, principle, the problem the reader hits, and the fix — per [Open issues](../resources/evaluation-report.md#template) — so the revision pass has no interpretation to redo
+- An overlay breach is an open issue on the same list, naming the STE rule it breaches in place of a principle guideline, so one count gates delivery
 
-### 4. Set the Revision Signal
+### 5. Set the Revision Signal
 
 - Set `{open_issue_count}` to the number of open issues and `{needs_revision}` true when any remain, false when every principle is met

--- a/plain-language/techniques/intake-and-profile.md
+++ b/plain-language/techniques/intake-and-profile.md
@@ -23,10 +23,6 @@ Free-form statement of the document the user wants authored, rewritten, or audit
 
 The classified operation — `author`, `rewrite`, or `audit`.
 
-### operation_type_ambiguous
-
-True when the request admits more than one plausible operation and the choice is not settled.
-
 ### controlled_language
 
 True when the document is technical documentation the user wants held to the ASD-STE100 controlled language.
@@ -35,13 +31,13 @@ True when the document is technical documentation the user wants held to the ASD
 
 Short title of the document this run produces or reads.
 
-### document_type
-
-The class of document (email, web page, instruction, report, form, and so on) chosen to match the reader profile.
-
 ### document_profile
 
-The settled reader, purpose, context, and content selection, shaped by [Template](../../resources/document-profile.md#template).
+The settled reader, purpose, context, and content selection, shaped by [Template](../resources/document-profile.md#template).
+
+#### document_type
+
+The class of document (email, web page, instruction, report, form, and so on) chosen to match the reader profile.
 
 #### artifact
 
@@ -56,20 +52,20 @@ True when the operation type is ambiguous or the reader profile cannot be settle
 ### 1. Classify the Operation
 
 - Classify `{user_request}` as `author` (a new document), `rewrite` (an existing document made plain), or `audit` (an existing document assessed against the principles) — a named `{source_document_path}` signals `rewrite` or `audit`; the user's goal selects between them
-- Set `{operation_type_ambiguous}` true when the request admits more than one plausible reading, false when it is clear
+- Set `{$operation_type_ambiguous}` true when the request admits more than one plausible reading, false when it is clear
 
 ### 2. Detect the Controlled-Language Mode
 
-- Determine whether the document is technical documentation to be held to [ASD-STE100](../../resources/asd-ste100.md) — procedures and descriptions in a technical domain, or an explicit user request — and set `{controlled_language}`
+- Determine whether the document is technical documentation to be held to [ASD-STE100](../resources/asd-ste100.md) — procedures and descriptions in a technical domain, or an explicit user request — and set `{controlled_language}`
 
 ### 3. Settle the Reader Profile
 
-- Capture the readers, their purpose, the reading context, the document type, and the content selection per [Relevance](../../resources/plain-language-standard.md#relevance), at the depth [Template](../../resources/document-profile.md#template) declares
+- Capture the readers, their purpose, the reading context, the document type, and the content selection per [Relevance](../resources/plain-language-standard.md#relevance), at the depth [Template](../resources/document-profile.md#template) declares
 - Omit a question already answered by the request; where an answer the user did not give would have to be invented, leave the gap rather than choosing for them
 
 ### 4. Flag Unsettled Intent
 
-- Set `{intent_needs_confirmation}` true when `{operation_type_ambiguous}` is true or the profile still carries an unsettled gap; false when operation and profile are both settled
+- Set `{intent_needs_confirmation}` true when `{$operation_type_ambiguous}` is true or the profile still carries an unsettled gap; false when operation and profile are both settled
 
 ## Rules
 

--- a/plain-language/workflow.yaml
+++ b/plain-language/workflow.yaml
@@ -34,13 +34,12 @@ variables:
   - name: planning_folder_path
     type: string
     description: Absolute path to this run's planning folder — the write location for every working artifact.
+  - name: user_request
+    type: string
+    description: The user's free-form request that opened this run.
   - name: operation_type
     type: string
     description: The classified operation for the request — author, rewrite, or audit.
-  - name: operation_type_ambiguous
-    type: boolean
-    description: True when intake cannot confidently classify author vs rewrite vs audit from the request alone.
-    defaultValue: false
   - name: intent_needs_confirmation
     type: boolean
     description: Composite gap flag for the intake gate — true when the operation type is ambiguous or the reader profile cannot be settled from the request.
@@ -60,10 +59,6 @@ variables:
   - name: document_title
     type: string
     description: Short title of the document this run authors, rewrites, or audits.
-    defaultValue: ""
-  - name: document_type
-    type: string
-    description: The class of document (email, web page, instruction, report, form, and so on) chosen to match the reader profile.
     defaultValue: ""
   - name: output_path
     type: string
@@ -122,10 +117,6 @@ variables:
     type: number
     description: Count of evaluate-revise rounds completed on the current document.
     defaultValue: 0
-  - name: checklist_complete
-    type: boolean
-    description: Whether the ISO 24495-1 Annex B checklist has been walked and recorded for the document.
-    defaultValue: false
   - name: checklist_path
     type: string
     description: Absolute path to the persisted iso-checklist artifact.


### PR DESCRIPTION
## Summary

The plain-language workflow landed with its five operations in a folder named after the workflow itself. When an activity step asks for `plain-language::intake-and-profile`, the loader reads the leading segment as a workflow name, looks for an operation of that name at the top of that workflow, finds none, and stops — it never falls back to reading the segment as a technique group. Every step in all five activities binds that way, so no step in the workflow resolves. The `workflows` branch has been failing its own guard suite since the merge.

This change gives the operations an address the loader resolves, settles four values that had no reader, and makes the controlled-language overlay leave evidence in the artifacts a run delivers.

## What happens today

A run reaches the first activity and asks for its operation. The loader treats `plain-language` as the workflow it already is, searches its top-level operations for `intake-and-profile`, and returns nothing — the operations live one level down, inside a group that shares the workflow's name. The same happens for the other four. The binding-fidelity guard reports all six bind sites as unresolvable.

Three techniques also declare `document_profile` a second time, though the root contract already merges it in, so one bind slot carries two descriptions that can drift apart.

Four values go nowhere. `user_request` is taken as an input by the intake operation with nothing seeding it. `operation_type_ambiguous` feeds one sentence of its own protocol and is cleared again by three checkpoint options, while `intent_needs_confirmation` is what actually opens the gate. `document_type` is a field of the profile document declared as though it were a separate product. `checklist_complete` restates what the checklist's own rules already require of every item.

Two resources keep operative prose above their first heading. A technique that cites a section by anchor receives only that heading's span, so it never sees that prose. The standard's scope — that plain language is measured by the reader's ability to use the document rather than by readability formulas, and is not the same as simplified language — never reaches the four techniques that cite individual principles. The controlled-language precedence — that the stricter rule wins at word and sentence level while the base standard keeps structure, audience fit and evaluation — never reaches the drafting step that applies it.

A run can also set the controlled-language flag, draft under the writing rules and the approved-word dictionary, and close on an evaluation and a checklist that never looked at either. The flag buys drafting behaviour and leaves no trace, so nothing downstream can tell a controlled-language run from a plain one.

## The fix

**Give the operations a resolvable address.** The five operations move directly under `techniques/`, with the shared contract in `TECHNIQUE.md` at that level — the shape the codebase-wiki workflow already uses for a library whose operations share one contract. Each step binds the bare operation name. The cross-workflow address stays `plain-language::operation`, which is what the resources README already advertised and which only becomes true after the move.

**Let the merged contract stand alone.** The three leaf declarations of `document_profile` go; the root contract supplies the slot and each protocol goes on referencing the designator unchanged.

**Settle the bag.** `user_request` becomes a workflow variable, as it is in every sibling workflow that takes one. `operation_type_ambiguous` becomes a protocol local, and the three checkpoint options that cleared it drop that effect. `document_type` becomes a component of the profile output rather than a sibling of it. `checklist_complete` goes.

**Put the stranded rules in a section a citer can ask for.** The standard's scope moves into Principles, which the evaluation step now cites alongside Usability. The overlay precedence moves into When It Applies, which the drafting step now cites where it applies the overlay.

**Verify the overlay where it applied.** Evaluation carries a verdict on the writing rules and the approved words when the overlay was on. A breach joins the same open-issue list as a principle failure, so delivery is gated on one count rather than two and a revision pass sees overlay issues alongside the rest. The report omits the section for a run that drafted without the overlay rather than recording it as absent. The audit walk gains the same reach, so an audit-only run of technical documentation reports the breaches it finds.

## Why now is cheap

The workflow has not run. Nothing depends on the current addresses, no artifact carries the current shape, and the branch is red until the bindings resolve. Every change here is to a workflow whose first run is still ahead of it.

## Scope of change

Fourteen files across one workflow: five operations and their shared contract move up one level, five activities bind the bare name, the workflow variables lose two entries and gain one, and four resources and techniques carry the overlay verdict and the two relocated rules.

## Acceptance criteria

- Every activity step resolves to an operation.
- The guard suite passes on the `workflows` branch: 25 of 25, from 23 of 25 today.
- No technique declares an input its container already merges in.
- Every declared output has a reader, and every input has a producer.
- A run with the controlled-language flag set produces an evaluation report carrying an overlay verdict; a run without it produces a report with no overlay section.

## Non-goals

The ISO 24495-1 Annex B checklist stays as it is. It is the standard's own instrument, and adding controlled-language rows would misrepresent what a completed checklist attests to — the overlay verdict lives in the evaluation report, which is the workflow's own artifact.

This change does not run the workflow. The bindings resolve and the guards pass, but that is static analysis; a first run is still owed.
