### PR TITLE
Section framing: report prose a section consumer never receives

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "check:binding": "tsx scripts/check-binding-fidelity.ts",
     "check:identifiers": "tsx scripts/check-identifier-qualification.ts",
     "check:inherited-inputs": "tsx scripts/check-inherited-inputs.ts",
+    "check:framing": "tsx scripts/check-section-framing.ts",
     "check:self-input": "tsx scripts/check-self-provisioned-input.ts",
     "check:activity-tech": "tsx scripts/check-activity-technique-overlap.ts",
     "check:prism-lenses": "tsx scripts/check-prism-lens-reachability.ts",

--- a/scripts/check-section-framing.ts
+++ b/scripts/check-section-framing.ts
@@ -1,0 +1,146 @@
+/**
+ * Section-framing guard.
+ *
+ * A resource cited by anchor is delivered one section at a time: `get_resource` for
+ * `example.md#rules` returns that heading's span and nothing else. Prose above the first `##`
+ * therefore reaches whoever loads the whole file and nobody who asks for a section — so an
+ * obligation parked there governs work that never sees it.
+ *
+ * That is not hypothetical. The controlled-language overlay stated its precedence — the stricter
+ * rule wins at word and sentence level, the base standard keeps structure and audience fit — above
+ * its first heading, while the drafting step that applies the overlay cites `#writing-rules`. The
+ * rule governed every drafting run and was delivered to none of them. The catalog entry
+ * `framing-outside-any-section` names the defect and specifies this test; nothing implemented it.
+ *
+ * Detect: a resource with at least MIN_FRAMING characters of body before its first `##`, which at
+ * least one other file cites by anchor. Both halves matter — framing in a resource nobody
+ * section-cites is delivered whole and strands no one.
+ *
+ * The judgement this cannot make is whether the framing is operative or orientation. A guide that
+ * opens "Creation guide for X. The reader is deciding whether to spend the run." strands nothing;
+ * one that opens with a precedence rule strands it. So a site is either classified in
+ * `section-framing-triage.json` with a verdict and a named rationale, or it is reported. An entry
+ * matching nothing is stale and reported too, so the triage cannot outlive the prose it describes.
+ *
+ * Run: npx tsx scripts/check-section-framing.ts [--root <workflows-dir>]
+ */
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { join, resolve, relative } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { resolveWorkflowsRoot } from './workflows-root.js';
+
+const DIR = fileURLToPath(new URL('.', import.meta.url));
+const ROOT = resolveWorkflowsRoot(resolve(join(DIR, '..', 'workflows')));
+const TRIAGE = resolve(join(DIR, 'section-framing-triage.json'));
+
+/**
+ * Below this, framing is a line of orientation rather than a place an obligation can hide. The
+ * catalog entry says "roughly 100+ characters", which is where this comes from.
+ */
+const MIN_FRAMING = 100;
+
+export interface FramingFinding {
+  check: 'framing-outside-any-section' | 'stale-triage';
+  site: string;
+  detail: string;
+}
+
+interface TriageEntry { site: string; verdict: string; rationale: string }
+interface Triage { rationales?: Record<string, string>; entries?: TriageEntry[] }
+
+function walkFiles(dir: string, out: string[] = []): string[] {
+  for (const e of readdirSync(dir)) {
+    if (e === '.git' || e === 'node_modules') continue;
+    const p = join(dir, e);
+    if (statSync(p).isDirectory()) walkFiles(p, out);
+    else if (e.endsWith('.md') || e.endsWith('.yaml')) out.push(p);
+  }
+  return out;
+}
+
+/** Characters of body before the first `##`, with frontmatter and the leading H1 removed. */
+function framingLength(text: string): number {
+  let body = text;
+  if (body.startsWith('---\n')) {
+    const end = body.indexOf('\n---', 4);
+    if (end !== -1) body = body.slice(end + 4);
+  }
+  const lines: string[] = [];
+  for (const line of body.split('\n')) {
+    if (line.startsWith('## ')) break;
+    if (line.startsWith('# ')) continue;
+    lines.push(line);
+  }
+  return lines.join('\n').trim().length;
+}
+
+export function collectFramingFindings(): FramingFinding[] {
+  const files = walkFiles(ROOT);
+
+  // Which resource slugs some other file cites with an #anchor. A file citing itself does not count:
+  // an internal cross-reference is read by whoever already has the whole file.
+  const anchoredBy = new Map<string, Set<string>>();
+  for (const file of files) {
+    const rel = relative(ROOT, file);
+    const text = readFileSync(file, 'utf-8');
+    for (const m of text.matchAll(/\]\(([^)\s]*?)([A-Za-z0-9._-]+)\.md#[a-z0-9-]+\)/g)) {
+      const slug = m[2]!.toLowerCase();
+      if (!anchoredBy.has(slug)) anchoredBy.set(slug, new Set());
+      anchoredBy.get(slug)!.add(rel);
+    }
+  }
+
+  const triage: Triage = existsSync(TRIAGE)
+    ? (JSON.parse(readFileSync(TRIAGE, 'utf-8')) as Triage)
+    : {};
+  const classified = new Map((triage.entries ?? []).map((e) => [e.site, e]));
+  const matched = new Set<string>();
+
+  const out: FramingFinding[] = [];
+  for (const file of files) {
+    if (!file.endsWith('.md')) continue;
+    const rel = relative(ROOT, file);
+    // Resources are what get section-delivered; a README is an index read whole.
+    if (!rel.includes('/resources/') || rel.endsWith('README.md')) continue;
+
+    const slug = rel.slice(rel.lastIndexOf('/') + 1, -3).toLowerCase();
+    const citers = new Set([...(anchoredBy.get(slug) ?? [])].filter((c) => c !== rel));
+    if (citers.size === 0) continue;
+
+    const chars = framingLength(readFileSync(file, 'utf-8'));
+    if (chars < MIN_FRAMING) continue;
+
+    const entry = classified.get(rel);
+    if (entry) { matched.add(rel); continue; }
+    out.push({
+      check: 'framing-outside-any-section',
+      site: rel,
+      detail: `${chars} characters before the first '##', and ${citers.size} file(s) cite this resource by anchor — `
+        + `a section consumer never receives that prose. Move an obligation into a section a citer can ask for, `
+        + `or classify the site in scripts/section-framing-triage.json when the framing is orientation only`,
+    });
+  }
+
+  for (const [site] of classified) {
+    if (!matched.has(site)) {
+      out.push({
+        check: 'stale-triage',
+        site,
+        detail: 'triaged framing no longer occurs — delete the entry from scripts/section-framing-triage.json',
+      });
+    }
+  }
+  return out;
+}
+
+const isMain = !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  const findings = collectFramingFindings();
+  if (findings.length === 0) {
+    process.stdout.write('section-framing: OK — no resource strands prose above its first section from an anchored citer\n');
+    process.exit(0);
+  }
+  process.stdout.write(`section-framing: ${findings.length} finding(s) — move the obligation into a section, or classify the site:\n`);
+  for (const f of findings) process.stdout.write(`  [${f.check}] ${f.site}\n     ${f.detail}\n`);
+  process.exit(1);
+}

