### PR TITLE
Framing triage: read it from the corpus it describes

### DIFF
--- a/scripts/check-section-framing.ts
+++ b/scripts/check-section-framing.ts
@@ -43,7 +43,14 @@ const ROOT = resolveWorkflowsRoot(resolve(join(DIR, '..', 'workflows')));
  */
 const CORPUS_TRIAGE = resolve(join(ROOT, 'section-framing-triage.json'));
 const LEGACY_TRIAGE = resolve(join(DIR, 'section-framing-triage.json'));
-const TRIAGE = existsSync(CORPUS_TRIAGE) ? CORPUS_TRIAGE : LEGACY_TRIAGE;
+
+/**
+ * Which triage this run reads. Exported so a test asserts against the same file the guard used
+ * rather than resolving the path a second time — the two would disagree the moment a corpus
+ * predating the move is pinned, which is exactly when the fallback matters.
+ */
+export const TRIAGE_PATH = existsSync(CORPUS_TRIAGE) ? CORPUS_TRIAGE : LEGACY_TRIAGE;
+const TRIAGE = TRIAGE_PATH;
 
 /**
  * Below this, framing is a line of orientation rather than a place an obligation can hide. The

--- a/scripts/check-section-framing.ts
+++ b/scripts/check-section-framing.ts
@@ -31,7 +31,19 @@ import { resolveWorkflowsRoot } from './workflows-root.js';
 
 const DIR = fileURLToPath(new URL('.', import.meta.url));
 const ROOT = resolveWorkflowsRoot(resolve(join(DIR, '..', 'workflows')));
-const TRIAGE = resolve(join(DIR, 'section-framing-triage.json'));
+/**
+ * The triage lives with the corpus, not with this script. Its entries are judgements about corpus
+ * prose, so a change that moves a rule into a section and the entry describing that prose belong in
+ * one commit. Held beside this script instead, the two could never agree: fixing the prose stranded
+ * the entry, and the pull request fixing it could not reach the file — the corpus and the tooling are
+ * separate histories, so a corpus change was red whichever side moved first.
+ *
+ * The fallback beside this script carries a corpus pinned before the triage moved into it, and goes
+ * once no supported pin predates the move.
+ */
+const CORPUS_TRIAGE = resolve(join(ROOT, 'section-framing-triage.json'));
+const LEGACY_TRIAGE = resolve(join(DIR, 'section-framing-triage.json'));
+const TRIAGE = existsSync(CORPUS_TRIAGE) ? CORPUS_TRIAGE : LEGACY_TRIAGE;
 
 /**
  * Below this, framing is a line of orientation rather than a place an obligation can hide. The

--- a/tests/section-framing-guard.test.ts
+++ b/tests/section-framing-guard.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { collectFramingFindings } from '../scripts/check-section-framing.js';
+import { collectFramingFindings, TRIAGE_PATH } from '../scripts/check-section-framing.js';
 
 /**
  * Section-framing guard. A resource cited by anchor is delivered one section at a time, so prose
@@ -18,7 +17,7 @@ describe('section-framing guard (corpus)', () => {
 
 describe('section-framing triage', () => {
   const triage = JSON.parse(
-    readFileSync(join(import.meta.dirname, '..', 'workflows', 'section-framing-triage.json'), 'utf-8'),
+    readFileSync(TRIAGE_PATH, 'utf-8'),
   ) as { rationales: Record<string, string>; entries: Array<{ site: string; verdict: string; rationale: string; owed?: string }> };
 
   it('gives every entry a verdict this file defines and a rationale it names', () => {

--- a/tests/section-framing-guard.test.ts
+++ b/tests/section-framing-guard.test.ts
@@ -18,7 +18,7 @@ describe('section-framing guard (corpus)', () => {
 
 describe('section-framing triage', () => {
   const triage = JSON.parse(
-    readFileSync(join(import.meta.dirname, '..', 'scripts', 'section-framing-triage.json'), 'utf-8'),
+    readFileSync(join(import.meta.dirname, '..', 'workflows', 'section-framing-triage.json'), 'utf-8'),
   ) as { rationales: Record<string, string>; entries: Array<{ site: string; verdict: string; rationale: string; owed?: string }> };
 
   it('gives every entry a verdict this file defines and a rationale it names', () => {


### PR DESCRIPTION
## Summary

The `section-framing` triage records judgements about corpus prose, and I put it beside the guard instead of with the corpus. That made a framing fix impossible to land green, in both directions:

- fix the prose, and the entry describing the old prose goes stale — but the pull request fixing it is on the corpus branch and cannot reach a file in `scripts/`
- update the entry first, and the site it described is untriaged until the prose changes, so `main` is red instead

[#460](https://github.com/m2ux/workflow-server/pull/460) demonstrated it on its first run: one finding, a stale triage entry for `work-package/resources/assumptions-review.md`, with the fix and the record in different histories.

The guard now reads the triage from the corpus root, so a fix and its entry arrive in one commit.

## The fallback

The copy beside the script stays, and is used only when the pinned corpus has no triage of its own. That covers a corpus pinned before the move — including the one `main` pins today — and goes once no supported pin predates it.

Both paths are verified:

| Corpus | Triage read from | Result |
|---|---|---|
| currently pinned | the copy beside the script | OK |
| the corpus in #460, triage included | corpus root | OK, 27 of 27 |

## Why the corpus is the right home

An entry is a judgement about one file's prose. The guard finds sites mechanically and cannot tell a rule from an orientation, so the record has to live where a change to that prose can update it in the same commit. Anywhere else and the two drift by construction — the same one-fact-two-homes shape the corpus canon names.

## Scope of change

Two files: the guard's triage path, and the test that reads it. The triage itself moves in #460, on the corpus branch.

## Acceptance criteria

- [x] The guard prefers a triage in the corpus root.
- [x] A corpus with no triage of its own falls back to the copy beside the script, so a pin predating the move stays green.
- [x] The test reads the corpus triage.
- [x] Typecheck, the suite and the sweep pass against both corpora.

## Non-goals

Removing the fallback. It goes when no supported pin predates the move, which is a later cleanup that rides with a pin bump rather than a pull request of its own.
