### PR TITLE
Artifact audience: settle the last four registers, one to JSON and three to prose

### DIFF
--- a/work-package/techniques/dco-provenance/append-task-row.md
+++ b/work-package/techniques/dco-provenance/append-task-row.md
@@ -59,6 +59,10 @@ The updated provenance log, with the appended task row
 
 `provenance-log.md`
 
+#### audience
+
+`human`
+
 ## Protocol
 
 1. Create the `{provenance_log}` when it does not exist, per [provenance-log](../../resources/provenance-log.md#template).

--- a/workflow-design/activities/01-intake-and-context.yaml
+++ b/workflow-design/activities/01-intake-and-context.yaml
@@ -18,7 +18,7 @@ steps:
     technique:
       name: work-package::manage-artifacts::write-artifact
       inputs:
-        bare_filename: structural-inventory.md
+        bare_filename: structural-inventory.json
         artifact_content: structural_inventory
         target_dir: planning_folder_path
     when: operation_type == "update" || operation_type == "review"
@@ -90,7 +90,7 @@ steps:
         target: review_scope_confirmed
         value: true
       - action: message
-        message: "Compliance review target set: {target_workflow_ids} ([structural inventory]({structural_inventory_path}))."
+        message: "Compliance review target set: {target_workflow_ids}."
   - kind: action
     id: announce-review-seeded-update
     when: update_seeded_from_review == true

--- a/workflow-design/resources/README.md
+++ b/workflow-design/resources/README.md
@@ -21,7 +21,7 @@ Markdown resources for design principles, construct inventories, anti-pattern ca
 | `08` | [Design Assumption Reconciliation](design-assumption-reconciliation.md) | Audit vs open resolvability vocabulary |
 | `09` | [Elicitation Guide](elicitation-guide.md) | Mode dimension sets + per-dimension capture/question bank |
 | `10` | [Convention Conformance](convention-conformance.md) | Reference conventions vs sibling workflows |
-| `11` | [Structural Inventory](structural-inventory.md) | Creation guide: `structural-inventory.md` |
+| `11` | [Structural Inventory](structural-inventory.md) | Creation guide: `structural-inventory.json` |
 | `12` | [Format Conventions](format-conventions.md) | Creation guide: `format-conventions.md` |
 | `13` | [Applicable Constructs](applicable-constructs.md) | Creation guide: `applicable-constructs.md` |
 | `14` | [Design Specification](design-specification.md) | Creation guide: `design-specification.md` |
@@ -43,7 +43,7 @@ Markdown resources for design principles, construct inventories, anti-pattern ca
 | `README.md` | [planning-readme](../../meta/resources/planning-readme.md) Template + [readme-seed](readme-seed.md) |
 | `COMPLETE.md` | [completion-artifact](completion-artifact.md) |
 | `assumptions-log.md` | [design-assumptions](design-assumptions.md) |
-| `structural-inventory.md` | [structural-inventory](structural-inventory.md) |
+| `structural-inventory.json` | [structural-inventory](structural-inventory.md) |
 | `format-conventions.md` | [format-conventions](format-conventions.md) |
 | `applicable-constructs.md` | [applicable-constructs](applicable-constructs.md) |
 | `design-specification.md` | [design-specification](design-specification.md) |

--- a/workflow-design/resources/anti-patterns.md
+++ b/workflow-design/resources/anti-patterns.md
@@ -1253,15 +1253,15 @@ Output-discipline rules exist without a verify gate.
 
 ### AP-96. artifact-audience-declared
 
-"assumptions-log / change-block-index / provenance-log / debt-ledger — dense ID-bearing tables as prose markdown between human documents"
+"`#### artifact` / `debt-ledger.md`" — a filename with no `#### audience` beneath it
 
 An artifact's primary audience is undeclared.
 
-**Detect:** Output declaration carries only a filename; agent-state artifacts (lifecycle logs, indexes, ledgers only downstream steps re-read) default to the same prose-markdown shape as human-facing documents.
+**Detect:** An output declaring `#### artifact` carries no `#### audience`. Absence reads as `human` by default, so an agent-state artifact — a lifecycle log, index or ledger only later steps re-read — silently keeps the prose-markdown shape a human document has.
 
-**Do not flag:** Human-primary documents that should stay prose.
+**Do not flag:** An output with no `#### artifact`. Audience is a property of a file on disk, so a component or in-memory output has none to declare.
 
-**Fix:** Decide each artifact's primary audience (human | agent) at design time — human → prose; agent state → structured one-row-per-item data. Record audience in the output declaration's description until the technique protocol carries a first-class audience attribute.
+**Fix:** Decide the audience at design time and declare it: `human` → prose; `agent` → structured one-entry-per-item data, serialized as JSON on disk (`check-audience` enforces the format, and `audience-declared` the presence). Where a person is pointed at the artifact — a progress-inventory row, a gate message linking it — that reader is the one the format has to serve.
 
 ### AP-97. link-named-artifacts
 

--- a/workflow-design/resources/impact-analysis.md
+++ b/workflow-design/resources/impact-analysis.md
@@ -19,7 +19,7 @@ Update-mode decision surface. Answers: what is touched, is integrity intact, and
 **Mode:** Update
 **Date:** YYYY-MM-DD
 **Change source:** [design specification](NN-design-specification.md)
-**Baseline:** [structural inventory](NN-structural-inventory.md)
+**Baseline:** [structural inventory](NN-structural-inventory.json)
 
 ---
 

--- a/workflow-design/resources/structural-inventory.md
+++ b/workflow-design/resources/structural-inventory.md
@@ -1,73 +1,80 @@
 ---
 name: structural-inventory
-description: Guidelines for creating the structural-inventory planning artifact (update/review baseline).
+description: Creation guide for bare filename `structural-inventory.json` — per-target baseline counts of an existing workflow, its activity ids, and the scope of the change under way.
 metadata:
   order: 11
 ---
 
 # Structural Inventory Guide
 
-Baseline snapshot of an existing workflow for update or review. Answers: what is here, and what change is in scope? Human gate surface at change-request confirmation.
+Creation guide for bare filename `structural-inventory.json`. The before-picture of a workflow that already exists: how much of each thing is there, and what this session intends to change. Later passes measure against it to tell an intentional removal from an accidental one.
 
 ## Template
 
-```markdown
-# Structural Inventory — {workflow-id}
+One object per target, carrying the three count groups, the activity ids in order, and the change scope.
 
-**Workflow:** {title}
-**ID:** `{workflow-id}`
-**Version:** {version}
-**Initial activity:** `{initialActivity}`
-**Catalog source:** committed workflow catalog (`list_workflows`)
-**Mode:** update | review
-
-## File counts
-
-| Kind | Count |
-|------|------:|
-| Root `workflow.yaml` | N |
-| Activity YAML files | N |
-| Technique leaf files (`.md`, excl. containers/README) | N |
-| Technique container `TECHNIQUE.md` files | N |
-| Resource files (excl. README) | N |
-| Total files under workflow tree | N |
-
-## Entity counts
-
-| Entity | Count |
-|--------|------:|
-| Activities | N |
-| Techniques (leaf) | N |
-| Resources | N |
-| Checkpoints (incl. nested in loops) | N |
-| Transitions | N |
-| Decisions | N |
-| Workflow variables | N |
-| Workflow rules (activity partition) | N |
-
-## Step kinds (across activities)
-
-| Kind | Count |
-|------|------:|
-| technique | N |
-| checkpoint | N |
-| action | N |
-| loop | N |
-
-## Activities
-
-| # | Activity ID |
-|---|-------------|
-| NN | `{activity-id}` |
-
-## Update scope
-
-[One short paragraph or bullet list: what this session intends to change. Omit in pure review when no change request.]
+```json
+{
+  "mode": "update",
+  "catalog_source": "committed workflow catalog (list_workflows)",
+  "targets": [
+    {
+      "workflow_id": "midnight-system-review",
+      "title": "Midnight System Review",
+      "version": "2.4.0",
+      "initial_activity": "01-intake-and-scope",
+      "file_counts": {
+        "workflow_yaml": 1,
+        "activity_yaml": 9,
+        "technique_leaf": 34,
+        "technique_container": 6,
+        "resources": 21,
+        "total": 71
+      },
+      "entity_counts": {
+        "activities": 9,
+        "techniques": 34,
+        "resources": 21,
+        "checkpoints": 12,
+        "transitions": 14,
+        "decisions": 3,
+        "variables": 27,
+        "rules": 9
+      },
+      "step_kinds": {
+        "technique": 61,
+        "checkpoint": 12,
+        "action": 18,
+        "loop": 4
+      },
+      "activities": [
+        { "ordinal": "01", "id": "intake-and-scope" },
+        { "ordinal": "02", "id": "evidence-probes" }
+      ],
+      "update_scope": "Add a verdict-rubric resource and bind it from the adjudication pass."
+    }
+  ]
+}
 ```
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `mode` | string | `update` or `review` |
+| `catalog_source` | string | Where the counts were read from |
+| `targets` | object[] | One entry per workflow under review, in the order they were named |
+| `targets[].workflow_id` | string | Id of the workflow this entry inventories |
+| `targets[].title` | string | Its declared title |
+| `targets[].version` | string | Its declared version at the time of the snapshot |
+| `targets[].initial_activity` | string | The activity the workflow starts at |
+| `targets[].file_counts` | object | Files by kind — `workflow_yaml`, `activity_yaml`, `technique_leaf`, `technique_container`, `resources`, `total`. Leaf counts exclude containers and READMEs; `resources` excludes README |
+| `targets[].entity_counts` | object | Definitions by kind — `activities`, `techniques` (leaf), `resources`, `checkpoints` (including those nested in loops), `transitions`, `decisions`, `variables`, `rules` (the activity partition) |
+| `targets[].step_kinds` | object | Steps across all activities by kind — `technique`, `checkpoint`, `action`, `loop` |
+| `targets[].activities` | object[] | The activity ids in workflow order, each with its `ordinal` |
+| `targets[].update_scope` | string \| null | What this session intends to change; null in a pure review with no change request |
 
 ## Rules
 
-- **Counts only, then scope.** No per-file essays; the activity id table is the structural list.
-- **One-line update scope** when mode is update — enough for the change-request gate.
-- **Line budget:** ~60 lines. Longer means dumping catalog detail the gate does not need.
-- Multi-target review: one inventory artifact per target (or clearly sectioned by workflow id).
+- **Counts, then scope.** The numbers and the activity id list are the inventory; per-file description belongs to the passes that read it.
+- **One entry per target.** A multi-target review appends entries rather than writing a second artifact.
+- **`update_scope` is set whenever mode is `update`.** It is what the change-request decision resolves against.
+- **Every count group is complete.** A partial group cannot be compared against a later one, so an absent count is recorded as `0`, never omitted.

--- a/workflow-design/techniques/TECHNIQUE.md
+++ b/workflow-design/techniques/TECHNIQUE.md
@@ -77,7 +77,7 @@ The canonical home for each shared design-session fact category. Templates carry
 | File manifest, structural design, drafting order | `scope-manifest.md` |
 | Format / YAML literacy | `format-conventions.md` |
 | Applicable schema constructs | `applicable-constructs.md` |
-| Structural inventory baseline | `structural-inventory.md` |
+| Structural inventory baseline | `structural-inventory.json` |
 | Pattern analysis findings | `pattern-analysis.md` |
 | Compliance / audit findings | `compliance-report.md` (and findings satellites) |
 | In-task follow-ups | `follow-ups.md` (see [follow-ups](../resources/follow-ups.md)) |

--- a/workflow-design/techniques/assemble-file-approach.md
+++ b/workflow-design/techniques/assemble-file-approach.md
@@ -27,6 +27,10 @@ The per-file delta for `{current_file}` following the [Drafting Plan Guide](../r
 
 `drafting-plan.md`
 
+#### audience
+
+`human`
+
 ### drafting_plan_path
 
 Absolute path to the persisted drafting-plan artifact for the current file.

--- a/workflow-design/techniques/intake-classification.md
+++ b/workflow-design/techniques/intake-classification.md
@@ -47,15 +47,15 @@ Ordered list of workflow ids to audit in review mode. One element for single-tar
 
 ### structural_inventory
 
-Per-target structural inventory following the [Structural Inventory Guide](../resources/structural-inventory.md#template): file counts, entity counts, activity ids, and one-line update scope.
+Per-target structural inventory following the [Structural Inventory Guide](../resources/structural-inventory.md#template): file counts, entity counts, step kinds, activity ids in order, and the scope of the change under way.
 
 #### artifact
 
-`structural-inventory.md`
+`structural-inventory.json`
 
-### structural_inventory_path
+#### audience
 
-Absolute path to the persisted structural-inventory artifact when `{operation_type}` is `update` or `review`; empty otherwise.
+`agent`
 
 ### change_category
 
@@ -86,8 +86,8 @@ When `{operation_type}` is `update`, the categorized change request derived from
 
 ### 5. Persist Structural Inventory
 
-- When `{operation_type}` is `update` or `review`: persist `{structural_inventory}` via the calling activity's bound `manage-artifacts::write-artifact` step with *target_dir* `{planning_folder_path}` and bare filename `structural-inventory.md` per [structural-inventory](../resources/structural-inventory.md#template); capture `{structural_inventory_path}`
-- When create mode: leave `{structural_inventory_path}` empty
+- When `{operation_type}` is `update` or `review`: persist `{structural_inventory}` via the calling activity's bound `manage-artifacts::write-artifact` step with *target_dir* `{planning_folder_path}` and bare filename `structural-inventory.json` per [structural-inventory](../resources/structural-inventory.md#template)
+- When create mode: build no inventory, there being no existing definition to snapshot
 
 ### 6. Parse Change Request
 

--- a/workflow-design/techniques/review-drafted-file.md
+++ b/workflow-design/techniques/review-drafted-file.md
@@ -27,6 +27,10 @@ Per-file delta note for `{current_file}` following the [File Review Note Guide](
 
 `file-review-note.md`
 
+#### audience
+
+`human`
+
 ### file_review_note_path
 
 Absolute path to the persisted file-review note (updated in place each file iteration).

--- a/workflow-design/workflow.yaml
+++ b/workflow-design/workflow.yaml
@@ -142,10 +142,6 @@ variables:
     type: string
     description: Absolute path to the persisted compliance or post-update review report.
     defaultValue: ""
-  - name: structural_inventory_path
-    type: string
-    description: Absolute path to the persisted structural-inventory artifact (update/review).
-    defaultValue: ""
   - name: drafting_plan_path
     type: string
     description: Absolute path to the persisted per-file drafting-plan artifact.


### PR DESCRIPTION
## Summary

Every output that names a file on disk says who reads it, except four. Those four were held back deliberately: an `agent` declaration means JSON on disk, so declaring it and converting the file are the same act, and each needed a decision about what the artifact is actually for. This settles all four — one converts, three are confirmed as documents a person reads.

With that, no artifact-bearing output is undeclared, which is the condition a presence check was waiting on.

## The one that converts

The **structural inventory** is the before-picture of a workflow that already exists: how many activities, techniques, resources, checkpoints, transitions and decisions are there, how many files of each kind, which activity ids exist, and what this session intends to change. The impact and drafting passes measure against it to tell an intentional removal from an accidental one. Three groups of counts and a list of ids, consumed by machinery — so it becomes `structural-inventory.json` and declares `agent`.

The conversion also fixes something the markdown shape could only ask for politely. A multi-target review needed "one inventory artifact per target, or clearly sectioned by workflow id" — a convention with nothing enforcing it. JSON makes it a `targets` array, so a second target appends an entry.

## The three that do not

| Register | Who reads it | Why prose |
|---|---|---|
| `provenance-log` | a later auditor | It records which assistant and model did each task and whether anything outside the repository informed it. Nothing in the run reads a field back — the only operation after creation is appending a row. Its reader may never have been in the run at all. |
| `drafting-plan` | the operator, at a gate | One row per file in scope with a one-line delta. The `file-approach-confirmed` checkpoint asks whether to proceed with this approach, and this artifact is the approach. |
| `file-review-note` | the operator, at a gate | What landed per file, and in update mode what was removed and whether the removal was flagged. The blocking `preservation-check` gate asks a person to authorise deletions from a committed workflow on the strength of it. |

All three declare `human`.

## What removing one link exposed

The review-scope message linked the structural inventory. Once the artifact is agent state, a message pointing a person at it is the wrong affordance, so the link goes — and the mention with it, since naming a durable artifact without linking it is its own defect.

That left `structural_inventory_path` with no consumer anywhere: the message was the only one. Later passes load the inventory's content, never its path. The guard caught it immediately, which is the guard doing its job — an output nothing consumes is dead weight. The path output and its workflow variable are removed.

## AP-96 refreshed

The catalog entry naming this defect still told an author to record audience "in the output declaration's description until the technique protocol carries a first-class audience attribute". The attribute has been first-class for some time, and the entry's example named `provenance-log` and `debt-ledger` as open cases — both now settled. Its Detect now keys on a filename with no audience beneath it, and its carve-out says what it should: an output with no `#### artifact` has no audience to declare, audience being a property of a file.

## Scope of change

Eleven files in two workflows: the inventory guide rewritten as JSON with a field table, four technique declarations, one activity, two READMEs and the canonical-home map, the impact-analysis baseline reference, one workflow variable removed, and the catalog entry.

## Acceptance criteria

- [x] Every output declaring `#### artifact` declares `#### audience`.
- [x] The structural inventory is JSON, declares `agent`, and its multi-target case is a field rather than a convention.
- [x] The three human registers declare `human` and keep their prose shape and their gates.
- [x] No output is left without a consumer.
- [x] Guard sweep 27 of 27; suite 1006 passed.

## Non-goals

The presence guard itself. It lives with the tooling on `main` and lands with the pin bump that picks this up — it cannot pass until this merges.
