### PR TITLE
All-workflows walk: say what it verifies, and name the guard that covers the rest

### DIFF
--- a/tests/e2e/all-workflows-walk.test.ts
+++ b/tests/e2e/all-workflows-walk.test.ts
@@ -12,14 +12,24 @@ import { corpusRoot } from '../corpus-root.js';
  * Unlike the work-package walk (which uses hand-tuned policies to steer specific branches), this
  * drives EACH workflow with the generic `defaultPolicy` + `autoAdvance`: the walker optimistically
  * satisfies forward gate conditions toward unvisited activities, standing in for the convergence
- * variables a real agent would set — so no workflow-specific simulation is needed. It is the
- * functional-drift guard for structural refactors: every activity the walk reaches must load via
- * the real loader and resolve every technique reference (zero `unresolved`).
+ * variables a real agent would set — so no workflow-specific simulation is needed.
+ *
+ * What it covers, precisely: every activity the graph reaches loads through the real loader, and
+ * the activity-level technique references resolve (zero `unresolved`). In `mode: 'graph'` the walk
+ * traverses activities and transitions and executes no steps at all — `stepsExecuted` is empty for
+ * every workflow here, work-package included — so it never fetches a step's technique and cannot
+ * see a step binding that fails to resolve. A workflow whose every step binding was broken walked
+ * this graph to completion and passed.
+ *
+ * Step-binding resolution has a home: the `binding-fidelity` guard resolves each step's `technique`
+ * ref the way the server does and reports the ones that do not, and it runs on corpus pull requests.
+ * Do not add a second resolver here — read that guard instead, and treat this walk as what it is,
+ * a graph-reachability and activity-load check.
  *
  * The roster comes from the corpus, not from a list here. A hand-maintained list is a second home
  * for which workflows exist, and it drifts silently: a workflow added to the corpus and omitted
- * here is not walked, and nothing reports that it was skipped — which is how a workflow whose every
- * step failed to resolve reached a merge.
+ * here is not walked, and nothing reports that it was skipped — which is how the workflow above
+ * reached a merge with nothing measuring it.
  */
 function corpusWorkflows(): string[] {
   const root = corpusRoot();


### PR DESCRIPTION
## Summary

The all-workflows walk described itself as the guard that proves every technique reference resolves. It is not, and I trusted the description: a workflow whose every step binding failed to resolve walked this graph to completion and passed, and I read that pass as evidence the workflow was sound.

This corrects the comment to say what the walk verifies and points at the guard that covers the rest. No behaviour changes.

## What the walk actually does

In `mode: 'graph'` it traverses activities and transitions and executes no steps. Measured on the current corpus, `stepsExecuted` is empty for every workflow it covers — work-package included, not only the newly-added four. Because no step runs, the walker never calls `get_technique` for one, so a step whose `technique` ref does not resolve is invisible to it.

What it does cover is real and worth keeping: every activity the graph reaches loads through the real loader, and the activity-level technique references resolve.

## What covers the rest

`binding-fidelity` resolves each step's `technique` ref the way the server does and names the ones that fail. Against the corpus that merged the unresolvable bindings it reports all six:

```
step technique 'plain-language::intake-and-profile' does not resolve
step technique 'plain-language::analyze-source'     does not resolve
step technique 'plain-language::draft-document'     does not resolve
step technique 'plain-language::complete-checklist' does not resolve
step technique 'plain-language::evaluate-document'  does not resolve
step technique 'plain-language::draft-document'     does not resolve
```

That guard now runs on corpus pull requests, so the class is caught before a merge rather than after one.

## Why not add a step resolver here

Because the resolution rule would then have two homes, and they would drift — which is the defect that produced this whole thread. The comment names the guard instead, and tells the next reader not to add one.

## Scope of change

One comment block in `tests/e2e/all-workflows-walk.test.ts`. No assertions added or removed; the walk still passes 18 of 18.

## Acceptance criteria

- [x] The comment states that graph mode executes no steps and that step bindings are out of its reach.
- [x] It names `binding-fidelity` as the home for step-binding resolution.
- [x] It tells a future reader not to add a second resolver here.
- [x] The walk still passes: 18 of 18.

## Non-goals

Making the walk execute steps. Driving every workflow's steps needs per-workflow policies to satisfy their gates — which is what the work-package walk already does with hand-tuned policies, and what this walk deliberately avoids so it can stay workflow-agnostic. The step-binding question is answered by a guard that reads the definitions directly, and answering it twice is worse than answering it once.
