### PR TITLE
Corpus CI: run the guards on a pull request against the workflows branch

### DIFF
--- a/.github/workflows/verify-corpus.yml
+++ b/.github/workflows/verify-corpus.yml
@@ -1,0 +1,63 @@
+name: Verify corpus
+
+# The guards run against a pull request on THIS branch.
+#
+# They live on `main`, and this branch holds definitions only — no package.json, no scripts, and
+# until now no CI. A pull request here therefore reported no checks at all: every guard ran only
+# once a later commit on main bumped the submodule pointer, which happens after the merge rather
+# than before it. A workflow whose every technique reference failed to resolve reached a merge that
+# way, and the guard that catches it had been passing on main the whole time — against the older
+# corpus the pointer still named.
+#
+# GitHub reads a pull-request workflow file from the head ref, so this file has to sit on the branch
+# it guards. It carries no logic of its own: it borrows main's tooling and points it at the corpus
+# under review.
+#
+# Guards only, not the test suite. The walk snapshots are stamped against one corpus commit, so
+# running them here would compare a pull request's corpus to a baseline generated from a different
+# one and fail on the difference rather than on a defect. `npm run check:all` walks the registry in
+# scripts/guards.ts, so a guard added there is enforced here without touching this file.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: verify-corpus-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  guards:
+    name: Guard sweep against the corpus under review
+    runs-on: ubuntu-latest
+    steps:
+      # The tooling: main's scripts, guard registry and package manifest.
+      - name: Check out the server tooling from main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          submodules: false
+
+      # The corpus under review, where check:all looks for it by default. For a pull request this is
+      # the merge result; for a manual run it is the ref the run was dispatched on.
+      - name: Check out the corpus under review
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          path: workflows
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      # A guard that cannot reach its corpus exits 2 and fails the job, so an unmeasured guard is
+      # never folded into a pass.
+      - name: Run every guard against the corpus
+        run: npm run check:all


### PR DESCRIPTION
## Summary

A pull request against this branch reports no checks. Not a failing check — none at all.

The guards live on `main`, with the scripts and the manifest that run them. This branch carries definitions only, so nothing measures a definition change until a later commit on `main` bumps the submodule pointer, and that happens after the merge rather than before it. Every definition change merges on review by eye.

This adds a job that runs the guard registry against the corpus a pull request proposes, before it merges.

## What happened without it

The plain-language workflow merged with a technique group named after the workflow itself. The loader reads a leading segment that names a real workflow as a cross-workflow prefix, looks for a top-level operation of that name, finds none and stops — so not one of the workflow's five operations resolved, across all five activities. The workflow could not dispatch a single step.

`binding-fidelity` catches this exactly. Run against the corpus that merge produced, the sweep fails and names all six bindings:

```
[FAIL] binding-fidelity
   step technique 'plain-language::intake-and-profile' does not resolve
   step technique 'plain-language::analyze-source'     does not resolve
   step technique 'plain-language::draft-document'     does not resolve
   step technique 'plain-language::complete-checklist' does not resolve
   step technique 'plain-language::evaluate-document'  does not resolve
   step technique 'plain-language::draft-document'     does not resolve
23 pass, 3 fail
```

The guard existed, worked, and was never invoked on the change that needed it. It had been passing on `main` throughout — against the older corpus the pointer still named.

## How it works

GitHub reads a pull-request workflow file from the head ref, so a job guarding this branch has to live on this branch. It carries no logic of its own:

- check out `main` for the tooling — scripts, guard registry, manifest
- check out the corpus under review at `workflows/`, where the guards look for it by default
- `npm ci`, then `npm run check:all`

Because the registry in `scripts/guards.ts` is the enumeration, a guard added there is enforced here without editing this file.

## What it does not run

The test suite. The walk snapshots are stamped against one corpus commit, so running them here would compare a pull request's corpus against a baseline generated from a different one and fail on the difference rather than on a defect. Guards are the part that measures a corpus rather than a pairing of corpus and baseline.

## Why now is cheap

The guards, the registry and the `--root` switch all exist and are in daily use. This job is a checkout, an install and one script call. Waiting costs a merge like the one above each time it happens, and the cost lands on whoever runs the workflow rather than on whoever changed it.

## Scope of change

One file, `.github/workflows/verify-corpus.yml`. No definition changes.

## Acceptance criteria

- [x] A pull request against this branch reports a guard sweep.
- [x] The sweep runs against the corpus the pull request proposes, not against whatever `main` currently pins.
- [x] The sweep passes on the current corpus: 26 of 26 guards, none unmeasured.
- [x] The sweep fails on the corpus that merged the unresolvable bindings, naming each one.
- [x] A guard added to the registry is enforced here without editing this file.

## Non-goals

This does not change what `main`'s own `Verify` job does. That job measures the corpus `main` adopts, which is the submodule bump's business and stays that way.

It also does not make the walk verify step bindings. The all-workflows walk passes against the broken corpus above — its own drift guard does not resolve step-level bindings — and that gap is worth closing separately.
