### PR TITLE
Corpus pin and walk roster: adopt the current corpus, and walk all of it

### DIFF
--- a/tests/e2e/__snapshots__/corpus-sha.json
+++ b/tests/e2e/__snapshots__/corpus-sha.json
@@ -1,4 +1,4 @@
 {
-  "corpusSha": "53e9294509b44c10b64a8339c1c4b546b844ebbb",
+  "corpusSha": "a3cd074b328644713415b2afa33285ff9a9222e4",
   "note": "Corpus commit the committed walk snapshots were generated against. Update it in the same commit that bumps the workflows submodule and re-baselines the walk (npm run baseline:stamp)."
 }

--- a/tests/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/tests/e2e/__snapshots__/snapshot.test.ts.snap
@@ -24,11 +24,11 @@ exports[`work-package walk snapshots (baseline) > [default] matches committed ba
     {
       "activity": "start-work-package",
       "artifacts": [
-        "prior-feedback-triage.md",
+        "prior-feedback-triage.json",
         "README.md",
       ],
       "artifactsWritten": [
-        "01-prior-feedback-triage.md",
+        "01-prior-feedback-triage.json",
         "01-README.md",
       ],
       "checkpoints": [
@@ -221,11 +221,11 @@ exports[`work-package walk snapshots (baseline) > [default] matches committed ba
     {
       "activity": "lean-coding-audit",
       "artifacts": [
-        "debt-ledger.md",
+        "debt-ledger.json",
         "lean-change.md",
       ],
       "artifactsWritten": [
-        "09-debt-ledger.md",
+        "09-debt-ledger.json",
         "09-lean-change.md",
       ],
       "checkpoints": [
@@ -463,11 +463,11 @@ exports[`work-package walk snapshots (baseline) > [elicitation-only] matches com
     {
       "activity": "start-work-package",
       "artifacts": [
-        "prior-feedback-triage.md",
+        "prior-feedback-triage.json",
         "README.md",
       ],
       "artifactsWritten": [
-        "01-prior-feedback-triage.md",
+        "01-prior-feedback-triage.json",
         "01-README.md",
       ],
       "checkpoints": [
@@ -724,11 +724,11 @@ exports[`work-package walk snapshots (baseline) > [elicitation-only] matches com
     {
       "activity": "lean-coding-audit",
       "artifacts": [
-        "debt-ledger.md",
+        "debt-ledger.json",
         "lean-change.md",
       ],
       "artifactsWritten": [
-        "09-debt-ledger.md",
+        "09-debt-ledger.json",
         "09-lean-change.md",
       ],
       "checkpoints": [
@@ -969,11 +969,11 @@ exports[`work-package walk snapshots (baseline) > [full-workflow] matches commit
     {
       "activity": "start-work-package",
       "artifacts": [
-        "prior-feedback-triage.md",
+        "prior-feedback-triage.json",
         "README.md",
       ],
       "artifactsWritten": [
-        "01-prior-feedback-triage.md",
+        "01-prior-feedback-triage.json",
         "01-README.md",
       ],
       "checkpoints": [
@@ -1258,11 +1258,11 @@ exports[`work-package walk snapshots (baseline) > [full-workflow] matches commit
     {
       "activity": "lean-coding-audit",
       "artifacts": [
-        "debt-ledger.md",
+        "debt-ledger.json",
         "lean-change.md",
       ],
       "artifactsWritten": [
-        "09-debt-ledger.md",
+        "09-debt-ledger.json",
         "09-lean-change.md",
       ],
       "checkpoints": [
@@ -1502,11 +1502,11 @@ exports[`work-package walk snapshots (baseline) > [research-only] matches commit
     {
       "activity": "start-work-package",
       "artifacts": [
-        "prior-feedback-triage.md",
+        "prior-feedback-triage.json",
         "README.md",
       ],
       "artifactsWritten": [
-        "01-prior-feedback-triage.md",
+        "01-prior-feedback-triage.json",
         "01-README.md",
       ],
       "checkpoints": [
@@ -1751,11 +1751,11 @@ exports[`work-package walk snapshots (baseline) > [research-only] matches commit
     {
       "activity": "lean-coding-audit",
       "artifacts": [
-        "debt-ledger.md",
+        "debt-ledger.json",
         "lean-change.md",
       ],
       "artifactsWritten": [
-        "09-debt-ledger.md",
+        "09-debt-ledger.json",
         "09-lean-change.md",
       ],
       "checkpoints": [
@@ -1993,11 +1993,11 @@ exports[`work-package walk snapshots (baseline) > [review-mode] matches committe
     {
       "activity": "start-work-package",
       "artifacts": [
-        "prior-feedback-triage.md",
+        "prior-feedback-triage.json",
         "README.md",
       ],
       "artifactsWritten": [
-        "01-prior-feedback-triage.md",
+        "01-prior-feedback-triage.json",
         "01-README.md",
       ],
       "checkpoints": [],
@@ -2155,11 +2155,11 @@ exports[`work-package walk snapshots (baseline) > [review-mode] matches committe
     {
       "activity": "lean-coding-audit",
       "artifacts": [
-        "debt-ledger.md",
+        "debt-ledger.json",
         "lean-change.md",
       ],
       "artifactsWritten": [
-        "09-debt-ledger.md",
+        "09-debt-ledger.json",
         "09-lean-change.md",
       ],
       "checkpoints": [],
@@ -2366,11 +2366,11 @@ exports[`work-package walk snapshots (baseline) > [skip-optional] matches commit
     {
       "activity": "start-work-package",
       "artifacts": [
-        "prior-feedback-triage.md",
+        "prior-feedback-triage.json",
         "README.md",
       ],
       "artifactsWritten": [
-        "01-prior-feedback-triage.md",
+        "01-prior-feedback-triage.json",
         "01-README.md",
       ],
       "checkpoints": [
@@ -2563,11 +2563,11 @@ exports[`work-package walk snapshots (baseline) > [skip-optional] matches commit
     {
       "activity": "lean-coding-audit",
       "artifacts": [
-        "debt-ledger.md",
+        "debt-ledger.json",
         "lean-change.md",
       ],
       "artifactsWritten": [
-        "09-debt-ledger.md",
+        "09-debt-ledger.json",
         "09-lean-change.md",
       ],
       "checkpoints": [

--- a/tests/e2e/all-workflows-walk.test.ts
+++ b/tests/e2e/all-workflows-walk.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { createHarness, type Harness } from './harness.js';
 import { walk } from './walker.js';
 import { defaultPolicy } from './policies.js';
+import { corpusRoot } from '../corpus-root.js';
 
 /**
  * Layer 1 (workflow-agnostic) — every workflow loads and resolves through the real server.
@@ -12,18 +15,30 @@ import { defaultPolicy } from './policies.js';
  * variables a real agent would set — so no workflow-specific simulation is needed. It is the
  * functional-drift guard for structural refactors: every activity the walk reaches must load via
  * the real loader and resolve every technique reference (zero `unresolved`).
+ *
+ * The roster comes from the corpus, not from a list here. A hand-maintained list is a second home
+ * for which workflows exist, and it drifts silently: a workflow added to the corpus and omitted
+ * here is not walked, and nothing reports that it was skipped — which is how a workflow whose every
+ * step failed to resolve reached a merge.
  */
-const WORKFLOWS = [
-  'work-package', 'work-packages', 'meta', 'workflow-design', 'requirements-refinement',
-  'prism', 'prism-audit', 'prism-evaluate', 'prism-update',
-  'cicd-pipeline-security-audit', 'substrate-node-security-audit', 'remediate-vuln',
-  'ponytail',
-];
+function corpusWorkflows(): string[] {
+  const root = corpusRoot();
+  return readdirSync(root)
+    .filter((d) => existsSync(join(root, d, 'workflow.yaml')))
+    .sort();
+}
+
+const WORKFLOWS = corpusWorkflows();
 
 describe('all-workflows E2E walk (workflow-agnostic drift guard)', () => {
   let h: Harness;
   beforeAll(async () => { h = await createHarness(); });
   afterAll(async () => { await h.close(); });
+
+  it('walks every workflow the corpus holds', () => {
+    // A corpus that resolves to nothing would pass every check below by having nothing to check.
+    expect(WORKFLOWS.length).toBeGreaterThan(0);
+  });
 
   for (const wf of WORKFLOWS) {
     it(`[${wf}] loads and resolves every technique reference`, async () => {


### PR DESCRIPTION
## Summary

Two changes, both about CI measuring the corpus that actually exists.

The pin moves to the `workflows` tip, adopting the artifact-audience work, the plain-language repair and the four registers now written as structured files. And the walk roster stops being a hand-maintained list: it named thirteen workflows while the corpus held seventeen, so four were never walked and nothing reported that they had been skipped.

## The pin

`main` pinned `53e92945`; the branch is at `a3cd074b`. The walk snapshots move with it, in two filenames — the prior-feedback triage and the debt ledger — each across the six policies that reach them. Nothing else drifted. The stamp advances in the same commit, so a later snapshot diff still reads as a code change rather than as corpus drift.

## The roster

The all-workflows walk is the functional-drift guard: every activity it reaches must load through the real loader and resolve every technique reference. Its roster was a literal list beside a corpus that can be read from disk, and it had gone stale by four:

| Never walked | |
|---|---|
| `codebase-wiki` | |
| `midnight-system-review` | |
| `workflow-authoring` | |
| `plain-language` | the workflow whose every technique reference failed to resolve |

A list beside a discoverable corpus is a second home for which workflows exist, and it drifts silently: a workflow omitted from it is not walked, and no check reports the omission. The roster now comes from the corpus, with an assertion that it is not empty — a corpus resolving to nothing would otherwise pass every check below it by having nothing to check.

All seventeen now walk and pass. The suite goes from 997 tests to 1002.

## What this does not fix

The walk is a weaker guard than its own description claims. It **passes** against the corpus that merged the unresolvable plain-language bindings, because it fetches a step by id and leans on the server rather than resolving the binding itself — its `StepDef` has no technique field at all. So the roster gap is what made the hole invisible, but the hole is separate and still open.

`binding-fidelity` is the guard that catches that class, and as of [#456](https://github.com/m2ux/workflow-server/pull/456) it runs on corpus pull requests, which is the coverage that matters most.

## Why now is cheap

The pin bump is one line plus a stamp, and the procedure for it is already written into the stamp test's own failure message. The roster fix is a directory read replacing a literal.

## Scope of change

Four files: the submodule pointer, the corpus stamp, the walk snapshots, and the walk test.

## Acceptance criteria

- [x] The pinned corpus is the `workflows` branch tip.
- [x] The corpus stamp names the pinned commit.
- [x] Every workflow the corpus holds is walked — seventeen of seventeen.
- [x] A corpus resolving to no workflows fails rather than passing vacuously.
- [x] Typecheck, the full suite and the guard sweep pass: 1002 tests, 26 of 26 guards.

## Non-goals

This does not make the walk resolve step-level technique bindings. That gap is real and worth closing, but it is a change to what the walker records, not to which workflows it walks.
