### PR TITLE
Corpus pin: point it at a commit the workflows branch still holds

### DIFF
--- a/tests/e2e/__snapshots__/corpus-sha.json
+++ b/tests/e2e/__snapshots__/corpus-sha.json
@@ -1,4 +1,4 @@
 {
-  "corpusSha": "acbbf1bc9b44622a76e23363fc96adbb109e9947",
+  "corpusSha": "53e9294509b44c10b64a8339c1c4b546b844ebbb",
   "note": "Corpus commit the committed walk snapshots were generated against. Update it in the same commit that bumps the workflows submodule and re-baselines the walk (npm run baseline:stamp)."
 }


### PR DESCRIPTION
## Summary

The guard suite and the test suite both read the workflows corpus at the commit this repository pins, and that pin names a commit the `workflows` branch has moved past. Nothing references it any more, so it survives only until the next garbage collection, and until then it hands every guard a corpus that predates the plain-language workflow by twenty-three files. A sweep that reports clean is reporting on a tree one whole workflow short of the branch.

## What happens today

`main` pins `acbbf1bc`. That commit was a feature branch's tip while the artifact-audience work was in review; the branch was force-pushed past it and no ref points at it now. CI resolves the pin with `git rev-parse HEAD:workflows` and checks the corpus out by that SHA, so the job depends on an unreferenced object staying alive.

The `workflows` branch is at `53e92945`, which carries the same artifact work plus the plain-language workflow that merged after the pin was set.

## The fix

The pin becomes `53e92945`, the branch tip, and the corpus stamp advances with it in the same commit.

The walk snapshots do not move. The corpus being replaced already carried the artifact-audience work, and the plain-language workflow is not on the work-package walk the snapshots record, so there is no drift to re-baseline — only the stamp changes, which is what keeps a later snapshot diff readable as a code change rather than as corpus drift.

## Why now is cheap

The pin is one line and the stamp is one field. The alternative is waiting, and waiting has a failure mode with no warning: the day the unreferenced commit is collected, CI stops being able to check out the corpus at all, and the error names a missing object rather than a stale pin.

## Scope of change

Two files: the submodule pointer and the corpus stamp.

## Acceptance criteria

- [x] The pinned corpus commit is reachable from the `workflows` branch.
- [x] The pinned corpus matches the branch tip, so the guards measure what the branch holds.
- [x] The corpus stamp names the pinned commit, so a snapshot diff is attributable.
- [x] Typecheck, the full test suite and the guard sweep pass: 997 tests, 26 of 26 guards.

## Non-goals

This does not adopt the agent-read register conversions in [#454](https://github.com/m2ux/workflow-server/pull/454). That branch moves the corpus again, and its pointer bump belongs with it.
