### PR TITLE
Stranded rules: put each one where the reader that needs it asks

### DIFF
--- a/.github/workflows/verify-corpus.yml
+++ b/.github/workflows/verify-corpus.yml
@@ -42,12 +42,19 @@ jobs:
           submodules: false
 
       # The corpus under review, where check:all looks for it by default. For a pull request this is
-      # the merge result; for a manual run it is the ref the run was dispatched on.
+      # the branch tip; for a manual run it is the ref the run was dispatched on.
+      #
+      # The tip, not the merge result. GitHub computes a pull request's merge commit asynchronously,
+      # so the sha in the event payload can name a merge of the previous push — the run then grades a
+      # corpus one commit behind the one that triggered it and reports on prose the branch no longer
+      # carries. That happened: a commit moving a triage record into the corpus was graded against
+      # the tree without it, and the failure named a file the push had already fixed. The tip is
+      # whatever was pushed, every time.
       - name: Check out the corpus under review
         uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           path: workflows
 
       - uses: actions/setup-node@v4

--- a/midnight-system-review/resources/grading-rubric.md
+++ b/midnight-system-review/resources/grading-rubric.md
@@ -7,9 +7,11 @@ metadata:
 
 # Finding Grading Rubric
 
-Every finding candidate is graded on all six dimensions below, from these definitions — never intuitively. The tuple is complete or the finding does not pass the grade-tuple completeness gate. Grade first, disposition second: acceptance is a threshold applied to finished grades.
+The six dimensions a finding candidate carries, the threshold that turns finished grades into a disposition, and calibration anchors from real findings.
 
 ## The Grade Tuple
+
+Every finding candidate is graded on all six dimensions below, from these definitions — never intuitively. The tuple is complete or the finding does not pass the grade-tuple completeness gate. Grade first, disposition second: acceptance is a threshold applied to finished grades.
 
 ### 1. Evidence anchor
 

--- a/midnight-system-review/resources/review-format.md
+++ b/midnight-system-review/resources/review-format.md
@@ -7,9 +7,11 @@ metadata:
 
 # Review Format
 
-The rendered review — both `review-report.md` and the posted `review_summary` — follows this structure. The summary is the report's publishable body, byte-for-byte; posting never re-renders it.
+The canonical shape of a rendered review, the per-area accounting, the verdict phrases, and the fill rules.
 
 ## Structure
+
+The rendered review — both `review-report.md` and the posted `review_summary` — follows this structure. The summary is the report's publishable body, byte-for-byte; posting never re-renders it.
 
 ```markdown
 ## System Review - Merge Readiness {verdict}/5

--- a/midnight-system-review/resources/verdict-rubric.md
+++ b/midnight-system-review/resources/verdict-rubric.md
@@ -7,9 +7,11 @@ metadata:
 
 # Merge-Readiness Verdict Rubric
 
-The verdict is computed from the **accepted** findings only. Observations and dismissed candidates never move the score — they may appear in the rationale and the report, but a review with zero accepted findings is merge-ready no matter how many observations it carries. Compute mechanically from the level definitions; record which line fired.
+The 1-5 merge-readiness scale, its calibration anchors, the run status vocabulary, and the mapping from a verdict to a review type.
 
 ## The Scale
+
+The verdict is computed from the **accepted** findings only. Observations and dismissed candidates never move the score — they may appear in the rationale and the report, but a review with zero accepted findings is merge-ready no matter how many observations it carries. Compute mechanically from the level definitions; record which line fired.
 
 | Verdict | Meaning | Definition (accepted-set profile) |
 |---------|---------|-----------------------------------|

--- a/ponytail/resources/review-taxonomy.md
+++ b/ponytail/resources/review-taxonomy.md
@@ -1,12 +1,12 @@
 # Review Taxonomy
 
-The single source for the over-engineering tags, the one-line-per-finding format, and the scoreboard that closes a review. Scope is over-engineering only — correctness, security, and performance belong to the safety floor and are never tagged here.
+The single source for the over-engineering tags, the one-line-per-finding format, and the scoreboard that closes a review.
 
 ---
 
 ## Tags
 
-Five tags classify every over-engineering finding. Each names the simpler rung that would replace the construct.
+Scope is over-engineering only — correctness, security, and performance belong to the safety floor and are never tagged here. Five tags classify every over-engineering finding. Each names the simpler rung that would replace the construct.
 
 - **delete** — The construct can be removed outright; nothing depends on it. Dead code, an unused parameter, a flag no path reads, a comment that restates the line below it, a comment/doc block whose bulk dwarfs the code it annotates with no unique why, or a speculative feature / unused flexibility that no path actually needs.
   *Example:* `L42: delete unused 'verbose' parameter — no caller passes it.`

--- a/prism-evaluate/resources/evaluation-report-template.md
+++ b/prism-evaluate/resources/evaluation-report-template.md
@@ -8,13 +8,11 @@ metadata:
 
 # Evaluation Report Template
 
-Template for the consolidated evaluation report. The
-report consolidates prism analysis artifacts across all evaluation dimensions into a unified, standalone
-document. The report MUST NOT
-contain methodology metadata — no lens names, pipeline modes, pass descriptions, or process narratives;
-findings are presented as conclusions.
+Template for the consolidated evaluation report, which gathers prism analysis artifacts across all evaluation dimensions into one standalone document.
 
 ## Evaluation Report Template
+
+The report MUST NOT contain methodology metadata — no lens names, pipeline modes, pass descriptions, or process narratives; findings are presented as conclusions.
 
 ```markdown
 # Evaluation Report: {target name}

