### PR TITLE
Agent-read registers: the four nobody opens become structured files

### DIFF
--- a/meta/resources/planning-readme.md
+++ b/meta/resources/planning-readme.md
@@ -78,6 +78,7 @@ Tracks workflow **activities** (primary) and their planning artifacts (siblings 
 - When an activity produces artifacts, add artifact link rows for it. Pattern: optional activity milestone row plus artifact siblings, or let the first artifact row stand for the activity — apply one pattern consistently per workflow seed. Minimum bar: every activity owns at least one row.
 - **Seed the optional paths too**, including rows the current mode excludes. Undecided optional-path rows start pending; rows already out of scope for this run start cancelled/N/A (e.g. review-only artifacts in an implement seed, create-only activities when `is_review_mode`) so the exclusion is visible immediately rather than indistinguishable from work still in contention. A later path skip writes the same cancelled/N/A — [Status vocabulary](#status-vocabulary) covers both.
 - Estimate: expected agentic time — adjust template defaults to the work's complexity.
+- **An agent-audience artifact gets no row.** The table is read by a person, and an artifact whose declaration names an agent as its reader is not one they open. The activity that produces it still owns a row, so the work stays visible without linking a file nobody reads.
 - Distinct from the header-line `**Status:**` lifecycle field (Planning/Drafting/…), which remains text and is **not** mutated by Progress Status writers — lifecycle updates stay with [commit-and-persist](../techniques/workflow-engine/commit-and-persist.md).
 
 #### Item cell

--- a/midnight-system-review/README.md
+++ b/midnight-system-review/README.md
@@ -8,7 +8,7 @@ Given a PR reference or local diff, the workflow derives investigation areas fro
 
 Four user decision points bound the run — scope confirmation (non-blocking, 30s auto-advance), investigation-plan approval (blocking, with an amendment loop), verdict sign-off (blocking, with a rework path back to area derivation), and publish authorization (blocking, only when a PR surface exists). Probing and adjudication run checkpoint-free between the plan and verdict gates.
 
-Declared variables are run configuration and boolean gates only (`review_target`, `target_repo_path`, `base_ref`, `planning_folder_path`, `insight_repo_path`, `probe_budget_per_area`, plus the `has_pr_surface`, toolchain, `plan_approved`, and `publish_requested` gates); rich data flows through step outputs and the planning-folder artifacts (`change-surface.md`, `investigation-plan.md`, `evidence-log.md`, `findings-register.md`, `review-report.md`, `publication-record.md`).
+Declared variables are run configuration and boolean gates only (`review_target`, `target_repo_path`, `base_ref`, `planning_folder_path`, `insight_repo_path`, `probe_budget_per_area`, plus the `has_pr_surface`, toolchain, `plan_approved`, and `publish_requested` gates); rich data flows through step outputs and the planning-folder artifacts (`change-surface.md`, `investigation-plan.md`, `evidence-log.json`, `findings-register.md`, `review-report.md`, `publication-record.md`).
 
 ## Getting Started
 

--- a/midnight-system-review/resources/README.md
+++ b/midnight-system-review/resources/README.md
@@ -26,7 +26,7 @@ Reference content loaded on demand by the workflow's techniques. The authoritati
 |---------------|-------|
 | `change-surface.md` | [change-surface](change-surface.md) |
 | `investigation-plan.md` | [investigation-plan](investigation-plan.md) |
-| `evidence-log.md` | [evidence-log](evidence-log.md) |
+| `evidence-log.json` | [evidence-log](evidence-log.md) |
 | `findings-register.md` | [findings-register](findings-register.md) |
 | `publication-record.md` | [publication-record](publication-record.md) |
 | `review-report.md` | [review-format](review-format.md) |

--- a/midnight-system-review/resources/evidence-log.md
+++ b/midnight-system-review/resources/evidence-log.md
@@ -1,41 +1,77 @@
 ---
 name: evidence-log
-description: Creation guide for bare filename `evidence-log.md` — the consolidated evidence base carrying per-area probe accounting, every evidence item with its anchor, the failure-class discharge records, and the blocked validations.
+description: Creation guide for bare filename `evidence-log.json` — the consolidated evidence base carrying per-area probe accounting, every evidence item with its anchor, the failure-class discharge records, and the blocked validations.
 metadata:
   order: 10
 ---
 
 # Evidence Log Guide
 
-Creation guide for bare filename `evidence-log.md`. The evidence every finding later rests on, plus the accounting the final report reconciles against. Adjudication reads entries by ID, so an entry without one is evidence nothing can cite.
+Creation guide for bare filename `evidence-log.json`. The evidence every finding later rests on, plus the accounting the final report reconciles against. Adjudication reads entries by ID, so an entry without one is evidence nothing can cite.
 
 ## Template
 
-```markdown
-# Evidence Log — {target identity}
+One object per planned area, in plan order, each carrying its accounting, its evidence items, its failure-class discharges, and the validations that could not run.
 
-| Area | Probes planned | Executed | Blocked | Candidates |
-|------|---------------:|---------:|--------:|-----------:|
-| `area-id` | 3 | 3 | 0 | 2 |
-
-## {Area title}
-
-| ID | Probe | Evidence | Anchor |
-|----|-------|----------|--------|
-| E1 | P7 | one line on what was observed | {locus link} |
-
-**Failure-class discharge**
-
-| Class | Verdict | Proof |
-|-------|---------|-------|
-| correlation-contract | confirmed \| refuted \| inconclusive \| blocked | {join-key table or per-caller path anchor} |
-
-**Blocked validations**
-
-| What | Why | Anchor |
-|------|-----|--------|
-| one line | the gate that was false | {locus link} |
+```json
+{
+  "target": "midnight-node @ 3f2a1c4",
+  "areas": [
+    {
+      "area_id": "storage-lifecycle",
+      "probes_planned": 3,
+      "probes_executed": 3,
+      "probes_blocked": 0,
+      "candidates": 2,
+      "evidence": [
+        {
+          "id": "E1",
+          "probe": "P7",
+          "observation": "close path leaves the storage record in place",
+          "anchor": "pallets/session/src/lib.rs#L412"
+        }
+      ],
+      "failure_class_discharge": [
+        {
+          "class": "correlation-contract",
+          "verdict": "refuted",
+          "proof": "pallets/session/src/tests.rs#L88"
+        }
+      ],
+      "blocked_validations": [
+        {
+          "validation": "runtime benchmark for the close path",
+          "gate": "benchmarking feature unavailable in the pinned toolchain",
+          "anchor": "Cargo.toml#L61"
+        }
+      ]
+    }
+  ]
+}
 ```
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `target` | string | The target identity the run investigated |
+| `areas` | object[] | One entry per planned investigation area, in plan order |
+| `areas[].area_id` | string | The area's id as the investigation plan declares it |
+| `areas[].probes_planned` | number | Probes the plan allocated to this area |
+| `areas[].probes_executed` | number | Probes actually run |
+| `areas[].probes_blocked` | number | Probes that could not run |
+| `areas[].candidates` | number | Candidate findings this area raised |
+| `areas[].evidence` | object[] | Every evidence item the area produced |
+| `areas[].evidence[].id` | string | Evidence id adjudication cites (`E1`, `E2`, …), unique across the log |
+| `areas[].evidence[].probe` | string | The probe class that produced it (`P7`, `P8a`, …) |
+| `areas[].evidence[].observation` | string | One line on what was observed |
+| `areas[].evidence[].anchor` | string | Locus the observation rests on |
+| `areas[].failure_class_discharge` | object[] | One entry per failure-class obligation the area carried |
+| `areas[].failure_class_discharge[].class` | string | The obligation discharged |
+| `areas[].failure_class_discharge[].verdict` | string | `confirmed`, `refuted`, `inconclusive`, or `blocked` |
+| `areas[].failure_class_discharge[].proof` | string | Join-key discharge or per-caller path anchor; required when the verdict is `refuted` |
+| `areas[].blocked_validations` | object[] | Validations nobody could run |
+| `areas[].blocked_validations[].validation` | string | What could not be validated |
+| `areas[].blocked_validations[].gate` | string | The gate that was false |
+| `areas[].blocked_validations[].anchor` | string | Where the gate is observable |
 
 ## Rules
 
@@ -44,4 +80,4 @@ Creation guide for bare filename `evidence-log.md`. The evidence every finding l
 - **A probe overage is recorded, not absorbed.** Exceeding the per-area budget signals a plan or discipline defect rather than extra rigour, so it appears in the accounting.
 - **Inconclusive is its own verdict.** A refuted discharge carries its proof — a join-key discharge table for a correlation class, a per-caller path anchor for a propagation or caller-accounting class. An inconclusive result is marked as such and never relabelled refuted.
 - **Blocked validations are listed with the gate that failed.** A validation nobody could run is evidence about the toolchain, and the report reconciles against it.
-- **Line budget:** one row per evidence item and per blocked validation, with no prose outside the tables.
+- **Line budget:** one object per evidence item and per blocked validation, and no field carrying prose beyond its one line.

--- a/midnight-system-review/resources/publication-record.md
+++ b/midnight-system-review/resources/publication-record.md
@@ -22,7 +22,7 @@ Creation guide for bare filename `publication-record.md`. The record answers one
 | Verdict | {merge-readiness verdict} |
 | Posted at | {timestamp} |
 
-**Traces to:** [review report](review-report.md) · [findings register](findings-register.md) · [evidence log](evidence-log.md)
+**Traces to:** [review report](review-report.md) · [findings register](findings-register.md) · [evidence log](evidence-log.json)
 
 {When the post failed: one line on the reason.}
 ```

--- a/midnight-system-review/techniques/evidence-probes/consolidate-evidence.md
+++ b/midnight-system-review/techniques/evidence-probes/consolidate-evidence.md
@@ -25,7 +25,11 @@ The consolidated evidence base: per-area probe accounting, all evidence items wi
 
 #### artifact
 
-`evidence-log.md`
+`evidence-log.json`
+
+#### audience
+
+`agent`
 
 ### candidate_findings
 

--- a/ponytail/README.md
+++ b/ponytail/README.md
@@ -129,8 +129,8 @@ workflows/ponytail/
 │   ├── apply-ladder.md                        # Climb the rungs → lean-change.md
 │   ├── review-over-engineering.md             # Diff-scoped tagged review → review-findings.md
 │   ├── audit-repo.md                          # Repo-wide hunt → audit-findings.md
-│   ├── harvest-debt.md                        # Grep ponytail markers → debt-ledger.md
-│   └── report-gain.md                         # Honesty-bounded gain scoreboard (appends to debt-ledger.md)
+│   ├── harvest-debt.md                        # Grep ponytail markers → debt-ledger.json
+│   └── report-gain.md                         # Honesty-bounded gain scoreboard (fills the ledger gain field)
 └── resources/
     ├── README.md                              # Resource catalog
     ├── the-ladder.md                          # 7 rungs + safety floor + understand-first

--- a/ponytail/resources/README.md
+++ b/ponytail/resources/README.md
@@ -19,7 +19,7 @@ The authoritative content lives in each `.md` file and is served by `get_resourc
 | [lean-brief.md](lean-brief.md) | Creation guide: `lean-brief.md` — the traced flow, reachable rungs, and obligations in play | `#template` |
 | [lean-change.md](lean-change.md) | Creation guide: `lean-change.md` — code first, then at most three lines on what was skipped | `#template` |
 | [audit-findings.md](audit-findings.md) | Creation guide: `audit-findings.md` — one line per finding, biggest cut first, net scoreboard | `#template` |
-| [debt-ledger.md](debt-ledger.md) | Creation guide: `debt-ledger.md` — one row per marker with its ceiling and upgrade trigger | `#template` |
+| [debt-ledger.md](debt-ledger.md) | Creation guide: `debt-ledger.json` — one row per marker with its ceiling and upgrade trigger | `#template` |
 
 ---
 
@@ -30,7 +30,7 @@ The authoritative content lives in each `.md` file and is served by `get_resourc
 | `lean-brief.md` | [lean-brief](lean-brief.md) |
 | `lean-change.md` | [lean-change](lean-change.md) |
 | `audit-findings.md` | [audit-findings](audit-findings.md) |
-| `debt-ledger.md` | [debt-ledger](debt-ledger.md) |
+| `debt-ledger.json` | [debt-ledger](debt-ledger.md) |
 
 ---
 

--- a/ponytail/resources/debt-ledger.md
+++ b/ponytail/resources/debt-ledger.md
@@ -1,6 +1,6 @@
 ---
 name: debt-ledger
-description: Creation guide for bare filename `debt-ledger.json` — one entry per ponytail marker with its ceiling and upgrade trigger, grouped by file, carrying the marker and no-trigger counts and the gain scoreboard the report appends.
+description: Creation guide for bare filename `debt-ledger.json` — one entry per ponytail marker with its ceiling and upgrade trigger, grouped by file, carrying the marker and no-trigger counts and the gain scoreboard.
 ---
 
 # Debt Ledger Guide
@@ -9,7 +9,7 @@ Creation guide for bare filename `debt-ledger.json`. Every deliberate simplifica
 
 ## Template
 
-One entry per marker, grouped under the file it sits in, with the counts the gain report totals against and the scoreboard it adds.
+One entry per marker, grouped under the file it sits in, with the counts that total it and the gain scoreboard.
 
 ```json
 {
@@ -51,16 +51,16 @@ One entry per marker, grouped under the file it sits in, with the counts the gai
 | `files[].entries[].simplified` | string | What was deliberately simplified |
 | `files[].entries[].ceiling` | string | The limit the simplification sets |
 | `files[].entries[].upgrade` | string | The trigger that would justify passing the ceiling, or `no-trigger` |
-| `gain` | object \| null | The gain scoreboard, null until the gain report writes it |
+| `gain` | object \| null | The gain scoreboard, null until it is written |
 | `gain.ledger_rows` | number | The marker count, which is the only genuine per-repo figure |
 | `gain.benchmark_medians` | object | Published aggregate medians — `lines_of_code`, `cost`, `speed` — labelled as medians over the benchmark suite |
 
 ## Rules
 
-- **One entry per marker, carrying all four fields.** Line, what was simplified, the ceiling, the upgrade trigger. The fields are what make the ledger totalable by the gain report.
+- **One entry per marker, carrying all four fields.** Line, what was simplified, the ceiling, the upgrade trigger. The fields are what make the ledger totalable.
 - **Grouped by file.** Entries sit under the file they came from, so a reader working on one file sees its debt together.
 - **A missing trigger is flagged, not omitted.** `upgrade` set to `no-trigger` marks a ceiling nobody can tell when to lift, which is the entry most worth revisiting.
 - **The counts are fields, not a closing line.** `markers` and `no_trigger` sum the entries. A harvest that found none writes both as `0` and `files` as an empty array.
-- **The gain scoreboard is a field of this file.** The gain report fills `gain` rather than appending to the end, so the ledger stays one parseable document with one writer per field.
+- **The gain scoreboard is a field, not an appendix.** It is written into `gain` rather than added after the document, so the ledger stays one parseable document with one writer per field.
 - **The ledger records, it does not judge.** A marker is debt with a stated ceiling, not a defect; whether to upgrade is decided when the trigger fires.
 - **Line budget:** one object per marker, each field held to one line.

--- a/ponytail/resources/debt-ledger.md
+++ b/ponytail/resources/debt-ledger.md
@@ -1,30 +1,66 @@
 ---
 name: debt-ledger
-description: Creation guide for bare filename `debt-ledger.md` — one row per ponytail marker with its ceiling and upgrade trigger, grouped by file, closing with the marker and no-trigger counts.
+description: Creation guide for bare filename `debt-ledger.json` — one entry per ponytail marker with its ceiling and upgrade trigger, grouped by file, carrying the marker and no-trigger counts and the gain scoreboard the report appends.
 ---
 
 # Debt Ledger Guide
 
-Creation guide for bare filename `debt-ledger.md`. Every deliberate simplification, with the limit it sets and the trigger that would justify passing it. A marker whose trigger is missing is the interesting row, so the ledger flags it rather than leaving it to be noticed.
+Creation guide for bare filename `debt-ledger.json`. Every deliberate simplification, with the limit it sets and the trigger that would justify passing it. A marker whose trigger is missing is the interesting entry, so the ledger flags it rather than leaving it to be noticed.
 
 ## Template
 
-```markdown
-# Debt Ledger — {target}
+One entry per marker, grouped under the file it sits in, with the counts the gain report totals against and the scoreboard it adds.
 
-## `{file path}`
-
-{file}:{line}, {what was simplified}. ceiling: {the limit}. upgrade: {the trigger}.
-{file}:{line}, {what was simplified}. ceiling: {the limit}. upgrade: no-trigger.
-
-{N} markers, {M} with no trigger.
+```json
+{
+  "target": "midnight-node",
+  "markers": 12,
+  "no_trigger": 3,
+  "files": [
+    {
+      "path": "pallets/session/src/lib.rs",
+      "entries": [
+        {
+          "line": 412,
+          "simplified": "single-validator assumption in the rotation path",
+          "ceiling": "one validator set per era",
+          "upgrade": "a second set is introduced"
+        },
+        {
+          "line": 511,
+          "simplified": "in-memory index instead of a persisted map",
+          "ceiling": "index fits in a block's memory budget",
+          "upgrade": "no-trigger"
+        }
+      ]
+    }
+  ],
+  "gain": null
+}
 ```
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `target` | string | The repository or component harvested |
+| `markers` | number | Total marker entries across every file |
+| `no_trigger` | number | Entries whose `upgrade` is `no-trigger` |
+| `files` | object[] | One entry per file carrying at least one marker, in path order |
+| `files[].path` | string | Path of the file the markers sit in |
+| `files[].entries` | object[] | The markers in that file, in line order |
+| `files[].entries[].line` | number | Line the marker sits on |
+| `files[].entries[].simplified` | string | What was deliberately simplified |
+| `files[].entries[].ceiling` | string | The limit the simplification sets |
+| `files[].entries[].upgrade` | string | The trigger that would justify passing the ceiling, or `no-trigger` |
+| `gain` | object \| null | The gain scoreboard, null until the gain report writes it |
+| `gain.ledger_rows` | number | The marker count, which is the only genuine per-repo figure |
+| `gain.benchmark_medians` | object | Published aggregate medians — `lines_of_code`, `cost`, `speed` — labelled as medians over the benchmark suite |
 
 ## Rules
 
-- **One row per marker, in the grammar above.** Location, what was simplified, the ceiling, the upgrade trigger. The grammar is what makes the ledger totalable by the gain report.
-- **Grouped by file.** Rows sort under the file they sit in, so a reader working on one file sees its debt together.
-- **A missing trigger is flagged, not omitted.** `upgrade: no-trigger` marks a ceiling nobody can tell when to lift, which is the row most worth revisiting.
-- **The counts close the file.** `N markers, M with no trigger.` sums both. When the harvest found none, the whole file is `No ponytail: debt. Clean ledger.` instead.
+- **One entry per marker, carrying all four fields.** Line, what was simplified, the ceiling, the upgrade trigger. The fields are what make the ledger totalable by the gain report.
+- **Grouped by file.** Entries sit under the file they came from, so a reader working on one file sees its debt together.
+- **A missing trigger is flagged, not omitted.** `upgrade` set to `no-trigger` marks a ceiling nobody can tell when to lift, which is the entry most worth revisiting.
+- **The counts are fields, not a closing line.** `markers` and `no_trigger` sum the entries. A harvest that found none writes both as `0` and `files` as an empty array.
+- **The gain scoreboard is a field of this file.** The gain report fills `gain` rather than appending to the end, so the ledger stays one parseable document with one writer per field.
 - **The ledger records, it does not judge.** A marker is debt with a stated ceiling, not a defect; whether to upgrade is decided when the trigger fires.
-- **Line budget:** one line per marker, with the file headings the only other content.
+- **Line budget:** one object per marker, each field held to one line.

--- a/ponytail/techniques/README.md
+++ b/ponytail/techniques/README.md
@@ -16,8 +16,8 @@ The technique library for the ponytail workflow. Each operation is one capabilit
 | [`apply-ladder`](apply-ladder.md) | Climb to the minimal solution, mark every deliberate simplification, and leave one runnable check | `lean-change.md` |
 | [`review-over-engineering`](review-over-engineering.md) | Tag the change's over-engineering one line per finding and close with a net-lines scoreboard | `review-findings.md` |
 | [`audit-repo`](audit-repo.md) | Hunt repo-wide over-engineering biggest-cut-first and close with a net lines-and-deps scoreboard | `audit-findings.md` |
-| [`harvest-debt`](harvest-debt.md) | Harvest every ponytail marker into a debt ledger and flag any marker missing an upgrade trigger | `debt-ledger.md` |
-| [`report-gain`](report-gain.md) | Append an honesty-bounded gain scoreboard to the foot of the debt ledger | *(appends to `debt-ledger.md`)* |
+| [`harvest-debt`](harvest-debt.md) | Harvest every ponytail marker into a debt ledger and flag any marker missing an upgrade trigger | `debt-ledger.jsod` |
+| [`report-gain`](report-gain.md) | Append an honesty-bounded gain scoreboard to the foot of the debt ledger | *(fills the `gain` field of `debt-ledger.json`)* |
 
 ---
 

--- a/ponytail/techniques/harvest-debt.md
+++ b/ponytail/techniques/harvest-debt.md
@@ -15,7 +15,11 @@ The debt ledger — one row per [ponytail marker](../../ponytail/resources/ponyt
 
 #### artifact
 
-`debt-ledger.md`
+`debt-ledger.json`
+
+#### audience
+
+`agent`
 
 ### has_debt_markers
 
@@ -29,7 +33,7 @@ Whether any ponytail marker was found — true when the ledger has at least one 
 
 ### 2. Build the ledger
 
-- Add a row per marker to `{debt_ledger}` in `{artifact_dir}` per [debt-ledger](../resources/debt-ledger.md#template) and its [Rules](../resources/debt-ledger.md#rules), with the ceiling and upgrade trigger drawn from the [marker convention](../../ponytail/resources/ponytail-marker-convention.md#convention) and a missing trigger flagged [no-trigger](../../ponytail/resources/ponytail-marker-convention.md#no-trigger)
+- Add an entry per marker to `{debt_ledger}` in `{artifact_dir}` per [debt-ledger](../resources/debt-ledger.md#template) and its [Rules](../resources/debt-ledger.md#rules), with the ceiling and upgrade trigger drawn from the [marker convention](../../ponytail/resources/ponytail-marker-convention.md#convention) and a missing trigger flagged [no-trigger](../../ponytail/resources/ponytail-marker-convention.md#no-trigger)
 - For an owner per row, optionally append the output of `git blame -L<line>,<line>` for the marker's line.
 
 ### 3. Signal the result

--- a/ponytail/techniques/report-gain.md
+++ b/ponytail/techniques/report-gain.md
@@ -5,36 +5,36 @@ metadata:
 
 ## Capability
 
-Summarize the honest gain from the lazy pass, appended to the foot of the debt ledger. Cite the aggregate [benchmark medians](../../ponytail/resources/honesty-boundary.md#medians) — lines of code, cost, and speed — point at the ledger for the only real per-repo count, and never fabricate a per-repo savings number. This is the workflow's adaptation of the source's read-only display: it appends a summary to the ledger and mutates no source code.
+Summarize the honest gain from the lazy pass into the debt ledger's gain field. Cite the aggregate [benchmark medians](../../ponytail/resources/honesty-boundary.md#medians) — lines of code, cost, and speed — point at the ledger for the only real per-repo count, and never fabricate a per-repo savings number. This is the workflow's adaptation of the source's read-only display: it appends a summary to the ledger and mutates no source code.
 
 ## Inputs
 
 ### debt_ledger
 
-The harvested debt [ledger](../../ponytail/resources/ponytail-marker-convention.md#convention) whose foot the gain scoreboard is appended to — its row count is the only genuine per-repo figure cited.
+The harvested debt [ledger](../../ponytail/resources/ponytail-marker-convention.md#convention) whose gain field the scoreboard fills — its marker count is the only genuine per-repo figure cited.
 
 ## Outputs
 
 ### gain_scoreboard
 
-The honesty-bounded gain summary appended to the foot of the debt ledger — the aggregate benchmark medians (lines of code, cost, speed), the real ledger row count as the only per-repo number, and no fabricated savings.
+The honesty-bounded gain summary written to the debt ledger's `gain` field — the aggregate benchmark medians (lines of code, cost, speed), the real marker count as the only per-repo number, and no fabricated savings.
 
 ## Protocol
 
 ### 1. Count the real ledger
 
-- Take the row count of the `{debt_ledger}` as the one genuine per-repo figure — the number of deliberate simplifications actually recorded.
+- Take the `markers` count of the `{debt_ledger}` as the one genuine per-repo figure — the number of deliberate simplifications actually recorded.
 
 ### 2. Cite benchmark medians
 
 - Cite the published aggregate [benchmark medians](../../ponytail/resources/honesty-boundary.md#medians) — lines of code, cost, and speed. Frame them as medians measured over the fixed benchmark suite, never as this repo's measured savings.
 
-### 3. Append the scoreboard
+### 3. Write the scoreboard
 
-- Append the `{gain_scoreboard}` to the foot of the debt ledger: the ledger row count, the aggregate benchmark medians, and a pointer to the ledger as the source of the real per-repo count. This append is the workflow's only mutation — it adds a summary to the ledger artifact and changes no source code.
+- Write the `{gain_scoreboard}` into the debt ledger's `gain` field per [debt-ledger](../resources/debt-ledger.md#template): the marker count, and the aggregate benchmark medians. This write is the workflow's only mutation — it fills one field of the ledger artifact and changes no source code.
 
 ## Rules
 
 ### honesty-boundary-on-reporting
 
-Never fabricate a per-repo savings number. The only genuine per-repo figure is the [debt-ledger](../../ponytail/resources/ponytail-marker-convention.md#convention) row count; everything else is a published aggregate [benchmark median](../../ponytail/resources/honesty-boundary.md#medians) and must be labelled as such.
+Never fabricate a per-repo savings number. The only genuine per-repo figure is the [debt-ledger](../../ponytail/resources/ponytail-marker-convention.md#convention) marker count; everything else is a published aggregate [benchmark median](../../ponytail/resources/honesty-boundary.md#medians) and must be labelled as such.

--- a/prism-audit/README.md
+++ b/prism-audit/README.md
@@ -8,7 +8,7 @@
 
 The prism-audit workflow orchestrates a security audit in two halves. First it **reads the target codebase** and composes a detailed, self-contained audit prompt grounded in that codebase's actual architecture, language, and risk exposure. Then it **triggers the generic [prism](../prism/README.md) workflow** to run the analysis against that prompt, and assembles prism's contract artifacts into the security-audit deliverables.
 
-All audit-specific customisation — prompt generation, domain mapping, trust-boundary analysis, cross-scope consolidation, the report split — lives in this workflow. Everything prism already provides is reused, not reimplemented: prism runs its lenses, enriches findings with blast radius, strips methodology, assigns finding IDs, and writes its contract artifacts (RUN-MANIFEST.md, REPORT.md, DEFINITIVE-FINDINGS.md). This workflow reads those and never re-opens prism's raw pass artifacts.
+All audit-specific customisation — prompt generation, domain mapping, trust-boundary analysis, cross-scope consolidation, the report split — lives in this workflow. Everything prism already provides is reused, not reimplemented: prism runs its lenses, enriches findings with blast radius, strips methodology, assigns finding IDs, and writes its contract artifacts (RUN-MANIFEST.json, REPORT.md, DEFINITIVE-FINDINGS.md). This workflow reads those and never re-opens prism's raw pass artifacts.
 
 **Why a dedicated audit workflow rather than prompting prism directly?**
 
@@ -55,7 +55,7 @@ The spine is linear — scope, prompt, analyse, finalize, deliver — with two b
 |---|----------|---------|
 | 00 | [**Define Audit Scope**](./activities/README.md#00-define-audit-scope) (`scope-definition`) | Collect the target, description, and output path; validate the target; index it with GitNexus when available; confirm scope |
 | 01 | [**Generate Audit Prompt**](./activities/README.md#01-generate-audit-prompt) (`prompt-generation`) | Survey the codebase, map trust boundaries and audit domains, and compose the tailored audit prompt + the scope list prism will run |
-| 02 | [**Execute Prism Analysis**](./activities/README.md#02-execute-prism-analysis) (`execute-analysis`) | Trigger the prism workflow once per audit scope and record each run from its `RUN-MANIFEST.md` |
+| 02 | [**Execute Prism Analysis**](./activities/README.md#02-execute-prism-analysis) (`execute-analysis`) | Trigger the prism workflow once per audit scope and record each run from its `RUN-MANIFEST.json` |
 | 03 | [**Audit Report Finalization**](./activities/README.md#03-audit-report-finalization) (`audit-finalize`) | Assemble prism's `REPORT.md` + `DEFINITIVE-FINDINGS.md` into the three audit deliverables and cross-validate them |
 | 04 | [**Deliver Audit Results**](./activities/README.md#04-deliver-audit-results) (`deliver-audit`) | Present the deliverables with finding counts, the core finding, top remediations, and a full artifact index |
 
@@ -70,7 +70,7 @@ The workflow writes all artifacts under the user-supplied `output_path`:
 | Artifact | Produced by | Contents |
 |----------|-------------|----------|
 | `audit-prompt.md` | prompt-generation | The self-contained, codebase-tailored audit prompt (also the `analysis_focus` handed to prism) |
-| `RUN-MANIFEST.md`, `REPORT.md`, `DEFINITIVE-FINDINGS.md` + analysis artifacts | triggered prism run(s) | prism's contract artifacts (the audit's inputs) plus the underlying raw pass artifacts prism produced |
+| `RUN-MANIFEST.json`, `REPORT.md`, `DEFINITIVE-FINDINGS.md` + analysis artifacts | triggered prism run(s) | prism's contract artifacts (the audit's inputs) plus the underlying raw pass artifacts prism produced |
 | `AUDIT-REPORT.md` | audit-finalize | Summary report — domain tables, systemic patterns, risk assessment, prioritized remediations (with an Impact column), appendices |
 | `DETAILED-FINDINGS.md` | audit-finalize | One expanded write-up per finding, taken from prism's `DEFINITIVE-FINDINGS.md` (Description, Impact, Location, Recommendation, Adversarial confirmation, and Graph Evidence carried from prism's blast-radius enrichment) |
 | `DESIGN-TRADE-OFFS.md` | audit-finalize | Falsifiable design trade-offs behind the findings, each with code-level evidence and actionable design questions |
@@ -113,7 +113,7 @@ Like the other workflows in this library, prism-audit runs under the **orchestra
 
 The prism analysis is reached through the **trigger mechanism**, not called inline: `execute-analysis` uses [`workflow-engine::handle-sub-workflow`](../meta/techniques/workflow-engine/handle-sub-workflow.md) to dispatch prism as a child workflow per audit scope. Two rules keep the boundary clean:
 
-- **Contract reuse.** The orchestrator sets prism's `analysis_focus` to the generated audit-prompt content (naming the scope's security domains so prism assigns domain-prefixed finding IDs). The audit then reads only prism's contract artifacts — `RUN-MANIFEST.md`, `REPORT.md`, `DEFINITIVE-FINDINGS.md` — and never re-derives what prism already produced (finding extraction, blast-radius enrichment, methodology-stripping, within-run consolidation).
+- **Contract reuse.** The orchestrator sets prism's `analysis_focus` to the generated audit-prompt content (naming the scope's security domains so prism assigns domain-prefixed finding IDs). The audit then reads only prism's contract artifacts — `RUN-MANIFEST.json`, `REPORT.md`, `DEFINITIVE-FINDINGS.md` — and never re-derives what prism already produced (finding extraction, blast-radius enrichment, methodology-stripping, within-run consolidation).
 - **Sequential execution.** Audit scopes are triggered one prism run at a time, so each run has full system resources and no cross-analysis context interference.
 
 ---
@@ -152,7 +152,7 @@ workflows/prism-audit/
 │   ├── execute-analysis/                      # Prism-trigger operation-group
 │   │   ├── TECHNIQUE.md                        # Group contract
 │   │   ├── compose-trigger-context.md          # Unpack a scope into prism trigger variables
-│   │   └── read-run-manifest.md                # Record a prism run from its RUN-MANIFEST.md
+│   │   └── read-run-manifest.md                # Record a prism run from its RUN-MANIFEST.json
 │   ├── audit-finalize/                        # Finalization operation-group
 │   │   ├── TECHNIQUE.md                        # Group contract
 │   │   ├── split-report.md                     # Split REPORT.md → AUDIT-REPORT.md

--- a/prism-audit/activities/README.md
+++ b/prism-audit/activities/README.md
@@ -26,7 +26,7 @@ Definition: [`01-prompt-generation.yaml`](01-prompt-generation.yaml). Leads to [
 
 ### 02. Execute Prism Analysis
 
-Trigger the generic [prism](../../prism/README.md) workflow once per entry in `audit_scopes`. After verifying the scopes exist, a `forEach` loop composes each scope's trigger context, dispatches prism as a child workflow via `workflow-engine::handle-sub-workflow`, and records the run from its `RUN-MANIFEST.md` — prism has already verified its own completion, so no re-scan or re-verification happens here. Scopes run sequentially so each prism run has full resources and no cross-analysis interference. **Value:** every audit scope has a completed prism analysis whose contract artifacts finalization can consolidate.
+Trigger the generic [prism](../../prism/README.md) workflow once per entry in `audit_scopes`. After verifying the scopes exist, a `forEach` loop composes each scope's trigger context, dispatches prism as a child workflow via `workflow-engine::handle-sub-workflow`, and records the run from its `RUN-MANIFEST.json` — prism has already verified its own completion, so no re-scan or re-verification happens here. Scopes run sequentially so each prism run has full resources and no cross-analysis interference. **Value:** every audit scope has a completed prism analysis whose contract artifacts finalization can consolidate.
 
 Definition: [`02-execute-analysis.yaml`](02-execute-analysis.yaml). Leads to [Audit Report Finalization](#03-audit-report-finalization).
 

--- a/prism-audit/techniques/README.md
+++ b/prism-audit/techniques/README.md
@@ -50,7 +50,7 @@ Four operation-groups (one per authoring activity) plus one standalone technique
 | Operation | Capability |
 |-----------|------------|
 | [`compose-trigger-context`](execute-analysis/compose-trigger-context.md) | Unpack a scope into the prism trigger variables (target, description, output, pipeline mode, focus) |
-| [`read-run-manifest`](execute-analysis/read-run-manifest.md) | Record a prism run from its `RUN-MANIFEST.md` (report + definitive-findings paths + status) into the audit accumulators |
+| [`read-run-manifest`](execute-analysis/read-run-manifest.md) | Record a prism run from its `RUN-MANIFEST.json` (report + definitive-findings paths + status) into the audit accumulators |
 
 ### audit-finalize (Audit Report Finalization)
 

--- a/prism-audit/techniques/execute-analysis/TECHNIQUE.md
+++ b/prism-audit/techniques/execute-analysis/TECHNIQUE.md
@@ -5,7 +5,7 @@ metadata:
 
 ## Capability
 
-Compose the prism trigger context for an audit scope, then record the triggered prism run from its RUN-MANIFEST.md — the report, definitive findings, artifact paths, and prism-reported completion status — into the audit's accumulators. Prism generates, enriches, and verifies its own results, so this set only composes the trigger context and reads the manifest; it does not re-extract findings, re-scan the output directory, or re-verify completion.
+Compose the prism trigger context for an audit scope, then record the triggered prism run from its RUN-MANIFEST.json — the report, definitive findings, artifact paths, and prism-reported completion status — into the audit's accumulators. Prism generates, enriches, and verifies its own results, so this set only composes the trigger context and reads the manifest; it does not re-extract findings, re-scan the output directory, or re-verify completion.
 
 ## Inputs
 

--- a/prism-audit/techniques/execute-analysis/read-run-manifest.md
+++ b/prism-audit/techniques/execute-analysis/read-run-manifest.md
@@ -5,7 +5,7 @@ metadata:
 
 ## Capability
 
-Read the triggered prism run's RUN-MANIFEST.md and record the run into the audit's accumulators — its report, definitive findings, artifact paths, and prism-reported completion status — without re-scanning the output directory. The scope's `output_subdir` (from the inherited `{current_scope}`) locates the run's `RUN-MANIFEST.md`.
+Read the triggered prism run's RUN-MANIFEST.json and record the run into the audit's accumulators — its report, definitive findings, artifact paths, and prism-reported completion status — without re-scanning the output directory. The scope's `output_subdir` (from the inherited `{current_scope}`) locates the run's `RUN-MANIFEST.json`.
 
 ## Outputs
 
@@ -21,7 +21,7 @@ Accumulated paths to all analysis artifacts across triggered prism runs, taken f
 
 ### 1. Read Run Manifest
 
-- Read `RUN-MANIFEST.md` from the scope's output location (its `output_subdir` under the audit output directory).
+- Read `RUN-MANIFEST.json` from the scope's output location (its `output_subdir` under the audit output directory).
 - From the manifest, take the run's `report_path`, `definitive_findings_path`, listed artifact paths, and its `status` (`complete` / `partial` / `error`) — prism has already verified completion, so no directory re-scan or per-artifact existence check is needed here.
 - Append the run's reference — `report_path`, `definitive_findings_path`, and the manifest `status` — to `{completed_analyses}`, and append the manifest's artifact paths to `{all_analysis_artifact_paths}`.
   > When the manifest reports `partial` or `error`, carry that status through on the run's `{completed_analyses}` entry so finalization surfaces the incomplete run rather than silently consolidating a gap.

--- a/prism-audit/workflow.yaml
+++ b/prism-audit/workflow.yaml
@@ -13,7 +13,7 @@ tags:
 rules:
   workflow:
     - ref: orchestration-model
-    - "CONTRACT REUSE: prism owns analysis, per-unit iteration, blast-radius enrichment, methodology-stripping, finding-ID assignment, and consolidation within a run. This workflow adds only what prism does not: audit-prompt generation (security characteristics, trust boundaries, audit domains), cross-scope consolidation, and the audit deliverables. It sets analysis_focus to the generated audit prompt (naming the scope's security domains so prism assigns domain-prefixed finding IDs), reads prism's contract artifacts (`RUN-MANIFEST.md`, `REPORT.md`, `DEFINITIVE-FINDINGS.md`), and never re-reads prism's raw pass artifacts."
+    - "CONTRACT REUSE: prism owns analysis, per-unit iteration, blast-radius enrichment, methodology-stripping, finding-ID assignment, and consolidation within a run. This workflow adds only what prism does not: audit-prompt generation (security characteristics, trust boundaries, audit domains), cross-scope consolidation, and the audit deliverables. It sets analysis_focus to the generated audit prompt (naming the scope's security domains so prism assigns domain-prefixed finding IDs), reads prism's contract artifacts (`RUN-MANIFEST.json`, `REPORT.md`, `DEFINITIVE-FINDINGS.md`), and never re-reads prism's raw pass artifacts."
   activity:
     - ref: prism::worker-permissions
     - ref: prism::artifact-verification
@@ -60,7 +60,7 @@ variables:
     description: Current audit scope during the execute-analysis iteration loop
   - name: completed_analyses
     type: array
-    description: "Array of completed prism runs, each read from that run's RUN-MANIFEST.md: { report_path, definitive_findings_path, status } plus the run's scope reference"
+    description: "Array of completed prism runs, each read from that run's RUN-MANIFEST.json: { report_path, definitive_findings_path, status } plus the run's scope reference"
   - name: all_analysis_artifact_paths
     type: array
     description: Accumulated paths to all analysis artifacts across triggered prism workflows, taken from each run's manifest

--- a/prism-evaluate/README.md
+++ b/prism-evaluate/README.md
@@ -77,7 +77,7 @@ Each activity step binds exactly one operation via `step.technique`. The operati
 | Technique group | Capability |
 |-----------------|------------|
 | [`plan-evaluation`](./techniques/plan-evaluation/TECHNIQUE.md) | Target classification, dimension derivation, target survey, dimension-to-lens mapping, execution grouping, and plan authoring |
-| [`execute-analysis`](./techniques/execute-analysis/TECHNIQUE.md) | Record a triggered prism run from its `RUN-MANIFEST.md` into the evaluation accumulators |
+| [`execute-analysis`](./techniques/execute-analysis/TECHNIQUE.md) | Record a triggered prism run from its `RUN-MANIFEST.json` into the evaluation accumulators |
 | [`compose-evaluation-report`](./techniques/compose-evaluation-report/TECHNIQUE.md) | Cross-artifact extraction, cross-dimensional synthesis, report composition and verification, result presentation |
 | [`resolve-findings`](./techniques/resolve-findings/TECHNIQUE.md) | Finding tier-classification, one-by-one mitigation proposal, mitigation-plan composition, and change application |
 
@@ -131,7 +131,7 @@ sequenceDiagram
     Orch->>User: report, mitigation plan, artifact index
 ```
 
-**Contract reuse:** the orchestrator sets prism's `analysis_focus` to the dimension-specific evaluation guidance (naming the dimension so prism assigns dimension-prefixed finding IDs). The evaluation then reads only prism's contract artifacts — `RUN-MANIFEST.md`, `REPORT.md`, `DEFINITIVE-FINDINGS.md` — and never re-derives what prism already produced (finding extraction, blast-radius enrichment, methodology-stripping, ID assignment). Consolidation adds the one thing prism cannot do across sibling runs: cross-dimensional synthesis.
+**Contract reuse:** the orchestrator sets prism's `analysis_focus` to the dimension-specific evaluation guidance (naming the dimension so prism assigns dimension-prefixed finding IDs). The evaluation then reads only prism's contract artifacts — `RUN-MANIFEST.json`, `REPORT.md`, `DEFINITIVE-FINDINGS.md` — and never re-derives what prism already produced (finding extraction, blast-radius enrichment, methodology-stripping, ID assignment). Consolidation adds the one thing prism cannot do across sibling runs: cross-dimensional synthesis.
 
 ---
 
@@ -144,14 +144,14 @@ For a standard 4-dimension evaluation (Consistency, Veracity, Plausibility, Feas
 ├── evaluation-plan.md              (dimension-to-lens mapping)
 ├── EVALUATION-REPORT.md            (consolidated evaluation)
 ├── consistency/
-│   ├── RUN-MANIFEST.md             (prism contract — run artifacts + status)
+│   ├── RUN-MANIFEST.json             (prism contract — run artifacts + status)
 │   ├── REPORT.md                   (prism contract — lean report)
 │   ├── DEFINITIVE-FINDINGS.md      (prism contract — findings source consolidation reads)
 │   ├── structural-analysis.md      (prism raw pass — full-prism)
 │   ├── adversarial-analysis.md     (prism raw pass — full-prism)
 │   └── synthesis.md                (prism raw pass — full-prism)
 └── dimensions/
-    ├── RUN-MANIFEST.md             (prism contract)
+    ├── RUN-MANIFEST.json             (prism contract)
     ├── REPORT.md                   (prism contract)
     ├── DEFINITIVE-FINDINGS.md      (prism contract — findings source)
     ├── claim-inversion.md          (Veracity — lens 07)
@@ -160,7 +160,7 @@ For a standard 4-dimension evaluation (Consistency, Veracity, Plausibility, Feas
     └── scarcity.md                 (Feasibility — lens 08)
 ```
 
-Consolidation reads each dimension's `DEFINITIVE-FINDINGS.md` (located from its `RUN-MANIFEST.md`); the raw pass artifacts are prism's internals, not read by this workflow. The resolution dialogue additionally produces a `MITIGATION-PLAN.md`.
+Consolidation reads each dimension's `DEFINITIVE-FINDINGS.md` (located from its `RUN-MANIFEST.json`); the raw pass artifacts are prism's internals, not read by this workflow. The resolution dialogue additionally produces a `MITIGATION-PLAN.md`.
 
 ---
 
@@ -183,7 +183,7 @@ workflows/prism-evaluate/
 │   ├── README.md                     # Technique library index
 │   ├── TECHNIQUE.md                  # Workflow-root base contract (inherited by all)
 │   ├── plan-evaluation/              # Target classification, dimension-to-lens mapping (one op per phase)
-│   ├── execute-analysis/             # Record each prism run from its RUN-MANIFEST.md
+│   ├── execute-analysis/             # Record each prism run from its RUN-MANIFEST.json
 │   ├── compose-evaluation-report/    # Cross-dimensional synthesis, report composition
 │   └── resolve-findings/             # Finding tier-classification, mitigation, change application
 └── resources/

--- a/prism-evaluate/activities/README.md
+++ b/prism-evaluate/activities/README.md
@@ -41,7 +41,7 @@ Definition: [`01-dimension-planning.yaml`](01-dimension-planning.yaml). Leads to
 
 ### 02. Execute Prism Analyses
 
-Trigger the generic prism workflow once per execution group and record each run from its `RUN-MANIFEST.md` — prism verifies its own completion, so a run the manifest flags `partial`/`error` is surfaced rather than dropped. **Value:** every planned dimension is analysed through the prism pipeline, yielding the per-dimension `DEFINITIVE-FINDINGS.md` consolidation draws on, with gaps made visible.
+Trigger the generic prism workflow once per execution group and record each run from its `RUN-MANIFEST.json` — prism verifies its own completion, so a run the manifest flags `partial`/`error` is surfaced rather than dropped. **Value:** every planned dimension is analysed through the prism pipeline, yielding the per-dimension `DEFINITIVE-FINDINGS.md` consolidation draws on, with gaps made visible.
 
 Definition: [`02-execute-analysis.yaml`](02-execute-analysis.yaml). Leads to [Consolidate Evaluation Report](#03-consolidate-evaluation-report).
 

--- a/prism-evaluate/resources/dimension-lens-mapping.md
+++ b/prism-evaluate/resources/dimension-lens-mapping.md
@@ -30,7 +30,7 @@ For dimensions not matching the standard patterns above, match the dimension's a
 
 ## Per-Dimension Findings Source
 
-Each triggered prism run writes its authoritative findings to `DEFINITIVE-FINDINGS.md` in the dimension's output subdirectory (see prism's [definitive-findings contract](../../prism/resources/definitive-findings-template.md)), alongside `REPORT.md` and `RUN-MANIFEST.md`. Consolidation reads DEFINITIVE-FINDINGS.md as the per-dimension findings source — it does not read the raw pass artifacts (`synthesis.md`, `portfolio-*.md`).
+Each triggered prism run writes its authoritative findings to `DEFINITIVE-FINDINGS.md` in the dimension's output subdirectory (see prism's [definitive-findings contract](../../prism/resources/definitive-findings-template.md)), alongside `REPORT.md` and `RUN-MANIFEST.json`. Consolidation reads DEFINITIVE-FINDINGS.md as the per-dimension findings source — it does not read the raw pass artifacts (`synthesis.md`, `portfolio-*.md`).
 
 ## Pipeline Mode Selection Guidance
 

--- a/prism-evaluate/techniques/README.md
+++ b/prism-evaluate/techniques/README.md
@@ -11,7 +11,7 @@ The technique library for the prism-evaluate workflow. Each operation is one cap
 | Technique group | Capability |
 |-----------------|------------|
 | [`plan-evaluation`](plan-evaluation/TECHNIQUE.md) | Collect the scope, classify the target, derive dimensions, survey the target, map each dimension to prism lenses and pipeline modes, group for execution, and author the evaluation plan |
-| [`execute-analysis`](execute-analysis/TECHNIQUE.md) | Record a triggered prism run from its `RUN-MANIFEST.md` into the evaluation accumulators |
+| [`execute-analysis`](execute-analysis/TECHNIQUE.md) | Record a triggered prism run from its `RUN-MANIFEST.json` into the evaluation accumulators |
 | [`compose-evaluation-report`](compose-evaluation-report/TECHNIQUE.md) | Consolidate the per-dimension prism artifacts into a unified, methodology-stripped evaluation report, then compile and present its metrics and deliverable index |
 | [`resolve-findings`](resolve-findings/TECHNIQUE.md) | Tier-classify findings, propose a mitigation per finding through one-by-one dialogue, compile the mitigation plan, and apply the accepted changes |
 
@@ -37,7 +37,7 @@ The technique library for the prism-evaluate workflow. Each operation is one cap
 
 | Operation | Capability |
 |-----------|------------|
-| [`read-run-manifest`](execute-analysis/read-run-manifest.md) | Record a prism run from its `RUN-MANIFEST.md` (report + definitive-findings paths + status) into the evaluation accumulators |
+| [`read-run-manifest`](execute-analysis/read-run-manifest.md) | Record a prism run from its `RUN-MANIFEST.json` (report + definitive-findings paths + status) into the evaluation accumulators |
 
 ### compose-evaluation-report (Consolidate Evaluation Report + Deliver Evaluation Results)
 

--- a/prism-evaluate/techniques/execute-analysis/TECHNIQUE.md
+++ b/prism-evaluate/techniques/execute-analysis/TECHNIQUE.md
@@ -5,7 +5,7 @@ metadata:
 
 ## Capability
 
-Record a triggered prism run from its RUN-MANIFEST.md — the report, definitive findings, artifact paths, and prism-reported completion status — into the evaluation's accumulators. prism generates, enriches, and verifies its own results, so this set only reads the manifest; it does not re-extract findings, re-scan the output directory, or re-verify completion.
+Record a triggered prism run from its RUN-MANIFEST.json — the report, definitive findings, artifact paths, and prism-reported completion status — into the evaluation's accumulators. prism generates, enriches, and verifies its own results, so this set only reads the manifest; it does not re-extract findings, re-scan the output directory, or re-verify completion.
 
 ## Inputs
 

--- a/prism-evaluate/techniques/execute-analysis/read-run-manifest.md
+++ b/prism-evaluate/techniques/execute-analysis/read-run-manifest.md
@@ -5,7 +5,7 @@ metadata:
 
 ## Capability
 
-Read the triggered prism run's RUN-MANIFEST.md and record the run into the evaluation's accumulators — its report, definitive findings, artifact paths, and prism-reported completion status — without re-scanning the output directory. The group's `output_subdir` (from the inherited `{current_group}`) locates the run's `RUN-MANIFEST.md`.
+Read the triggered prism run's RUN-MANIFEST.json and record the run into the evaluation's accumulators — its report, definitive findings, artifact paths, and prism-reported completion status — without re-scanning the output directory. The group's `output_subdir` (from the inherited `{current_group}`) locates the run's `RUN-MANIFEST.json`.
 
 ## Outputs
 
@@ -21,7 +21,7 @@ Accumulated paths to all analysis artifacts across triggered prism runs, taken f
 
 ### 1. Read Run Manifest
 
-- Read `RUN-MANIFEST.md` from the group's output location (its `output_subdir` under the evaluation output directory).
+- Read `RUN-MANIFEST.json` from the group's output location (its `output_subdir` under the evaluation output directory).
 - From the manifest, take the run's `report_path`, `definitive_findings_path`, listed artifact paths, and its `status` (`complete` / `partial` / `error`) — prism has already verified completion, so no directory re-scan or per-artifact existence check is needed here.
 - Append the run's reference — `report_path`, `definitive_findings_path`, and the manifest `status` — to `{completed_analyses}`, and append the manifest's artifact paths to `{all_artifact_paths}`.
   > When the manifest reports `partial` or `error`, carry that status through on the run's `{completed_analyses}` entry so consolidation surfaces the incomplete run rather than silently dropping a dimension.

--- a/prism-evaluate/workflow.yaml
+++ b/prism-evaluate/workflow.yaml
@@ -14,7 +14,7 @@ rules:
   workflow:
     - ref: prism-audit::orchestration-model
     - Agents MUST NOT proceed past blocking checkpoints without user confirmation — auto-resolving a checkpoint is a protocol violation
-    - "CONTRACT REUSE: prism owns analysis, per-unit iteration, blast-radius enrichment, methodology-stripping, finding-ID assignment, and consolidation within a run. This workflow adds only what prism does not: evaluation dimensions, cross-dimensional synthesis, and the resolution dialogue. It sets analysis_focus to the dimension-specific evaluation guidance (naming the dimension so prism assigns dimension-prefixed IDs), reads prism's contract artifacts (`RUN-MANIFEST.md`, `REPORT.md`, `DEFINITIVE-FINDINGS.md`), and never re-reads prism's raw pass artifacts."
+    - "CONTRACT REUSE: prism owns analysis, per-unit iteration, blast-radius enrichment, methodology-stripping, finding-ID assignment, and consolidation within a run. This workflow adds only what prism does not: evaluation dimensions, cross-dimensional synthesis, and the resolution dialogue. It sets analysis_focus to the dimension-specific evaluation guidance (naming the dimension so prism assigns dimension-prefixed IDs), reads prism's contract artifacts (`RUN-MANIFEST.json`, `REPORT.md`, `DEFINITIVE-FINDINGS.md`), and never re-reads prism's raw pass artifacts."
   activity:
     - ref: prism::worker-permissions
     - ref: prism::artifact-verification
@@ -60,7 +60,7 @@ variables:
     description: Current execution group during the execute-analysis iteration loop
   - name: completed_analyses
     type: array
-    description: "Array of completed prism runs, each read from that run's `RUN-MANIFEST.md`: { report_path, definitive_findings_path, status } plus the run's group reference"
+    description: "Array of completed prism runs, each read from that run's `RUN-MANIFEST.json`: { report_path, definitive_findings_path, status } plus the run's group reference"
   - name: all_artifact_paths
     type: array
     description: Accumulated paths to all analysis artifacts across triggered prism workflows

--- a/prism/README.md
+++ b/prism/README.md
@@ -1,6 +1,6 @@
 # Prism Analysis Workflow
 
-> v2.1.0 — Structured analytical prompts that find what asking a model directly misses. Ten modes, 58 lenses, isolated multi-pass pipelines, and a stable output contract (REPORT.md, DEFINITIVE-FINDINGS.md, RUN-MANIFEST.md) that consumer workflows build on.
+> v2.1.0 — Structured analytical prompts that find what asking a model directly misses. Ten modes, 58 lenses, isolated multi-pass pipelines, and a stable output contract (REPORT.md, DEFINITIVE-FINDINGS.md, RUN-MANIFEST.json) that consumer workflows build on.
 
 ---
 
@@ -169,7 +169,7 @@ graph TD
 | 01 | **Structural Analysis Pass** | Run the assigned analysis for each unit: L12 (single with lens `l12`, or full-prism's structural pass), the plan's chosen single lens (single with any other lens), a portfolio, or the behavioral pipeline |
 | 02 | **Adversarial Analysis Pass** | Run the adversarial lens against each full-prism unit's structural artifact (full-prism only) |
 | 03 | **Synthesis Pass** | Run the synthesis lens against each full-prism unit's structural + adversarial artifacts (full-prism only) |
-| 04 | **Deliver Result** | Emit RUN-MANIFEST.md, then present the final report to the user with artifact paths |
+| 04 | **Deliver Result** | Emit RUN-MANIFEST.json, then present the final report to the user with artifact paths |
 | 05 | **Behavioral Synthesis Pass** | Run the behavioral synthesis lens against each behavioral unit's artifacts (behavioral only) |
 | 06 | **Generate Final Report** | Produce the clean REPORT.md (definitive findings only, no methodology language) and the detailed DEFINITIVE-FINDINGS.md contract (full per-finding field set + surviving conservation laws) from analysis artifacts |
 | 07 | **Dispute Analysis Pass** | Run two orthogonal prisms and synthesize their disagreements (dispute only) |
@@ -202,7 +202,7 @@ The cross-cutting `variable-binding` technique is declared once at the workflow 
 | `smart-analysis::*` | Adaptively compose the analysis pipeline |
 | `adaptive-analysis::*` | Cost-minimizing depth escalation (SDL → L12 → full-prism) |
 | `generate-report` | Produce the clean REPORT.md and the detailed DEFINITIVE-FINDINGS.md from analysis artifacts |
-| `emit-run-manifest` | Write RUN-MANIFEST.md recording produced artifacts + completion status; verify the run completed |
+| `emit-run-manifest` | Write RUN-MANIFEST.json recording produced artifacts + completion status; verify the run completed |
 | `present-result` | Cross-reference-format and present the final report with the definitive-findings and manifest paths |
 
 The `::*` techniques are **operation-groups** — a `techniques/<group>/` directory holding a `TECHNIQUE.md` shared contract plus one `<op>.md` file per operation. The rest are standalone `techniques/<slug>.md` files.
@@ -283,9 +283,9 @@ sequenceDiagram
 
     Orch->>W4: spawn-agent(generate report, all artifacts)
     W4-->>Orch: REPORT.md + DEFINITIVE-FINDINGS.md
-    Note over Orch: deliver-result → emit RUN-MANIFEST.md
+    Note over Orch: deliver-result → emit RUN-MANIFEST.json
 
-    Orch->>User: REPORT.md, DEFINITIVE-FINDINGS.md, RUN-MANIFEST.md + all artifact paths
+    Orch->>User: REPORT.md, DEFINITIVE-FINDINGS.md, RUN-MANIFEST.json + all artifact paths
 ```
 
 Unlike the work-package workflow (which resumes a persistent worker), the prism workflow creates a **new worker for each pass**. This is the isolation guarantee — the adversarial worker has never seen the structural analysis being generated.
@@ -300,7 +300,7 @@ A prism run always produces three artifacts in `output_path`, regardless of pipe
 |----------|---------|
 | `REPORT.md` | Lean, methodology-free report for the reader — findings by severity, blast radius, core finding. |
 | `DEFINITIVE-FINDINGS.md` | The detailed findings contract: every finding with its full field set (Description, Impact, Location, Recommendation, Classification, Blast radius, Adversarial confirmation) plus the surviving conservation laws / design trade-offs. |
-| `RUN-MANIFEST.md` | Records the produced artifacts, per-unit status, and overall completion status. |
+| `RUN-MANIFEST.json` | Records the produced artifacts, per-unit status, and overall completion status. |
 
 **Triggering workflows read these three artifacts and never re-open the raw pass artifacts** (`structural-analysis.md`, `adversarial-analysis.md`, `synthesis.md`, `portfolio-*.md`). To get domain-prefixed finding IDs (e.g. `CON-xx`, `VER-xx`), pass the dimension or domain names via `analysis_focus` — prism assigns the IDs in both reports, so consumers do not re-number findings. `prism-audit` and `prism-evaluate` are built on exactly this contract.
 
@@ -318,7 +318,7 @@ workflows/prism/
 │   ├── 01-structural-pass.yaml              # L12, portfolio, or behavioral lens dispatch
 │   ├── 02-adversarial-pass.yaml             # Adversarial lens (full-prism only)
 │   ├── 03-synthesis-pass.yaml               # Synthesis lens (full-prism only)
-│   ├── 04-deliver-result.yaml               # Emit RUN-MANIFEST.md, then present final report
+│   ├── 04-deliver-result.yaml               # Emit RUN-MANIFEST.json, then present final report
 │   ├── 05-behavioral-synthesis-pass.yaml    # Behavioral synthesis (behavioral only)
 │   ├── 06-generate-report.yaml              # Generate REPORT.md + DEFINITIVE-FINDINGS.md from analysis artifacts
 │   ├── 07-dispute-pass.yaml                 # Two orthogonal prisms + disagreement synthesis (dispute only)
@@ -336,7 +336,7 @@ workflows/prism/
 │   ├── dispute-analysis.md                  # Dispute pipeline
 │   ├── reflect-analysis.md                  # Reflect pipeline
 │   ├── generate-report.md                   # REPORT.md + DEFINITIVE-FINDINGS.md generation from analysis artifacts
-│   ├── emit-run-manifest.md                 # Write RUN-MANIFEST.md + verify run completion
+│   ├── emit-run-manifest.md                 # Write RUN-MANIFEST.json + verify run completion
 │   ├── present-result.md                    # Format and present the final report with artifact paths
 │   ├── full-prism/                          # Full Prism operation-group
 │   │   ├── TECHNIQUE.md                      # Group contract

--- a/prism/resources/README.md
+++ b/prism/resources/README.md
@@ -307,7 +307,7 @@ Document skeletons, as distinct from the lens prompts above. A per-lens analysis
 | `behavioral-promises.md` | [api-surface](api-surface.md) |
 | `subsystem-synthesis.md` | [subsystem-synthesis](subsystem-synthesis.md) |
 | `smart-prereq.md` | [prereq](prereq.md) |
-| `RUN-MANIFEST.md` | [run-manifest](run-manifest.md) |
+| `RUN-MANIFEST.json` | [run-manifest](run-manifest.md) |
 | `portfolio-synthesis.md` | [portfolio-synthesis](portfolio-synthesis.md) |
 | `reflect-synthesis.md` | [reflect-synthesis](reflect-synthesis.md) |
 

--- a/prism/resources/run-manifest.md
+++ b/prism/resources/run-manifest.md
@@ -1,6 +1,6 @@
 ---
 name: run-manifest
-description: Creation guide for bare filename `RUN-MANIFEST.md` — the contract a triggering workflow reads to locate a run's artifacts and confirm it completed, without re-scanning the output directory.
+description: Creation guide for bare filename `RUN-MANIFEST.json` — the contract a triggering workflow reads to locate a run's artifacts and confirm it completed, without re-scanning the output directory.
 metadata:
   order: 67
   type: template
@@ -8,33 +8,59 @@ metadata:
 
 # Run Manifest Guide
 
-Creation guide for bare filename `RUN-MANIFEST.md`. One file that answers two questions for whoever triggered the run: did it finish, and where is everything it produced. A consumer reads this instead of walking the output directory, so what it records is a contract rather than a convenience.
+Creation guide for bare filename `RUN-MANIFEST.json`. One file that answers two questions for whoever triggered the run: did it finish, and where is everything it produced. A consumer reads this instead of walking the output directory, so what it records is a contract rather than a convenience.
 
 ## Template
 
-````markdown
-# Prism Run Manifest
+The run's status and the two report paths, then one object per analysis unit, then the flat list of every artifact path the run produced.
 
-- **Status:** {complete | partial | error}
-- **Pipeline mode:** {pipeline mode}
-- **Report:** [REPORT.md]({report path})
-- **Definitive findings:** [DEFINITIVE-FINDINGS.md]({definitive findings path})
+```json
+{
+  "status": "complete",
+  "pipeline_mode": "full-prism",
+  "report_path": "REPORT.md",
+  "definitive_findings_path": "DEFINITIVE-FINDINGS.md",
+  "units": [
+    {
+      "unit": "pallets/session",
+      "output_subdir": "session",
+      "pipeline_mode": "full-prism",
+      "status": "complete",
+      "artifacts": [
+        "session/structural-analysis.md",
+        "session/adversarial-analysis.md",
+        "session/synthesis.md"
+      ]
+    }
+  ],
+  "artifacts": [
+    "REPORT.md",
+    "DEFINITIVE-FINDINGS.md",
+    "session/structural-analysis.md",
+    "session/adversarial-analysis.md",
+    "session/synthesis.md"
+  ]
+}
+```
 
-## Units
-
-| Unit | Output subdir | Pipeline mode | Status | Artifacts |
-|------|---------------|---------------|--------|-----------|
-| {unit name} | {output subdir, or "."} | {unit pipeline mode} | complete \| partial | {artifact filenames} |
-
-## Artifacts
-
-- [{artifact filename}]({artifact path})
-````
+| Field | Type | Meaning |
+|-------|------|---------|
+| `status` | string | `complete`, `partial`, or `error` — the run's own verdict on its completeness |
+| `pipeline_mode` | string | The pipeline mode the run executed |
+| `report_path` | string | Path to the run's report, relative to the output directory |
+| `definitive_findings_path` | string | Path to the run's definitive findings, relative to the output directory |
+| `units` | object[] | One entry per analysis unit, in execution order |
+| `units[].unit` | string | The unit's name as the analysis plan declares it |
+| `units[].output_subdir` | string | The unit's output subdirectory, or `.` when the run has one unit |
+| `units[].pipeline_mode` | string | The pipeline mode this unit ran |
+| `units[].status` | string | `complete` or `partial` for this unit |
+| `units[].artifacts` | string[] | The artifacts this unit's pipeline mode was expected to produce |
+| `artifacts` | string[] | Every path the run produced, flat, so a consumer enumerates them from one field |
 
 ## Rules
 
-- **Every unit is a row.** One row per analysis unit, carrying the artifacts its pipeline mode was expected to produce. A unit absent from the table is a unit whose completion nobody recorded.
-- **The flat artifact list is complete.** Every path the run produced appears under Artifacts as a link, so a consumer needs no second source to enumerate them.
+- **Every unit is an entry.** One object per analysis unit, carrying the artifacts its pipeline mode was expected to produce. A unit absent from `units` is a unit whose completion nobody recorded.
+- **The flat artifact list is complete.** Every path the run produced appears in `artifacts`, so a consumer needs no second source to enumerate them.
 - **Status reflects the filesystem, not the intent.** `complete` when the report, the definitive findings and every unit's expected artifacts are present; `partial` when the reports exist and a unit is missing artifacts; `error` when either report is missing or empty. A missing artifact is never reported as success — the caller decides what to do about an incomplete run.
-- **Paths are links, not bare text.** A consumer resolves them; a reader follows them.
-- **Line budget:** one row per unit and one line per artifact, with no prose beyond the header block.
+- **Paths are values a consumer resolves.** They are recorded relative to the output directory, so a consumer joins them to the run's location rather than parsing a link.
+- **Line budget:** one object per unit and one string per artifact, with no field carrying prose.

--- a/prism/techniques/emit-run-manifest.md
+++ b/prism/techniques/emit-run-manifest.md
@@ -37,11 +37,15 @@ Machine-readable manifest of the run's artifacts and completion status.
 
 #### artifact
 
-`RUN-MANIFEST.md`
+`RUN-MANIFEST.json`
+
+#### audience
+
+`agent`
 
 ### run_manifest_path
 
-Full filesystem path to `RUN-MANIFEST.md`.
+Full filesystem path to `RUN-MANIFEST.json`.
 
 ### run_status
 
@@ -69,7 +73,7 @@ REPORT.md or DEFINITIVE-FINDINGS.md is missing or empty.
 
 ### 2. Write Manifest
 
-- Write `{run_manifest}` as `RUN-MANIFEST.md` into `{output_path}` per [run-manifest](../resources/run-manifest.md#template) and its [Rules](../resources/run-manifest.md#rules), capturing its full filesystem path as `{run_manifest_path}`
+- Write `{run_manifest}` as `RUN-MANIFEST.json` into `{output_path}` per [run-manifest](../resources/run-manifest.md#template) and its [Rules](../resources/run-manifest.md#rules), capturing its full filesystem path as `{run_manifest_path}`
 - Fill it from `{run_status}`, `{pipeline_mode}`, `{report_path}`, `{definitive_findings_path}`, the per-unit expectations in `{analysis_units}`, and every path in `{all_artifact_paths}`
 
 ## Rules

--- a/prism/techniques/present-result.md
+++ b/prism/techniques/present-result.md
@@ -19,7 +19,7 @@ Filesystem path to DEFINITIVE-FINDINGS.md — the detailed companion where each 
 
 ### run_manifest_path
 
-Filesystem path to RUN-MANIFEST.md — the manifest recording the run's artifacts and completion status.
+Filesystem path to RUN-MANIFEST.json — the manifest recording the run's artifacts and completion status.
 
 ### run_status
 

--- a/prism/workflow.yaml
+++ b/prism/workflow.yaml
@@ -95,7 +95,7 @@ variables:
     description: File path to the generated DEFINITIVE-FINDINGS.md artifact — the detailed findings contract (full per-finding field set + surviving conservation laws) that consumer workflows read instead of the raw pass artifacts
   - name: run_manifest_path
     type: string
-    description: File path to the generated RUN-MANIFEST.md artifact — records the run's produced artifacts and completion status; the single file a triggering workflow reads to locate results and confirm completion
+    description: File path to the generated RUN-MANIFEST.json artifact — records the run's produced artifacts and completion status; the single file a triggering workflow reads to locate results and confirm completion
   - name: run_status
     type: string
     description: Completion status of the run recorded in the manifest — 'complete', 'partial', or 'error'

--- a/work-package/resources/README.md
+++ b/work-package/resources/README.md
@@ -38,7 +38,7 @@ Markdown resources for planning-folder templates, elicitation and review guidanc
 | `assumption-reconciliation` | Assumption Reconciliation | Assumptions-log integration and scorecard formats |
 | `research-reconciliation` | Research Reconciliation | Research-candidate inventory shape, reconcilability statuses, and scorecard format |
 | `pr-review-response` | PR Review Response | Response-format and review-document templates |
-| `prior-feedback-triage` | Prior Feedback Triage | Creation guide: `prior-feedback-triage.md` — the disposition register the rating cap is computed from |
+| `prior-feedback-triage` | Prior Feedback Triage | Creation guide: `prior-feedback-triage.json` — the disposition register the rating cap is computed from |
 | `token-usage` | Token Usage | Creation guide: `token-usage.md` — the run's sole cost home, reconciled or labelled a floor |
 | `provenance-log` | Provenance Log | Creation guide: `provenance-log.md` — one appended row per task |
 | `adr` | Architecture Decision Record | Creation guide: `NNNN-{decision_title}.md` — standard ADR form with at least one rejected alternative |

--- a/work-package/resources/prior-feedback-triage.md
+++ b/work-package/resources/prior-feedback-triage.md
@@ -1,31 +1,74 @@
 ---
 name: prior-feedback-triage
-description: Creation guide for bare filename `prior-feedback-triage.md` — the register of every prior comment and review on the PR under review, each with its disposition, author class, and blocker class.
+description: Creation guide for bare filename `prior-feedback-triage.json` — the register of every prior comment and review on the PR under review, each with its disposition, author class, and blocker class.
 metadata:
   order: 29
 ---
 
 # Prior Feedback Triage Guide
 
-Creation guide for bare filename `prior-feedback-triage.md`. Answers: what did earlier readers already say, which of it still stands, and does any of it cap the verdict. Author class and blocker class are columns of this register in particular, because the rating cap is derived from them.
+Creation guide for bare filename `prior-feedback-triage.json`. Answers: what did earlier readers already say, which of it still stands, and does any of it cap the verdict. Author class and blocker class are fields of this register in particular, because the rating cap is derived from them.
 
 ## Template
 
-```markdown
-# Prior Feedback Triage — PR #{n}
+One object per prior comment or review thread, plus the cap the register derives.
 
-**Threads:** {n} · **Confirmed:** {n} · **Blocker-class confirmed:** {n} · **Rating cap:** request-changes | unset
-
-| # | Finding | Author | Class | Blocker | Reasoning | Disposition |
-|---|---------|--------|-------|---------|-----------|-------------|
-| [1](pr-comment-url) | Storage record never cleared on close | reviewer | human | yes | Clear missing on the governance-close path | Confirmed |
-| [2](pr-comment-url) | Naming nit on handler | bot | bot | no | Name follows the crate convention | Refuted |
+```json
+{
+  "pr": 412,
+  "threads": 2,
+  "confirmed": 1,
+  "blocker_class_confirmed": 1,
+  "rating_cap": "request-changes",
+  "entries": [
+    {
+      "id": 1,
+      "comment_url": "https://github.com/org/repo/pull/412#discussion_r1",
+      "finding": "Storage record never cleared on close",
+      "author": "reviewer",
+      "author_class": "human",
+      "blocker": true,
+      "reasoning": "Clear missing on the governance-close path",
+      "disposition": "Confirmed",
+      "reported_failure": false
+    },
+    {
+      "id": 2,
+      "comment_url": "https://github.com/org/repo/pull/412#discussion_r2",
+      "finding": "Naming nit on handler",
+      "author": "bot",
+      "author_class": "bot",
+      "blocker": false,
+      "reasoning": "Name follows the crate convention",
+      "disposition": "Refuted",
+      "reported_failure": false
+    }
+  ]
+}
 ```
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `pr` | number | The pull request under review |
+| `threads` | number | Prior comment or review threads found |
+| `confirmed` | number | Entries dispositioned `Confirmed` |
+| `blocker_class_confirmed` | number | Confirmed entries whose `blocker` is true — what the cap turns on |
+| `rating_cap` | string | `request-changes` when any blocker-class entry is confirmed, otherwise `unset` |
+| `entries` | object[] | One entry per prior comment or review thread, human and bot alike |
+| `entries[].id` | number | Stable index within this register, cited by the posted summary |
+| `entries[].comment_url` | string | The thread the entry dispositions |
+| `entries[].finding` | string | What the earlier reader said, in one line |
+| `entries[].author` | string | Who said it |
+| `entries[].author_class` | string | `human` or `bot` |
+| `entries[].blocker` | boolean | Whether the concern is blocker-class |
+| `entries[].reasoning` | string | Why the disposition holds |
+| `entries[].disposition` | string | `Confirmed`, `Refuted`, or `Superseded` |
+| `entries[].reported_failure` | boolean | True on the single entry that ingests a reported runtime error |
 
 ## Rules
 
-- **Row shape follows the shared table.** Finding, Author, Reasoning and Disposition carry the same content as [Prior Feedback Triage](./review-mode.md#prior-feedback-triage); this register adds the Class and Blocker columns the cap is derived from.
-- **Every thread is a row.** Confirmed, Refuted, or Superseded, one per prior comment or review thread, human and bot alike. A thread with no row is a thread nobody dispositioned.
-- **The header states the cap.** The cap is a fact of this register, stated once here and never recomputed elsewhere.
-- **A reported runtime error is tagged once.** The row carrying it is the single ingest point, and the tag is what makes it traceable without re-reading the thread.
-- **Line budget:** ~40 lines. A thread whose reasoning needs a paragraph gets a link to the report section that holds it.
+- **Entry fields follow the shared table.** `finding`, `author`, `reasoning` and `disposition` carry the same content as [Prior Feedback Triage](./review-mode.md#prior-feedback-triage); this register adds `author_class` and `blocker`, which the cap is derived from.
+- **Every thread is an entry.** Confirmed, Refuted, or Superseded, one per prior comment or review thread, human and bot alike. A thread with no entry is a thread nobody dispositioned.
+- **The header states the cap.** `rating_cap` is a fact of this register, stated once here and never recomputed elsewhere.
+- **A reported runtime error is tagged once.** Exactly one entry carries `reported_failure` true, and that entry is the single ingest point, which is what makes it traceable without re-reading the thread.
+- **Line budget:** one object per thread, `reasoning` held to its one line. A thread whose reasoning needs a paragraph carries a link to the report section that holds it.

--- a/work-package/resources/prior-feedback-triage.md
+++ b/work-package/resources/prior-feedback-triage.md
@@ -55,7 +55,7 @@ One object per prior comment or review thread, plus the cap the register derives
 | `blocker_class_confirmed` | number | Confirmed entries whose `blocker` is true — what the cap turns on |
 | `rating_cap` | string | `request-changes` when any blocker-class entry is confirmed, otherwise `unset` |
 | `entries` | object[] | One entry per prior comment or review thread, human and bot alike |
-| `entries[].id` | number | Stable index within this register, cited by the posted summary |
+| `entries[].id` | number | Index within this register, unchanged for the run so a citation of it resolves |
 | `entries[].comment_url` | string | The thread the entry dispositions |
 | `entries[].finding` | string | What the earlier reader said, in one line |
 | `entries[].author` | string | Who said it |

--- a/work-package/resources/readme-seed.md
+++ b/work-package/resources/readme-seed.md
@@ -28,38 +28,36 @@ Lifecycle **Status** values: `Planning`, `Ready`, `In Progress`, `Complete`.
 | # | Item | Description | Estimate | Status |
 |---|------|-------------|----------|--------|
 | 1 | Start work package | Issue, branch, worktree, planning folder | 20-40m | ⬚ |
-| 2 | [Prior feedback triage](01-prior-feedback-triage.md) | Review-mode prior feedback ingest | 15-30m | ⊘ |
-| 3 | [Design philosophy](02-design-philosophy.md) | Problem classification, workflow path | 15-30m | ⬚ |
-| 4 | [Assumptions log](02-assumptions-log.md) | Tracked assumptions across activities | 10-15m | ⬚ |
-| 5 | Codebase comprehension | Persistent knowledge under comprehension/ | 20-45m | ⬚ |
-| 6 | [Requirements elicitation](03-requirements-elicitation.md) | Scope, success criteria, boundaries | 30-60m | ⬚ |
-| 7 | [KB research](04-kb-research.md) | Knowledge-base and web synthesis | 20-45m | ⬚ |
-| 8 | [Implementation analysis](05-implementation-analysis.md) | Baselines, gaps, measurement | 20-45m | ⬚ |
-| 9 | [Work package plan](06-work-package-plan.md) | Tasks, estimates, dependencies | 20-45m | ⬚ |
-| 10 | [Test plan](06-test-plan.md) | Test cases, coverage strategy | 15-30m | ⬚ |
-| 11 | [Deferred items](deferred-items.md) | Out-of-scope deferral register | 5-10m | ⬚ |
-| 12 | [Follow-ups](follow-ups.md) | In-task follow-ups register | 5-10m | ⬚ |
-| 13 | Assumptions review | Converge open assumptions | 20-40m | ⬚ |
-| 14 | Implementation | Code changes per plan | 1-4h | ⬚ |
-| 15 | [Provenance log](08-provenance-log.md) | Per-task AI-assistance provenance | 5-15m | ⬚ |
-| 16 | Lean-coding audit | Ponytail lean lens on the change | 15-30m | ⬚ |
-| 17 | [Code review](09-code-review.md) | Consolidated review findings home | 15-30m | ⬚ |
-| 18 | [Debt ledger](09-debt-ledger.json) | Harvested ponytail debt markers | 10-20m | ⬚ |
-| 19 | [Lean change](09-lean-change.md) | Applied lean simplifications record | 10-20m | ⬚ |
-| 20 | Post-implementation review | Quality review before validation | 30-60m | ⬚ |
-| 21 | [Change block index](10-change-block-index.md) | Indexed diff hunks for review | 5-10m | ⬚ |
-| 22 | [Code review method](10-code-review-method.md) | What the code review walked and swept | 5-10m | ⬚ |
-| 23 | [Test suite review](10-test-suite-review.md) | Test quality and coverage | 10-20m | ⬚ |
-| 24 | [Test suite review method](10-test-suite-review-method.md) | Suite baseline, coverage map, sweeps | 5-10m | ⬚ |
-| 25 | [Structural analysis](10-structural-analysis.md) | Prism L12 when written standalone | 15-30m | ⬚ |
-| 26 | [Architecture summary](10-architecture-summary.md) | Stakeholder architecture overview | 15-30m | ⬚ |
-| 27 | Validation | Build, test, lint verification | 15-30m | ⬚ |
-| 28 | [Strategic review](12-strategic-review-1.md) | Scope/minimality series (`strategic-review-{n}`) | 15-30m | ⬚ |
-| 29 | [Strategic review method](12-strategic-review-1-method.md) | Scope, conformance, minimality and delivery passes | 5-10m | ⬚ |
-| 30 | Submit for review | PR review lifecycle / stealth push | 30-60m | ⬚ |
-| 31 | [Close-out](14-COMPLETE.md) | Deliverables, limitations, retrospective; ADR when owed | 10-20m | ⬚ |
-| 32 | [Token usage](14-token-usage.md) | Session token and cost summary | 5-10m | ⬚ |
-| 33 | [Session trace](14-session-trace.md) | Lean mechanical execution trace | 5-10m | ⬚ |
+| 2 | [Design philosophy](02-design-philosophy.md) | Problem classification, workflow path | 15-30m | ⬚ |
+| 3 | [Assumptions log](02-assumptions-log.md) | Tracked assumptions across activities | 10-15m | ⬚ |
+| 4 | Codebase comprehension | Persistent knowledge under comprehension/ | 20-45m | ⬚ |
+| 5 | [Requirements elicitation](03-requirements-elicitation.md) | Scope, success criteria, boundaries | 30-60m | ⬚ |
+| 6 | [KB research](04-kb-research.md) | Knowledge-base and web synthesis | 20-45m | ⬚ |
+| 7 | [Implementation analysis](05-implementation-analysis.md) | Baselines, gaps, measurement | 20-45m | ⬚ |
+| 8 | [Work package plan](06-work-package-plan.md) | Tasks, estimates, dependencies | 20-45m | ⬚ |
+| 9 | [Test plan](06-test-plan.md) | Test cases, coverage strategy | 15-30m | ⬚ |
+| 10 | [Deferred items](deferred-items.md) | Out-of-scope deferral register | 5-10m | ⬚ |
+| 11 | [Follow-ups](follow-ups.md) | In-task follow-ups register | 5-10m | ⬚ |
+| 12 | Assumptions review | Converge open assumptions | 20-40m | ⬚ |
+| 13 | Implementation | Code changes per plan | 1-4h | ⬚ |
+| 14 | [Provenance log](08-provenance-log.md) | Per-task AI-assistance provenance | 5-15m | ⬚ |
+| 15 | Lean-coding audit | Ponytail lean lens on the change | 15-30m | ⬚ |
+| 16 | [Code review](09-code-review.md) | Consolidated review findings home | 15-30m | ⬚ |
+| 17 | [Lean change](09-lean-change.md) | Applied lean simplifications record | 10-20m | ⬚ |
+| 18 | Post-implementation review | Quality review before validation | 30-60m | ⬚ |
+| 19 | [Change block index](10-change-block-index.md) | Indexed diff hunks for review | 5-10m | ⬚ |
+| 20 | [Code review method](10-code-review-method.md) | What the code review walked and swept | 5-10m | ⬚ |
+| 21 | [Test suite review](10-test-suite-review.md) | Test quality and coverage | 10-20m | ⬚ |
+| 22 | [Test suite review method](10-test-suite-review-method.md) | Suite baseline, coverage map, sweeps | 5-10m | ⬚ |
+| 23 | [Structural analysis](10-structural-analysis.md) | Prism L12 when written standalone | 15-30m | ⬚ |
+| 24 | [Architecture summary](10-architecture-summary.md) | Stakeholder architecture overview | 15-30m | ⬚ |
+| 25 | Validation | Build, test, lint verification | 15-30m | ⬚ |
+| 26 | [Strategic review](12-strategic-review-1.md) | Scope/minimality series (`strategic-review-{n}`) | 15-30m | ⬚ |
+| 27 | [Strategic review method](12-strategic-review-1-method.md) | Scope, conformance, minimality and delivery passes | 5-10m | ⬚ |
+| 28 | Submit for review | PR review lifecycle / stealth push | 30-60m | ⬚ |
+| 29 | [Close-out](14-COMPLETE.md) | Deliverables, limitations, retrospective; ADR when owed | 10-20m | ⬚ |
+| 30 | [Token usage](14-token-usage.md) | Session token and cost summary | 5-10m | ⬚ |
+| 31 | [Session trace](14-session-trace.md) | Lean mechanical execution trace | 5-10m | ⬚ |
 
 Rows run in the order the activities execute, which is the order a reader watches them complete in. Codebase comprehension therefore sits third, between design philosophy and requirements elicitation, though its artifact prefix is the highest of the set — the prefix follows the definition file, the row follows the run.
 
@@ -73,7 +71,7 @@ Which activity owns which rows, per [row-ownership map](../../meta/resources/pla
 
 | @ | Rows |
 |---|------|
-| 01 | Start work package · Prior feedback triage |
+| 01 | Start work package |
 | 02 | Design philosophy · Assumptions log |
 | 03 | Requirements elicitation |
 | 04 | KB research |
@@ -81,7 +79,7 @@ Which activity owns which rows, per [row-ownership map](../../meta/resources/pla
 | 06 | Work package plan · Test plan · Deferred items · Follow-ups |
 | 07 | Assumptions review |
 | 08 | Implementation · Provenance log |
-| 09 | Lean-coding audit · Code review · Debt ledger · Lean change |
+| 09 | Lean-coding audit · Code review · Lean change |
 | 10 | Post-implementation review · Change block index · Code review method · Test suite review · Test suite review method · Structural analysis · Architecture summary |
 | 11 | Validation |
 | 12 | Strategic review · Strategic review method |
@@ -99,4 +97,4 @@ Leave Progress Status as authored in [Progress inventory](#progress-inventory) (
 
 ### Review (`is_review_mode` true)
 
-Set cancelled/N/A on the rows owned by `03`, `04`, and `08`. Flip Prior feedback triage from cancelled/N/A to pending. Do not overwrite unrelated pending / in-progress / complete cells.
+Set cancelled/N/A on the rows owned by `03`, `04`, and `08`. Do not overwrite unrelated pending / in-progress / complete cells.

--- a/work-package/resources/readme-seed.md
+++ b/work-package/resources/readme-seed.md
@@ -44,7 +44,7 @@ Lifecycle **Status** values: `Planning`, `Ready`, `In Progress`, `Complete`.
 | 15 | [Provenance log](08-provenance-log.md) | Per-task AI-assistance provenance | 5-15m | ⬚ |
 | 16 | Lean-coding audit | Ponytail lean lens on the change | 15-30m | ⬚ |
 | 17 | [Code review](09-code-review.md) | Consolidated review findings home | 15-30m | ⬚ |
-| 18 | [Debt ledger](09-debt-ledger.md) | Harvested ponytail debt markers | 10-20m | ⬚ |
+| 18 | [Debt ledger](09-debt-ledger.json) | Harvested ponytail debt markers | 10-20m | ⬚ |
 | 19 | [Lean change](09-lean-change.md) | Applied lean simplifications record | 10-20m | ⬚ |
 | 20 | Post-implementation review | Quality review before validation | 30-60m | ⬚ |
 | 21 | [Change block index](10-change-block-index.md) | Indexed diff hunks for review | 5-10m | ⬚ |

--- a/work-package/techniques/review-existing-feedback.md
+++ b/work-package/techniques/review-existing-feedback.md
@@ -21,7 +21,11 @@ The triage table: one row per prior comment or review thread, each marked Confir
 
 #### artifact
 
-`prior-feedback-triage.md`
+`prior-feedback-triage.json`
+
+#### audience
+
+`agent`
 
 ### rating_cap
 


### PR DESCRIPTION
## Summary

Some of the files a run writes are never opened by a person. A later step reads them back — by ID, by disposition, by field — and every one of them was prose markdown, so the consumer re-parsed a rendered table to reach a value and the producer spent words on presentation nobody read.

W3 of [#403](https://github.com/m2ux/workflow-server/issues/403) set out to convert eight such registers. Verifying each one's actual consumers before converting it turned up that four of the eight are handed to a person: a run links them from a message or, in one case, from a blocking certification gate. Those four are left as they are, with the evidence below. The four that are genuinely read only by a later step are converted here.

## What changes

Four artifacts become JSON on disk and declare `agent`, which is what that declaration already means in the technique protocol.

| Artifact | Producer | What reads it back |
|---|---|---|
| `evidence-log.json` | midnight-system-review `consolidate-evidence` | adjudication, which cites evidence by ID |
| `prior-feedback-triage.json` | work-package `review-existing-feedback` | the review summary, by disposition, to apply the rating cap |
| `debt-ledger.json` | ponytail `harvest-debt` | the gain report, which totals its entries |
| `RUN-MANIFEST.json` | prism `emit-run-manifest` | prism-audit and prism-evaluate, to locate a finished run's artifacts |

Each creation guide keeps its `## Template` heading and its `## Rules`, and the section's content becomes a field schema — the shape, then a table naming every field, its type and its meaning. The heading stays because it is what resolves an artifact to its guide when no map names the filename, and because it leaves every existing anchor citation pointing where it did.

Every ID binding survives. The evidence log keeps its item IDs and probe classes, the triage keeps its per-thread index and comment links, the ledger keeps a line reference per marker, and the manifest keeps its per-unit names alongside the flat artifact list a consumer enumerates from.

## Two consumers changed shape, not just target

The gain report appended its scoreboard to the foot of the debt ledger. A JSON document has no foot to append to, so the ledger now declares a `gain` field and the report fills it — one parseable document, one writer per field.

The prism manifest's readers already spoke in fields: `report_path`, `definitive_findings_path`, `status`. The conversion makes their own language true rather than changing what they ask for.

## The four left as prose

Each of these is linked from a surface a person is shown, so converting it would put a person one click from a JSON file.

| Artifact | The surface that hands it to a person |
|---|---|
| `provenance-log.md` | A **blocking DCO certification checkpoint** — the run asks the reader to certify the Developer Certificate of Origin having read it, both option descriptions link it again, and the PR description template carries it as a row |
| `file-review-note.md` | Two run messages, one of them the content-removal alert a reader acts on |
| `drafting-plan.md` | The run message that shows the drafting approach for the current file |
| `structural-inventory.md` | The run message that confirms the compliance review target |

The provenance log is the clearest of the four and should come out of W3's scope for good: it is a legal attestation record a person signs, and it is published in the pull request body, which this epic's non-goals already protect.

The other three are weaker — an `action: message` offering the artifact, not a gate demanding it. Converting any of them means either the message links to JSON or the message stops linking it, and the second changes what a run shows a user, which is a decision rather than a format change.

## Why now is cheap

The declaration, the guard that enforces it, and the activity-contract carry-through all shipped in [#227](https://github.com/m2ux/workflow-server/issues/227). Every one of the four already had a creation guide with rules and a budget from W4, so the conversion rewrites a template rather than inventing one, and the security audits' intermediate schemas are the corpus's worked example of what a field schema reads like.

## Scope of change

34 files across five workflows. Four producers declare the new filename and its reader; four creation guides carry a field schema; the gain report fills a field instead of appending; and 42 textual references across prism, prism-audit and prism-evaluate follow the manifest's rename.

## Acceptance criteria

- [x] The four converted artifacts are JSON on disk, each declaring `agent`.
- [x] Each one's creation guide states its field schema and field rules, and its producing technique cites that guide.
- [x] Every consuming step reads the structured form.
- [x] Every ID binding that exists today still exists.
- [x] Schema, reference, anchor, audience, creation-guide and binding-fidelity checks stay clean: 26 of 26 guards, none unmeasured.
- [ ] The remaining four registers — W3 stays open until their user-facing links are settled.

## Non-goals

The five candidates the epic reviewed and kept as prose stay as they are, each for the reason already on the record: both findings registers, the follow-ups and deferred-items pair, the assumptions log, and the change-block index.

This does not change any consuming step's behaviour beyond the form it reads. No workflow gains or loses a step, and no run produces an artifact it did not produce before.