--- a/scripts/guards.ts
+++ b/scripts/guards.ts
@@ -42,6 +42,13 @@ export const GUARDS: GuardSpec[] = [
     proves: 'no technique redeclares an input a container contract already merges into it',
   },
   {
+    id: 'section-framing',
+    script: 'scripts/check-section-framing.ts',
+    npmScript: 'check:framing',
+    scope: 'corpus',
+    proves: 'no resource strands prose above its first section from a consumer that cites it by anchor',
+  },
+  {
     id: 'identifier-qualification',
     script: 'scripts/check-identifier-qualification.ts',
     npmScript: 'check:identifiers',

--- a/scripts/section-framing-triage.json
+++ b/scripts/section-framing-triage.json
@@ -1,0 +1,552 @@
+{
+  "note": "Triage of the section-framing guard's findings. A resource cited by anchor is delivered one section at a time, so prose above the first '##' reaches whoever loads the whole file and nobody who asks for a section. The guard finds every such site mechanically; whether the prose is an obligation or an orientation is a judgement, and this file records it. orientation-only = the framing says what the resource is and who reads it, so a section consumer needs none of it. operative-owed-a-section = the framing states a rule that binds work the section consumer does, which is real debt: suppressed here and counted, to be closed by moving the rule into a section a citer can request. A site absent from this file is untriaged and reported; an entry matching nothing is stale and reported.",
+  "rationales": {
+    "orientation-only": "The framing names the resource, its subject and its reader. A consumer that asks for one section can apply that section without it, so nothing is stranded. This is the shape the creation guides share: 'Creation guide for bare filename X', then what the document answers.",
+    "operative-owed-a-section": "The framing states a rule rather than an orientation, and a consumer citing a section never receives it. Closing this means moving the rule into a section a citer can request, or into the technique that applies it — a content change in the owning workflow, not a triage entry. Counted here so the debt is visible rather than silent."
+  },
+  "entries": [
+    {
+      "site": "cicd-pipeline-security-audit/resources/cicd-audit-report-template.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "cicd-pipeline-security-audit/resources/cicd-severity-rubric.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "cicd-pipeline-security-audit/resources/intermediate-artifact-schemas.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "cicd-pipeline-security-audit/resources/sub-agent-output-schema.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "codebase-wiki/resources/citation-conventions.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "codebase-wiki/resources/index-and-log.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "codebase-wiki/resources/wiki-format.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "meta/resources/session-summary-template.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "meta/resources/writing-register.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "midnight-system-review/resources/change-surface.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "midnight-system-review/resources/evidence-log.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "midnight-system-review/resources/findings-register.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "midnight-system-review/resources/grading-rubric.md",
+      "verdict": "fix-later",
+      "rationale": "operative-owed-a-section",
+      "owed": "grade every dimension from the definitions, never intuitively; complete tuple or the gate fails; grade before disposition"
+    },
+    {
+      "site": "midnight-system-review/resources/investigation-plan.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "midnight-system-review/resources/publication-record.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "midnight-system-review/resources/review-format.md",
+      "verdict": "fix-later",
+      "rationale": "operative-owed-a-section",
+      "owed": "the summary is the report body byte-for-byte, and posting never re-renders it"
+    },
+    {
+      "site": "midnight-system-review/resources/verdict-rubric.md",
+      "verdict": "fix-later",
+      "rationale": "operative-owed-a-section",
+      "owed": "the verdict counts accepted findings only, computed mechanically"
+    },
+    {
+      "site": "plain-language/resources/asd-ste100.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "plain-language/resources/document-profile.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "plain-language/resources/evaluation-report.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "plain-language/resources/iso-checklist.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "plain-language/resources/plain-language-standard.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "plain-language/resources/source-analysis.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "ponytail/resources/audit-findings.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "ponytail/resources/debt-ledger.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "ponytail/resources/honesty-boundary.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "ponytail/resources/lean-brief.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "ponytail/resources/lean-change.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "ponytail/resources/ponytail-marker-convention.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "ponytail/resources/review-taxonomy.md",
+      "verdict": "fix-later",
+      "rationale": "operative-owed-a-section",
+      "owed": "scope is over-engineering only; correctness, security and performance are never tagged here"
+    },
+    {
+      "site": "ponytail/resources/the-ladder.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "prism-audit/resources/audit-prompt-template.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "prism-audit/resources/audit-report.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "prism-audit/resources/design-trade-offs.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "prism-audit/resources/detailed-findings.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "prism-evaluate/resources/evaluation-plan-template.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "prism-evaluate/resources/evaluation-report-template.md",
+      "verdict": "fix-later",
+      "rationale": "operative-owed-a-section",
+      "owed": "the report must not carry methodology metadata"
+    },
+    {
+      "site": "prism-evaluate/resources/mitigation-plan-template.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "prism/resources/analysis-plan.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "prism/resources/portfolio-synthesis.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "prism/resources/reflect-synthesis.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "prism/resources/run-manifest.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "requirements-refinement/resources/change-summary.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "requirements-refinement/resources/failure-report.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "requirements-refinement/resources/intake-record.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "requirements-refinement/resources/requirements-analysis-report.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "requirements-refinement/resources/specification-protocol.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "requirements-refinement/resources/validation-report.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "requirements-refinement/resources/validation-rubric.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "substrate-node-security-audit/resources/audit-prompt-template.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "substrate-node-security-audit/resources/audit-template-reference.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "substrate-node-security-audit/resources/second-pass-findings.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "substrate-node-security-audit/resources/static-analysis-patterns.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "substrate-node-security-audit/resources/target-profile.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/adr.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/architecture-review.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/architecture-summary.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/assumption-reconciliation.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/assumptions-review.md",
+      "verdict": "fix-later",
+      "rationale": "operative-owed-a-section",
+      "owed": "one row per assumption updated in place, and never restated in another artifact"
+    },
+    {
+      "site": "work-package/resources/codebase-comprehension.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/deferred-items.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/design-framework.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/follow-ups.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/github-issue-creation.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/implementation-analysis.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/jira-issue-creation.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/knowledge-base-research.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/pr-description.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/prior-feedback-triage.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/provenance-log.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/readme.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/requirements-elicitation.md",
+      "verdict": "fix-later",
+      "rationale": "operative-owed-a-section",
+      "owed": "applies to features and major enhancements only, and is skipped for fixes, refactors and chores"
+    },
+    {
+      "site": "work-package/resources/research-reconciliation.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/review-mode.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/strategic-review.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/test-plan.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/test-suite-review.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/token-usage.md",
+      "verdict": "fix-later",
+      "rationale": "operative-owed-a-section",
+      "owed": "a number is either reconciled or labelled a floor"
+    },
+    {
+      "site": "work-package/resources/wp-plan.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-packages/resources/prioritization-framework.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-packages/resources/priority-ranking.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-packages/resources/workflow-triggering-protocol.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-authoring/resources/change-brief.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-authoring/resources/completion-artifact.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-authoring/resources/elicitation-guide.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-authoring/resources/findings-register.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-authoring/resources/impact-analysis.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-authoring/resources/scope-manifest.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/anti-patterns.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/applicable-constructs.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/completion-artifact.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/compliance-report.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/convention-conformance.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/design-assumptions.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/design-principles.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/design-specification.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/draft-attestation.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/drafting-plan.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/elicitation-guide.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/file-review-note.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/findings-satellite.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/follow-ups.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/format-conventions.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/impact-analysis.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/pattern-analysis.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/scope-manifest.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/structural-inventory.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    }
+  ]
+}

--- a/tests/section-framing-guard.test.ts
+++ b/tests/section-framing-guard.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { collectFramingFindings } from '../scripts/check-section-framing.js';
+
+/**
+ * Section-framing guard. A resource cited by anchor is delivered one section at a time, so prose
+ * above the first `##` never reaches a section consumer. The guard finds those sites mechanically;
+ * `scripts/section-framing-triage.json` carries the judgement of whether the prose is an obligation
+ * or an orientation, and an untriaged site is reported.
+ */
+describe('section-framing guard (corpus)', () => {
+  it('leaves no framing site untriaged and no triage entry stale', () => {
+    const findings = collectFramingFindings();
+    expect(findings.map((f) => `[${f.check}] ${f.site}`)).toEqual([]);
+  });
+});
+
+describe('section-framing triage', () => {
+  const triage = JSON.parse(
+    readFileSync(join(import.meta.dirname, '..', 'scripts', 'section-framing-triage.json'), 'utf-8'),
+  ) as { rationales: Record<string, string>; entries: Array<{ site: string; verdict: string; rationale: string; owed?: string }> };
+
+  it('gives every entry a verdict this file defines and a rationale it names', () => {
+    const verdicts = new Set(['harmless', 'fix-later']);
+    for (const e of triage.entries) {
+      expect(verdicts, `${e.site} carries an unknown verdict`).toContain(e.verdict);
+      expect(Object.keys(triage.rationales), `${e.site} names an undefined rationale`).toContain(e.rationale);
+    }
+  });
+
+  it('records what a fix-later site owes, so the debt is legible without re-reading the file', () => {
+    for (const e of triage.entries.filter((x) => x.verdict === 'fix-later')) {
+      expect(e.owed, `${e.site} is deferred without naming the rule it strands`).toBeTruthy();
+    }
+  });
+
+  it('carries no duplicate sites', () => {
+    const sites = triage.entries.map((e) => e.site);
+    expect(sites.length).toBe(new Set(sites).size);
+  });
+});


### PR DESCRIPTION
## Summary

A resource cited by anchor is delivered one section at a time: asking for `example.md#rules` returns that heading's span and nothing else. Prose above the first `##` therefore reaches whoever loads the whole file and nobody who asks for a section, so an obligation parked there governs work that never sees it.

The catalog entry `framing-outside-any-section` names this and specifies the test. Nothing implemented it. This adds the guard, and records a judgement for every site it finds.

## What it cost to not have

The controlled-language overlay stated its precedence — the stricter rule wins at word and sentence level, the base standard keeps structure and audience fit — above its first heading. The drafting step that applies the overlay cites the writing rules by anchor. So the rule governed every drafting run and was delivered to none of them, and it took a hand audit to notice.

## What the guard checks

A resource is reported when it has enough prose before its first `##` to hide an obligation in, **and** at least one other file cites it by anchor. Both halves matter: framing in a resource nobody section-cites is delivered whole and strands no one, so flagging it would be noise.

## What it cannot decide

Whether the prose is a rule or an orientation. That is a judgement, so it lives in `scripts/section-framing-triage.json` per site, the way `binding-fidelity` records its own. A site absent from the file is untriaged and reported; an entry matching nothing is stale and reported, so the triage cannot outlive the prose it describes.

| Verdict | Sites | Meaning |
|---|---:|---|
| `orientation-only` | 99 | Names the resource, its subject and its reader. A section consumer applies its section without it. |
| `operative-owed-a-section` | 8 | States a rule a section consumer never receives. Real debt, counted rather than hidden. |

## The eight, and what each strands

| Resource | The rule above the fold |
|---|---|
| `midnight-system-review/…/grading-rubric.md` | grade every dimension from the definitions, never intuitively; complete tuple or the gate fails; grade before disposition |
| `midnight-system-review/…/verdict-rubric.md` | the verdict counts accepted findings only, computed mechanically |
| `midnight-system-review/…/review-format.md` | the summary is the report body byte-for-byte, and posting never re-renders it |
| `ponytail/…/review-taxonomy.md` | scope is over-engineering only; correctness, security and performance are never tagged here |
| `prism-evaluate/…/evaluation-report-template.md` | the report must not carry methodology metadata |
| `work-package/…/assumptions-review.md` | one row per assumption updated in place, and never restated in another artifact |
| `work-package/…/token-usage.md` | a number is either reconciled or labelled a floor |
| `work-package/…/requirements-elicitation.md` | applies to features and major enhancements only; skipped for fixes, refactors and chores |

Closing each means moving the rule into a section a citer can request, or into the technique that applies it. That is a content change in the owning workflow, so it is a separate change on the `workflows` branch rather than an entry here.

## Why now is cheap

The entry already specifies the test, the corpus is settled after the artifact-audience work, and the triage seeds from one pass over the current corpus. Waiting means seeding it against a moving corpus, and every resource authored in the meantime joins the set unreviewed.

## Scope of change

A guard, its triage, a test, and two registry lines. No definition changes.

## Acceptance criteria

- [x] Every resource with framing above its first section and an anchored citer is either triaged or reported.
- [x] A site removed from the triage is reported — verified by removing one and seeing it named.
- [x] A triage entry matching nothing is reported as stale.
- [x] Every entry carries a verdict the file defines and a rationale it names; every deferred entry records the rule it strands.
- [x] Typecheck, the full suite and the sweep pass: 1006 tests, 27 of 27 guards.

## Non-goals

Fixing the eight. Each is a rule that has to move into a section of the resource that owns it, in the workflow that owns that resource — content work with its own review, and the debt is legible here until it is done.

Flagging README files. A README is an index read whole, not a resource delivered by section.