--- a/section-framing-triage.json
+++ b/section-framing-triage.json
@@ -1,0 +1,539 @@
+{
+  "note": "Triage of the section-framing guard's findings. A resource cited by anchor is delivered one section at a time, so prose above the first '##' reaches whoever loads the whole file and nobody who asks for a section. The guard finds every such site mechanically; whether the prose is an obligation or an orientation is a judgement, and this file records it. orientation-only = the framing says what the resource is and who reads it, so a section consumer needs none of it. operative-owed-a-section = the framing states a rule that binds work the section consumer does, which is real debt: suppressed here and counted, to be closed by moving the rule into a section a citer can request. A site absent from this file is untriaged and reported; an entry matching nothing is stale and reported.",
+  "rationales": {
+    "orientation-only": "The framing names the resource, its subject and its reader. A consumer that asks for one section can apply that section without it, so nothing is stranded. This is the shape the creation guides share: 'Creation guide for bare filename X', then what the document answers.",
+    "operative-owed-a-section": "The framing states a rule rather than an orientation, and a consumer citing a section never receives it. Closing this means moving the rule into a section a citer can request, or into the technique that applies it — a content change in the owning workflow, not a triage entry. Counted here so the debt is visible rather than silent."
+  },
+  "entries": [
+    {
+      "site": "cicd-pipeline-security-audit/resources/cicd-audit-report-template.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "cicd-pipeline-security-audit/resources/cicd-severity-rubric.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "cicd-pipeline-security-audit/resources/intermediate-artifact-schemas.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "cicd-pipeline-security-audit/resources/sub-agent-output-schema.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "codebase-wiki/resources/citation-conventions.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "codebase-wiki/resources/index-and-log.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "codebase-wiki/resources/wiki-format.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "meta/resources/session-summary-template.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "meta/resources/writing-register.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "midnight-system-review/resources/change-surface.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "midnight-system-review/resources/evidence-log.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "midnight-system-review/resources/findings-register.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "midnight-system-review/resources/grading-rubric.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "midnight-system-review/resources/investigation-plan.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "midnight-system-review/resources/publication-record.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "midnight-system-review/resources/review-format.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "midnight-system-review/resources/verdict-rubric.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "plain-language/resources/asd-ste100.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "plain-language/resources/document-profile.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "plain-language/resources/evaluation-report.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "plain-language/resources/iso-checklist.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "plain-language/resources/plain-language-standard.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "plain-language/resources/source-analysis.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "ponytail/resources/audit-findings.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "ponytail/resources/debt-ledger.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "ponytail/resources/honesty-boundary.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "ponytail/resources/lean-brief.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "ponytail/resources/lean-change.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "ponytail/resources/ponytail-marker-convention.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "ponytail/resources/review-taxonomy.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "ponytail/resources/the-ladder.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "prism-audit/resources/audit-prompt-template.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "prism-audit/resources/audit-report.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "prism-audit/resources/design-trade-offs.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "prism-audit/resources/detailed-findings.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "prism-evaluate/resources/evaluation-plan-template.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "prism-evaluate/resources/evaluation-report-template.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "prism-evaluate/resources/mitigation-plan-template.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "prism/resources/analysis-plan.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "prism/resources/portfolio-synthesis.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "prism/resources/reflect-synthesis.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "prism/resources/run-manifest.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "requirements-refinement/resources/change-summary.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "requirements-refinement/resources/failure-report.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "requirements-refinement/resources/intake-record.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "requirements-refinement/resources/requirements-analysis-report.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "requirements-refinement/resources/specification-protocol.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "requirements-refinement/resources/validation-report.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "requirements-refinement/resources/validation-rubric.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "substrate-node-security-audit/resources/audit-prompt-template.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "substrate-node-security-audit/resources/audit-template-reference.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "substrate-node-security-audit/resources/second-pass-findings.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "substrate-node-security-audit/resources/static-analysis-patterns.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "substrate-node-security-audit/resources/target-profile.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/adr.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/architecture-review.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/architecture-summary.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/assumption-reconciliation.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/codebase-comprehension.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/deferred-items.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/design-framework.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/follow-ups.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/github-issue-creation.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/implementation-analysis.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/jira-issue-creation.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/knowledge-base-research.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/pr-description.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/prior-feedback-triage.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/provenance-log.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/readme.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/requirements-elicitation.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/research-reconciliation.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/review-mode.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/strategic-review.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/test-plan.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/test-suite-review.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/token-usage.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-package/resources/wp-plan.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-packages/resources/prioritization-framework.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-packages/resources/priority-ranking.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "work-packages/resources/workflow-triggering-protocol.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-authoring/resources/change-brief.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-authoring/resources/completion-artifact.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-authoring/resources/elicitation-guide.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-authoring/resources/findings-register.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-authoring/resources/impact-analysis.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-authoring/resources/scope-manifest.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/anti-patterns.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/applicable-constructs.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/completion-artifact.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/compliance-report.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/convention-conformance.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/design-assumptions.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/design-principles.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/design-specification.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/draft-attestation.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/drafting-plan.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/elicitation-guide.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/file-review-note.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/findings-satellite.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/follow-ups.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/format-conventions.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/impact-analysis.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/pattern-analysis.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/scope-manifest.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    },
+    {
+      "site": "workflow-design/resources/structural-inventory.md",
+      "verdict": "harmless",
+      "rationale": "orientation-only"
+    }
+  ]
+}

--- a/work-package/resources/assumptions-review.md
+++ b/work-package/resources/assumptions-review.md
@@ -10,7 +10,7 @@ metadata:
 
 # Assumptions Guide
 
-The assumptions log is the single record of truth for assumptions — one row per assumption, updated in place. Never restate assumption content in other artifacts (single-source-and-link).
+The assumptions log template, with the category, risk and probe vocabulary that fills its rows.
 
 ## Probe Vocabulary
 
@@ -40,6 +40,7 @@ Common origins of false assumptions: missing/stale information, conditions that 
 
 ## Assumptions Log Template
 
+The log is the single record of truth for assumptions — one row per assumption, updated in place. Never restate assumption content in another artifact; link to the row instead (single-source-and-link).
 
 **Template:**
 

--- a/work-package/resources/requirements-elicitation.md
+++ b/work-package/resources/requirements-elicitation.md
@@ -10,7 +10,7 @@ metadata:
 
 # Requirements Elicitation Guide
 
-Requirements elicitation discovers **what** the user needs before planning **how** to implement it — a dialogue, not a checklist. Use for new features and major enhancements only; skip for bug fixes, refactors, chores, and minor updates.
+Requirements elicitation discovers **what** the user needs before planning **how** to implement it — a dialogue, not a checklist.
 
 Goals: discover what the user actually needs (which may differ from the initial ask), clarify ambiguities before they become implementation assumptions, establish scope boundaries, define measurable success criteria.
 

--- a/work-package/resources/token-usage.md
+++ b/work-package/resources/token-usage.md
@@ -7,7 +7,7 @@ metadata:
 
 # Token Usage Guide
 
-Creation guide for bare filename `token-usage.md`. The one place a run's token counts and cost estimate live, so every other artifact links here rather than repeating a figure. A number in it is either reconciled or labelled a floor — an unlabelled understatement reads as a measurement.
+Creation guide for bare filename `token-usage.md`. The one place a run's token counts and cost estimate live, so every other artifact links here rather than repeating a figure.
 
 ## Template
 
@@ -37,6 +37,7 @@ Cost is an estimate, meaningful for API-key per-token billing. On a subscription
 
 ## Rules
 
+- **A number is reconciled or labelled a floor.** An unlabelled understatement reads as a measurement, so a figure that could not be reconciled says so.
 - **One row per activity.** Cache columns appear when the harness surfaced them; a null cost is `unknown` rather than zero, because zero is a measurement and unknown is not.
 - **Duration converts from the harness figure.** Milliseconds to minutes, one decimal.
 - **A total is a total only when coverage is complete.** With any dispatch unaccounted, the figure is labelled a floor and the unaccounted count sits beside it.


### PR DESCRIPTION
## Summary

Asking the server for `grading-rubric.md#the-grade-tuple` returns that heading's span and nothing else. Prose above the first `##` reaches only a consumer that loads the whole file, so a rule parked up there binds work that never receives it: the reader gets the section, applies it, and never sees the constraint on how to apply it.

Eight resources kept a rule up there. Seven move into the section that governs the same work; one is deleted, because it was a second copy of a decision an activity already owns.

This is what the `section-framing` guard recorded as owed when it landed. The guard names the sites mechanically and cannot judge whether the prose is a rule or an orientation, so it deferred these eight with the rule each one strands. This closes them.

## The eight

| Resource | The rule that was stranded | What it prevents | Now in |
|---|---|---|---|
| `grading-rubric` | Grade all six dimensions from the definitions, never intuitively; an incomplete tuple fails the gate; grade before disposition | A grader fetching the tuple and scoring from intuition, or dispositioning while grading | `#the-grade-tuple` |
| `verdict-rubric` | The verdict counts accepted findings only; observations never move the score | Twenty observations dragging down a review with no accepted findings, which is merge-ready | `#the-scale` |
| `review-format` | The posted summary is the report body byte-for-byte; posting never re-renders it | The posted text drifting from the report it claims to be | `#structure` |
| `review-taxonomy` | Scope is over-engineering only — correctness, security and performance are never tagged here | A security finding filed as over-engineering | `#tags` |
| `evaluation-report-template` | The report must not carry methodology metadata — no lens names, pipeline modes, pass descriptions | The report shipping the process narrative it exists to exclude | the template it constrains |
| `token-usage` | A number is reconciled or labelled a floor | An unreconciled figure reading as a measurement, understating cost silently | `#rules` |
| `assumptions-review` | One row per assumption, updated in place; never restate assumption content elsewhere | Assumptions duplicated across artifacts, drifting apart | `#assumptions-log-template` |
| `requirements-elicitation` | Use for features and major enhancements; skip fixes, refactors and chores | — | deleted, see below |

## Two that are not simple relocations

**`assumptions-review`** — placement mattered rather than just section-ness. Its citers ask for `#assumptions-log-template` eleven times and other sections once or twice, so the rule went there. A generic `## Rules` section would have stranded it again one level down.

**`requirements-elicitation`** — deleted rather than moved, because the line is routing and not a fill rule. Which path a run takes is decided at the design-philosophy checkpoint, whose own options carry the criteria ("Complex feature requiring requirements discovery and research", "Requirements unclear but domain is well-understood"). The resource held a second and coarser copy of a decision the activity owns; moving it into a section would have preserved the duplicate.

## What the framings keep

What they were for: what the resource is, and who reads it. `grading-rubric` now opens with "The six dimensions a finding candidate carries, the threshold that turns finished grades into a disposition, and calibration anchors from real findings" — orientation a section consumer does not need, which is what belongs above the fold.

## Scope of change

Eight resource files across four workflows, 19 lines added and 13 removed. No technique, activity or workflow definition changes, and no rule is dropped except the routing duplicate named above. Two supporting files: the triage record, and one line of the corpus CI job.

## Acceptance criteria

- [x] Every rule that was above a first section is now inside a section a citer requests, or removed because another surface owns it.
- [x] Each framing retains the orientation a whole-file reader needs.
- [x] The guard sweep passes against this corpus: 27 of 27.

## Verification

The guard caught a consequence of its own fix, which is the behaviour worth reporting: removing the rule from `assumptions-review` dropped that framing below the reporting threshold, so its triage entry stopped matching anything and was reported as stale. That is the entry-cannot-outlive-the-prose contract working.

The corpus sweep passes on this branch, 27 of 27.

## Two things this pulled in

**The triage moved into the corpus.** Its entries are judgements about corpus prose, so fixing a rule and updating the record describing it belong in one commit. Held beside the guard on `main`, they could never agree: this pull request's fix stranded seven entries and deleted the need for an eighth, and a corpus branch cannot reach a file in `scripts/`. The guard now reads the record from the corpus root, falling back to the copy beside the script for a corpus pinned before the move — that half landed as [#461](https://github.com/m2ux/workflow-server/pull/461). The record itself moves here, with the prose it describes.

**Corpus CI graded the wrong commit.** GitHub computes a pull request's merge commit asynchronously, so the sha in the event payload can name a merge of the *previous* push. This pull request caught it: the run triggered by the triage-move commit checked out the tree without the triage, and failed on an entry that commit had already deleted — a real finding about prose the branch no longer carried. The job now checks out the branch tip, which is whatever was pushed, every time.
